### PR TITLE
Support yarn execpath

### DIFF
--- a/bin/tasks/build.js
+++ b/bin/tasks/build.js
@@ -27,7 +27,7 @@ export const setSpawnParams = (ctx) => {
   // Based on https://github.com/mysticatea/npm-run-all/blob/52eaf86242ba408dedd015f53ca7ca368f25a026/lib/run-task.js#L156-L174
   const npmExecPath = process.env.npm_execpath;
   const isJsPath = typeof npmExecPath === 'string' && /\.m?js/.test(path.extname(npmExecPath));
-  const isYarn = npmExecPath && path.basename(npmExecPath) === 'yarn.js';
+  const isYarn = npmExecPath && /^yarn(\.js)?$/.test(path.basename(npmExecPath));
   ctx.spawnParams = {
     command: (isJsPath ? process.execPath : npmExecPath) || 'npm',
     clientArgs: isJsPath ? [npmExecPath, 'run'] : ['run', '--silent'],

--- a/bin/tasks/build.test.js
+++ b/bin/tasks/build.test.js
@@ -41,6 +41,17 @@ describe('setSpawnParams', () => {
       scriptArgs: ['build:storybook', '--', '--output-dir', './source-dir/'],
     });
   });
+
+  it('supports yarn', async () => {
+    process.env.npm_execpath = '/path/to/yarn';
+    const ctx = { sourceDir: './source-dir/', options: { buildScriptName: 'build:storybook' } };
+    await setSpawnParams(ctx);
+    expect(ctx.spawnParams).toEqual({
+      command: '/path/to/yarn',
+      clientArgs: ['run', '--silent'],
+      scriptArgs: ['build:storybook', '--output-dir', './source-dir/'],
+    });
+  });
 });
 
 describe('buildStorybook', () => {


### PR DESCRIPTION
I don't know why, but yarn was not being correctly detected on my system (maybe because I'm using yarn 2?).

In my case, `process.env.npm_execpath` was returning `/path/to/yarn` rather than `/path/to/yarn.js`.