### PR TITLE
Set commit details when using env var and warn if it's missing

### DIFF
--- a/bin-src/git/getCommitAndBranch.js
+++ b/bin-src/git/getCommitAndBranch.js
@@ -5,14 +5,14 @@ import gitOneCommit from '../ui/messages/errors/gitOneCommit';
 import missingGitHubInfo from '../ui/messages/errors/missingGitHubInfo';
 import missingTravisInfo from '../ui/messages/errors/missingTravisInfo';
 import travisInternalBuild from '../ui/messages/warnings/travisInternalBuild';
+import noCommitDetails from '../ui/messages/warnings/noCommitDetails';
 import { getBranch, getCommit, hasPreviousCommit } from './git';
 
 const ORIGIN_PREFIX_REGEXP = /^origin\//;
 const notHead = (branch) => (branch && branch !== 'HEAD' ? branch : false);
 
 export async function getCommitAndBranch({ branchName, patchBaseRef, ci, log } = {}) {
-  // eslint-disable-next-line prefer-const
-  let { commit, committedAt, committerEmail, committerName } = await getCommit();
+  let commit = await getCommit();
   let branch = notHead(branchName) || notHead(patchBaseRef) || (await getBranch());
   let slug;
 
@@ -25,7 +25,6 @@ export async function getCommitAndBranch({ branchName, patchBaseRef, ci, log } =
     GITHUB_ACTIONS,
     GITHUB_EVENT_NAME,
     GITHUB_REPOSITORY,
-    GITHUB_SHA,
     GITHUB_BASE_REF,
     GITHUB_HEAD_REF,
     CHROMATIC_SHA,
@@ -33,7 +32,7 @@ export async function getCommitAndBranch({ branchName, patchBaseRef, ci, log } =
     CHROMATIC_SLUG,
   } = process.env;
 
-  const isFromEnvVariable = CHROMATIC_SHA && CHROMATIC_BRANCH;
+  const isFromEnvVariable = CHROMATIC_SHA && CHROMATIC_BRANCH; // Our GitHub Action also sets these
   const isTravisPrBuild = TRAVIS_EVENT_TYPE === 'pull_request';
   const isGitHubAction = GITHUB_ACTIONS === 'true';
   const isGitHubPrBuild = GITHUB_EVENT_NAME === 'pull_request';
@@ -42,36 +41,48 @@ export async function getCommitAndBranch({ branchName, patchBaseRef, ci, log } =
     throw new Error(gitOneCommit(isGitHubAction));
   }
 
-  if (isTravisPrBuild && TRAVIS_PULL_REQUEST_SLUG === TRAVIS_REPO_SLUG) {
-    log.warn(travisInternalBuild());
-  }
-
   if (isFromEnvVariable) {
-    // Our GitHub Action will also set these
-    commit = CHROMATIC_SHA;
+    commit = await getCommit(CHROMATIC_SHA).catch((err) => {
+      log.warn(noCommitDetails(CHROMATIC_SHA, 'CHROMATIC_SHA'));
+      log.debug(err);
+      return { sha: CHROMATIC_SHA };
+    });
     branch = CHROMATIC_BRANCH;
     slug = CHROMATIC_SLUG;
   } else if (isTravisPrBuild) {
+    if (TRAVIS_PULL_REQUEST_SLUG === TRAVIS_REPO_SLUG) {
+      log.warn(travisInternalBuild());
+    }
+    if (!TRAVIS_PULL_REQUEST_SHA || !TRAVIS_PULL_REQUEST_BRANCH) {
+      throw new Error(missingTravisInfo({ TRAVIS_EVENT_TYPE }));
+    }
+
     // Travis PR builds are weird, we want to ensure we mark build against the commit that was
     // merged from, rather than the resulting "psuedo" merge commit that doesn't stick around in the
     // history of the project (so approvals will get lost). We also have to ensure we use the right branch.
-    commit = TRAVIS_PULL_REQUEST_SHA;
+    commit = await getCommit(TRAVIS_PULL_REQUEST_SHA).catch((err) => {
+      log.warn(noCommitDetails(TRAVIS_PULL_REQUEST_SHA, 'TRAVIS_PULL_REQUEST_SHA'));
+      log.debug(err);
+      return { sha: TRAVIS_PULL_REQUEST_SHA };
+    });
     branch = TRAVIS_PULL_REQUEST_BRANCH;
     slug = TRAVIS_PULL_REQUEST_SLUG;
-    if (!commit || !branch) {
-      throw new Error(missingTravisInfo({ TRAVIS_EVENT_TYPE }));
-    }
   } else if (isGitHubPrBuild) {
-    // GitHub PR builds run against a "virtual merge commit" with a SHA unknown to Chromatic and an
-    // invalid branch name, so we override these using environment variables available in the action.
-    // This does not apply to our GitHub Action, because it'll set CHROMATIC_SHA, -BRANCH and -SLUG.
-    if (!GITHUB_SHA || !GITHUB_HEAD_REF) {
+    if (!GITHUB_HEAD_REF) {
       throw new Error(missingGitHubInfo({ GITHUB_EVENT_NAME }));
     }
     if (GITHUB_BASE_REF === GITHUB_HEAD_REF) {
       throw new Error(forksUnsupported({ GITHUB_HEAD_REF }));
     }
-    commit = GITHUB_SHA;
+
+    // GitHub PR builds run against a "virtual merge commit" with a SHA unknown to Chromatic and an
+    // invalid branch name, so we override these using environment variables available in the action.
+    // This does not apply to our GitHub Action, because it'll set CHROMATIC_SHA, -BRANCH and -SLUG.
+    commit = await getCommit(GITHUB_HEAD_REF).catch((err) => {
+      log.warn(noCommitDetails(GITHUB_HEAD_REF, 'GITHUB_HEAD_REF'));
+      log.debug(err);
+      return { sha: GITHUB_HEAD_REF };
+    });
     branch = GITHUB_HEAD_REF;
     slug = GITHUB_REPOSITORY;
   }
@@ -89,7 +100,11 @@ export async function getCommitAndBranch({ branchName, patchBaseRef, ci, log } =
   // On certain CI systems, a branch is not checked out
   // (instead a detached head is used for the commit).
   if (!notHead(branch)) {
-    commit = ciCommit;
+    commit = await getCommit(ciCommit).catch((err) => {
+      log.warn(noCommitDetails(ciCommit));
+      log.debug(err);
+      return { sha: ciCommit };
+    });
     branch =
       notHead(prBranch) ||
       notHead(ciBranch) ||
@@ -116,9 +131,6 @@ export async function getCommitAndBranch({ branchName, patchBaseRef, ci, log } =
   log.debug(
     `git info: ${JSON.stringify({
       commit,
-      committedAt,
-      committerEmail,
-      committerName,
       branch,
       slug,
       isTravisPrBuild,
@@ -127,11 +139,10 @@ export async function getCommitAndBranch({ branchName, patchBaseRef, ci, log } =
     })}`
   );
 
+  const { sha, ...commitInfo } = commit;
   return {
-    commit,
-    committedAt,
-    committerEmail,
-    committerName,
+    commit: sha,
+    ...commitInfo,
     branch,
     slug,
     isTravisPrBuild,

--- a/bin-src/git/getCommitAndBranch.js
+++ b/bin-src/git/getCommitAndBranch.js
@@ -4,6 +4,7 @@ import forksUnsupported from '../ui/messages/errors/forksUnsupported';
 import gitOneCommit from '../ui/messages/errors/gitOneCommit';
 import missingGitHubInfo from '../ui/messages/errors/missingGitHubInfo';
 import missingTravisInfo from '../ui/messages/errors/missingTravisInfo';
+import customGitHubAction from '../ui/messages/info/customGitHubAction';
 import travisInternalBuild from '../ui/messages/warnings/travisInternalBuild';
 import noCommitDetails from '../ui/messages/warnings/noCommitDetails';
 import { getBranch, getCommit, hasPreviousCommit } from './git';
@@ -69,7 +70,9 @@ export async function getCommitAndBranch({ log }, { branchName, patchBaseRef, ci
     branch = TRAVIS_PULL_REQUEST_BRANCH;
     slug = TRAVIS_PULL_REQUEST_SLUG;
   } else if (isGitHubPrBuild) {
-    if (!GITHUB_HEAD_REF) {
+    log.info(customGitHubAction());
+
+    if (!GITHUB_HEAD_REF || !GITHUB_SHA) {
       throw new Error(missingGitHubInfo({ GITHUB_EVENT_NAME }));
     }
     if (GITHUB_BASE_REF === GITHUB_HEAD_REF) {

--- a/bin-src/git/getCommitAndBranch.test.js
+++ b/bin-src/git/getCommitAndBranch.test.js
@@ -1,0 +1,193 @@
+import envCi from 'env-ci';
+import { getBranch, getCommit, hasPreviousCommit } from './git';
+
+import { getCommitAndBranch } from './getCommitAndBranch';
+
+jest.mock('env-ci');
+jest.mock('./git');
+
+const log = { info: jest.fn(), warn: jest.fn(), debug: jest.fn() };
+
+const processEnv = process.env;
+beforeEach(() => {
+  process.env = { ...processEnv };
+  envCi.mockReturnValue({});
+  getBranch.mockResolvedValue('main');
+  getCommit.mockResolvedValue({
+    commit: '48e0c83fadbf504c191bc868040b7a969a4f1feb',
+    committedAt: 1640094096000,
+    committerEmail: 'noreply@github.com',
+    committerName: 'GitHub',
+  });
+  hasPreviousCommit.mockResolvedValue(true);
+});
+
+afterEach(() => {
+  envCi.mockReset();
+  getBranch.mockReset();
+  getCommit.mockReset();
+});
+
+describe('getCommitAndBranch', () => {
+  it('returns commit and branch info', async () => {
+    const info = await getCommitAndBranch({ log });
+    expect(info).toMatchObject({
+      branch: 'main',
+      commit: '48e0c83fadbf504c191bc868040b7a969a4f1feb',
+      committedAt: 1640094096000,
+      committerEmail: 'noreply@github.com',
+      committerName: 'GitHub',
+      slug: undefined,
+    });
+  });
+
+  it('retrieves CI context', async () => {
+    envCi.mockReturnValue({
+      isCi: true,
+      service: 'ci-service',
+      branch: 'ci-branch',
+      commit: 'ci-commit',
+      slug: 'chromaui/env-ci',
+    });
+    getBranch.mockResolvedValue('HEAD');
+    getCommit.mockImplementation((commit) => Promise.resolve({ commit }));
+    const info = await getCommitAndBranch({ log });
+    expect(info).toMatchObject({
+      branch: 'ci-branch',
+      commit: 'ci-commit',
+      slug: 'chromaui/env-ci',
+      fromCI: true,
+      ciService: 'ci-service',
+    });
+  });
+
+  it('prefers prBranch over ciBranch', async () => {
+    envCi.mockReturnValue({
+      branch: 'ci-branch',
+      prBranch: 'ci-pr-branch',
+    });
+    getBranch.mockResolvedValue('HEAD');
+    const info = await getCommitAndBranch({ log });
+    expect(info).toMatchObject({ branch: 'ci-pr-branch' });
+  });
+
+  it('removes origin/ prefix in branch name', async () => {
+    getBranch.mockResolvedValue('origin/master');
+    const info = await getCommitAndBranch({ log });
+    expect(info).toMatchObject({ branch: 'master' });
+  });
+
+  it('throws when there is only one commit', async () => {
+    hasPreviousCommit.mockResolvedValue(false);
+    await expect(getCommitAndBranch({ log })).rejects.toThrow('Found only one commit');
+  });
+
+  describe('with branchName', () => {
+    it('uses provided branchName as branch', async () => {
+      const info = await getCommitAndBranch({ log }, { branchName: 'foobar' });
+      expect(info).toMatchObject({ branch: 'foobar' });
+    });
+
+    it('does not remove origin/ prefix in branch name', async () => {
+      const info = await getCommitAndBranch({ log }, { branchName: 'origin/foobar' });
+      expect(info).toMatchObject({ branch: 'origin/foobar' });
+    });
+  });
+
+  describe('with patchBaseRef', () => {
+    it('uses provided patchBaseRef as branch', async () => {
+      const info = await getCommitAndBranch({ log }, { patchBaseRef: 'foobar' });
+      expect(info).toMatchObject({ branch: 'foobar' });
+    });
+
+    it('prefers branchName over patchBaseRef', async () => {
+      const info = await getCommitAndBranch({ log }, { branchName: 'foo', patchBaseRef: 'bar' });
+      expect(info).toMatchObject({ branch: 'foo' });
+    });
+  });
+
+  describe('with chromatic env vars', () => {
+    it('sets the expected info', async () => {
+      process.env.CHROMATIC_SHA = 'f78db92d';
+      process.env.CHROMATIC_BRANCH = 'feature';
+      process.env.CHROMATIC_SLUG = 'chromaui/chromatic';
+      getCommit.mockImplementation((commit) => Promise.resolve({ commit }));
+      const info = await getCommitAndBranch({ log });
+      expect(info).toMatchObject({
+        branch: 'feature',
+        commit: 'f78db92d',
+        slug: 'chromaui/chromatic',
+      });
+    });
+
+    it('falls back to the provided SHA when commit cannot be retrieved', async () => {
+      process.env.CHROMATIC_SHA = 'f78db92d';
+      process.env.CHROMATIC_BRANCH = 'feature';
+      getCommit.mockResolvedValueOnce().mockRejectedValueOnce();
+      const info = await getCommitAndBranch({ log });
+      expect(info).toMatchObject({ branch: 'feature', commit: 'f78db92d' });
+      expect(log.warn).toHaveBeenCalledWith(expect.stringMatching('Commit f78db92 does not exist'));
+    });
+
+    it('does not remove origin/ prefix in branch name', async () => {
+      process.env.CHROMATIC_SHA = 'f78db92d';
+      process.env.CHROMATIC_BRANCH = 'origin/feature';
+      const info = await getCommitAndBranch({ log });
+      expect(info).toMatchObject({ branch: 'origin/feature' });
+    });
+  });
+
+  describe('GitHub PR build', () => {
+    it('sets the expected info', async () => {
+      process.env.GITHUB_EVENT_NAME = 'pull_request';
+      process.env.GITHUB_HEAD_REF = 'github';
+      process.env.GITHUB_REPOSITORY = 'chromaui/github';
+      getCommit.mockResolvedValue({ commit: 'c11da9a9' });
+      const info = await getCommitAndBranch({ log });
+      expect(getCommit).toHaveBeenCalledWith('github');
+      expect(info).toMatchObject({
+        branch: 'github',
+        commit: 'c11da9a9',
+        slug: 'chromaui/github',
+      });
+    });
+
+    it('throws on missing variable', async () => {
+      process.env.GITHUB_EVENT_NAME = 'pull_request';
+      await expect(getCommitAndBranch({ log })).rejects.toThrow(
+        'Missing GitHub environment variable'
+      );
+    });
+
+    it('throws on cross-fork PR (where refs are equal)', async () => {
+      process.env.GITHUB_EVENT_NAME = 'pull_request';
+      process.env.GITHUB_BASE_REF = 'github';
+      process.env.GITHUB_HEAD_REF = 'github';
+      await expect(getCommitAndBranch({ log })).rejects.toThrow('Cross-fork PR builds unsupported');
+    });
+  });
+
+  describe('Travis PR build', () => {
+    it('sets the expected info', async () => {
+      process.env.TRAVIS_EVENT_TYPE = 'pull_request';
+      process.env.TRAVIS_PULL_REQUEST_SHA = 'ef765ac7';
+      process.env.TRAVIS_PULL_REQUEST_BRANCH = 'travis';
+      process.env.TRAVIS_PULL_REQUEST_SLUG = 'chromaui/travis';
+      getCommit.mockImplementation((commit) => Promise.resolve({ commit }));
+      const info = await getCommitAndBranch({ log });
+      expect(info).toMatchObject({
+        branch: 'travis',
+        commit: 'ef765ac7',
+        slug: 'chromaui/travis',
+      });
+    });
+
+    it('throws on missing variable', async () => {
+      process.env.TRAVIS_EVENT_TYPE = 'pull_request';
+      process.env.TRAVIS_PULL_REQUEST_SHA = 'ef765ac7';
+      await expect(getCommitAndBranch({ log })).rejects.toThrow(
+        'Missing Travis environment variable'
+      );
+    });
+  });
+});

--- a/bin-src/git/getCommitAndBranch.test.js
+++ b/bin-src/git/getCommitAndBranch.test.js
@@ -149,6 +149,7 @@ describe('getCommitAndBranch', () => {
       process.env.GITHUB_EVENT_NAME = 'pull_request';
       process.env.GITHUB_HEAD_REF = 'github';
       process.env.GITHUB_REPOSITORY = 'chromaui/github';
+      process.env.GITHUB_SHA = '3276c796';
       getCommit.mockResolvedValue({ commit: 'c11da9a9', ...commitInfo });
       const info = await getCommitAndBranch({ log });
       expect(getCommit).toHaveBeenCalledWith('github');
@@ -162,6 +163,12 @@ describe('getCommitAndBranch', () => {
 
     it('throws on missing variable', async () => {
       process.env.GITHUB_EVENT_NAME = 'pull_request';
+      process.env.GITHUB_HEAD_REF = 'github';
+      await expect(getCommitAndBranch({ log })).rejects.toThrow(
+        'Missing GitHub environment variable'
+      );
+      process.env.GITHUB_HEAD_REF = '';
+      process.env.GITHUB_SHA = '3276c796';
       await expect(getCommitAndBranch({ log })).rejects.toThrow(
         'Missing GitHub environment variable'
       );
@@ -171,6 +178,7 @@ describe('getCommitAndBranch', () => {
       process.env.GITHUB_EVENT_NAME = 'pull_request';
       process.env.GITHUB_BASE_REF = 'github';
       process.env.GITHUB_HEAD_REF = 'github';
+      process.env.GITHUB_SHA = '3276c796';
       await expect(getCommitAndBranch({ log })).rejects.toThrow('Cross-fork PR builds unsupported');
     });
   });

--- a/bin-src/git/getCommitAndBranch.test.js
+++ b/bin-src/git/getCommitAndBranch.test.js
@@ -16,8 +16,8 @@ beforeEach(() => {
   getCommit.mockResolvedValue({
     commit: '48e0c83fadbf504c191bc868040b7a969a4f1feb',
     committedAt: 1640094096000,
-    committerEmail: 'noreply@github.com',
     committerName: 'GitHub',
+    committerEmail: 'noreply@github.com',
   });
   hasPreviousCommit.mockResolvedValue(true);
 });
@@ -28,6 +28,12 @@ afterEach(() => {
   getCommit.mockReset();
 });
 
+const commitInfo = {
+  committedAt: 1640131292,
+  committerName: 'Gert Hengeveld',
+  committerEmail: 'gert@chromatic.com',
+};
+
 describe('getCommitAndBranch', () => {
   it('returns commit and branch info', async () => {
     const info = await getCommitAndBranch({ log });
@@ -35,8 +41,8 @@ describe('getCommitAndBranch', () => {
       branch: 'main',
       commit: '48e0c83fadbf504c191bc868040b7a969a4f1feb',
       committedAt: 1640094096000,
-      committerEmail: 'noreply@github.com',
       committerName: 'GitHub',
+      committerEmail: 'noreply@github.com',
       slug: undefined,
     });
   });
@@ -111,11 +117,12 @@ describe('getCommitAndBranch', () => {
       process.env.CHROMATIC_SHA = 'f78db92d';
       process.env.CHROMATIC_BRANCH = 'feature';
       process.env.CHROMATIC_SLUG = 'chromaui/chromatic';
-      getCommit.mockImplementation((commit) => Promise.resolve({ commit }));
+      getCommit.mockImplementation((commit) => Promise.resolve({ commit, ...commitInfo }));
       const info = await getCommitAndBranch({ log });
       expect(info).toMatchObject({
         branch: 'feature',
         commit: 'f78db92d',
+        ...commitInfo,
         slug: 'chromaui/chromatic',
       });
     });
@@ -142,12 +149,13 @@ describe('getCommitAndBranch', () => {
       process.env.GITHUB_EVENT_NAME = 'pull_request';
       process.env.GITHUB_HEAD_REF = 'github';
       process.env.GITHUB_REPOSITORY = 'chromaui/github';
-      getCommit.mockResolvedValue({ commit: 'c11da9a9' });
+      getCommit.mockResolvedValue({ commit: 'c11da9a9', ...commitInfo });
       const info = await getCommitAndBranch({ log });
       expect(getCommit).toHaveBeenCalledWith('github');
       expect(info).toMatchObject({
         branch: 'github',
         commit: 'c11da9a9',
+        ...commitInfo,
         slug: 'chromaui/github',
       });
     });
@@ -173,11 +181,12 @@ describe('getCommitAndBranch', () => {
       process.env.TRAVIS_PULL_REQUEST_SHA = 'ef765ac7';
       process.env.TRAVIS_PULL_REQUEST_BRANCH = 'travis';
       process.env.TRAVIS_PULL_REQUEST_SLUG = 'chromaui/travis';
-      getCommit.mockImplementation((commit) => Promise.resolve({ commit }));
+      getCommit.mockImplementation((commit) => Promise.resolve({ commit, ...commitInfo }));
       const info = await getCommitAndBranch({ log });
       expect(info).toMatchObject({
         branch: 'travis',
         commit: 'ef765ac7',
+        ...commitInfo,
         slug: 'chromaui/travis',
       });
     });

--- a/bin-src/git/git.js
+++ b/bin-src/git/git.js
@@ -98,8 +98,10 @@ export async function getSlug() {
 // adhoc builds.
 
 // We could cache this, but it's probably pretty quick
-export async function getCommit() {
-  const result = await execGitCommand(`git --no-pager log -n 1 --format="%H ## %ct ## %ce ## %cn"`);
+export async function getCommit(revision = '') {
+  const result = await execGitCommand(
+    `git --no-pager log -n 1 --format="%H ## %ct ## %ce ## %cn" ${revision}`
+  );
   const [commit, committedAtSeconds, committerEmail, committerName] = result.split(' ## ');
   return { commit, committedAt: committedAtSeconds * 1000, committerEmail, committerName };
 }

--- a/bin-src/main.test.js
+++ b/bin-src/main.test.js
@@ -4,6 +4,7 @@ import { confirm } from 'node-ask';
 import kill from 'tree-kill';
 
 import jsonfile from 'jsonfile';
+import { getCommit } from './git/git';
 import getEnv from './lib/getEnv';
 import parseArgs from './lib/parseArgs';
 import startApp, { checkResponse } from './lib/startStorybook';
@@ -158,13 +159,7 @@ fs.statSync = jest.fn((path) => {
 
 jest.mock('./git/git', () => ({
   hasPreviousCommit: () => Promise.resolve(true),
-  getCommit: () =>
-    Promise.resolve({
-      commit: 'commit',
-      committedAt: 1234,
-      committerEmail: 'test@test.com',
-      committerName: 'tester',
-    }),
+  getCommit: jest.fn(),
   getBranch: () => Promise.resolve('branch'),
   getParentCommits: () => Promise.resolve(['baseline']),
   getSlug: () => Promise.resolve('user/repo'),
@@ -190,6 +185,14 @@ beforeEach(() => {
   };
   execa.mockReset();
   execa.mockReturnValue(Promise.resolve({ stdout: '1.2.3' }));
+  getCommit.mockReturnValue(
+    Promise.resolve({
+      commit: 'commit',
+      committedAt: 1234,
+      committerEmail: 'test@test.com',
+      committerName: 'tester',
+    })
+  );
 });
 afterEach(() => {
   process.env = processEnv;
@@ -505,6 +508,14 @@ describe('in CI', () => {
       TRAVIS_PULL_REQUEST_BRANCH: 'travis-branch',
       DISABLE_LOGGING: 'true',
     };
+    getCommit.mockReturnValue(
+      Promise.resolve({
+        commit: 'travis-commit',
+        committedAt: 1234,
+        committerEmail: 'test@test.com',
+        committerName: 'tester',
+      })
+    );
     const ctx = getContext(['--project-token=asdf1234']);
     await runBuild(ctx);
     expect(ctx.exitCode).toBe(1);
@@ -530,6 +541,14 @@ describe('in CI', () => {
       TRAVIS_PULL_REQUEST_BRANCH: 'travis-branch',
       DISABLE_LOGGING: 'true',
     };
+    getCommit.mockReturnValue(
+      Promise.resolve({
+        commit: 'travis-commit',
+        committedAt: 1234,
+        committerEmail: 'test@test.com',
+        committerName: 'tester',
+      })
+    );
     const ctx = getContext(['--project-token=asdf1234']);
     await runBuild(ctx);
     expect(ctx.exitCode).toBe(1);

--- a/bin-src/tasks/gitInfo.js
+++ b/bin-src/tasks/gitInfo.js
@@ -41,7 +41,7 @@ const TesterLastBuildQuery = `
 
 export const setGitInfo = async (ctx, task) => {
   const { branchName, patchBaseRef, fromCI: ci } = ctx.options;
-  ctx.git = await getCommitAndBranch({ branchName, patchBaseRef, ci, log: ctx.log });
+  ctx.git = await getCommitAndBranch(ctx, { branchName, patchBaseRef, ci });
   ctx.git.version = await getVersion();
   if (!ctx.git.slug) {
     ctx.git.slug = await getSlug().catch((e) => ctx.log.warn('Failed to retrieve slug', e));

--- a/bin-src/tasks/upload.test.js
+++ b/bin-src/tasks/upload.test.js
@@ -9,7 +9,7 @@ jest.mock('progress-stream');
 jest.mock('../lib/getDependentStoryFiles');
 
 const env = { CHROMATIC_RETRIES: 2 };
-const log = { warn: jest.fn(), debug: jest.fn() };
+const log = { info: jest.fn(), warn: jest.fn(), debug: jest.fn() };
 const http = { fetch: jest.fn() };
 
 describe('validateFiles', () => {

--- a/bin-src/ui/messages/errors/missingGitHubInfo.js
+++ b/bin-src/ui/messages/errors/missingGitHubInfo.js
@@ -7,7 +7,6 @@ import link from '../../components/link';
 export default ({ GITHUB_EVENT_NAME }) =>
   dedent(chalk`
     ${error} {bold Missing GitHub environment variable}
-    \`GITHUB_EVENT_NAME\` environment variable set to '${GITHUB_EVENT_NAME}', but
-    \`GITHUB_SHA\` and \`GITHUB_REF\` are not both set.
+    \`GITHUB_EVENT_NAME\` environment variable set to '${GITHUB_EVENT_NAME}', but \`GITHUB_HEAD_REF\` is not set.
     ${info} Read more at ${link('https://www.chromatic.com/docs/github-actions')}
   `);

--- a/bin-src/ui/messages/errors/missingGitHubInfo.js
+++ b/bin-src/ui/messages/errors/missingGitHubInfo.js
@@ -7,6 +7,7 @@ import link from '../../components/link';
 export default ({ GITHUB_EVENT_NAME }) =>
   dedent(chalk`
     ${error} {bold Missing GitHub environment variable}
-    \`GITHUB_EVENT_NAME\` environment variable set to '${GITHUB_EVENT_NAME}', but \`GITHUB_HEAD_REF\` is not set.
+    \`GITHUB_EVENT_NAME\` environment variable set to '${GITHUB_EVENT_NAME}', but
+    \`GITHUB_SHA\` and \`GITHUB_HEAD_REF\` are not both set.
     ${info} Read more at ${link('https://www.chromatic.com/docs/github-actions')}
   `);

--- a/bin-src/ui/messages/errors/missingGitHubInfo.js
+++ b/bin-src/ui/messages/errors/missingGitHubInfo.js
@@ -7,7 +7,6 @@ import link from '../../components/link';
 export default ({ GITHUB_EVENT_NAME }) =>
   dedent(chalk`
     ${error} {bold Missing GitHub environment variable}
-    \`GITHUB_EVENT_NAME\` environment variable set to '${GITHUB_EVENT_NAME}', but
-    \`GITHUB_SHA\` and \`GITHUB_HEAD_REF\` are not both set.
+    \`GITHUB_EVENT_NAME\` environment variable is set to '${GITHUB_EVENT_NAME}', but \`GITHUB_SHA\` and \`GITHUB_HEAD_REF\` are not both set.
     ${info} Read more at ${link('https://www.chromatic.com/docs/github-actions')}
   `);

--- a/bin-src/ui/messages/info/customGitHubAction.js
+++ b/bin-src/ui/messages/info/customGitHubAction.js
@@ -1,0 +1,12 @@
+import chalk from 'chalk';
+import { dedent } from 'ts-dedent';
+
+import { info } from '../../components/icons';
+import link from '../../components/link';
+
+export default () =>
+  dedent(chalk`
+    ${info} {bold Use our GitHub Action}
+    It appears you are using a GitHub Actions workflow, but are not using the official GitHub Action for Chromatic.
+    Find it at ${link('https://github.com/marketplace/actions/publish-to-chromatic')}
+  `);

--- a/bin-src/ui/messages/info/customGitHubAction.stories.js
+++ b/bin-src/ui/messages/info/customGitHubAction.stories.js
@@ -1,0 +1,7 @@
+import customGitHubAction from './customGitHubAction';
+
+export default {
+  title: 'CLI/Messages/Info',
+};
+
+export const CustomGitHubAction = () => customGitHubAction();

--- a/bin-src/ui/messages/warnings/noCommitDetails.js
+++ b/bin-src/ui/messages/warnings/noCommitDetails.js
@@ -1,0 +1,18 @@
+import chalk from 'chalk';
+import { dedent } from 'ts-dedent';
+
+import { warning } from '../../components/icons';
+
+export default (sha, envVar) =>
+  envVar
+    ? dedent(chalk`
+      ${warning} {bold Commit ${sha.substr(0, 7)} does not exist}
+      We tried to retrieve the commit details but couldn't find it in your Git history.
+      Check your {bold ${envVar}} environment variable.
+      Continuing with just the commit hash.
+    `)
+    : dedent(chalk`
+      ${warning} {bold Commit ${sha.substr(0, 7)} does not exist}
+      We tried to retrieve the commit details but couldn't find it in your Git history.
+      Continuing with just the commit hash.
+    `);

--- a/bin-src/ui/messages/warnings/noCommitDetails.stories.js
+++ b/bin-src/ui/messages/warnings/noCommitDetails.stories.js
@@ -1,0 +1,10 @@
+import noCommitDetails from './noCommitDetails';
+
+export default {
+  title: 'CLI/Messages/Warnings',
+};
+
+export const NoCommitDetails = () => noCommitDetails('57745fe300dfee73c8c068154867c9366ad5ab99');
+
+export const NoCommitDetailsEnvironment = () =>
+  noCommitDetails('57745fe300dfee73c8c068154867c9366ad5ab99', 'CHROMATIC_SHA');


### PR DESCRIPTION
When passing the commit SHA using an environment variable (either explicitly or by using GitHub Actions or Travis), also set the committer name / email or show a warning when the given commit isn't found in history.