### PR TITLE
Fix untracing changed package files

### DIFF
--- a/bin-src/lib/getDependentStoryFiles.js
+++ b/bin-src/lib/getDependentStoryFiles.js
@@ -49,8 +49,6 @@ export async function getDependentStoryFiles(ctx, stats, statsPath, changedFiles
   const { configDir = '.storybook', staticDir = [], viewLayer } = ctx.storybook || {};
   const { storybookBaseDir, untraced = [] } = ctx.options;
 
-  // Currently we enforce Storybook to be built by the Chromatic CLI, to ensure absolute paths match
-  // up between the webpack stats and the git repo root.
   const rootPath = await getRepositoryRoot(); // e.g. `/path/to/project` (always absolute posix)
   const workingDir = getWorkingDir(rootPath, storybookBaseDir); // e.g. `packages/storybook` or empty string
   const normalize = (posixPath) => normalizePath(posixPath, rootPath, workingDir); // e.g. `src/file.js` (no ./ prefix)

--- a/bin-src/lib/getDependentStoryFiles.js
+++ b/bin-src/lib/getDependentStoryFiles.js
@@ -122,7 +122,7 @@ export async function getDependentStoryFiles(ctx, stats, statsPath, changedFiles
   const checkedIds = {};
   const toCheck = [];
 
-  const changedPackageFile = changedFiles.find(isPackageFile);
+  const changedPackageFile = tracedFiles.find(isPackageFile);
   if (changedPackageFile) ctx.turboSnap.bailReason = { changedPackageFile };
 
   function shouldBail(name) {


### PR DESCRIPTION
Previously, `--untraced` would not be respected for changes to package files, making it impossible to ignore those, regardless of where they are in the repository. This fixes that.

I also dropped an outdated comment.