### PR TITLE
Support resolving webpack stats in subdirectory

### DIFF
--- a/bin/git/git.js
+++ b/bin/git/git.js
@@ -450,5 +450,6 @@ export async function discardChanges() {
 
 export async function getWorkingDir() {
   const rootDir = await execGitCommand(`git rev-parse --show-toplevel`);
-  return path.relative(rootDir, '.');
+  // Normalize to forward slashes, consistent with git's output (even on Windows)
+  return path.relative(rootDir, '.').split(path.sep).join(path.posix.sep);
 }

--- a/bin/git/git.js
+++ b/bin/git/git.js
@@ -1,3 +1,4 @@
+import path from 'path';
 import execa from 'execa';
 import gql from 'fake-tag';
 import { EOL } from 'os';
@@ -445,4 +446,9 @@ export async function checkoutPrevious() {
 
 export async function discardChanges() {
   return execGitCommand(`git reset --hard`);
+}
+
+export async function getWorkingDir() {
+  const rootDir = await execGitCommand(`git rev-parse --show-toplevel`);
+  return path.relative(rootDir, '.');
 }

--- a/bin/lib/getDependentStoryFiles.test.js
+++ b/bin/lib/getDependentStoryFiles.test.js
@@ -1,7 +1,85 @@
+import path from 'path';
+
 import { getDependentStoryFiles } from './getDependentStoryFiles';
+import { getWorkingDir } from '../git/git';
+
+jest.mock('../git/git');
+
+const CSF_GLOB = './src sync ^\\.\\/(?:(?!\\.)(?=.)[^/]*?\\.stories\\.js)$';
+
+const ctx = {
+  log: { warn: jest.fn() },
+};
 
 describe('getDependentStoryFiles', () => {
-  it('traverses the reasons to find affected CSF files', () => {
-    // getDependentStoryFiles([], { idsByName: {}, reasonsById: {}, isCsfGlob: {} });
+  it('detects direct changes to CSF files', async () => {
+    const changedFiles = ['./src/foo.stories.js'];
+    const modules = [
+      {
+        id: 1,
+        name: './src/foo.stories.js',
+        reasons: [{ moduleName: CSF_GLOB }],
+      },
+      {
+        id: 999,
+        name: CSF_GLOB,
+        reasons: [{ moduleName: './.storybook/generated-stories-entry.js' }],
+      },
+    ];
+    const res = await getDependentStoryFiles(ctx, { modules }, changedFiles);
+    expect(res).toEqual({
+      1: './src/foo.stories.js',
+    });
+  });
+
+  it('detects indirect changes to CSF files', async () => {
+    const changedFiles = ['./src/foo.js'];
+    const modules = [
+      {
+        id: 1,
+        name: './src/foo.js',
+        reasons: [{ moduleName: './src/foo.stories.js' }],
+      },
+      {
+        id: 2,
+        name: './src/foo.stories.js',
+        reasons: [{ moduleName: CSF_GLOB }],
+      },
+      {
+        id: 999,
+        name: CSF_GLOB,
+        reasons: [{ moduleName: './.storybook/generated-stories-entry.js' }],
+      },
+    ];
+    const res = await getDependentStoryFiles(ctx, { modules }, changedFiles);
+    expect(res).toEqual({
+      2: './src/foo.stories.js',
+    });
+  });
+
+  it('supports webpack root in git subdirectory', async () => {
+    getWorkingDir.mockResolvedValueOnce('frontend');
+    const changedFiles = ['./frontend/src/foo.js'];
+    const modules = [
+      {
+        id: 1,
+        name: './src/foo.js',
+        reasons: [{ moduleName: './src/foo.stories.js' }],
+      },
+      {
+        id: 2,
+        name: './src/foo.stories.js',
+        reasons: [{ moduleName: CSF_GLOB }],
+      },
+      {
+        id: 999,
+        name: CSF_GLOB,
+        reasons: [{ moduleName: './.storybook/generated-stories-entry.js' }],
+      },
+    ];
+    const res = await getDependentStoryFiles(ctx, { modules }, changedFiles);
+    expect(res).toEqual({
+      2: './src/foo.stories.js',
+    });
   });
 });

--- a/bin/tasks/upload.js
+++ b/bin/tasks/upload.js
@@ -119,7 +119,7 @@ export const traceChangedFiles = async (ctx, task) => {
   const { changedFiles } = ctx.git;
   try {
     const stats = await fs.readJson(statsPath);
-    ctx.onlyStoryFiles = getDependentStoryFiles(ctx, stats, changedFiles);
+    ctx.onlyStoryFiles = await getDependentStoryFiles(ctx, stats, changedFiles);
     ctx.log.debug(
       `Found affected story files:\n${Object.entries(ctx.onlyStoryFiles)
         .map(([id, f]) => `  ${f} [${id}]`)

--- a/scripts/stats-to-story-files.js
+++ b/scripts/stats-to-story-files.js
@@ -13,7 +13,7 @@ const main = async () => {
     },
   };
   // eslint-disable-next-line no-console
-  console.log(getDependentStoryFiles(ctx, stats, changedFiles));
+  console.log(await getDependentStoryFiles(ctx, stats, changedFiles));
 };
 
 main();


### PR DESCRIPTION
This should fix `--only-changed` for monorepos (or any other case where Chromatic is executed from a subdirectory of the git repo).