### PR TITLE
Fix `npx chromatic` timing out on build-storybook

### DIFF
--- a/bin/tasks/build.js
+++ b/bin/tasks/build.js
@@ -28,6 +28,8 @@ export const setSpawnParams = (ctx) => {
   const npmExecPath = process.env.npm_execpath;
   const isJsPath = typeof npmExecPath === 'string' && /\.m?js/.test(path.extname(npmExecPath));
   const isYarn = npmExecPath && /^yarn(\.js)?$/.test(path.basename(npmExecPath));
+  ctx.log.debug('process.env.npm_execpath', process.env.npm_execpath);
+  ctx.log.debug('process.execPath', process.execPath);
   ctx.spawnParams = {
     client: isYarn ? 'yarn' : 'npm',
     platform: process.platform,

--- a/bin/tasks/build.js
+++ b/bin/tasks/build.js
@@ -29,6 +29,8 @@ export const setSpawnParams = (ctx) => {
   const isJsPath = typeof npmExecPath === 'string' && /\.m?js/.test(path.extname(npmExecPath));
   const isYarn = npmExecPath && path.basename(npmExecPath) === 'yarn.js';
   ctx.spawnParams = {
+    client: isYarn ? 'yarn' : 'npm',
+    platform: process.platform,
     command: (isJsPath ? process.execPath : npmExecPath) || 'npm',
     clientArgs: isJsPath ? [npmExecPath, 'run'] : ['run', '--silent'],
     scriptArgs: [
@@ -53,6 +55,7 @@ export const buildStorybook = async (ctx) => {
 
   try {
     const { command, clientArgs, scriptArgs } = ctx.spawnParams;
+    ctx.log.debug('Using spawnParams:', JSON.stringify(ctx.spawnParams, null, 2));
     await Promise.race([
       execa(command, [...clientArgs, ...scriptArgs], { stdio: [null, logFile, logFile] }),
       timeoutAfter(ctx.env.STORYBOOK_BUILD_TIMEOUT),

--- a/bin/tasks/build.js
+++ b/bin/tasks/build.js
@@ -39,6 +39,10 @@ export const setSpawnParams = (ctx) => {
       '--output-dir',
       ctx.sourceDir,
     ].filter(Boolean),
+    spawnOptions: {
+      preferLocal: true,
+      localDir: path.resolve('node_modules/.bin'),
+    },
   };
 };
 
@@ -54,10 +58,13 @@ export const buildStorybook = async (ctx) => {
   });
 
   try {
-    const { command, clientArgs, scriptArgs } = ctx.spawnParams;
+    const { command, clientArgs, scriptArgs, spawnOptions } = ctx.spawnParams;
     ctx.log.debug('Using spawnParams:', JSON.stringify(ctx.spawnParams, null, 2));
     await Promise.race([
-      execa(command, [...clientArgs, ...scriptArgs], { stdio: [null, logFile, logFile] }),
+      execa(command, [...clientArgs, ...scriptArgs], {
+        stdio: [null, logFile, logFile],
+        ...spawnOptions,
+      }),
       timeoutAfter(ctx.env.STORYBOOK_BUILD_TIMEOUT),
     ]);
   } catch (e) {

--- a/bin/tasks/build.js
+++ b/bin/tasks/build.js
@@ -27,7 +27,7 @@ export const setSpawnParams = (ctx) => {
   // Based on https://github.com/mysticatea/npm-run-all/blob/52eaf86242ba408dedd015f53ca7ca368f25a026/lib/run-task.js#L156-L174
   const npmExecPath = process.env.npm_execpath;
   const isJsPath = typeof npmExecPath === 'string' && /\.m?js/.test(path.extname(npmExecPath));
-  const isYarn = npmExecPath && path.basename(npmExecPath) === 'yarn.js';
+  const isYarn = npmExecPath && /^yarn(\.js)?$/.test(path.basename(npmExecPath));
   ctx.spawnParams = {
     client: isYarn ? 'yarn' : 'npm',
     platform: process.platform,

--- a/bin/tasks/build.js
+++ b/bin/tasks/build.js
@@ -50,20 +50,11 @@ const timeoutAfter = (ms) =>
   new Promise((resolve, reject) => setTimeout(reject, ms, new Error(`Operation timed out`)));
 
 export const buildStorybook = async (ctx) => {
-  ctx.log.debug('buildStorybook')
   ctx.buildLogFile = path.resolve('./build-storybook.log');
-  ctx.log.debug(ctx.buildLogFile);
   const logFile = fs.createWriteStream(ctx.buildLogFile);
-  ctx.log.debug(logFile);
   await new Promise((resolve, reject) => {
-    logFile.on('open', () => {
-      ctx.log.debug('open');
-      resolve();
-    });
-    logFile.on('error', (e) => {
-      ctx.log.debug('error', e);
-      reject();
-    });
+    logFile.on('open', resolve);
+    logFile.on('error', reject);
   });
 
   try {

--- a/bin/tasks/build.js
+++ b/bin/tasks/build.js
@@ -50,11 +50,20 @@ const timeoutAfter = (ms) =>
   new Promise((resolve, reject) => setTimeout(reject, ms, new Error(`Operation timed out`)));
 
 export const buildStorybook = async (ctx) => {
+  ctx.log.debug('buildStorybook')
   ctx.buildLogFile = path.resolve('./build-storybook.log');
+  ctx.log.debug(ctx.buildLogFile);
   const logFile = fs.createWriteStream(ctx.buildLogFile);
+  ctx.log.debug(logFile);
   await new Promise((resolve, reject) => {
-    logFile.on('open', resolve);
-    logFile.on('error', reject);
+    logFile.on('open', () => {
+      ctx.log.debug('open');
+      resolve();
+    });
+    logFile.on('error', (e) => {
+      ctx.log.debug('error', e);
+      reject();
+    });
   });
 
   try {

--- a/bin/tasks/build.js
+++ b/bin/tasks/build.js
@@ -28,8 +28,6 @@ export const setSpawnParams = (ctx) => {
   const npmExecPath = process.env.npm_execpath;
   const isJsPath = typeof npmExecPath === 'string' && /\.m?js/.test(path.extname(npmExecPath));
   const isYarn = npmExecPath && /^yarn(\.js)?$/.test(path.basename(npmExecPath));
-  ctx.log.debug('process.env.npm_execpath', process.env.npm_execpath);
-  ctx.log.debug('process.execPath', process.execPath);
   ctx.spawnParams = {
     client: isYarn ? 'yarn' : 'npm',
     platform: process.platform,

--- a/bin/tasks/build.test.js
+++ b/bin/tasks/build.test.js
@@ -36,9 +36,15 @@ describe('setSpawnParams', () => {
     const ctx = { sourceDir: './source-dir/', options: { buildScriptName: 'build:storybook' } };
     await setSpawnParams(ctx);
     expect(ctx.spawnParams).toEqual({
+      client: 'npm',
+      platform: expect.stringMatching(/darwin|linux|win32/),
       command: 'npm',
       clientArgs: ['run', '--silent'],
       scriptArgs: ['build:storybook', '--', '--output-dir', './source-dir/'],
+      spawnOptions: {
+        preferLocal: true,
+        localDir: expect.stringMatching(/node_modules[/\\]\.bin$/),
+      },
     });
   });
 });
@@ -52,6 +58,7 @@ describe('buildStorybook', () => {
         scriptArgs: ['--script-args'],
       },
       env: { STORYBOOK_BUILD_TIMEOUT: 1000 },
+      log: { debug: jest.fn() },
     };
     await buildStorybook(ctx);
     expect(ctx.buildLogFile).toMatch(/build-storybook\.log$/);
@@ -59,6 +66,10 @@ describe('buildStorybook', () => {
       'build:storybook',
       ['--client-args', '--script-args'],
       expect.objectContaining({ stdio: expect.any(Array) })
+    );
+    expect(ctx.log.debug).toHaveBeenCalledWith(
+      'Using spawnParams:',
+      JSON.stringify(ctx.spawnParams, null, 2)
     );
   });
 
@@ -71,7 +82,7 @@ describe('buildStorybook', () => {
       },
       options: { buildScriptName: '' },
       env: { STORYBOOK_BUILD_TIMEOUT: 0 },
-      log: { error: jest.fn() },
+      log: { debug: jest.fn(), error: jest.fn() },
     };
     execa.mockReturnValue(new Promise((resolve) => setTimeout(resolve, 10)));
     await expect(buildStorybook(ctx)).rejects.toThrow('Command failed');

--- a/bin/tasks/build.test.js
+++ b/bin/tasks/build.test.js
@@ -47,6 +47,17 @@ describe('setSpawnParams', () => {
       },
     });
   });
+
+  it('supports yarn', async () => {
+    process.env.npm_execpath = '/path/to/yarn';
+    const ctx = { sourceDir: './source-dir/', options: { buildScriptName: 'build:storybook' } };
+    await setSpawnParams(ctx);
+    expect(ctx.spawnParams).toEqual({
+      command: '/path/to/yarn',
+      clientArgs: ['run', '--silent'],
+      scriptArgs: ['build:storybook', '--output-dir', './source-dir/'],
+    });
+  });
 });
 
 describe('buildStorybook', () => {

--- a/bin/tasks/build.test.js
+++ b/bin/tasks/build.test.js
@@ -53,9 +53,15 @@ describe('setSpawnParams', () => {
     const ctx = { sourceDir: './source-dir/', options: { buildScriptName: 'build:storybook' } };
     await setSpawnParams(ctx);
     expect(ctx.spawnParams).toEqual({
+      client: 'yarn',
+      platform: expect.stringMatching(/darwin|linux|win32/),
       command: '/path/to/yarn',
       clientArgs: ['run', '--silent'],
       scriptArgs: ['build:storybook', '--output-dir', './source-dir/'],
+      spawnOptions: {
+        preferLocal: true,
+        localDir: expect.stringMatching(/node_modules[/\\]\.bin$/),
+      },
     });
   });
 });

--- a/bin/ui/messages/errors/fatalError.js
+++ b/bin/ui/messages/errors/fatalError.js
@@ -14,7 +14,7 @@ export default function fatalError(ctx, error, timestamp = new Date().toISOStrin
   const website = link(pkg.docs);
   const errors = [].concat(error);
 
-  const { git = {}, storybook, exitCode, isolatorUrl, cachedUrl, build } = ctx;
+  const { git = {}, storybook, spawnParams, exitCode, isolatorUrl, cachedUrl, build } = ctx;
   const debugInfo = {
     timestamp,
     sessionId,
@@ -27,6 +27,7 @@ export default function fatalError(ctx, error, timestamp = new Date().toISOStrin
     flags,
     ...(options.buildScriptName ? { buildScript: scripts[options.buildScriptName] } : {}),
     ...(options.scriptName ? { storybookScript: scripts[options.scriptName] } : {}),
+    ...(spawnParams ? { spawnParams } : {}),
     exitCode,
     errorType: errors.map((err) => err.name).join('\n'),
     errorMessage: stripAnsi(errors[0].message.split('\n')[0].trim()),

--- a/bin/ui/tasks/build.js
+++ b/bin/ui/tasks/build.js
@@ -7,7 +7,7 @@ export const initial = {
 
 export const pending = (ctx) => ({
   status: 'pending',
-  title: 'Building your Storybook',
+  title: `Building your Storybook with ${ctx.spawnParams.client}`,
   output: `Running command: ${ctx.spawnParams.scriptArgs.join(' ')}`,
 });
 
@@ -25,6 +25,6 @@ export const skipped = (ctx) => ({
 
 export const failed = (ctx) => ({
   status: 'error',
-  title: 'Building your Storybook',
+  title: `Building your Storybook with ${ctx.spawnParams.client}`,
   output: `Command failed: ${ctx.spawnParams.scriptArgs.join(' ')}`,
 });

--- a/bin/ui/tasks/build.js
+++ b/bin/ui/tasks/build.js
@@ -1,5 +1,8 @@
 import { getDuration } from '../../lib/tasks';
 
+const fullCommand = ({ command, clientArgs, scriptArgs }) =>
+  [command, ...clientArgs, ...scriptArgs].join(' ');
+
 export const initial = {
   status: 'initial',
   title: 'Build Storybook',
@@ -7,8 +10,8 @@ export const initial = {
 
 export const pending = (ctx) => ({
   status: 'pending',
-  title: `Building your Storybook with ${ctx.spawnParams.client}`,
-  output: `Running command: ${ctx.spawnParams.scriptArgs.join(' ')}`,
+  title: `Building your Storybook`,
+  output: `Running command: ${fullCommand(ctx.spawnParams)}`,
 });
 
 export const success = (ctx) => ({
@@ -25,6 +28,6 @@ export const skipped = (ctx) => ({
 
 export const failed = (ctx) => ({
   status: 'error',
-  title: `Building your Storybook with ${ctx.spawnParams.client}`,
-  output: `Command failed: ${ctx.spawnParams.scriptArgs.join(' ')}`,
+  title: `Building your Storybook`,
+  output: `Command failed: ${fullCommand(ctx.spawnParams)}`,
 });

--- a/bin/ui/tasks/build.stories.js
+++ b/bin/ui/tasks/build.stories.js
@@ -7,7 +7,8 @@ export default {
 };
 
 const spawnParams = {
-  client: 'yarn',
+  command: 'yarn',
+  clientArgs: ['run', '--silent'],
   scriptArgs: ['build-storybook', '-o', 'storybook-static'],
 };
 

--- a/bin/ui/tasks/build.stories.js
+++ b/bin/ui/tasks/build.stories.js
@@ -1,17 +1,19 @@
 import task from '../components/task';
-import { initial, pending, skipped, success } from './build';
+import { initial, pending, skipped, success, failed } from './build';
 
 export default {
   title: 'CLI/Tasks/Build',
   decorators: [(storyFn) => task(storyFn())],
 };
 
+const spawnParams = {
+  client: 'yarn',
+  scriptArgs: ['build-storybook', '-o', 'storybook-static'],
+};
+
 export const Initial = () => initial;
 
-export const Building = () =>
-  pending({
-    spawnParams: { scriptArgs: ['build-storybook', '-o', 'storybook-static'] },
-  });
+export const Building = () => pending({ spawnParams });
 
 export const Built = () =>
   success({
@@ -24,3 +26,5 @@ export const Skipped = () =>
   skipped({
     options: { storybookBuildDir: '/users/me/project/storybook-static' },
   });
+
+export const Failed = () => failed({ spawnParams });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chromatic",
-  "version": "5.8.0-debug.0",
+  "version": "5.8.0-debug.1",
   "description": "Automate visual testing across browsers. Gather UI feedback. Versioned documentation.",
   "homepage": "https://www.chromatic.com",
   "bugs": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chromatic",
-  "version": "5.8.0-canary.0",
+  "version": "5.8.0-debug.0",
   "description": "Automate visual testing across browsers. Gather UI feedback. Versioned documentation.",
   "homepage": "https://www.chromatic.com",
   "bugs": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chromatic",
-  "version": "5.8.0-debug.1",
+  "version": "5.8.0-debug.2",
   "description": "Automate visual testing across browsers. Gather UI feedback. Versioned documentation.",
   "homepage": "https://www.chromatic.com",
   "bugs": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chromatic",
-  "version": "5.7.0",
+  "version": "5.8.0-canary.0",
   "description": "Visual Testing for Storybook",
   "homepage": "https://www.chromatic.com",
   "bugs": {


### PR DESCRIPTION
This uses `yarn-or-npm` to decide which client to use. It appears the original method doesn't work because I couldn't get it to use Yarn while running `yarn chromatic`. So rather than trying to detect the currently used client, this looks at the presence of yarn.lock (among other things) to determine the correct client.

Important detail: this means we'll be executing `npm run build-storybook` instead of `node /path/to/npm-cli.js run build-storybook`. It remains to be seen whether that will have an impact.