### PR TITLE
Add `--diagnostics` flag to write process context data to a file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@ action/main.js
 storybook-static
 subdir-static
 chromatic-build-*.xml
-chromatic-report.json
+chromatic-diagnostics.json
 # the dist folder IS included so we can test every version in the CI without publishing
 bin
 action

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ action/main.js
 storybook-static
 subdir-static
 chromatic-build-*.xml
+chromatic-report.json
 # the dist folder IS included so we can test every version in the CI without publishing
 bin
 action

--- a/action-src/main.ts
+++ b/action-src/main.ts
@@ -130,6 +130,7 @@ async function run() {
     const onlyChanged = getInput('onlyChanged');
     const externals = getInput('externals');
     const doNotStart = getInput('doNotStart');
+    const report = getInput('report');
     const storybookPort = getInput('storybookPort');
     const storybookUrl = getInput('storybookUrl');
     const storybookBuildDir = getInput('storybookBuildDir');
@@ -170,6 +171,7 @@ async function run() {
       storybookCa: maybe(storybookCa),
       fromCI: true,
       interactive: false,
+      report: maybe(report),
       preserveMissing: maybe(preserveMissing),
       autoAcceptChanges: maybe(autoAcceptChanges),
       exitZeroOnChanges: maybe(exitZeroOnChanges, true),

--- a/action-src/main.ts
+++ b/action-src/main.ts
@@ -130,7 +130,7 @@ async function run() {
     const onlyChanged = getInput('onlyChanged');
     const externals = getInput('externals');
     const doNotStart = getInput('doNotStart');
-    const report = getInput('report');
+    const diagnostics = getInput('diagnostics');
     const storybookPort = getInput('storybookPort');
     const storybookUrl = getInput('storybookUrl');
     const storybookBuildDir = getInput('storybookBuildDir');
@@ -156,6 +156,7 @@ async function run() {
       workingDir: maybe(workingDir),
       buildScriptName: maybe(buildScriptName),
       scriptName: maybe(scriptName),
+      diagnostics: maybe(diagnostics),
       exec: maybe(exec),
       skip: maybe(skip),
       only: maybe(only),
@@ -171,7 +172,6 @@ async function run() {
       storybookCa: maybe(storybookCa),
       fromCI: true,
       interactive: false,
-      report: maybe(report),
       preserveMissing: maybe(preserveMissing),
       autoAcceptChanges: maybe(autoAcceptChanges),
       exitZeroOnChanges: maybe(exitZeroOnChanges, true),

--- a/action.yml
+++ b/action.yml
@@ -43,7 +43,7 @@ inputs:
     description: 'Do not attempt to start or build; use if your Storybook is already running'
     required: false
   report:
-    description: 'Write process context information to chromatic-report.json'
+    description: 'Write process context information to chromatic-diagnostics.json'
     required: false
   storybookBuildDir:
     description: 'Provide a directory with your built storybook; use if you have already built your storybook'

--- a/action.yml
+++ b/action.yml
@@ -42,6 +42,9 @@ inputs:
   doNotStart:
     description: 'Do not attempt to start or build; use if your Storybook is already running'
     required: false
+  report:
+    description: 'Write process context information to chromatic-report.json'
+    required: false
   storybookBuildDir:
     description: 'Provide a directory with your built storybook; use if you have already built your storybook'
     required: false

--- a/bin-src/lib/getOptions.js
+++ b/bin-src/lib/getOptions.js
@@ -38,11 +38,11 @@ export default async function getOptions({ argv, env, flags, log, packageJson })
     list: flags.list,
     fromCI,
     skip: trueIfSet(flags.skip),
+    diagnostics: !!flags.diagnostics,
     dryRun: !!flags.dryRun,
     verbose: !!flags.debug,
     interactive: !flags.debug && !fromCI && !!flags.interactive && !!process.stdout.isTTY,
     junitReport: trueIfSet(flags.junitReport),
-    report: !!flags.report,
     zip: trueIfSet(flags.zip),
 
     autoAcceptChanges: trueIfSet(flags.autoAcceptChanges),

--- a/bin-src/lib/getOptions.js
+++ b/bin-src/lib/getOptions.js
@@ -42,6 +42,7 @@ export default async function getOptions({ argv, env, flags, log, packageJson })
     verbose: !!flags.debug,
     interactive: !flags.debug && !fromCI && !!flags.interactive && !!process.stdout.isTTY,
     junitReport: trueIfSet(flags.junitReport),
+    report: !!flags.report,
     zip: trueIfSet(flags.zip),
 
     autoAcceptChanges: trueIfSet(flags.autoAcceptChanges),

--- a/bin-src/lib/parseArgs.js
+++ b/bin-src/lib/parseArgs.js
@@ -39,7 +39,7 @@ export default function parseArgs(argv) {
       --list  List available stories. This requires running a full build.
       --no-interactive  Don't ask interactive questions about your setup and don't overwrite output. Always true in non-TTY environments.
       --only <storypath>  Only run a single story or a subset of stories. Story paths typically look like "Path/To/Story". Globs are supported via picomatch. All other snapshots will be inherited from the prior commit. This option implies --preserve-missing.
-      --report  Write process context information to chromatic-report.json.
+      --diagnostics  Write process context information to chromatic-diagnostics.json.
     `,
     {
       argv,
@@ -73,11 +73,11 @@ export default function parseArgs(argv) {
         // Debug options
         ci: { type: 'boolean' },
         debug: { type: 'boolean' },
+        diagnostics: { type: 'boolean' },
         dryRun: { type: 'boolean' },
         junitReport: { type: 'string' },
         list: { type: 'boolean' },
         interactive: { type: 'boolean', default: true },
-        report: { type: 'boolean' },
 
         // Deprecated options for tunneled builds
         doNotStart: { type: 'boolean', alias: 'S' }, // assumes already started

--- a/bin-src/lib/parseArgs.js
+++ b/bin-src/lib/parseArgs.js
@@ -39,6 +39,7 @@ export default function parseArgs(argv) {
       --list  List available stories. This requires running a full build.
       --no-interactive  Don't ask interactive questions about your setup and don't overwrite output. Always true in non-TTY environments.
       --only <storypath>  Only run a single story or a subset of stories. Story paths typically look like "Path/To/Story". Globs are supported via picomatch. All other snapshots will be inherited from the prior commit. This option implies --preserve-missing.
+      --report  Write process context information to chromatic-report.json.
     `,
     {
       argv,
@@ -76,6 +77,7 @@ export default function parseArgs(argv) {
         junitReport: { type: 'string' },
         list: { type: 'boolean' },
         interactive: { type: 'boolean', default: true },
+        report: { type: 'boolean' },
 
         // Deprecated options for tunneled builds
         doNotStart: { type: 'boolean', alias: 'S' }, // assumes already started

--- a/bin-src/lib/writeChromaticDiagnostics.js
+++ b/bin-src/lib/writeChromaticDiagnostics.js
@@ -4,16 +4,16 @@ import wroteReport from '../ui/messages/info/wroteReport';
 const { writeFile } = jsonfile;
 
 // Extract important information from ctx, sort it and output into a json file
-export async function writeChromaticReport(ctx) {
-  const chromaticReportPath = 'chromatic-report.json';
+export async function writeChromaticDiagnostics(ctx) {
+  const chromaticDiagnosticsPath = 'chromatic-diagnostics.json';
   const { argv, client, env, help, http, log, pkg, task, title, ...restCtx } = ctx;
-  const reportContext = Object.keys(restCtx)
+  const diagnosticsContext = Object.keys(restCtx)
     .sort((a, b) => a.localeCompare(b))
     .reduce((acc, key) => ({ ...acc, [key]: restCtx[key] }), {});
   try {
-    await writeFile(chromaticReportPath, reportContext, { spaces: 2 });
+    await writeFile(chromaticDiagnosticsPath, diagnosticsContext, { spaces: 2 });
 
-    ctx.log.info(wroteReport(chromaticReportPath, 'Chromatic'));
+    ctx.log.info(wroteReport(chromaticDiagnosticsPath, 'Chromatic diagnostics'));
   } catch (error) {
     ctx.log.error(error);
   }

--- a/bin-src/lib/writeChromaticReport.js
+++ b/bin-src/lib/writeChromaticReport.js
@@ -1,0 +1,18 @@
+import jsonfile from 'jsonfile';
+import wroteReport from '../ui/messages/info/wroteReport';
+
+const { writeFile } = jsonfile;
+
+// Extract important information from ctx, sort it and output into a json file
+export async function writeChromaticReport(ctx) {
+  const chromaticReportPath = 'chromatic-report.json';
+  const { argv, client, env, help, http, log, pkg, task, title, ...restCtx } = ctx;
+  const reportContext = Object.keys(restCtx)
+    .sort((a, b) => a.localeCompare(b))
+    .reduce((acc, key) => ({ ...acc, [key]: restCtx[key] }), {});
+  return writeFile(chromaticReportPath, reportContext, { spaces: 2 })
+    .then(() => ctx.log.info(wroteReport(chromaticReportPath, 'Chromatic')))
+    .catch((err) => {
+      ctx.log.error(err);
+    });
+}

--- a/bin-src/lib/writeChromaticReport.js
+++ b/bin-src/lib/writeChromaticReport.js
@@ -10,9 +10,11 @@ export async function writeChromaticReport(ctx) {
   const reportContext = Object.keys(restCtx)
     .sort((a, b) => a.localeCompare(b))
     .reduce((acc, key) => ({ ...acc, [key]: restCtx[key] }), {});
-  return writeFile(chromaticReportPath, reportContext, { spaces: 2 })
-    .then(() => ctx.log.info(wroteReport(chromaticReportPath, 'Chromatic')))
-    .catch((err) => {
-      ctx.log.error(err);
-    });
+  try {
+    await writeFile(chromaticReportPath, reportContext, { spaces: 2 });
+
+    ctx.log.info(wroteReport(chromaticReportPath, 'Chromatic'));
+  } catch (error) {
+    ctx.log.error(error);
+  }
 }

--- a/bin-src/main.js
+++ b/bin-src/main.js
@@ -13,7 +13,7 @@ import { createLogger } from './lib/log';
 import NonTTYRenderer from './lib/NonTTYRenderer';
 import parseArgs from './lib/parseArgs';
 import { rewriteErrorMessage } from './lib/utils';
-import { writeChromaticReport } from './lib/writeChromaticReport';
+import { writeChromaticDiagnostics } from './lib/writeChromaticDiagnostics';
 import getTasks from './tasks';
 import fatalError from './ui/messages/errors/fatalError';
 import fetchError from './ui/messages/errors/fetchError';
@@ -62,8 +62,8 @@ export async function runAll(ctx) {
     await checkPackageJson(ctx);
   }
 
-  if (ctx.options.report) {
-    await writeChromaticReport(ctx);
+  if (ctx.options.diagnostics) {
+    await writeChromaticDiagnostics(ctx);
   }
 }
 

--- a/bin-src/main.js
+++ b/bin-src/main.js
@@ -13,6 +13,7 @@ import { createLogger } from './lib/log';
 import NonTTYRenderer from './lib/NonTTYRenderer';
 import parseArgs from './lib/parseArgs';
 import { rewriteErrorMessage } from './lib/utils';
+import { writeChromaticReport } from './lib/writeChromaticReport';
 import getTasks from './tasks';
 import fatalError from './ui/messages/errors/fatalError';
 import fetchError from './ui/messages/errors/fetchError';
@@ -59,6 +60,10 @@ export async function runAll(ctx) {
 
   if (!ctx.exitCode || ctx.exitCode === 1) {
     await checkPackageJson(ctx);
+  }
+
+  if (ctx.options.report) {
+    await writeChromaticReport(ctx);
   }
 }
 

--- a/bin-src/main.test.js
+++ b/bin-src/main.test.js
@@ -1,9 +1,9 @@
 import execa from 'execa';
 import fs from 'fs-extra';
 import { confirm } from 'node-ask';
-import fetch from 'node-fetch';
 import kill from 'tree-kill';
 
+import jsonfile from 'jsonfile';
 import getEnv from './lib/getEnv';
 import parseArgs from './lib/parseArgs';
 import startApp, { checkResponse } from './lib/startStorybook';
@@ -11,6 +11,7 @@ import TestLogger from './lib/testLogger';
 import openTunnel from './lib/tunnel';
 import uploadFiles from './lib/uploadFiles';
 import { runAll, runBuild } from './main';
+import { writeChromaticReport } from './lib/writeChromaticReport';
 
 let lastBuild;
 let mockBuildFeatures;
@@ -20,10 +21,10 @@ jest.useFakeTimers();
 afterEach(() => {
   // This would clear all existing timer functions
   jest.clearAllTimers();
+  jest.clearAllMocks();
 });
 
 beforeEach(() => {
-  fetch.mockClear();
   mockBuildFeatures = {
     features: { uiTests: true, uiReview: true },
     wasLimited: false,
@@ -31,6 +32,18 @@ beforeEach(() => {
 });
 
 jest.mock('execa');
+
+jest.mock('jsonfile', () => {
+  const originalModule = jest.requireActual('jsonfile');
+  return {
+    __esModule: true,
+    ...originalModule,
+    default: {
+      ...originalModule.default,
+      writeFile: jest.fn(() => Promise.resolve()),
+    },
+  };
+});
 
 jest.mock('node-ask');
 
@@ -534,22 +547,50 @@ describe('in CI', () => {
   });
 });
 
-it('checks for updates', async () => {
-  const ctx = getContext(['--project-token=asdf1234']);
-  ctx.pkg.version = '4.3.2';
-  ctx.http.fetch.mockReturnValueOnce(
-    Promise.resolve({ json: () => ({ 'dist-tags': { latest: '5.0.0' } }) })
-  );
-  await runAll(ctx);
-  expect(ctx.exitCode).toBe(1);
-  expect(ctx.http.fetch).toHaveBeenCalledWith('https://registry.npmjs.org/chromatic');
-  expect(ctx.log.warnings[0]).toMatch('Using outdated package');
-});
+describe('runAll', () => {
+  it('checks for updates', async () => {
+    const ctx = getContext(['--project-token=asdf1234']);
+    ctx.pkg.version = '4.3.2';
+    ctx.http.fetch.mockReturnValueOnce(
+      Promise.resolve({ json: () => ({ 'dist-tags': { latest: '5.0.0' } }) })
+    );
+    await runAll(ctx);
+    expect(ctx.exitCode).toBe(1);
+    expect(ctx.http.fetch).toHaveBeenCalledWith('https://registry.npmjs.org/chromatic');
+    expect(ctx.log.warnings[0]).toMatch('Using outdated package');
+  });
 
-it('prompts you to add a script to your package.json', async () => {
-  process.stdout.isTTY = true; // enable interactive mode
-  const ctx = getContext(['--project-token=asdf1234']);
-  await runAll(ctx);
-  expect(ctx.exitCode).toBe(1);
-  expect(confirm).toHaveBeenCalled();
+  it('prompts you to add a script to your package.json', async () => {
+    process.stdout.isTTY = true; // enable interactive mode
+    const ctx = getContext(['--project-token=asdf1234']);
+    await runAll(ctx);
+    expect(ctx.exitCode).toBe(1);
+    expect(confirm).toHaveBeenCalled();
+  });
+
+  it('ctx should be JSON serializable', async () => {
+    const ctx = getContext(['--project-token=asdf1234']);
+    expect(() => writeChromaticReport(ctx)).not.toThrow();
+  });
+
+  it('should write context to chromatic-report.json if --report is passed', async () => {
+    const ctx = getContext(['--project-token=asdf1234', '--report']);
+    await runAll(ctx);
+    expect(jsonfile.writeFile).toHaveBeenCalledWith(
+      'chromatic-report.json',
+      expect.objectContaining({
+        options: expect.objectContaining({
+          projectToken: 'asdf1234',
+          report: true,
+        }),
+      }),
+      { spaces: 2 }
+    );
+  });
+
+  it('should not write context to chromatic-report.json if --report is not passed', async () => {
+    const ctx = getContext(['--project-token=asdf1234']);
+    await runAll(ctx);
+    expect(jsonfile.writeFile).not.toHaveBeenCalled();
+  });
 });

--- a/bin-src/main.test.js
+++ b/bin-src/main.test.js
@@ -11,7 +11,7 @@ import TestLogger from './lib/testLogger';
 import openTunnel from './lib/tunnel';
 import uploadFiles from './lib/uploadFiles';
 import { runAll, runBuild } from './main';
-import { writeChromaticReport } from './lib/writeChromaticReport';
+import { writeChromaticDiagnostics } from './lib/writeChromaticDiagnostics';
 
 let lastBuild;
 let mockBuildFeatures;
@@ -570,25 +570,25 @@ describe('runAll', () => {
 
   it('ctx should be JSON serializable', async () => {
     const ctx = getContext(['--project-token=asdf1234']);
-    expect(() => writeChromaticReport(ctx)).not.toThrow();
+    expect(() => writeChromaticDiagnostics(ctx)).not.toThrow();
   });
 
-  it('should write context to chromatic-report.json if --report is passed', async () => {
-    const ctx = getContext(['--project-token=asdf1234', '--report']);
+  it('should write context to chromatic-diagnostics.json if --diagnostics is passed', async () => {
+    const ctx = getContext(['--project-token=asdf1234', '--diagnostics']);
     await runAll(ctx);
     expect(jsonfile.writeFile).toHaveBeenCalledWith(
-      'chromatic-report.json',
+      'chromatic-diagnostics.json',
       expect.objectContaining({
         options: expect.objectContaining({
           projectToken: 'asdf1234',
-          report: true,
+          diagnostics: true,
         }),
       }),
       { spaces: 2 }
     );
   });
 
-  it('should not write context to chromatic-report.json if --report is not passed', async () => {
+  it('should not write context to chromatic-diagnostics.json if --diagnostics is not passed', async () => {
     const ctx = getContext(['--project-token=asdf1234']);
     await runAll(ctx);
     expect(jsonfile.writeFile).not.toHaveBeenCalled();

--- a/bin-src/tasks/report.js
+++ b/bin-src/tasks/report.js
@@ -92,7 +92,7 @@ export const generateReport = async (ctx) => {
   });
 
   reportBuilder.writeTo(ctx.reportPath);
-  log.info(wroteReport(ctx.reportPath));
+  log.info(wroteReport(ctx.reportPath, 'JUnit XML'));
 };
 
 export default createTask({

--- a/bin-src/ui/messages/info/wroteReport.js
+++ b/bin-src/ui/messages/info/wroteReport.js
@@ -2,4 +2,4 @@ import chalk from 'chalk';
 
 import { info } from '../../components/icons';
 
-export default (filePath) => chalk`${info} Wrote JUnit XML report to {bold ${filePath}}`;
+export default (filePath, label) => chalk`${info} Wrote ${label} report to {bold ${filePath}}`;

--- a/bin-src/ui/messages/info/wroteReport.stories.js
+++ b/bin-src/ui/messages/info/wroteReport.stories.js
@@ -4,5 +4,6 @@ export default {
   title: 'CLI/Messages/Info',
 };
 
-export const WroteReport = () => wroteReport('./chromatic-report.xml', 'Chromatic');
+export const WroteChromaticDiagnostics = () =>
+  wroteReport('./chromatic-diagnostics.json', 'Chromatic diagnostics');
 export const WroteJUnitReport = () => wroteReport('./chromatic-build-123.xml', 'JUnit XML');

--- a/bin-src/ui/messages/info/wroteReport.stories.js
+++ b/bin-src/ui/messages/info/wroteReport.stories.js
@@ -4,4 +4,5 @@ export default {
   title: 'CLI/Messages/Info',
 };
 
-export const WroteReport = () => wroteReport('./chromatic-test-report.xml');
+export const WroteReport = () => wroteReport('./chromatic-report.xml', 'Chromatic');
+export const WroteJUnitReport = () => wroteReport('./chromatic-build-123.xml', 'JUnit XML');

--- a/bin-src/ui/messages/info/wroteReport.stories.js
+++ b/bin-src/ui/messages/info/wroteReport.stories.js
@@ -6,4 +6,5 @@ export default {
 
 export const WroteChromaticDiagnostics = () =>
   wroteReport('./chromatic-diagnostics.json', 'Chromatic diagnostics');
+
 export const WroteJUnitReport = () => wroteReport('./chromatic-build-123.xml', 'JUnit XML');

--- a/chromatic-report.json
+++ b/chromatic-report.json
@@ -1,0 +1,2880 @@
+{
+  "build": {
+    "id": "61b37015c64988004aa763ba",
+    "number": 5296,
+    "specCount": 184,
+    "componentCount": 21,
+    "testCount": 190,
+    "actualTestCount": 190,
+    "actualCaptureCount": 380,
+    "webUrl": "https://www.chromatic.com/build?appId=5d67dc0374b2e300209c41e7&number=5296",
+    "cachedUrl": "https://5d67dc0374b2e300209c41e7-gtdpecvcej.chromatic.com/iframe.html",
+    "reportToken": "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJhcHBJZCI6IjVkNjdkYzAzNzRiMmUzMDAyMDljNDFlNyIsImJ1aWxkSWQiOiI2MWIzNzAxNWM2NDk4ODAwNGFhNzYzYmEiLCJhdCI6MTYzOTE0OTU5MDIwOH0.jXJkuoZgc4mGVrrrp6GdtjFREDVsd4r_WfpSlXuGYGc",
+    "browsers": [
+      {
+        "browser": "chrome"
+      },
+      {
+        "browser": "firefox"
+      }
+    ],
+    "features": {
+      "uiTests": true,
+      "uiReview": true
+    },
+    "wasLimited": false,
+    "app": {
+      "account": {
+        "exceededThreshold": false,
+        "paymentRequired": false,
+        "billingUrl": "https://www.chromatic.com/billing?accountId=5af25af03c9f2c4bdccc0fcb"
+      },
+      "repository": {
+        "provider": "github"
+      },
+      "setupUrl": "https://www.chromatic.com/setup?appId=5d67dc0374b2e300209c41e7"
+    },
+    "tests": [
+      {
+        "spec": {
+          "name": "Info",
+          "component": {
+            "name": "CLI/Components/Icons",
+            "displayName": "Icons"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "Success",
+          "component": {
+            "name": "CLI/Components/Icons",
+            "displayName": "Icons"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "Warning",
+          "component": {
+            "name": "CLI/Components/Icons",
+            "displayName": "Icons"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "Error",
+          "component": {
+            "name": "CLI/Components/Icons",
+            "displayName": "Icons"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "Arrow Down",
+          "component": {
+            "name": "CLI/Components/Icons",
+            "displayName": "Icons"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "Arrow Right",
+          "component": {
+            "name": "CLI/Components/Icons",
+            "displayName": "Icons"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "Chevron Right",
+          "component": {
+            "name": "CLI/Components/Icons",
+            "displayName": "Icons"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "Default",
+          "component": {
+            "name": "CLI/Components/Link",
+            "displayName": "Link"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "Initial",
+          "component": {
+            "name": "CLI/Components/Task",
+            "displayName": "Task"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "Pending",
+          "component": {
+            "name": "CLI/Components/Task",
+            "displayName": "Task"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "Skipped",
+          "component": {
+            "name": "CLI/Components/Task",
+            "displayName": "Task"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "Success",
+          "component": {
+            "name": "CLI/Components/Task",
+            "displayName": "Task"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "Warning",
+          "component": {
+            "name": "CLI/Components/Task",
+            "displayName": "Task"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "Info",
+          "component": {
+            "name": "CLI/Components/Task",
+            "displayName": "Task"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "Error",
+          "component": {
+            "name": "CLI/Components/Task",
+            "displayName": "Task"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "Build Failed",
+          "component": {
+            "name": "CLI/Messages/Errors",
+            "displayName": "Errors"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "Build Has Changes",
+          "component": {
+            "name": "CLI/Messages/Errors",
+            "displayName": "Errors"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "Build Has Errors",
+          "component": {
+            "name": "CLI/Messages/Errors",
+            "displayName": "Errors"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "Duplicate Patch Build",
+          "component": {
+            "name": "CLI/Messages/Errors",
+            "displayName": "Errors"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "Fatal Error",
+          "component": {
+            "name": "CLI/Messages/Errors",
+            "displayName": "Errors"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "Fatal Error Simple",
+          "component": {
+            "name": "CLI/Messages/Errors",
+            "displayName": "Errors"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "Fetch Error",
+          "component": {
+            "name": "CLI/Messages/Errors",
+            "displayName": "Errors"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "Forks Unsupported",
+          "component": {
+            "name": "CLI/Messages/Errors",
+            "displayName": "Errors"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "Git No Commits",
+          "component": {
+            "name": "CLI/Messages/Errors",
+            "displayName": "Errors"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "Git Not Initialized",
+          "component": {
+            "name": "CLI/Messages/Errors",
+            "displayName": "Errors"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "Git Not Installed",
+          "component": {
+            "name": "CLI/Messages/Errors",
+            "displayName": "Errors"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "Git One Commit",
+          "component": {
+            "name": "CLI/Messages/Errors",
+            "displayName": "Errors"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "Incompatible Options",
+          "component": {
+            "name": "CLI/Messages/Errors",
+            "displayName": "Errors"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "Invalid Exit Once Uploaded",
+          "component": {
+            "name": "CLI/Messages/Errors",
+            "displayName": "Errors"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "Invalid Only",
+          "component": {
+            "name": "CLI/Messages/Errors",
+            "displayName": "Errors"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "Invalid Only Changed",
+          "component": {
+            "name": "CLI/Messages/Errors",
+            "displayName": "Errors"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "Invalid Package Json",
+          "component": {
+            "name": "CLI/Messages/Errors",
+            "displayName": "Errors"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "Invalid Patch Build",
+          "component": {
+            "name": "CLI/Messages/Errors",
+            "displayName": "Errors"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "Invalid Project Token",
+          "component": {
+            "name": "CLI/Messages/Errors",
+            "displayName": "Errors"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "Invalid Report Path",
+          "component": {
+            "name": "CLI/Messages/Errors",
+            "displayName": "Errors"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "Invalid Singular Options",
+          "component": {
+            "name": "CLI/Messages/Errors",
+            "displayName": "Errors"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "Merge Base Not Found",
+          "component": {
+            "name": "CLI/Messages/Errors",
+            "displayName": "Errors"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "Missing Build Script Name",
+          "component": {
+            "name": "CLI/Messages/Errors",
+            "displayName": "Errors"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "Missing Git Hub Info",
+          "component": {
+            "name": "CLI/Messages/Errors",
+            "displayName": "Errors"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "Missing Project Token",
+          "component": {
+            "name": "CLI/Messages/Errors",
+            "displayName": "Errors"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "Missing Script Name",
+          "component": {
+            "name": "CLI/Messages/Errors",
+            "displayName": "Errors"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "Missing Stories",
+          "component": {
+            "name": "CLI/Messages/Errors",
+            "displayName": "Errors"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "Missing Storybook Port",
+          "component": {
+            "name": "CLI/Messages/Errors",
+            "displayName": "Errors"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "Missing Travis Info",
+          "component": {
+            "name": "CLI/Messages/Errors",
+            "displayName": "Errors"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "No Package Json",
+          "component": {
+            "name": "CLI/Messages/Errors",
+            "displayName": "Errors"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "No View Layer Package",
+          "component": {
+            "name": "CLI/Messages/Errors",
+            "displayName": "Errors"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "Runtime Error",
+          "component": {
+            "name": "CLI/Messages/Errors",
+            "displayName": "Errors"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "Runtime Error Simple",
+          "component": {
+            "name": "CLI/Messages/Errors",
+            "displayName": "Errors"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "Runtime Warning",
+          "component": {
+            "name": "CLI/Messages/Errors",
+            "displayName": "Errors"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "Allow Runtime Error",
+          "component": {
+            "name": "CLI/Messages/Errors",
+            "displayName": "Errors"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "Task Error",
+          "component": {
+            "name": "CLI/Messages/Errors",
+            "displayName": "Errors"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "Unknown Storybook Port",
+          "component": {
+            "name": "CLI/Messages/Errors",
+            "displayName": "Errors"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "Workspace Not Clean",
+          "component": {
+            "name": "CLI/Messages/Errors",
+            "displayName": "Errors"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "Workspace Not Up To Date",
+          "component": {
+            "name": "CLI/Messages/Errors",
+            "displayName": "Errors"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "Added Script",
+          "component": {
+            "name": "CLI/Messages/Info",
+            "displayName": "Info"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "Build Passed",
+          "component": {
+            "name": "CLI/Messages/Info",
+            "displayName": "Info"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "First Build Passed",
+          "component": {
+            "name": "CLI/Messages/Info",
+            "displayName": "Info"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "Intro",
+          "component": {
+            "name": "CLI/Messages/Info",
+            "displayName": "Info"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "Listing Stories",
+          "component": {
+            "name": "CLI/Messages/Info",
+            "displayName": "Info"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "Not Added Script",
+          "component": {
+            "name": "CLI/Messages/Info",
+            "displayName": "Info"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "Speed Up CI",
+          "component": {
+            "name": "CLI/Messages/Info",
+            "displayName": "Info"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "Storybook Published",
+          "component": {
+            "name": "CLI/Messages/Info",
+            "displayName": "Info"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "Wrote Report",
+          "component": {
+            "name": "CLI/Messages/Info",
+            "displayName": "Info"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "Wrote J Unit Report",
+          "component": {
+            "name": "CLI/Messages/Info",
+            "displayName": "Info"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "Bail File",
+          "component": {
+            "name": "CLI/Messages/Warnings",
+            "displayName": "Warnings"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "Build Limited",
+          "component": {
+            "name": "CLI/Messages/Warnings",
+            "displayName": "Warnings"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "Deviating Output Dir",
+          "component": {
+            "name": "CLI/Messages/Warnings",
+            "displayName": "Warnings"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "Deviating Output Dir Chained",
+          "component": {
+            "name": "CLI/Messages/Warnings",
+            "displayName": "Warnings"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "Deviating Output Dir Npm Run",
+          "component": {
+            "name": "CLI/Messages/Warnings",
+            "displayName": "Warnings"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "Externals Changed",
+          "component": {
+            "name": "CLI/Messages/Warnings",
+            "displayName": "Warnings"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "Invalid Changed Files",
+          "component": {
+            "name": "CLI/Messages/Warnings",
+            "displayName": "Warnings"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "Is Rebuild",
+          "component": {
+            "name": "CLI/Messages/Warnings",
+            "displayName": "Warnings"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "No Stats File",
+          "component": {
+            "name": "CLI/Messages/Warnings",
+            "displayName": "Warnings"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "Outdated Package",
+          "component": {
+            "name": "CLI/Messages/Warnings",
+            "displayName": "Warnings"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "Outdated Yarn Package",
+          "component": {
+            "name": "CLI/Messages/Warnings",
+            "displayName": "Warnings"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "Payment Required",
+          "component": {
+            "name": "CLI/Messages/Warnings",
+            "displayName": "Warnings"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "Script Not Found",
+          "component": {
+            "name": "CLI/Messages/Warnings",
+            "displayName": "Warnings"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "Snapshot Quota Reached",
+          "component": {
+            "name": "CLI/Messages/Warnings",
+            "displayName": "Warnings"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "Travis Internal Build",
+          "component": {
+            "name": "CLI/Messages/Warnings",
+            "displayName": "Warnings"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "Initial",
+          "component": {
+            "name": "CLI/Tasks/Auth",
+            "displayName": "Auth"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "Authenticating",
+          "component": {
+            "name": "CLI/Tasks/Auth",
+            "displayName": "Auth"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "Authenticated",
+          "component": {
+            "name": "CLI/Tasks/Auth",
+            "displayName": "Auth"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "Invalid Token",
+          "component": {
+            "name": "CLI/Tasks/Auth",
+            "displayName": "Auth"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "Initial",
+          "component": {
+            "name": "CLI/Tasks/Build",
+            "displayName": "Build"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "Building",
+          "component": {
+            "name": "CLI/Tasks/Build",
+            "displayName": "Build"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "Built",
+          "component": {
+            "name": "CLI/Tasks/Build",
+            "displayName": "Build"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "Skipped",
+          "component": {
+            "name": "CLI/Tasks/Build",
+            "displayName": "Build"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "Failed",
+          "component": {
+            "name": "CLI/Tasks/Build",
+            "displayName": "Build"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "Initial",
+          "component": {
+            "name": "CLI/Tasks/GitInfo",
+            "displayName": "GitInfo"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "Pending",
+          "component": {
+            "name": "CLI/Tasks/GitInfo",
+            "displayName": "GitInfo"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "Success",
+          "component": {
+            "name": "CLI/Tasks/GitInfo",
+            "displayName": "GitInfo"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "No Baselines",
+          "component": {
+            "name": "CLI/Tasks/GitInfo",
+            "displayName": "GitInfo"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "Skipping",
+          "component": {
+            "name": "CLI/Tasks/GitInfo",
+            "displayName": "GitInfo"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "Skipped",
+          "component": {
+            "name": "CLI/Tasks/GitInfo",
+            "displayName": "GitInfo"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "Skipped Rebuild",
+          "component": {
+            "name": "CLI/Tasks/GitInfo",
+            "displayName": "GitInfo"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "Skip Failed",
+          "component": {
+            "name": "CLI/Tasks/GitInfo",
+            "displayName": "GitInfo"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "Initial",
+          "component": {
+            "name": "CLI/Tasks/PrepareWorkspace",
+            "displayName": "PrepareWorkspace"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "Pending",
+          "component": {
+            "name": "CLI/Tasks/PrepareWorkspace",
+            "displayName": "PrepareWorkspace"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "Lookup Merge Base",
+          "component": {
+            "name": "CLI/Tasks/PrepareWorkspace",
+            "displayName": "PrepareWorkspace"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "Checkout Merge Base",
+          "component": {
+            "name": "CLI/Tasks/PrepareWorkspace",
+            "displayName": "PrepareWorkspace"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "Installing Dependencies",
+          "component": {
+            "name": "CLI/Tasks/PrepareWorkspace",
+            "displayName": "PrepareWorkspace"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "Success",
+          "component": {
+            "name": "CLI/Tasks/PrepareWorkspace",
+            "displayName": "PrepareWorkspace"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "Initial",
+          "component": {
+            "name": "CLI/Tasks/Report",
+            "displayName": "Report"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "Pending",
+          "component": {
+            "name": "CLI/Tasks/Report",
+            "displayName": "Report"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "Success",
+          "component": {
+            "name": "CLI/Tasks/Report",
+            "displayName": "Report"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "Initial",
+          "component": {
+            "name": "CLI/Tasks/RestoreWorkspace",
+            "displayName": "RestoreWorkspace"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "Pending",
+          "component": {
+            "name": "CLI/Tasks/RestoreWorkspace",
+            "displayName": "RestoreWorkspace"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "Success",
+          "component": {
+            "name": "CLI/Tasks/RestoreWorkspace",
+            "displayName": "RestoreWorkspace"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "Initial",
+          "component": {
+            "name": "CLI/Tasks/Snapshot",
+            "displayName": "Snapshot"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "Dry Run",
+          "component": {
+            "name": "CLI/Tasks/Snapshot",
+            "displayName": "Snapshot"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "Pending",
+          "component": {
+            "name": "CLI/Tasks/Snapshot",
+            "displayName": "Snapshot"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "Pending Only",
+          "component": {
+            "name": "CLI/Tasks/Snapshot",
+            "displayName": "Snapshot"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "Pending Only Changed",
+          "component": {
+            "name": "CLI/Tasks/Snapshot",
+            "displayName": "Snapshot"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "Build Passed",
+          "component": {
+            "name": "CLI/Tasks/Snapshot",
+            "displayName": "Snapshot"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "Build Complete",
+          "component": {
+            "name": "CLI/Tasks/Snapshot",
+            "displayName": "Snapshot"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "Build Auto Accepted",
+          "component": {
+            "name": "CLI/Tasks/Snapshot",
+            "displayName": "Snapshot"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "Build Failed",
+          "component": {
+            "name": "CLI/Tasks/Snapshot",
+            "displayName": "Snapshot"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "Build Error",
+          "component": {
+            "name": "CLI/Tasks/Snapshot",
+            "displayName": "Snapshot"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "Skipped Publish Only",
+          "component": {
+            "name": "CLI/Tasks/Snapshot",
+            "displayName": "Snapshot"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "Skipped List",
+          "component": {
+            "name": "CLI/Tasks/Snapshot",
+            "displayName": "Snapshot"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "Skipped Exit Once Uploaded",
+          "component": {
+            "name": "CLI/Tasks/Snapshot",
+            "displayName": "Snapshot"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "Initial",
+          "component": {
+            "name": "CLI/Tasks/Start",
+            "displayName": "Start"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "Starting",
+          "component": {
+            "name": "CLI/Tasks/Start",
+            "displayName": "Start"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "Starting Command",
+          "component": {
+            "name": "CLI/Tasks/Start",
+            "displayName": "Start"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "Started",
+          "component": {
+            "name": "CLI/Tasks/Start",
+            "displayName": "Start"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "Skipped",
+          "component": {
+            "name": "CLI/Tasks/Start",
+            "displayName": "Start"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "No Start",
+          "component": {
+            "name": "CLI/Tasks/Start",
+            "displayName": "Start"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "Skip Failed",
+          "component": {
+            "name": "CLI/Tasks/Start",
+            "displayName": "Start"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "Initial",
+          "component": {
+            "name": "CLI/Tasks/StorybookInfo",
+            "displayName": "StorybookInfo"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "Pending",
+          "component": {
+            "name": "CLI/Tasks/StorybookInfo",
+            "displayName": "StorybookInfo"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "Success",
+          "component": {
+            "name": "CLI/Tasks/StorybookInfo",
+            "displayName": "StorybookInfo"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "With Addons",
+          "component": {
+            "name": "CLI/Tasks/StorybookInfo",
+            "displayName": "StorybookInfo"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "Initial",
+          "component": {
+            "name": "CLI/Tasks/Tunnel",
+            "displayName": "Tunnel"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "Pending",
+          "component": {
+            "name": "CLI/Tasks/Tunnel",
+            "displayName": "Tunnel"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "Success",
+          "component": {
+            "name": "CLI/Tasks/Tunnel",
+            "displayName": "Tunnel"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "Failed",
+          "component": {
+            "name": "CLI/Tasks/Tunnel",
+            "displayName": "Tunnel"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "Initial",
+          "component": {
+            "name": "CLI/Tasks/Upload",
+            "displayName": "Upload"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "Dry Run",
+          "component": {
+            "name": "CLI/Tasks/Upload",
+            "displayName": "Upload"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "Skipped",
+          "component": {
+            "name": "CLI/Tasks/Upload",
+            "displayName": "Upload"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "Validating",
+          "component": {
+            "name": "CLI/Tasks/Upload",
+            "displayName": "Upload"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "Invalid",
+          "component": {
+            "name": "CLI/Tasks/Upload",
+            "displayName": "Upload"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "Tracing",
+          "component": {
+            "name": "CLI/Tasks/Upload",
+            "displayName": "Upload"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "Traced",
+          "component": {
+            "name": "CLI/Tasks/Upload",
+            "displayName": "Upload"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "Preparing",
+          "component": {
+            "name": "CLI/Tasks/Upload",
+            "displayName": "Upload"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "Starting",
+          "component": {
+            "name": "CLI/Tasks/Upload",
+            "displayName": "Upload"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "Uploading",
+          "component": {
+            "name": "CLI/Tasks/Upload",
+            "displayName": "Upload"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "Success",
+          "component": {
+            "name": "CLI/Tasks/Upload",
+            "displayName": "Upload"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "Failed",
+          "component": {
+            "name": "CLI/Tasks/Upload",
+            "displayName": "Upload"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "Initial",
+          "component": {
+            "name": "CLI/Tasks/Verify",
+            "displayName": "Verify"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "Dry Run",
+          "component": {
+            "name": "CLI/Tasks/Verify",
+            "displayName": "Verify"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "Pending",
+          "component": {
+            "name": "CLI/Tasks/Verify",
+            "displayName": "Verify"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "Run Only",
+          "component": {
+            "name": "CLI/Tasks/Verify",
+            "displayName": "Verify"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "Run Only Files",
+          "component": {
+            "name": "CLI/Tasks/Verify",
+            "displayName": "Verify"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "Started",
+          "component": {
+            "name": "CLI/Tasks/Verify",
+            "displayName": "Verify"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "Published",
+          "component": {
+            "name": "CLI/Tasks/Verify",
+            "displayName": "Verify"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "Continue Setup",
+          "component": {
+            "name": "CLI/Tasks/Verify",
+            "displayName": "Verify"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "No Stories",
+          "component": {
+            "name": "CLI/Tasks/Verify",
+            "displayName": "Verify"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "No Matches",
+          "component": {
+            "name": "CLI/Tasks/Verify",
+            "displayName": "Verify"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "Initial",
+          "component": {
+            "name": "CLI/Workflows/TunnelBuild",
+            "displayName": "TunnelBuild"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "Authenticating",
+          "component": {
+            "name": "CLI/Workflows/TunnelBuild",
+            "displayName": "TunnelBuild"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "Retrieving Git Info",
+          "component": {
+            "name": "CLI/Workflows/TunnelBuild",
+            "displayName": "TunnelBuild"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "Retrieving Storybook Info",
+          "component": {
+            "name": "CLI/Workflows/TunnelBuild",
+            "displayName": "TunnelBuild"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "Starting",
+          "component": {
+            "name": "CLI/Workflows/TunnelBuild",
+            "displayName": "TunnelBuild"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "Opening Tunnel",
+          "component": {
+            "name": "CLI/Workflows/TunnelBuild",
+            "displayName": "TunnelBuild"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "Verifying",
+          "component": {
+            "name": "CLI/Workflows/TunnelBuild",
+            "displayName": "TunnelBuild"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "Snapshotting",
+          "component": {
+            "name": "CLI/Workflows/TunnelBuild",
+            "displayName": "TunnelBuild"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "Passed",
+          "component": {
+            "name": "CLI/Workflows/TunnelBuild",
+            "displayName": "TunnelBuild"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "Initial",
+          "component": {
+            "name": "CLI/Workflows/UploadBuild",
+            "displayName": "UploadBuild"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "Authenticating",
+          "component": {
+            "name": "CLI/Workflows/UploadBuild",
+            "displayName": "UploadBuild"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "Retrieving Git Info",
+          "component": {
+            "name": "CLI/Workflows/UploadBuild",
+            "displayName": "UploadBuild"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "Retrieving Storybook Info",
+          "component": {
+            "name": "CLI/Workflows/UploadBuild",
+            "displayName": "UploadBuild"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "Building",
+          "component": {
+            "name": "CLI/Workflows/UploadBuild",
+            "displayName": "UploadBuild"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "Uploading",
+          "component": {
+            "name": "CLI/Workflows/UploadBuild",
+            "displayName": "UploadBuild"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "Verifying",
+          "component": {
+            "name": "CLI/Workflows/UploadBuild",
+            "displayName": "UploadBuild"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "Snapshotting",
+          "component": {
+            "name": "CLI/Workflows/UploadBuild",
+            "displayName": "UploadBuild"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "Passed",
+          "component": {
+            "name": "CLI/Workflows/UploadBuild",
+            "displayName": "UploadBuild"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "Changes Found",
+          "component": {
+            "name": "CLI/Workflows/UploadBuild",
+            "displayName": "UploadBuild"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "First Build",
+          "component": {
+            "name": "CLI/Workflows/UploadBuild",
+            "displayName": "UploadBuild"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "Published",
+          "component": {
+            "name": "CLI/Workflows/UploadBuild",
+            "displayName": "UploadBuild"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": true
+        }
+      },
+      {
+        "spec": {
+          "name": "With Viewports",
+          "component": {
+            "name": "Tests",
+            "displayName": "Tests"
+          }
+        },
+        "parameters": {
+          "viewport": 320,
+          "viewportIsDefault": false
+        }
+      },
+      {
+        "spec": {
+          "name": "With Viewports",
+          "component": {
+            "name": "Tests",
+            "displayName": "Tests"
+          }
+        },
+        "parameters": {
+          "viewport": 600,
+          "viewportIsDefault": false
+        }
+      },
+      {
+        "spec": {
+          "name": "With Viewports",
+          "component": {
+            "name": "Tests",
+            "displayName": "Tests"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": false
+        }
+      },
+      {
+        "spec": {
+          "name": "With Delay",
+          "component": {
+            "name": "Tests",
+            "displayName": "Tests"
+          }
+        },
+        "parameters": {
+          "viewport": 600,
+          "viewportIsDefault": false
+        }
+      },
+      {
+        "spec": {
+          "name": "With Delay",
+          "component": {
+            "name": "Tests",
+            "displayName": "Tests"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": false
+        }
+      },
+      {
+        "spec": {
+          "name": "Ignored Elements",
+          "component": {
+            "name": "Tests",
+            "displayName": "Tests"
+          }
+        },
+        "parameters": {
+          "viewport": 600,
+          "viewportIsDefault": false
+        }
+      },
+      {
+        "spec": {
+          "name": "Ignored Elements",
+          "component": {
+            "name": "Tests",
+            "displayName": "Tests"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": false
+        }
+      },
+      {
+        "spec": {
+          "name": "Right To Left Body",
+          "component": {
+            "name": "Tests",
+            "displayName": "Tests"
+          }
+        },
+        "parameters": {
+          "viewport": 600,
+          "viewportIsDefault": false
+        }
+      },
+      {
+        "spec": {
+          "name": "Right To Left Body",
+          "component": {
+            "name": "Tests",
+            "displayName": "Tests"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": false
+        }
+      },
+      {
+        "spec": {
+          "name": "Right To Left Container",
+          "component": {
+            "name": "Tests",
+            "displayName": "Tests"
+          }
+        },
+        "parameters": {
+          "viewport": 600,
+          "viewportIsDefault": false
+        }
+      },
+      {
+        "spec": {
+          "name": "Right To Left Container",
+          "component": {
+            "name": "Tests",
+            "displayName": "Tests"
+          }
+        },
+        "parameters": {
+          "viewport": 1200,
+          "viewportIsDefault": false
+        }
+      }
+    ]
+  },
+  "buildLogFile": "/Users/yannbraga/Dev/chromatic-cli/build-storybook.log",
+  "environment": "{}",
+  "exitCode": 0,
+  "fileInfo": {
+    "lengths": [
+      {
+        "pathname": "0.82418226a2e594184a89.manager.bundle.js",
+        "contentLength": 65993,
+        "knownAs": "0.82418226a2e594184a89.manager.bundle.js"
+      },
+      {
+        "pathname": "4.c752b12d282471219c21.manager.bundle.js",
+        "contentLength": 102511,
+        "knownAs": "4.c752b12d282471219c21.manager.bundle.js"
+      },
+      {
+        "pathname": "4.c752b12d282471219c21.manager.bundle.js.LICENSE.txt",
+        "contentLength": 193,
+        "knownAs": "4.c752b12d282471219c21.manager.bundle.js.LICENSE.txt"
+      },
+      {
+        "pathname": "5.d37815c095753c53e000.manager.bundle.js",
+        "contentLength": 149090,
+        "knownAs": "5.d37815c095753c53e000.manager.bundle.js"
+      },
+      {
+        "pathname": "5.d37815c095753c53e000.manager.bundle.js.LICENSE.txt",
+        "contentLength": 227,
+        "knownAs": "5.d37815c095753c53e000.manager.bundle.js.LICENSE.txt"
+      },
+      {
+        "pathname": "6.1da253eb25ef596a3706.manager.bundle.js",
+        "contentLength": 11222,
+        "knownAs": "6.1da253eb25ef596a3706.manager.bundle.js"
+      },
+      {
+        "pathname": "7.1bc8c5b08c7c19110053.manager.bundle.js",
+        "contentLength": 1000,
+        "knownAs": "7.1bc8c5b08c7c19110053.manager.bundle.js"
+      },
+      {
+        "pathname": "css/global.css",
+        "contentLength": 37,
+        "knownAs": "css/global.css"
+      },
+      {
+        "pathname": "favicon.ico",
+        "contentLength": 32988,
+        "knownAs": "favicon.ico"
+      },
+      {
+        "pathname": "iframe.html",
+        "contentLength": 4744,
+        "knownAs": "iframe.html"
+      },
+      {
+        "pathname": "index.html",
+        "contentLength": 2002,
+        "knownAs": "index.html"
+      },
+      {
+        "pathname": "main.cb032825101ef5ab8365.manager.bundle.js",
+        "contentLength": 218,
+        "knownAs": "main.cb032825101ef5ab8365.manager.bundle.js"
+      },
+      {
+        "pathname": "main.f6ddd36e.iframe.bundle.js",
+        "contentLength": 158443,
+        "knownAs": "main.f6ddd36e.iframe.bundle.js"
+      },
+      {
+        "pathname": "runtime~main.703a968a58d4164612a1.manager.bundle.js",
+        "contentLength": 4497,
+        "knownAs": "runtime~main.703a968a58d4164612a1.manager.bundle.js"
+      },
+      {
+        "pathname": "runtime~main.bf4428eb.iframe.bundle.js",
+        "contentLength": 2937,
+        "knownAs": "runtime~main.bf4428eb.iframe.bundle.js"
+      },
+      {
+        "pathname": "vendors~main.ac0a3c71.iframe.bundle.js",
+        "contentLength": 898019,
+        "knownAs": "vendors~main.ac0a3c71.iframe.bundle.js"
+      },
+      {
+        "pathname": "vendors~main.ac0a3c71.iframe.bundle.js.LICENSE.txt",
+        "contentLength": 1812,
+        "knownAs": "vendors~main.ac0a3c71.iframe.bundle.js.LICENSE.txt"
+      },
+      {
+        "pathname": "vendors~main.ac0a3c71.iframe.bundle.js.map",
+        "contentLength": 106,
+        "knownAs": "vendors~main.ac0a3c71.iframe.bundle.js.map"
+      },
+      {
+        "pathname": "vendors~main.db5d5cbc0d6afb0766db.manager.bundle.js",
+        "contentLength": 1567408,
+        "knownAs": "vendors~main.db5d5cbc0d6afb0766db.manager.bundle.js"
+      },
+      {
+        "pathname": "vendors~main.db5d5cbc0d6afb0766db.manager.bundle.js.LICENSE.txt",
+        "contentLength": 2171,
+        "knownAs": "vendors~main.db5d5cbc0d6afb0766db.manager.bundle.js.LICENSE.txt"
+      }
+    ],
+    "paths": [
+      "0.82418226a2e594184a89.manager.bundle.js",
+      "4.c752b12d282471219c21.manager.bundle.js",
+      "4.c752b12d282471219c21.manager.bundle.js.LICENSE.txt",
+      "5.d37815c095753c53e000.manager.bundle.js",
+      "5.d37815c095753c53e000.manager.bundle.js.LICENSE.txt",
+      "6.1da253eb25ef596a3706.manager.bundle.js",
+      "7.1bc8c5b08c7c19110053.manager.bundle.js",
+      "css/global.css",
+      "favicon.ico",
+      "iframe.html",
+      "index.html",
+      "main.cb032825101ef5ab8365.manager.bundle.js",
+      "main.f6ddd36e.iframe.bundle.js",
+      "runtime~main.703a968a58d4164612a1.manager.bundle.js",
+      "runtime~main.bf4428eb.iframe.bundle.js",
+      "vendors~main.ac0a3c71.iframe.bundle.js",
+      "vendors~main.ac0a3c71.iframe.bundle.js.LICENSE.txt",
+      "vendors~main.ac0a3c71.iframe.bundle.js.map",
+      "vendors~main.db5d5cbc0d6afb0766db.manager.bundle.js",
+      "vendors~main.db5d5cbc0d6afb0766db.manager.bundle.js.LICENSE.txt"
+    ],
+    "total": 3005618
+  },
+  "flags": {
+    "projectToken": [
+      "gcaw1ai2dgo"
+    ],
+    "report": true,
+    "exitOnceUploaded": "",
+    "appCode": [],
+    "outputDir": [],
+    "storybookBuildDir": [],
+    "externals": [],
+    "interactive": true
+  },
+  "git": {
+    "commit": "c3ac4603fb8e1532aae61e1e9081c426a1a14399",
+    "committedAt": 1639068407000,
+    "committerEmail": "noreply@github.com",
+    "committerName": "GitHub",
+    "branch": "add-report-flag",
+    "slug": "chromaui/chromatic-cli",
+    "isTravisPrBuild": false,
+    "fromCI": false,
+    "version": "2.33.1",
+    "parentCommits": [
+      "c3ac4603fb8e1532aae61e1e9081c426a1a14399"
+    ]
+  },
+  "input": [],
+  "isolatorUrl": "https://5d67dc0374b2e300209c41e7-gtdpecvcej.chromatic.com/iframe.html",
+  "isPublishOnly": false,
+  "options": {
+    "projectToken": "gcaw1ai2dgo",
+    "externals": [],
+    "fromCI": false,
+    "dryRun": false,
+    "verbose": false,
+    "interactive": true,
+    "report": true,
+    "exitOnceUploaded": true,
+    "preserveMissingSpecs": false,
+    "originalArgv": [
+      "-t",
+      "gcaw1ai2dgo",
+      "--report",
+      "--exit-once-uploaded"
+    ],
+    "buildScriptName": "build-storybook",
+    "noStart": true,
+    "createTunnel": true,
+    "branchName": "",
+    "useTunnel": false
+  },
+  "packageJson": {
+    "name": "chromatic",
+    "version": "6.2.0",
+    "description": "Automate visual testing across browsers. Gather UI feedback. Versioned documentation.",
+    "keywords": [
+      "storybook-addon",
+      "storybook",
+      "addon",
+      "test",
+      "popular"
+    ],
+    "homepage": "https://www.chromatic.com",
+    "bugs": {
+      "url": "https://github.com/chromaui/chromatic-cli",
+      "email": "support@chromatic.com"
+    },
+    "repository": {
+      "type": "git",
+      "url": "https://github.com/chromaui/chromatic-cli.git"
+    },
+    "license": "MIT",
+    "main": "isChromatic.js",
+    "module": "isChromatic.mjs",
+    "bin": {
+      "chroma": "bin/main.cjs",
+      "chromatic": "bin/main.cjs",
+      "chromatic-cli": "bin/main.cjs"
+    },
+    "files": [
+      "bin",
+      "dist",
+      "isChromatic.js",
+      "isChromatic.mjs",
+      "isChromatic.d.ts"
+    ],
+    "scripts": {
+      "build": "npm-run-all --serial -l bundle:**",
+      "build-storybook": "build-storybook -s static",
+      "build-subdir": "cd subdir ; yarn build ; cd ..",
+      "chromatic": "./bin/main.cjs",
+      "chromatic-prebuilt": "./bin/main.cjs --storybook-build-dir=\"storybook-static\"",
+      "chromatic-staging": "CHROMATIC_INDEX_URL=https://www.staging-chromatic.com ./bin/main.cjs",
+      "chromatic-verbose": "cross-env LOG_LEVEL=verbose ./bin/main.cjs",
+      "lint": "yarn lint:js .storybook bin-src stories ./isChromatic.js ./isChromatic.mjs",
+      "lint:js": "cross-env NODE_ENV=production eslint --fix --cache --cache-location=.cache/eslint --ext .js,.json,.mjs,.ts,.cjs --report-unused-disable-directives",
+      "lint:package": "sort-package-json",
+      "prepublish": "npm run build",
+      "postpublish": "npm run publish-action",
+      "publish-action": "node scripts/publish-action.js",
+      "trim-stats": "node -r esm bin-src/trim-stats-file.js",
+      "stats-to-story-files": "node -r esm bin-src/stats-to-story-files.js",
+      "storybook": "start-storybook -p 9009 -s static",
+      "test": "jest",
+      "prepare": "husky install",
+      "bundle:bin": "webpack --config=webpack-bin.config.js && chmod +x ./bin/main.cjs",
+      "bundle:action": "webpack --config=webpack-action.config.js",
+      "dev": "webpack --config=webpack-bin.config.js --watch --progress --mode=development",
+      "lint-staged": "lint-staged"
+    },
+    "lint-staged": {
+      "*.ts": [
+        "yarn lint:js --fix"
+      ],
+      "*.js": [
+        "yarn lint:js --fix"
+      ],
+      "*.json": [
+        "yarn lint:js --fix"
+      ],
+      "package.json": [
+        "yarn lint:package"
+      ]
+    },
+    "resolutions": {
+      "any-observable": "^0.5.1"
+    },
+    "devDependencies": {
+      "@actions/core": "^1.5.0",
+      "@actions/github": "^5.0.0",
+      "@babel/cli": "^7.14.8",
+      "@babel/core": "^7.15.0",
+      "@babel/node": "^7.15.4",
+      "@babel/plugin-transform-runtime": "^7.15.0",
+      "@babel/preset-env": "^7.15.0",
+      "@babel/preset-typescript": "^7.15.0",
+      "@babel/runtime": "^7.15.3",
+      "@chromaui/localtunnel": "^2.0.3",
+      "@storybook/eslint-config-storybook": "^3.1.2",
+      "@storybook/linter-config": "^3.1.2",
+      "@storybook/react": "^6.3.7",
+      "@types/node": "^14.14.25",
+      "@typescript-eslint/eslint-plugin": "^4.29.3",
+      "@typescript-eslint/parser": "^4.29.3",
+      "ansi-html": "0.0.7",
+      "any-observable": "^0.5.1",
+      "archiver": "^5.3.0",
+      "async-retry": "^1.3.3",
+      "babel-preset-minify": "^0.5.1",
+      "chalk": "^4.1.2",
+      "cpy": "^8.1.2",
+      "cross-env": "^7.0.3",
+      "cross-spawn": "^7.0.2",
+      "debug": "^4.3.2",
+      "dotenv": "^8.2.0",
+      "env-ci": "^5.0.2",
+      "eslint": "^7.32.0",
+      "esm": "^3.2.25",
+      "execa": "^5.0.0",
+      "fake-tag": "^2.0.0",
+      "fs-extra": "^10.0.0",
+      "https-proxy-agent": "^5.0.0",
+      "husky": "^7.0.0",
+      "jest": "^27.0.6",
+      "jsonfile": "^6.0.1",
+      "junit-report-builder": "2.1.0",
+      "lint-staged": "^11.1.2",
+      "listr": "0.14.3",
+      "meow": "^9.0.0",
+      "mock-fs": "^5.1.2",
+      "no-proxy": "^1.0.3",
+      "node-ask": "^1.0.1",
+      "node-fetch": "3.0.0",
+      "node-loggly-bulk": "^2.2.4",
+      "npm-run-all": "^4.0.2",
+      "observable": "^2.1.4",
+      "p-limit": "3.1.0",
+      "picomatch": "2.2.2",
+      "pkg-up": "^3.1.0",
+      "pluralize": "^8.0.0",
+      "prettier": "^2.3.2",
+      "progress-stream": "^2.0.0",
+      "prop-types": "^15.7.2",
+      "react": "^17.0.2",
+      "react-dom": "^17.0.2",
+      "semver": "^7.3.5",
+      "slash": "^3.0.0",
+      "sort-package-json": "1.50.0",
+      "string-argv": "^0.3.1",
+      "strip-ansi": "6.0.0",
+      "tmp-promise": "3.0.2",
+      "tree-kill": "^1.2.2",
+      "ts-dedent": "^1.0.0",
+      "ts-loader": "^9.2.5",
+      "typescript": "^4.3.5",
+      "util-deprecate": "^1.0.2",
+      "uuid": "^8.3.2",
+      "webpack": "^5.51.1",
+      "webpack-cli": "^4.8.0",
+      "why-is-node-running": "^2.1.2",
+      "yarn-or-npm": "^3.0.1",
+      "zen-observable": "^0.8.15"
+    },
+    "docs": "https://www.chromatic.com/docs/cli",
+    "storybook": {
+      "icon": "https://user-images.githubusercontent.com/263385/101995175-2e087800-3c96-11eb-9a33-9860a1c3ce62.gif",
+      "displayName": "Chromatic"
+    }
+  },
+  "packagePath": "/Users/yannbraga/Dev/chromatic-cli/package.json",
+  "rebuild": true,
+  "sessionId": "4714e0b1-4230-4afc-9b24-273907d36d82",
+  "skipSnapshots": true,
+  "sourceDir": "/var/folders/sv/lg8lnv0s4gg6_rt7s6cd52qr0000gn/T/chromatic--64444-R60dbCu9WSmP",
+  "spawnParams": {
+    "client": "yarn",
+    "clientVersion": "1.22.17",
+    "nodeVersion": "v14.18.1",
+    "platform": "darwin",
+    "command": "/Users/yannbraga/.n/bin/node",
+    "clientArgs": [
+      "/opt/homebrew/Cellar/yarn/1.22.17/libexec/bin/yarn.js",
+      "run"
+    ],
+    "scriptArgs": [
+      "build-storybook",
+      "--output-dir",
+      "/var/folders/sv/lg8lnv0s4gg6_rt7s6cd52qr0000gn/T/chromatic--64444-R60dbCu9WSmP"
+    ]
+  },
+  "startedAt": "2021-12-10T15:19:45.163Z",
+  "storybook": {
+    "addons": [],
+    "staticDir": [
+      "static"
+    ],
+    "viewLayer": "react",
+    "version": "6.3.8"
+  },
+  "uploadedBytes": 3005618
+}


### PR DESCRIPTION
This PR introduces a new flag to the CLI called `--report` which will write a log file called `chromatic-report.json` containing pretty useful information:

![image](https://user-images.githubusercontent.com/1671563/145598567-552ce2bc-8241-48b4-939e-0f429ae2011f.png)

Will be useful in case we want to implement a fluid workflow with the storybook test-runner in CI.

Thanks @ghengeveld for all the help! <3