### PR TITLE
fix: use correct project token for action workflow

### DIFF
--- a/.github/workflows/action-run.yml
+++ b/.github/workflows/action-run.yml
@@ -11,5 +11,5 @@ jobs:
     - run: yarn build-storybook
     - uses: ./
       with: 
-        projectToken: 5oy3iw6rkio
+        projectToken: gcaw1ai2dgo
         storybookBuildDir: storybook-static


### PR DESCRIPTION
The action was using a wrong token which was triggering wrong chromatic builds for months!