### PR TITLE
Fix consistent naming of flags for `trace` util

### DIFF
--- a/bin-src/trace.js
+++ b/bin-src/trace.js
@@ -45,6 +45,7 @@ export async function main(argv) {
     `,
     {
       argv,
+      description: 'Trace utility for TurboSnap',
       flags: {
         statsFile: {
           type: 'string',

--- a/bin-src/trace.js
+++ b/bin-src/trace.js
@@ -36,30 +36,30 @@ export async function main(argv) {
       $ chromatic trace [-b|--base-dir] [-c|--config-dir] [-s|--stats-file] [-u|--untraced] [-m|--mode] [<changed files>...]
 
     Options
-      <changed files>...  List of changed files relative to repository root.
-      --base-dir <dirname>, -b  Relative path from repository root to Storybook project root. Alternatively, set STORYBOOK_BASE_DIR. Use when your Storybook is located in a subdirectory of your repository.
-      --config-dir <dirname>, -c  Directory where to load Storybook configurations from. Alternatively, set STORYBOOK_CONFIG_DIR. (default: '.storybook')
-      --stats-file <filepath>, -s  Path to preview-stats.json. Alternatively, set WEBPACK_STATS_FILE. (default: 'storybook-static/preview-stats.json')
-      --untraced <filepath>, -u  Disregard these files and their dependencies. Globs are supported via picomatch. This flag can be specified multiple times.
-      --mode <mode>, -m  Set to 'expanded' to reveal the underlying list of files for each bundle, or set to 'compact' to only show a flat list of affected story files.
+      <changed files>...                    List of changed files relative to repository root.
+      --stats-file, -s <filepath>           Path to preview-stats.json. Alternatively, set WEBPACK_STATS_FILE. (default: 'storybook-static/preview-stats.json')
+      --storybook-base-dir, -b <dirname>    Relative path from repository root to Storybook project root. Alternatively, set STORYBOOK_BASE_DIR. Use when your Storybook is located in a subdirectory of your repository.
+      --storybook-config-dir, -c <dirname>  Directory where to load Storybook configurations from. Alternatively, set STORYBOOK_CONFIG_DIR. (default: '.storybook')
+      --untraced, -u <filepath>             Disregard these files and their dependencies. Globs are supported via picomatch. This flag can be specified multiple times.
+      --mode, -m <mode>                     Set to 'expanded' to reveal the underlying list of files for each bundle, or set to 'compact' to only show a flat list of affected story files.
     `,
     {
       argv,
       flags: {
-        baseDir: {
-          type: 'string',
-          alias: 'b',
-          default: STORYBOOK_BASE_DIR || '.',
-        },
-        configDir: {
-          type: 'string',
-          alias: 'c',
-          default: STORYBOOK_CONFIG_DIR || '.storybook',
-        },
         statsFile: {
           type: 'string',
           alias: 's',
           default: WEBPACK_STATS_FILE || 'storybook-static/preview-stats.json',
+        },
+        storybookBaseDir: {
+          type: 'string',
+          alias: 'b',
+          default: STORYBOOK_BASE_DIR || '.',
+        },
+        storybookConfigDir: {
+          type: 'string',
+          alias: 'c',
+          default: STORYBOOK_CONFIG_DIR || '.storybook',
         },
         untraced: {
           type: 'string',
@@ -77,8 +77,8 @@ export async function main(argv) {
   const ctx = {
     log: console,
     options: {
-      storybookBaseDir: flags.baseDir,
-      storybookConfigDir: flags.configDir,
+      storybookBaseDir: flags.storybookBaseDir,
+      storybookConfigDir: flags.storybookConfigDir,
       untraced: flags.untraced,
       traceChanged: flags.mode || true,
     },


### PR DESCRIPTION
The main Chromatic CLI has `--storybook-base-dir` and `--storybook-config-dir`. This PR updates the flags for `trace` to use the same names.

This can be a patch release because `trace` is undocumented, effectively in beta, and not part of anyone's CI job.