### PR TITLE
Handle the `CANCELLED` build status separately

### DIFF
--- a/bin-src/lib/setExitCode.js
+++ b/bin-src/lib/setExitCode.js
@@ -12,6 +12,7 @@ export const exitCodes = {
   BUILD_FAILED: 3,
   BUILD_NO_STORIES: 4,
   BUILD_WAS_LIMITED: 5,
+  BUILD_CANCELLED: 6,
 
   // Chromatic account issues
   ACCOUNT_QUOTA_REACHED: 11,

--- a/bin-src/lib/setExitCode.js
+++ b/bin-src/lib/setExitCode.js
@@ -12,7 +12,7 @@ export const exitCodes = {
   BUILD_FAILED: 3,
   BUILD_NO_STORIES: 4,
   BUILD_WAS_LIMITED: 5,
-  BUILD_CANCELLED: 6,
+  BUILD_CANCELED: 6,
 
   // Chromatic account issues
   ACCOUNT_QUOTA_REACHED: 11,

--- a/bin-src/lib/setExitCode.js
+++ b/bin-src/lib/setExitCode.js
@@ -12,7 +12,7 @@ export const exitCodes = {
   BUILD_FAILED: 3,
   BUILD_NO_STORIES: 4,
   BUILD_WAS_LIMITED: 5,
-  BUILD_CANCELED: 6,
+  BUILD_WAS_CANCELED: 6,
 
   // Chromatic account issues
   ACCOUNT_QUOTA_REACHED: 11,

--- a/bin-src/tasks/snapshot.js
+++ b/bin-src/tasks/snapshot.js
@@ -8,9 +8,10 @@ import buildPassedMessage from '../ui/messages/info/buildPassed';
 import speedUpCI from '../ui/messages/info/speedUpCI';
 import {
   buildComplete,
-  buildError,
-  buildFailed,
   buildPassed,
+  buildBroken,
+  buildFailed,
+  buildCancelled,
   initial,
   dryRun,
   skipped,
@@ -95,13 +96,17 @@ export const takeSnapshots = async (ctx, task) => {
     case 'BROKEN':
       setExitCode(ctx, exitCodes.BUILD_HAS_ERRORS, true);
       ctx.log.error(buildHasErrors(ctx));
-      transitionTo(buildFailed, true)(ctx, task);
+      transitionTo(buildBroken, true)(ctx, task);
       break;
 
     case 'FAILED':
-    case 'CANCELLED':
       setExitCode(ctx, exitCodes.BUILD_FAILED, true);
-      transitionTo(buildError, true)(ctx, task);
+      transitionTo(buildFailed, true)(ctx, task);
+      break;
+
+    case 'CANCELLED':
+      setExitCode(ctx, exitCodes.BUILD_CANCELLED, true);
+      transitionTo(buildCancelled, true)(ctx, task);
       break;
 
     default:

--- a/bin-src/tasks/snapshot.js
+++ b/bin-src/tasks/snapshot.js
@@ -105,7 +105,7 @@ export const takeSnapshots = async (ctx, task) => {
       break;
 
     case 'CANCELLED':
-      setExitCode(ctx, exitCodes.BUILD_CANCELED, true);
+      setExitCode(ctx, exitCodes.BUILD_WAS_CANCELED, true);
       transitionTo(buildCanceled, true)(ctx, task);
       break;
 

--- a/bin-src/tasks/snapshot.js
+++ b/bin-src/tasks/snapshot.js
@@ -11,7 +11,7 @@ import {
   buildPassed,
   buildBroken,
   buildFailed,
-  buildCancelled,
+  buildCanceled,
   initial,
   dryRun,
   skipped,
@@ -105,8 +105,8 @@ export const takeSnapshots = async (ctx, task) => {
       break;
 
     case 'CANCELLED':
-      setExitCode(ctx, exitCodes.BUILD_CANCELLED, true);
-      transitionTo(buildCancelled, true)(ctx, task);
+      setExitCode(ctx, exitCodes.BUILD_CANCELED, true);
+      transitionTo(buildCanceled, true)(ctx, task);
       break;
 
     default:

--- a/bin-src/ui/tasks/snapshot.js
+++ b/bin-src/ui/tasks/snapshot.js
@@ -81,11 +81,11 @@ export const buildFailed = (ctx) => {
   };
 };
 
-export const buildCancelled = (ctx) => {
+export const buildCanceled = (ctx) => {
   return {
     status: 'error',
-    title: `Build ${ctx.build.number} cancelled`,
-    output: `Someone cancelled the build before it completed`,
+    title: `Build ${ctx.build.number} canceled`,
+    output: `Someone canceled the build before it completed`,
   };
 };
 

--- a/bin-src/ui/tasks/snapshot.js
+++ b/bin-src/ui/tasks/snapshot.js
@@ -17,7 +17,7 @@ export const dryRun = () => ({
 export const stats = (ctx) => {
   return {
     tests: pluralize('test', ctx.build.actualTestCount, true),
-    errors: pluralize('error', ctx.build.errorCount, true),
+    errors: pluralize('component error', ctx.build.errorCount, true),
     changes: pluralize('change', ctx.build.changeCount, true),
     stories: pluralize('story', ctx.build.specCount, true),
     components: pluralize('component', ctx.build.componentCount, true),
@@ -64,7 +64,7 @@ export const buildComplete = (ctx) => {
   };
 };
 
-export const buildFailed = (ctx) => {
+export const buildBroken = (ctx) => {
   const { snapshots, components, stories, errors } = stats(ctx);
   return {
     status: 'error',
@@ -73,11 +73,19 @@ export const buildFailed = (ctx) => {
   };
 };
 
-export const buildError = (ctx) => {
+export const buildFailed = (ctx) => {
   return {
     status: 'error',
-    title: `Build ${ctx.build.number} errored`,
+    title: `Build ${ctx.build.number} failed due to system error`,
     output: `Please try again, or contact us if the problem persists`,
+  };
+};
+
+export const buildCancelled = (ctx) => {
+  return {
+    status: 'error',
+    title: `Build ${ctx.build.number} cancelled`,
+    output: `Someone cancelled the build before it completed`,
   };
 };
 

--- a/bin-src/ui/tasks/snapshot.stories.js
+++ b/bin-src/ui/tasks/snapshot.stories.js
@@ -103,7 +103,7 @@ export const BuildCanceled = () =>
     build,
     now,
     startedAt,
-    exitCode: exitCodes.BUILD_CANCELED,
+    exitCode: exitCodes.BUILD_WAS_CANCELED,
   });
 
 export const SkippedPublishOnly = () =>

--- a/bin-src/ui/tasks/snapshot.stories.js
+++ b/bin-src/ui/tasks/snapshot.stories.js
@@ -5,7 +5,7 @@ import {
   buildBroken,
   buildPassed,
   buildFailed,
-  buildCancelled,
+  buildCanceled,
   initial,
   dryRun,
   pending,
@@ -98,12 +98,12 @@ export const BuildFailed = () =>
     exitCode: exitCodes.BUILD_FAILED,
   });
 
-export const BuildCancelled = () =>
-  buildCancelled({
+export const BuildCanceled = () =>
+  buildCanceled({
     build,
     now,
     startedAt,
-    exitCode: exitCodes.BUILD_CANCELLED,
+    exitCode: exitCodes.BUILD_CANCELED,
   });
 
 export const SkippedPublishOnly = () =>

--- a/bin-src/ui/tasks/snapshot.stories.js
+++ b/bin-src/ui/tasks/snapshot.stories.js
@@ -1,9 +1,11 @@
+import { exitCodes } from '../../lib/setExitCode';
 import task from '../components/task';
 import {
   buildComplete,
-  buildError,
-  buildFailed,
+  buildBroken,
   buildPassed,
+  buildFailed,
+  buildCancelled,
   initial,
   dryRun,
   pending,
@@ -80,20 +82,28 @@ export const BuildAutoAccepted = () =>
     startedAt,
   });
 
+export const BuildBroken = () =>
+  buildBroken({
+    build,
+    now,
+    startedAt,
+    exitCode: exitCodes.BUILD_HAS_ERRORS,
+  });
+
 export const BuildFailed = () =>
   buildFailed({
     build,
     now,
     startedAt,
-    exitCode: 2,
+    exitCode: exitCodes.BUILD_FAILED,
   });
 
-export const BuildError = () =>
-  buildError({
+export const BuildCancelled = () =>
+  buildCancelled({
     build,
     now,
     startedAt,
-    exitCode: 3,
+    exitCode: exitCodes.BUILD_CANCELLED,
   });
 
 export const SkippedPublishOnly = () =>


### PR DESCRIPTION
Currently it's getting lumped in with `FAILED` but they are two different things so I split them up.

Note I used the correct spelling here, but the Chromatic API still gives us the wrong spelling. Not sure what to do about that.

Docs update: https://github.com/chromaui/chromatic-docs/pull/102