### PR TITLE
Enable proxy authentication.  CH-813

### DIFF
--- a/bin-src/io/getProxyAgent.js
+++ b/bin-src/io/getProxyAgent.js
@@ -11,8 +11,9 @@ const getProxyAgent = ({ env, log }, url, options = {}) => {
   log.debug({ url, proxy, options }, 'Using proxy agent');
   const requestHost = new URL(url).host;
   if (!agents[requestHost]) {
-    const { hostname, port, protocol } = new URL(proxy);
-    agents[requestHost] = new HttpsProxyAgent({ hostname, port, protocol, ...options });
+    const { hostname, port, protocol, username, password } = new URL(proxy);
+    const auth = username && password ? `${username}:${password}` : undefined;
+    agents[requestHost] = new HttpsProxyAgent({ auth, hostname, port, protocol, ...options });
   }
   return agents[requestHost];
 };


### PR DESCRIPTION
Our current code does not support using authenticated proxies, this change pulls out the username and password if present and configures `https-proxy-agent` to use those credentials.