### PR TITLE
Add support for custom npm registry url

### DIFF
--- a/bin-src/lib/checkForUpdates.ts
+++ b/bin-src/lib/checkForUpdates.ts
@@ -18,12 +18,14 @@ export default async function checkForUpdates(ctx: Context) {
 
   let latestVersion: string;
   try {
-    const registryUrl = await spawn(['config', 'get', 'registry']).catch(() => '');
+    const registryUrl = await spawn(['config', 'get', 'registry']).catch(
+      () => 'https://registry.npmjs.org/'
+    );
     if (!['https://registry.npmjs.org/', 'https://registry.yarnpkg.com'].includes(registryUrl)) {
       ctx.log.info(`Using custom npm registry: ${registryUrl}`);
     }
 
-    const pkgUrl = new URL(ctx.pkg.name, registryUrl || 'https://registry.npmjs.org').href;
+    const pkgUrl = new URL(ctx.pkg.name, registryUrl).href;
     const res = await withTimeout(ctx.http.fetch(pkgUrl), 5000); // If not fetched within 5 seconds, nevermind.
     const { 'dist-tags': distTags = {} } = (await res.json()) as any;
     if (!semver.valid(distTags.latest)) {

--- a/bin-src/lib/checkForUpdates.ts
+++ b/bin-src/lib/checkForUpdates.ts
@@ -19,9 +19,12 @@ export default async function checkForUpdates(ctx: Context) {
   let latestVersion: string;
   try {
     const registryUrl = await spawn(['config', 'get', 'registry']).catch(() => '');
+    if (!['https://registry.npmjs.org/', 'https://registry.yarnpkg.com'].includes(registryUrl)) {
+      ctx.log.info(`Using custom npm registry: ${registryUrl}`);
+    }
+
     const pkgUrl = new URL(ctx.pkg.name, registryUrl || 'https://registry.npmjs.org').href;
-    // If not fetched within 5 seconds, nevermind.
-    const res = await withTimeout(ctx.http.fetch(pkgUrl), 5000);
+    const res = await withTimeout(ctx.http.fetch(pkgUrl), 5000); // If not fetched within 5 seconds, nevermind.
     const { 'dist-tags': distTags = {} } = (await res.json()) as any;
     if (!semver.valid(distTags.latest)) {
       ctx.log.warn(`Invalid dist-tag 'latest' returned from registry; skipping update check`);

--- a/bin-src/lib/spawn.ts
+++ b/bin-src/lib/spawn.ts
@@ -1,0 +1,19 @@
+import { spawn } from 'yarn-or-npm';
+
+export default (args: Parameters<typeof spawn>[0], options: Parameters<typeof spawn>[1] = {}) =>
+  new Promise<string>((resolve, reject) => {
+    let stdout = '';
+    let stderr = '';
+    const child = spawn(args, options);
+    child.stdout.on('data', (chunk) => {
+      stdout += chunk;
+    });
+    child.stderr.on('data', (chunk) => {
+      stderr += chunk;
+    });
+    child.on('error', reject);
+    child.on('close', (code) => {
+      if (code === 0) resolve(stdout.trim());
+      else reject(new Error(stderr));
+    });
+  });

--- a/bin-src/main.test.ts
+++ b/bin-src/main.test.ts
@@ -190,6 +190,8 @@ const openTunnel = <jest.MockedFunction<typeof tunnel>>tunnel;
 
 jest.mock('./lib/uploadFiles');
 
+jest.mock('./lib/spawn', () => () => Promise.resolve('https://npm.example.com'));
+
 let processEnv;
 beforeEach(() => {
   processEnv = process.env;
@@ -614,7 +616,7 @@ describe('runAll', () => {
     } as any);
     await runAll(ctx);
     expect(ctx.exitCode).toBe(1);
-    expect(ctx.http.fetch).toHaveBeenCalledWith('https://registry.npmjs.org/chromatic');
+    expect(ctx.http.fetch).toHaveBeenCalledWith('https://npm.example.com/chromatic');
     expect(ctx.testLogger.warnings[0]).toMatch('Using outdated package');
   });
 


### PR DESCRIPTION
Fixes #512

This attempts to retrieve the current registry url using `npm config get registry` or the Yarn equivalent. Failing that, it falls back to the default registry url for npm.