### PR TITLE
Increase unpack wait timeout to 3 minutes

### DIFF
--- a/bin-src/lib/uploadZip.js
+++ b/bin-src/lib/uploadZip.js
@@ -71,8 +71,8 @@ export async function waitForUnpack(ctx, url) {
       }
     },
     {
-      retries: 30,
-      minTimeout: 500,
+      retries: 185, // 3 minutes and some change (matches the lambda timeout with some extra buffer)
+      minTimeout: 1000,
       maxTimeout: 1000,
     }
   );

--- a/bin-src/lib/uploadZip.js
+++ b/bin-src/lib/uploadZip.js
@@ -60,6 +60,10 @@ export async function waitForUnpack(ctx, url) {
       try {
         res = await ctx.http.fetch(url, {}, { retries: 0, noLogErrorBody: true });
       } catch (e) {
+        const { response = {} } = e;
+        if (response.status === 403) {
+          bail(new Error('Provided signature expired.'));
+        }
         throw new Error('Sentinel file not present.');
       }
 


### PR DESCRIPTION
Just a quick update to increase the sentinel file timeout to a minimum of 3 minutes to match the new Lambda timeout.