### PR TITLE
Fix Intl mocks version 2

### DIFF
--- a/.github/workflows/chromatic-action.yml
+++ b/.github/workflows/chromatic-action.yml
@@ -8,7 +8,7 @@ jobs:
     - uses: actions/checkout@v1
     - run: |
         yarn
-    - uses: chromaui/action@releases/v1
+    - uses: chromaui/action@v1
       env:
         DEBUG: chromatic-cli
       with:

--- a/bin/lib/jsdom-shims.js
+++ b/bin/lib/jsdom-shims.js
@@ -286,11 +286,23 @@ export function addShimsToJSDOM(window) {
     }
   }
 
-  const alwaysFn = C =>
-    // eslint-disable-next-line func-names
-    Object.assign(function() {
-      return new C();
-    }, C);
+  const alwaysFn = C => {
+    const statics = Object.getOwnPropertyNames(C)
+      .filter(n => typeof C[n] === 'function')
+      .reduce((acc, name) => {
+        acc[name] = C[name];
+        return acc;
+      }, {});
+
+    return Object.assign(
+      // eslint-disable-next-line func-names
+      function() {
+        return new C();
+      },
+      C,
+      statics
+    );
+  };
 
   class IntlDateTimeFormatMock extends IntlFormatMock {}
   class IntlNumberFormatMock extends IntlFormatMock {}

--- a/bin/lib/jsdom-shims.js
+++ b/bin/lib/jsdom-shims.js
@@ -296,7 +296,7 @@ export function addShimsToJSDOM(window) {
     // Get all static methods defined on any ancestor
     const statics = classHierarchy
       .map(klass => Object.getOwnPropertyNames(klass))
-      .flat()
+      .reduce((a, b) => [...a, ...b], []) // flatten
       .filter(n => typeof C[n] === 'function')
       .reduce((acc, name) => {
         acc[name] = C[name];

--- a/bin/lib/jsdom-shims.js
+++ b/bin/lib/jsdom-shims.js
@@ -287,7 +287,16 @@ export function addShimsToJSDOM(window) {
   }
 
   const alwaysFn = C => {
-    const statics = Object.getOwnPropertyNames(C)
+    // Search up the prototype chain until we hit base. The base class of Class has no name I guess.
+    const classHierarchy = [];
+    for (let curr = C; curr.name; curr = Object.getPrototypeOf(curr)) {
+      classHierarchy.push(curr);
+    }
+
+    // Get all static methods defined on any ancestor
+    const statics = classHierarchy
+      .map(klass => Object.getOwnPropertyNames(klass))
+      .flat()
       .filter(n => typeof C[n] === 'function')
       .reduce((acc, name) => {
         acc[name] = C[name];


### PR DESCRIPTION
Hotfix for #115.

Do the minimum to make our `alwaysFn()` work with static methods.

To verify that `alwaysFn` works, try the following:

```js
const alwaysFn = /*  as defined */;

class A {
  static method() {}
}

class B {}

const Bprime = alwaysFn(B);

Bprime.method();
```

