### PR TITLE
Fix `storybookUrl` by removing `iframe.html` suffix

### DIFF
--- a/action-src/main.ts
+++ b/action-src/main.ts
@@ -107,7 +107,7 @@ async function runChromatic(options): Promise<Output> {
     url: ctx.build?.webUrl,
     code: ctx.exitCode,
     buildUrl: ctx.build?.webUrl,
-    storybookUrl: ctx.build?.cachedUrl,
+    storybookUrl: ctx.build?.cachedUrl.replace(/iframe\.html.*$/, ''),
   };
 }
 


### PR DESCRIPTION
update the action's storybookUrl output, to NOT include `iframe.html` as requested in #409 