### PR TITLE
Handle the case where both ref+sha are unset on workflow_dispatch

### DIFF
--- a/action-src/main.ts
+++ b/action-src/main.ts
@@ -54,15 +54,10 @@ const getBuildInfo = (event: typeof context) => {
       };
     }
     case 'workflow_dispatch': {
-      const { ref, sha } = event.payload.inputs;
+      const { ref, sha } = event.payload.inputs || {};
 
-      if (!ref) {
-        setFailed(`When triggering via workflow_dispatch, ref is a required input.`);
-        return null;
-      }
-
-      if (!sha) {
-        setFailed(`When triggering via workflow_dispatch, sha is a required input.`);
+      if (!ref || !sha) {
+        setFailed(`When triggering via workflow_dispatch, ref & sha are required inputs.`);
         return null;
       }
 

--- a/action-src/main.ts
+++ b/action-src/main.ts
@@ -57,7 +57,7 @@ const getBuildInfo = (event: typeof context) => {
       const { ref, sha } = event.payload.inputs || {};
 
       if (!ref || !sha) {
-        setFailed(`When triggering via workflow_dispatch, ref & sha are required inputs.`);
+        setFailed(`When triggering via workflow_dispatch, ref & sha are required inputs. See https://github.com/chromaui/action#triggering-from-workflow_dispatch`);
         return null;
       }
 


### PR DESCRIPTION
This was leading to this error, I guess:

```
Cannot read property 'ref' of undefined
```

I'm actually not entirely sure how to reproduce.