### PR TITLE
Fix runtime issues with HTTP_PROXY / NO_PROXY

### DIFF
--- a/bin/io/getProxyAgent.js
+++ b/bin/io/getProxyAgent.js
@@ -1,6 +1,6 @@
 import HttpsProxyAgent from 'https-proxy-agent';
 import noProxy from 'no-proxy';
-import URL from 'url';
+import { URL } from 'url';
 
 const agents = {};
 
@@ -11,8 +11,8 @@ const getProxyAgent = ({ env, log }, url, options = {}) => {
   log.debug({ url, proxy, options }, 'Using proxy agent');
   const requestHost = new URL(url).host;
   if (!agents[requestHost]) {
-    const { host, port, protocol } = new URL(proxy);
-    agents[requestHost] = new HttpsProxyAgent({ host, port, protocol, ...options });
+    const { hostname, port, protocol } = new URL(proxy);
+    agents[requestHost] = new HttpsProxyAgent({ hostname, port, protocol, ...options });
   }
   return agents[requestHost];
 };


### PR DESCRIPTION
Testing with 5.10.0 canary I hit issues on the proxy.

1. Initially, with the HTTP proxy on, I was seeing a runtime error related to the `URL` import
```
TypeError:
URL is not a constructor
    at getProxyAgent (/Users/jmhobbs/Working/chromatic-cli/bin/io/getProxyAgent.js:12:23)
    at HTTPClient.fetch (/Users/jmhobbs/Working/chromatic-cli/bin/io/HTTPClient.js:33:36)
    at GraphQLClient.runQuery (/Users/jmhobbs/Working/chromatic-cli/bin/io/GraphQLClient.js:16:40)
    at setAuthorizationToken (/Users/jmhobbs/Working/chromatic-cli/bin/tasks/auth.js:16:45)
    at Task.task (/Users/jmhobbs/Working/chromatic-cli/bin/lib/tasks.js:13:13)
```
2. Secondly, my proxy server URL has a port in it, and `https-proxy-agent` appeared to be attempting to resolve the full host+port as a hostname (since `url.parse` returns both as `host`)

```
{
  "url":"https://www.staging-chromatic.com/graphql",
  "err":{
    "message":"request to https://www.staging-chromatic.com/graphql failed, reason: getaddrinfo ENOTFOUND 127.0.0.1:8888",
    "type":"system",
    "errno":"ENOTFOUND",
    "code":"ENOTFOUND"
  }
} Fetch failed; retrying 1/3
```

Switching to `hostname`, which the package supports on the constructor, fixes the issue.

Additionally, it is notable that the `no-proxy` package only supports the upcased `NO_PROXY` variable.  I didn't see documentation anywhere on the HTTP proxy support, but that might be worth noting since we support both cases for the other proxy configs.