### PR TITLE
Add `--force-rebuild` to prevent skipping on rebuild

### DIFF
--- a/.github/workflows/smoke-test-action.yml
+++ b/.github/workflows/smoke-test-action.yml
@@ -12,6 +12,7 @@ jobs:
         with:
           buildScriptName: build-test-storybook
           exitZeroOnChanges: true
+          forceRebuild: true
         env:
           LOG_LEVEL: debug
           DEBUG: chromatic-cli

--- a/.github/workflows/smoke-test-node12.yml
+++ b/.github/workflows/smoke-test-node12.yml
@@ -17,6 +17,7 @@ jobs:
         with:
           buildScriptName: build-test-storybook
           exitZeroOnChanges: true
+          forceRebuild: true
         env:
           LOG_LEVEL: debug
           DEBUG: chromatic-cli

--- a/.github/workflows/smoke-test-npx.yml
+++ b/.github/workflows/smoke-test-npx.yml
@@ -15,7 +15,7 @@ jobs:
         run: ./scripts/rename.js storybook-chromatic
       - run: yarn bundle:bin
       - name: run chromatic
-        run: npx -p . chromatic --build-script-name build-test-storybook --exit-zero-on-changes
+        run: npx -p . chromatic --build-script-name build-test-storybook --exit-zero-on-changes --force-rebuild
         env:
           LOG_LEVEL: debug
           DEBUG: chromatic-cli

--- a/.github/workflows/smoke-test-windows.yml
+++ b/.github/workflows/smoke-test-windows.yml
@@ -15,7 +15,7 @@ jobs:
         run: node ./scripts/rename.js storybook-chromatic
       - run: yarn bundle:bin
       - name: run chromatic
-        run: npx -p . chromatic --build-script-name build-test-storybook --exit-zero-on-changes
+        run: npx -p . chromatic --build-script-name build-test-storybook --exit-zero-on-changes --force-rebuild
         env:
           LOG_LEVEL: debug
           DEBUG: chromatic-cli

--- a/.github/workflows/smoke-test-yarn-berry.yml
+++ b/.github/workflows/smoke-test-yarn-berry.yml
@@ -12,7 +12,7 @@ jobs:
       - run: yarn install
       - run: yarn set version berry
       - name: run chromatic
-        run: npx -p . chromatic --build-script-name build-test-storybook --exit-zero-on-changes
+        run: npx -p . chromatic --build-script-name build-test-storybook --exit-zero-on-changes --force-rebuild
         env:
           LOG_LEVEL: debug
           DEBUG: chromatic-cli

--- a/.github/workflows/smoke-test-yarn-canary.yml
+++ b/.github/workflows/smoke-test-yarn-canary.yml
@@ -13,7 +13,7 @@ jobs:
       - run: yarn set version berry
       - run: yarn set version canary
       - name: run chromatic
-        run: npx -p . chromatic --build-script-name build-test-storybook --exit-zero-on-changes
+        run: npx -p . chromatic --build-script-name build-test-storybook --exit-zero-on-changes --force-rebuild
         env:
           LOG_LEVEL: debug
           DEBUG: chromatic-cli

--- a/.github/workflows/smoke-test-yarn-classic.yml
+++ b/.github/workflows/smoke-test-yarn-classic.yml
@@ -12,7 +12,7 @@ jobs:
       - run: yarn install
       - run: yarn set version 1.x.x
       - name: run chromatic
-        run: npx -p . chromatic --build-script-name build-test-storybook --exit-zero-on-changes
+        run: npx -p . chromatic --build-script-name build-test-storybook --exit-zero-on-changes --force-rebuild
         env:
           LOG_LEVEL: debug
           DEBUG: chromatic-cli

--- a/.github/workflows/smoke-test-yarn.yml
+++ b/.github/workflows/smoke-test-yarn.yml
@@ -8,7 +8,7 @@ jobs:
       - uses: actions/checkout@v1
       - run: yarn
       - run: yarn bundle:bin
