### PR TITLE
Use commit author info instead of committer info [CH-1282]

### DIFF
--- a/bin-src/git/git.js
+++ b/bin-src/git/git.js
@@ -101,7 +101,7 @@ export async function getSlug() {
 export async function getCommit(revision = '') {
   const result = await execGitCommand(
     // Technically this yields the author info, not committer info
-    `git --no-pager log -n 1 --format="%H ## %at ## %ae ## %an" ${revision}`
+    `git --no-pager log -n 1 --format="%H ## %ct ## %ae ## %an" ${revision}`
   );
   const [commit, committedAtSeconds, committerEmail, committerName] = result.split(' ## ');
   return { commit, committedAt: committedAtSeconds * 1000, committerEmail, committerName };

--- a/bin-src/git/git.js
+++ b/bin-src/git/git.js
@@ -100,7 +100,8 @@ export async function getSlug() {
 // We could cache this, but it's probably pretty quick
 export async function getCommit(revision = '') {
   const result = await execGitCommand(
-    `git --no-pager log -n 1 --format="%H ## %ct ## %ce ## %cn" ${revision}`
+    // Technically this yields the author info, not committer info
+    `git --no-pager log -n 1 --format="%H ## %at ## %ae ## %an" ${revision}`
   );
   const [commit, committedAtSeconds, committerEmail, committerName] = result.split(' ## ');
   return { commit, committedAt: committedAtSeconds * 1000, committerEmail, committerName };


### PR DESCRIPTION
This updates the log format to yield the author info, which is more correct for merge commits.