### PR TITLE
Sets exitCode 0 when branch is skipped with skip flag. 

### DIFF
--- a/bin-src/main.test.js
+++ b/bin-src/main.test.js
@@ -115,6 +115,14 @@ jest.mock('node-fetch', () =>
         };
       }
 
+      if (query.match('TesterSkipBuildMutation')) {
+        return {
+          data: {
+            skipBuild: true,
+          },
+        };
+      }
+
       throw new Error(`Unknown Query: ${query}`);
     },
   }))
@@ -240,6 +248,12 @@ it('returns 0 when the build is publish only', async () => {
     wasLimited: false,
   };
   const ctx = getContext(['--project-token=asdf1234']);
+  await runBuild(ctx);
+  expect(ctx.exitCode).toBe(0);
+});
+
+it('should exit with code 0 when the current branch is skipped', async () => {
+  const ctx = getContext(['--project-token=asdf1234', '--skip=branch']);
   await runBuild(ctx);
   expect(ctx.exitCode).toBe(0);
 });

--- a/bin-src/tasks/gitInfo.js
+++ b/bin-src/tasks/gitInfo.js
@@ -62,6 +62,7 @@ export const setGitInfo = async (ctx, task) => {
     if (await ctx.client.runQuery(TesterSkipBuildMutation, { commit })) {
       ctx.skip = true;
       transitionTo(skippedForCommit, true)(ctx, task);
+      ctx.exitCode = 0;
       return;
     }
     throw new Error(skipFailed(ctx).output);


### PR DESCRIPTION
This should prevent the GitHub action from throwing an error when it tries to call `toString()` on the exit code.

resolves #309