### PR TITLE
Fix crash when code uses random generators (uuid)

### DIFF
--- a/bin/lib/jsdom-shims.js
+++ b/bin/lib/jsdom-shims.js
@@ -173,7 +173,7 @@ function mockCrypto(window) {
   if (!window.crypto) {
     Object.defineProperty(window, 'crypto', {
       value: {
-        getRandomValues: () => 0,
+        getRandomValues: (arr) => arr.fill(0),
       },
       writable: true,
     });


### PR DESCRIPTION
Chromatic jsdom `window.crypto.getRandomValues` shim returns number instead of writing "random" numbers to array. That breaks some random generators including `uuid`.

This fixes that with minimal change so the behaviour is the same like in browser. https://developer.mozilla.org/en-US/docs/Web/API/Crypto/getRandomValues

Error before fix:
```
chroma info Uploaded your build, verifying
chroma info Uploading and verifying build (this may take a few minutes depending on your connection)
...
chroma ERR! Error: Uncaught [TypeError: Cannot create property '6' on number '0']
    at reportException (/Users/jakubriedl/repositories/iflix/clients-web/node_modules/storybook-chroma/node_modules/jsdom/lib/jsdom/living/helpers/runtime-script-errors.js:62:24)
    at processJavaScript (/Users/jakubriedl/repositories/iflix/clients-web/node_modules/storybook-chroma/node_modules/jsdom/lib/jsdom/living/nodes/HTMLScriptElement-impl.js:243:7)
    at HTMLScriptElementImpl._innerEval (/Users/jakubriedl/repositories/iflix/clients-web/node_modules/storybook-chroma/node_modules/jsdom/lib/jsdom/living/nodes/HTMLScriptElement-impl.js:168:5)
    at onLoadExternalScript (/Users/jakubriedl/repositories/iflix/clients-web/node_modules/storybook-chroma/node_modules/jsdom/lib/jsdom/living/nodes/HTMLScriptElement-impl.js:90:12)
    at onLoadWrapped (/Users/jakubriedl/repositories/iflix/clients-web/node_modules/storybook-chroma/node_modules/jsdom/lib/jsdom/browser/resources/per-document-resource-loader.js:53:33)
    at Object.check (/Users/jakubriedl/repositories/iflix/clients-web/node_modules/storybook-chroma/node_modules/jsdom/lib/jsdom/browser/resources/resource-queue.js:76:23)
    at /Users/jakubriedl/repositories/iflix/clients-web/node_modules/storybook-chroma/node_modules/jsdom/lib/jsdom/browser/resources/resource-queue.js:83:27
    at runMicrotasks (<anonymous>)
    at processTicksAndRejections (internal/process/task_queues.js:97:5)     at v4 (https://5dcb3d5a6ce19b0020240833-axfnzkbpbw.chromatic.com/vendors~main.4c6b4a8e2eb317392d9c.bundle.js:2:3797748)
```

After:
```
chroma info Uploaded your build, verifying
chroma info Uploading and verifying build (this may take a few minutes depending on your connection)
chroma info Found 124 stories
chroma info Started Build 751 (52 components, 120 stories, 275 snapshots).
...
```

And code that was causing that in `uuid.v4` https://github.com/uuidjs/uuid/blob/master/src/v4.js#L16
```js
  var rnds = options.random || (options.rng || rng)();
  // rnds should be an Array(16) with random numbers (fixed in chromatic) but it is 0 instead
  rnds[6] = (rnds[6] & 0x0f) | 0x40;
```