-      - run: yarn chromatic --build-script-name build-test-storybook --exit-zero-on-changes
+      - run: yarn chromatic --build-script-name build-test-storybook --exit-zero-on-changes --force-rebuild
         env:
           LOG_LEVEL: debug
           DEBUG: chromatic-cli

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - [495](https://github.com/chromaui/chromatic-cli/pull/495) TurboSnap: Add `--trace-changed` flag and `trace` utility
 - [490](https://github.com/chromaui/chromatic-cli/pull/490) TurboSnap: Detect mismatching entry file and suggest a fix
+- [502](https://github.com/chromaui/chromatic-cli/pull/502) Add `--force-rebuild` to prevent skipping on rebuild
 - [500](https://github.com/chromaui/chromatic-cli/pull/500) Use commit author info instead of committer info
 - [487](https://github.com/chromaui/chromatic-cli/pull/487) Improve how process exit code is set
 - [488](https://github.com/chromaui/chromatic-cli/pull/488) Fix `--untraced` for package files

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,11 @@
-# 6.4.0 - unreleased
+# 6.4.0 - 2022-01-18
 
+- [495](https://github.com/chromaui/chromatic-cli/pull/495) TurboSnap: Add `--trace-changed` flag and `trace` utility
 - [490](https://github.com/chromaui/chromatic-cli/pull/490) TurboSnap: Detect mismatching entry file and suggest a fix
-- [495](https://github.com/chromaui/chromatic-cli/pull/495) Allow tracing changed files to affected story files
 - [500](https://github.com/chromaui/chromatic-cli/pull/500) Use commit author info instead of committer info
 - [487](https://github.com/chromaui/chromatic-cli/pull/487) Improve how process exit code is set
 - [488](https://github.com/chromaui/chromatic-cli/pull/488) Fix `--untraced` for package files
+- [474](https://github.com/chromaui/chromatic-cli/pull/474) Fix commit status update for UI Review when using `--skip`
 
 # 6.3.4 - 2022-01-10
 

--- a/action-src/main.ts
+++ b/action-src/main.ts
@@ -126,6 +126,8 @@ async function run() {
     const scriptName = getInput('scriptName');
     const exec = getInput('exec');
     const skip = getInput('skip');
+    const dryRun = getInput('dryRun');
+    const forceRebuild = getInput('forceRebuild');
     const storybookBaseDir = getInput('storybookBaseDir');
     const storybookConfigDir = getInput('storybookConfigDir');
     const only = getInput('only');
@@ -164,6 +166,8 @@ async function run() {
       diagnostics: maybe(diagnostics),
       exec: maybe(exec),
       skip: maybe(skip),
+      dryRun: maybe(dryRun),
+      forceRebuild: maybe(forceRebuild),
       only: maybe(only),
       onlyChanged: maybe(onlyChanged),
       externals: maybe(externals),

--- a/action.yml
+++ b/action.yml
@@ -30,6 +30,12 @@ inputs:
   skip:
     description: 'Skip Chromatic tests, but mark the commit as passing'
     required: false
+  dryRun:
+    description: 'Run without actually publishing to Chromatic'
+    required: false
+  forceRebuild:
+    description: 'Do not skip build when a rebuild is detected'
+    required: false
   storybookBaseDir:
     description: 'Relative path from repository root to Storybook project root'
     required: false

--- a/bin-src/lib/getOptions.js
+++ b/bin-src/lib/getOptions.js
@@ -47,6 +47,7 @@ export default async function getOptions({ argv, env, flags, log, packageJson })
     fromCI,
     skip: trueIfSet(flags.skip),
     dryRun: !!flags.dryRun,
+    forceRebuild: trueIfSet(flags.forceRebuild),
     verbose: !!flags.debug,
     interactive: !flags.debug && !fromCI && !!flags.interactive && !!process.stdout.isTTY,
     junitReport: trueIfSet(flags.junitReport),

--- a/bin-src/lib/parseArgs.js
+++ b/bin-src/lib/parseArgs.js
@@ -37,7 +37,7 @@ export default function parseArgs(argv) {
       --ci  Mark this build as a CI build. Alternatively, set the CI environment variable (present in most CI systems). This option implies --no-interactive.
       --debug  Output verbose debugging information. This option implies --no-interactive.
       --dry-run  Run without actually publishing to Chromatic.
-      --force-rebuild  Do not skip build when a rebuild is detected. Only for [branch], if specified. Globs are supported via picomatch.
+      --force-rebuild [branch]  Do not skip build when a rebuild is detected. Only for [branch], if specified. Globs are supported via picomatch.
       --junit-report [filepath]  Write build results to a JUnit XML file. {buildNumber} will be replaced with the actual build number. [chromatic-build-{buildNumber}.xml]
       --list  List available stories. This requires running a full build.
       --no-interactive  Don't ask interactive questions about your setup and don't overwrite output. Always true in non-TTY environments.

--- a/bin-src/lib/parseArgs.js
+++ b/bin-src/lib/parseArgs.js
@@ -37,6 +37,7 @@ export default function parseArgs(argv) {
       --ci  Mark this build as a CI build. Alternatively, set the CI environment variable (present in most CI systems). This option implies --no-interactive.
       --debug  Output verbose debugging information. This option implies --no-interactive.
       --dry-run  Run without actually publishing to Chromatic.
+      --force-rebuild  Do not skip build when a rebuild is detected. Only for [branch], if specified. Globs are supported via picomatch.
       --junit-report [filepath]  Write build results to a JUnit XML file. {buildNumber} will be replaced with the actual build number. [chromatic-build-{buildNumber}.xml]
       --list  List available stories. This requires running a full build.
       --no-interactive  Don't ask interactive questions about your setup and don't overwrite output. Always true in non-TTY environments.
@@ -80,6 +81,7 @@ export default function parseArgs(argv) {
         debug: { type: 'boolean' },
         diagnostics: { type: 'boolean' },
         dryRun: { type: 'boolean' },
+        forceRebuild: { type: 'string' },
         junitReport: { type: 'string' },
         list: { type: 'boolean' },
         interactive: { type: 'boolean', default: true },

--- a/bin-src/tasks/gitInfo.js
+++ b/bin-src/tasks/gitInfo.js
@@ -86,7 +86,10 @@ export const setGitInfo = async (ctx, task) => {
     const mostRecentAncestor = result && result.app && result.app.lastBuild;
     if (mostRecentAncestor) {
       ctx.rebuildForBuildId = mostRecentAncestor.id;
-      if (['PASSED', 'ACCEPTED'].includes(mostRecentAncestor.status)) {
+      if (
+        ['PASSED', 'ACCEPTED'].includes(mostRecentAncestor.status) &&
+        !matchesBranch(ctx.options.forceRebuild)
+      ) {
         ctx.skip = true;
         transitionTo(skippedRebuild, true)(ctx, task);
         ctx.exitCode = 0;

--- a/bin-src/ui/messages/errors/noCSFGlobs.js
+++ b/bin-src/ui/messages/errors/noCSFGlobs.js
@@ -7,8 +7,8 @@ import link from '../../components/link';
 export default ({ statsPath, storybookDir, storybookBuildDir, entryFile, viewLayer = 'react' }) => {
   if (entryFile) {
     const hint = storybookBuildDir
-      ? `Configure {bold --storybook-config-dir} with the value for {bold --config-dir} or {bold -c} from your build-storybook script.`
-      : `Configure {bold --build-script-name} to point at the {bold build-storybook} script which has {bold --config-dir} or {bold -c} set.`;
+      ? chalk`Configure {bold --storybook-config-dir} with the value for {bold --config-dir} or {bold -c} from your build-storybook script.`
+      : chalk`Configure {bold --build-script-name} to point at the {bold build-storybook} script which has {bold --config-dir} or {bold -c} set.`;
     return dedent(chalk`
       ${error} Did not find any CSF globs in {bold ${statsPath}}
       Found an entry file at {bold ${entryFile}} but expected it at {bold ${storybookDir}/generated-stories-entry.js}.


### PR DESCRIPTION
Also adds `dryRun` to the GitHub Action options, as it was missing.

We need this for our own CI tests because we run the same build multiple times with various versions of the CLI. Right now our smoke tests are succeeding because they skip "due to rebuild".