### PR TITLE
Show "Continue setup at ..." link after running the very first build

### DIFF
--- a/bin/io/gql-queries.js
+++ b/bin/io/gql-queries.js
@@ -24,6 +24,7 @@ export const TesterCreateBuildMutation = `
           paymentRequired
           billingUrl
         }
+        setupUrl
       }
     }
   }

--- a/bin/tester/index.js
+++ b/bin/tester/index.js
@@ -373,6 +373,7 @@ export async function runTest({
   let uiReview;
   let wasLimited;
   let billingUrl;
+  let setupUrl;
   let exceededThreshold;
   let paymentRequired;
 
@@ -430,6 +431,7 @@ export async function runTest({
         wasLimited,
         app: {
           account: { billingUrl, exceededThreshold, paymentRequired },
+          setupUrl,
         },
       },
     } = await client.runQuery(TesterCreateBuildMutation, {
@@ -482,9 +484,7 @@ export async function runTest({
     }
 
     const onlineHint =
-      buildNumber === 1
-        ? `Continue setup at ${exitUrl.replace('/build', '/setup').replace('&number=1', '')}`
-        : `View it online at ${exitUrl}`;
+      buildNumber === 1 ? `Continue setup at ${setupUrl}` : `View it online at ${exitUrl}`;
 
     if (publishOnly) {
       log.info(`Published your Storybook. ${onlineHint}`);

--- a/bin/tester/index.js
+++ b/bin/tester/index.js
@@ -540,7 +540,7 @@ export async function runTest({
           ${onlineHint}
         `);
         console.log('');
-        exitCode = isOnboarding || doExitZeroOnChanges || buildOutput.autoAcceptChanges ? 0 : 1;
+        exitCode = doExitZeroOnChanges || buildOutput.autoAcceptChanges ? 0 : 1;
         if (exitCode !== 0) {
           log.info(dedent`
             Pass --exit-zero-on-changes if you want this command to exit successfully in this case.

--- a/bin/tester/index.js
+++ b/bin/tester/index.js
@@ -51,9 +51,10 @@ async function waitForBuild(client, variables) {
   if (status === 'BUILD_IN_PROGRESS') {
     if (inProgressCount !== lastInProgressCount) {
       lastInProgressCount = inProgressCount;
+      const progress = snapshotCount - inProgressCount + 1;
 
       log.info(
-        `Taking snapshots ${inProgressCount}/${snapshotCount}${
+        `Taking snapshots ${progress}/${snapshotCount}${
           errorCount > 0 ? ` (${pluralize(errorCount, 'error')})` : ''
         }`
       );

--- a/bin/tester/index.js
+++ b/bin/tester/index.js
@@ -457,8 +457,6 @@ export async function runTest({
       isolatorUrl,
     }));
 
-    const onlineHint = `View it online at ${exitUrl}`;
-
     const publishOnly = !uiReview && !uiTests;
     if (wasLimited) {
       if (exceededThreshold) {
@@ -483,17 +481,21 @@ export async function runTest({
       }
     }
 
-    if (!publishOnly) {
-      log.info(dedent`
-      Started Build ${buildNumber} (${pluralize(componentCount, 'component')}, ${pluralize(
-        specCount,
-        'story'
-      )}, ${pluralize(snapshotCount, 'snapshot')}).
+    const onlineHint =
+      buildNumber === 1
+        ? `Continue setup at ${exitUrl.replace('/build', '/setup').replace('&number=1', '')}`
+        : `View it online at ${exitUrl}`;
 
-      ${onlineHint}.
-    `);
-    } else {
+    if (publishOnly) {
       log.info(`Published your Storybook. ${onlineHint}`);
+    } else {
+      const components = pluralize(componentCount, 'component');
+      const specs = pluralize(specCount, 'story');
+      const snapshots = pluralize(snapshotCount, 'snapshot');
+      log.info(`Started build ${buildNumber} (${components}, ${specs}, ${snapshots}).`);
+      if (buildNumber > 1) {
+        log.info(onlineHint);
+      }
     }
 
     if (publishOnly || doExitOnceSentToChromatic) {
@@ -515,8 +517,8 @@ export async function runTest({
       case 'BUILD_PASSED':
         log.info(
           uiTests
-            ? `Build ${buildNumber} passed! ${onlineHint}.`
-            : `Build ${buildNumber} published! ${onlineHint}.`
+            ? `Build ${buildNumber} passed! ${onlineHint}`
+            : `Build ${buildNumber} published! ${onlineHint}`
         );
         exitCode = 0;
         break;
@@ -527,7 +529,7 @@ export async function runTest({
         log.info(dedent`
           Build ${buildNumber} has ${pluralize(changeCount, 'change')}.
 
-          ${onlineHint}.
+          ${onlineHint}
         `);
         console.log('');
         exitCode = doExitZeroOnChanges || buildOutput.autoAcceptChanges ? 0 : 1;
@@ -544,7 +546,7 @@ export async function runTest({
           dedent`
             Build ${buildNumber} has ${pluralize(errorCount, 'error')}.
               
-            ${onlineHint}.`
+            ${onlineHint}`
         );
         exitCode = 2;
         break;

--- a/bin/tester/index.js
+++ b/bin/tester/index.js
@@ -530,15 +530,16 @@ export async function runTest({
       // They may have sneakily looked at the build while we were waiting
       case 'BUILD_ACCEPTED':
       case 'BUILD_PENDING':
-      case 'BUILD_DENIED':
-        if (!isOnboarding) {
-          log.info(dedent`
-          Build ${buildNumber} has ${pluralize(changeCount, 'change')}.
+      case 'BUILD_DENIED': {
+        const statusText = isOnboarding
+          ? 'Build complete.'
+          : `Build ${buildNumber} has ${pluralize(changeCount, 'change')}.`;
+        log.info(dedent`
+          ${statusText}
 
           ${onlineHint}
         `);
-          console.log('');
-        }
+        console.log('');
         exitCode = isOnboarding || doExitZeroOnChanges || buildOutput.autoAcceptChanges ? 0 : 1;
         if (exitCode !== 0) {
           log.info(dedent`
@@ -548,6 +549,7 @@ export async function runTest({
           `);
         }
         break;
+      }
       case 'BUILD_FAILED':
         log.info(
           dedent`


### PR DESCRIPTION
This is meant to prevent users from ending up on the builds page while they're supposed to be following the onboarding flow.

<img width="838" alt="Screenshot 2020-04-15 om 14 39 22" src="https://user-images.githubusercontent.com/321738/79338305-5b463000-7f27-11ea-892b-038b4033b9a2.png">

This is only shown for build 1.

Also I removed the `.` after the link because my terminal was treating it as part of the URL when clicked.