### PR TITLE
Retry createBuild based on error messages

### DIFF
--- a/bin-src/io/GraphQLClient.js
+++ b/bin-src/io/GraphQLClient.js
@@ -1,4 +1,7 @@
+import retry from 'async-retry';
 import HTTPClient from './HTTPClient';
+
+const RETRYABLE_ERROR_CODE = 'RETRYABLE_ERROR_CODE';
 
 export default class GraphQLClient {
   constructor({ uri, ...httpClientOptions }) {
@@ -12,35 +15,46 @@ export default class GraphQLClient {
     this.headers.Authorization = `Bearer ${token}`;
   }
 
-  async runQuery(query, variables, headers) {
-    const response = await this.client.fetch(this.uri, {
-      body: JSON.stringify({ query, variables }),
-      headers: { ...this.headers, ...headers },
-      method: 'post',
-    });
-
-    const { data, errors } = await response.json();
-
-    if (errors) {
-      if (Array.isArray(errors)) {
-        errors.forEach((err) => {
-          // eslint-disable-next-line no-param-reassign
-          err.name = err.name || 'GraphQLError';
-          // eslint-disable-next-line no-param-reassign
-          err.at = `${err.path.join('.')} ${err.locations
-            .map((l) => `${l.line}:${l.column}`)
-            .join(', ')}`;
+  async runQuery(query, variables, { headers = {}, retries = 0 } = {}) {
+    return retry(
+      async (bail) => {
+        const response = await this.client.fetch(this.uri, {
+          body: JSON.stringify({ query, variables }),
+          headers: { ...this.headers, ...headers },
+          method: 'post',
         });
-        throw errors.length === 1 ? errors[0] : errors;
-      }
-      throw errors;
-    }
 
-    return data;
+        const { data, errors } = await response.json();
+
+        if (errors) {
+          if (Array.isArray(errors)) {
+            errors.forEach((err) => {
+              const { extensions = {} } = err;
+              if (extensions.code === RETRYABLE_ERROR_CODE) {
+                // throw an error to retry the query
+                throw err;
+              }
+
+              // eslint-disable-next-line no-param-reassign
+              err.name = err.name || 'GraphQLError';
+              // eslint-disable-next-line no-param-reassign
+              err.at = `${err.path.join('.')} ${err.locations
+                .map((l) => `${l.line}:${l.column}`)
+                .join(', ')}`;
+            });
+            bail(errors.length === 1 ? errors[0] : errors);
+          }
+          bail(errors);
+        }
+
+        return data;
+      },
+      { retries }
+    );
   }
 
   // Convenience static method.
-  static async runQuery(options, query, variables) {
-    return new GraphQLClient(options).runQuery(query, variables);
+  static async runQuery(options, query, variables, runQueryOptions) {
+    return new GraphQLClient(options).runQuery(query, variables, runQueryOptions);
   }
 }

--- a/bin-src/tasks/report.js
+++ b/bin-src/tasks/report.js
@@ -49,7 +49,7 @@ export const generateReport = async (ctx) => {
   } = await client.runQuery(
     ReportQuery,
     { buildNumber },
-    { Authorization: `Bearer ${reportToken}` }
+    { headers: { Authorization: `Bearer ${reportToken}` } }
   );
   const buildTime = (build.completedAt || Date.now()) - build.createdAt;
 

--- a/bin-src/tasks/verify.js
+++ b/bin-src/tasks/verify.js
@@ -1,4 +1,3 @@
-import retry from 'async-retry';
 import { createTask, transitionTo } from '../lib/tasks';
 import listingStories from '../ui/messages/info/listingStories';
 import storybookPublished from '../ui/messages/info/storybookPublished';

--- a/bin-src/tasks/verify.js
+++ b/bin-src/tasks/verify.js
@@ -1,3 +1,4 @@
+import retry from 'async-retry';
 import { createTask, transitionTo } from '../lib/tasks';
 import listingStories from '../ui/messages/info/listingStories';
 import storybookPublished from '../ui/messages/info/storybookPublished';
@@ -85,24 +86,28 @@ export const createBuild = async (ctx, task) => {
     transitionTo(runOnlyFiles)(ctx, task);
   }
 
-  const { createBuild: build } = await client.runQuery(TesterCreateBuildMutation, {
-    input: {
-      ...commitInfo,
-      ...(only && { only }),
-      ...(onlyStoryFiles && { onlyStoryFiles: Object.keys(onlyStoryFiles) }),
-      autoAcceptChanges,
-      cachedUrl: ctx.cachedUrl,
-      environment: ctx.environment,
-      patchBaseRef,
-      patchHeadRef,
-      preserveMissingSpecs,
-      packageVersion: ctx.pkg.version,
-      storybookVersion: ctx.storybook.version,
-      viewLayer: ctx.storybook.viewLayer,
-      addons: ctx.storybook.addons,
+  const { createBuild: build } = await client.runQuery(
+    TesterCreateBuildMutation,
+    {
+      input: {
+        ...commitInfo,
+        ...(only && { only }),
+        ...(onlyStoryFiles && { onlyStoryFiles: Object.keys(onlyStoryFiles) }),
+        autoAcceptChanges,
+        cachedUrl: ctx.cachedUrl,
+        environment: ctx.environment,
+        patchBaseRef,
+        patchHeadRef,
+        preserveMissingSpecs,
+        packageVersion: ctx.pkg.version,
+        storybookVersion: ctx.storybook.version,
+        viewLayer: ctx.storybook.viewLayer,
+        addons: ctx.storybook.addons,
+      },
+      isolatorUrl,
     },
-    isolatorUrl,
-  });
+    { retries: 3 }
+  );
 
   ctx.build = build;
   ctx.isPublishOnly = !build.features.uiReview && !build.features.uiTests;


### PR DESCRIPTION
Connections to the Chromatic backend can get a 503 return error from Heroku after 30 seconds which are then retried by our [HTTPClient](https://github.com/chromaui/chromatic-cli/blob/c3ac4603fb8e1532aae61e1e9081c426a1a14399/bin-src/io/HTTPClient.js#L39-L55). We want to lower our error rates to reduce noise in our monitoring by throwing errors before that occurs. Doing this returns a 200 from the fetch then we throw an error in our [GraphQLClient](https://github.com/chromaui/chromatic-cli/blob/c3ac4603fb8e1532aae61e1e9081c426a1a14399/bin-src/io/GraphQLClient.js#L24-L37). This allows known errors to retry again when creating a build!