### PR TITLE
Fix yarn cmd in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,6 @@ npm install --save-dev chromatic
 **With yarn:**
 
 ```
-yarn remove --dev storybook-chromatic
+yarn remove storybook-chromatic
 yarn add --dev chromatic
 ```


### PR DESCRIPTION
The yarn remove command doesn't allow the `--dev` param and will throw an error if the documented code is run

`yarn remove --dev ...` > `yarn remove ...`

