### PR TITLE
Add `--dry-run` to skip publishing CH-1068

### DIFF
--- a/bin-src/lib/getOptions.js
+++ b/bin-src/lib/getOptions.js
@@ -38,6 +38,7 @@ export default async function getOptions({ argv, env, flags, log, packageJson })
     list: flags.list,
     fromCI,
     skip: trueIfSet(flags.skip),
+    dryRun: !!flags.dryRun,
     verbose: !!flags.debug,
     interactive: !flags.debug && !fromCI && !!flags.interactive && !!process.stdout.isTTY,
     junitReport: trueIfSet(flags.junitReport),

--- a/bin-src/lib/parseArgs.js
+++ b/bin-src/lib/parseArgs.js
@@ -32,6 +32,7 @@ export default function parseArgs(argv) {
     Debug options
       --ci  Mark this build as a CI build. Alternatively, set the CI environment variable (present in most CI systems). This option implies --no-interactive.
       --debug  Output verbose debugging information. This option implies --no-interactive.
+      --dry-run  Run without actually publishing to Chromatic.
       --junit-report [filepath]  Write build results to a JUnit XML file. {buildNumber} will be replaced with the actual build number. [chromatic-build-{buildNumber}.xml]
       --list  List available stories. This requires running a full build.
       --no-interactive  Don't ask interactive questions about your setup and don't overwrite output. Always true in non-TTY environments.
@@ -67,6 +68,7 @@ export default function parseArgs(argv) {
         // Debug options
         ci: { type: 'boolean' },
         debug: { type: 'boolean' },
+        dryRun: { type: 'boolean' },
         junitReport: { type: 'string' },
         list: { type: 'boolean' },
         interactive: { type: 'boolean', default: true },

--- a/bin-src/tasks/snapshot.js
+++ b/bin-src/tasks/snapshot.js
@@ -11,8 +11,9 @@ import {
   buildFailed,
   buildPassed,
   initial,
-  pending,
+  dryRun,
   skipped,
+  pending,
 } from '../ui/tasks/snapshot';
 
 const TesterBuildQuery = `
@@ -112,6 +113,7 @@ export default createTask({
   skip: (ctx) => {
     if (ctx.skip) return true;
     if (ctx.skipSnapshots) return skipped(ctx).output;
+    if (ctx.options.dryRun) return dryRun(ctx).output;
     return false;
   },
   steps: [transitionTo(pending), takeSnapshots],

--- a/bin-src/tasks/upload.js
+++ b/bin-src/tasks/upload.js
@@ -12,6 +12,7 @@ import noStatsFile from '../ui/messages/warnings/noStatsFile';
 import {
   failed,
   initial,
+  dryRun,
   skipped,
   validating,
   invalid,
@@ -19,8 +20,8 @@ import {
   tracing,
   traced,
   starting,
-  success,
   uploading,
+  success,
 } from '../ui/tasks/upload';
 
 const TesterGetUploadUrlsMutation = `
@@ -170,6 +171,7 @@ export default createTask({
   title: initial.title,
   skip: (ctx) => {
     if (ctx.skip) return true;
+    if (ctx.options.dryRun) return dryRun(ctx).output;
     if (ctx.options.storybookUrl) return skipped(ctx).output;
     return false;
   },

--- a/bin-src/tasks/verify.js
+++ b/bin-src/tasks/verify.js
@@ -4,7 +4,7 @@ import storybookPublished from '../ui/messages/info/storybookPublished';
 import buildLimited from '../ui/messages/warnings/buildLimited';
 import paymentRequired from '../ui/messages/warnings/paymentRequired';
 import snapshotQuotaReached from '../ui/messages/warnings/snapshotQuotaReached';
-import { initial, pending, runOnly, runOnlyFiles, success } from '../ui/tasks/verify';
+import { initial, dryRun, pending, runOnly, runOnlyFiles, success } from '../ui/tasks/verify';
 
 const TesterCreateBuildMutation = `
   mutation TesterCreateBuildMutation($input: CreateBuildInput!, $isolatorUrl: String!) {
@@ -138,6 +138,10 @@ export const createBuild = async (ctx, task) => {
 
 export default createTask({
   title: initial.title,
-  skip: (ctx) => ctx.skip,
+  skip: (ctx) => {
+    if (ctx.skip) return true;
+    if (ctx.options.dryRun) return dryRun(ctx).output;
+    return false;
+  },
   steps: [transitionTo(pending), setEnvironment, createBuild],
 });

--- a/bin-src/ui/tasks/snapshot.js
+++ b/bin-src/ui/tasks/snapshot.js
@@ -8,6 +8,12 @@ export const initial = {
   title: 'Test your stories',
 };
 
+export const dryRun = () => ({
+  status: 'skipped',
+  title: 'Test your stories',
+  output: 'Skipped due to --dry-run',
+});
+
 export const stats = (ctx) => {
   return {
     tests: pluralize('test', ctx.build.actualTestCount, true),

--- a/bin-src/ui/tasks/snapshot.stories.js
+++ b/bin-src/ui/tasks/snapshot.stories.js
@@ -5,6 +5,7 @@ import {
   buildFailed,
   buildPassed,
   initial,
+  dryRun,
   pending,
   skipped,
 } from './snapshot';
@@ -31,6 +32,8 @@ const now = 0;
 const startedAt = -123456;
 
 export const Initial = () => initial;
+
+export const DryRun = () => dryRun();
 
 export const Pending = () =>
   pending({

--- a/bin-src/ui/tasks/upload.js
+++ b/bin-src/ui/tasks/upload.js
@@ -6,6 +6,12 @@ export const initial = {
   title: 'Publish your built Storybook',
 };
 
+export const dryRun = () => ({
+  status: 'skipped',
+  title: 'Publish your built Storybook',
+  output: 'Skipped due to --dry-run',
+});
+
 export const skipped = (ctx) => ({
   status: 'skipped',
   title: 'Publish your built Storybook [skipped]',

--- a/bin-src/ui/tasks/upload.stories.js
+++ b/bin-src/ui/tasks/upload.stories.js
@@ -1,6 +1,7 @@
 import task from '../components/task';
 import {
   initial,
+  dryRun,
   skipped,
   validating,
   invalid,
@@ -22,6 +23,8 @@ const isolatorUrl = 'https://5eb48280e78a12aeeaea33cf-kdypokzbrs.chromatic.com/i
 const storybookUrl = 'https://self-hosted-storybook.netlify.app';
 
 export const Initial = () => initial;
+
+export const DryRun = () => dryRun();
 
 export const Skipped = () => skipped({ options: { storybookUrl } });
 

--- a/bin-src/ui/tasks/verify.js
+++ b/bin-src/ui/tasks/verify.js
@@ -3,6 +3,12 @@ export const initial = {
   title: 'Verify your Storybook',
 };
 
+export const dryRun = () => ({
+  status: 'skipped',
+  title: 'Verify your Storybook',
+  output: 'Skipped due to --dry-run',
+});
+
 export const pending = (ctx) => ({
   status: 'pending',
   title: 'Verifying your Storybook',

--- a/bin-src/ui/tasks/verify.stories.js
+++ b/bin-src/ui/tasks/verify.stories.js
@@ -1,5 +1,5 @@
 import task from '../components/task';
-import { failed, initial, pending, runOnly, runOnlyFiles, success } from './verify';
+import { initial, dryRun, pending, runOnly, runOnlyFiles, success, failed } from './verify';
 
 export default {
   title: 'CLI/Tasks/Verify',
@@ -13,6 +13,8 @@ const build = {
 };
 
 export const Initial = () => initial;
+
+export const DryRun = () => dryRun();
 
 export const Pending = () => pending();
 


### PR DESCRIPTION
This adds the `--dry-run` flag which will cause the CLI to skip the publish, verify and snapshot steps.
Useful if you just want to verify metadata detection and build behavior.

<img width="797" alt="Screenshot 2021-11-26 at 14 59 14" src="https://user-images.githubusercontent.com/321738/143591958-1f9f0483-d474-4700-9a33-f94a7c686d52.png">