### PR TITLE
also use pathname for creating proxy.

### DIFF
--- a/bin-src/io/getProxyAgent.js
+++ b/bin-src/io/getProxyAgent.js
@@ -11,9 +11,9 @@ const getProxyAgent = ({ env, log }, url, options = {}) => {
   log.debug({ url, proxy, options }, 'Using proxy agent');
   const requestHost = new URL(url).host;
   if (!agents[requestHost]) {
-    const { hostname, port, protocol, username, password } = new URL(proxy);
+    const { hostname, port, protocol, username, password, pathname } = new URL(proxy);
     const auth = username && password ? `${username}:${password}` : undefined;
-    agents[requestHost] = new HttpsProxyAgent({ auth, hostname, port, protocol, ...options });
+    agents[requestHost] = new HttpsProxyAgent({ auth, hostname, port, protocol, pathname, ...options });
   }
   return agents[requestHost];
 };


### PR DESCRIPTION
We need to use our own proxy to push to chromatic. This is specified with a host and subpath. But the pathname gets ignored. Maybe you could included that. We would appreciate.  