### PR TITLE
ADD web-components as valid storybook app package name

### DIFF
--- a/bin/storybook/get-info.js
+++ b/bin/storybook/get-info.js
@@ -9,6 +9,7 @@ const viewLayers = [
   'vue',
   'angular',
   'html',
+  'web-components',
   'polymer',
   'ember',
   'marko',


### PR DESCRIPTION
This resolves an issue a customer had.

The list of `viewLayers` should contain all storybook's supported frameworks.