### PR TITLE
Fix cross-fork builds from GitHub Action

### DIFF
--- a/bin/git/getCommitAndBranch.js
+++ b/bin/git/getCommitAndBranch.js
@@ -1,5 +1,6 @@
 import envCi from 'env-ci';
 
+import forksUnsupported from '../ui/messages/errors/forksUnsupported';
 import gitOneCommit from '../ui/messages/errors/gitOneCommit';
 import missingGitHubInfo from '../ui/messages/errors/missingGitHubInfo';
 import missingTravisInfo from '../ui/messages/errors/missingTravisInfo';
@@ -13,6 +14,7 @@ export async function getCommitAndBranch({ branchName, patchBaseRef, ci, log } =
   // eslint-disable-next-line prefer-const
   let { commit, committedAt, committerEmail, committerName } = await getCommit();
   let branch = notHead(branchName) || notHead(patchBaseRef) || (await getBranch());
+  let slug;
 
   const {
     TRAVIS_EVENT_TYPE,
@@ -21,17 +23,20 @@ export async function getCommitAndBranch({ branchName, patchBaseRef, ci, log } =
     TRAVIS_PULL_REQUEST_SHA,
     TRAVIS_PULL_REQUEST_BRANCH,
     GITHUB_ACTIONS,
-    GITHUB_WORKFLOW,
+    GITHUB_EVENT_NAME,
+    GITHUB_REPOSITORY,
     GITHUB_SHA,
-    GITHUB_REF,
+    GITHUB_BASE_REF,
+    GITHUB_HEAD_REF,
     CHROMATIC_SHA,
     CHROMATIC_BRANCH,
+    CHROMATIC_SLUG,
   } = process.env;
 
   const isFromEnvVariable = CHROMATIC_SHA && CHROMATIC_BRANCH;
   const isTravisPrBuild = TRAVIS_EVENT_TYPE === 'pull_request';
   const isGitHubAction = GITHUB_ACTIONS === 'true';
-  const isGitHubPrBuild = GITHUB_WORKFLOW;
+  const isGitHubPrBuild = GITHUB_EVENT_NAME === 'pull_request';
 
   if (!(await hasPreviousCommit())) {
     throw new Error(gitOneCommit(isGitHubAction));
@@ -42,28 +47,44 @@ export async function getCommitAndBranch({ branchName, patchBaseRef, ci, log } =
   }
 
   if (isFromEnvVariable) {
+    // Our GitHub Action will also set these
     commit = CHROMATIC_SHA;
     branch = CHROMATIC_BRANCH;
+    slug = CHROMATIC_SLUG;
   } else if (isTravisPrBuild) {
     // Travis PR builds are weird, we want to ensure we mark build against the commit that was
     // merged from, rather than the resulting "psuedo" merge commit that doesn't stick around in the
     // history of the project (so approvals will get lost). We also have to ensure we use the right branch.
     commit = TRAVIS_PULL_REQUEST_SHA;
     branch = TRAVIS_PULL_REQUEST_BRANCH;
+    slug = TRAVIS_PULL_REQUEST_SLUG;
     if (!commit || !branch) {
       throw new Error(missingTravisInfo({ TRAVIS_EVENT_TYPE }));
     }
   } else if (isGitHubPrBuild) {
-    // GitHub PR builds are weird. push events are fine, but PR in events, the sha will point to a not-yet-committed sha of a final merge.
-    // This trips up chromatic, also the GITHUB_REF will be prefixed with 'refs/heads/' for some reason.
-    commit = GITHUB_SHA;
-    branch = GITHUB_REF.replace('refs/heads/', '');
-    if (!commit || !branch) {
-      throw new Error(missingGitHubInfo({ GITHUB_WORKFLOW }));
+    // GitHub PR builds run against a "virtual merge commit" with a SHA unknown to Chromatic and an
+    // invalid branch name, so we override these using environment variables available in the action.
+    // This does not apply to our GitHub Action, because it'll set CHROMATIC_SHA, -BRANCH and -SLUG.
+    if (!GITHUB_SHA || !GITHUB_HEAD_REF) {
+      throw new Error(missingGitHubInfo({ GITHUB_EVENT_NAME }));
     }
+    if (GITHUB_BASE_REF === GITHUB_HEAD_REF) {
+      throw new Error(forksUnsupported({ GITHUB_HEAD_REF }));
+    }
+    commit = GITHUB_SHA;
+    branch = GITHUB_HEAD_REF;
+    slug = GITHUB_REPOSITORY;
   }
 
-  const { isCi, service: ciService, prBranch, branch: ciBranch, commit: ciCommit, slug } = envCi();
+  const {
+    isCi,
+    service: ciService,
+    prBranch,
+    branch: ciBranch,
+    commit: ciCommit,
+    slug: ciSlug,
+  } = envCi();
+  slug = slug || ciSlug;
 
   // On certain CI systems, a branch is not checked out
   // (instead a detached head is used for the commit).

--- a/bin/ui/messages/errors/forksUnsupported.js
+++ b/bin/ui/messages/errors/forksUnsupported.js
@@ -1,0 +1,13 @@
+import chalk from 'chalk';
+import dedent from 'ts-dedent';
+
+import { error, info } from '../../components/icons';
+import link from '../../components/link';
+
+export default () =>
+  dedent(chalk`
+    ${error} {bold Cross-fork PR builds unsupported in custom GitHub workflows}
+    GitHub actions triggered by a fork do not report their repository owner, so cannot be properly linked to a pull request in Chromatic.
+    Consider using the official Chromatic GitHub Action, or set CHROMATIC_BRANCH to include the forked repository owner (e.g. owner:branch).
+    ${info} Read more at ${link('https://www.chromatic.com/docs/github-actions')}
+  `);

--- a/bin/ui/messages/errors/forksUnsupported.stories.js
+++ b/bin/ui/messages/errors/forksUnsupported.stories.js
@@ -1,0 +1,7 @@
+import forksUnsupported from './forksUnsupported';
+
+export default {
+  title: 'CLI/Messages/Errors',
+};
+
+export const ForksUnsupported = () => forksUnsupported();

--- a/bin/ui/messages/errors/gitOneCommit.js
+++ b/bin/ui/messages/errors/gitOneCommit.js
@@ -6,7 +6,7 @@ import link from '../../components/link';
 
 const githubActionNote = dedent`
   In {bold GitHub Actions}, you can enable this by setting \`fetch-depth: 0\`.
-  ${info} Read more at ${link('https://www.chromatic.com/docs/ci#github-actions')}
+  ${info} Read more at ${link('https://www.chromatic.com/docs/github-actions')}
 `;
 const genericNote = dedent`
   Refer to your CI provider's documentation for details.

--- a/bin/ui/messages/errors/missingGitHubInfo.js
+++ b/bin/ui/messages/errors/missingGitHubInfo.js
@@ -4,10 +4,10 @@ import dedent from 'ts-dedent';
 import { error, info } from '../../components/icons';
 import link from '../../components/link';
 
-export default ({ GITHUB_WORKFLOW }) =>
+export default ({ GITHUB_EVENT_NAME }) =>
   dedent(chalk`
     ${error} {bold Missing GitHub environment variable}
-    \`GITHUB_WORKFLOW\` environment variable set to '${GITHUB_WORKFLOW}', but
+    \`GITHUB_EVENT_NAME\` environment variable set to '${GITHUB_EVENT_NAME}', but
     \`GITHUB_SHA\` and \`GITHUB_REF\` are not both set.
-    ${info} Read more at ${link('https://www.chromatic.com/docs/ci#github-actions')}
+    ${info} Read more at ${link('https://www.chromatic.com/docs/github-actions')}
   `);


### PR DESCRIPTION
Turns out we weren't setting the branch and slug properly for cross-fork builds in our GitHub Action.

Reported here: https://app.intercom.com/a/apps/zj7sn9j1/inbox/inbox/conversation/27253931490