### PR TITLE
Add TurboSnap support for Vite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 6.5.0 - 2022-02-19
 
 - [513](https://github.com/chromaui/chromatic-cli/pull/513) Add support for custom npm registry url
+- [521](https://github.com/chromaui/chromatic-cli/pull/521) Add TurboSnap support for Vite
 - [523](https://github.com/chromaui/chromatic-cli/pull/523) Fix TurboSnap support for Storybook 6.5 with `.cjs` extension
 
 # 6.4.3 - 2022-01-31

--- a/bin-src/lib/getDependentStoryFiles.test.ts
+++ b/bin-src/lib/getDependentStoryFiles.test.ts
@@ -6,6 +6,7 @@ import * as git from '../git/git';
 jest.mock('../git/git');
 
 const CSF_GLOB = './src sync ^\\.\\/(?:(?!\\.)(?=.)[^/]*?\\.stories\\.js)$';
+const VITE_ENTRY = '/virtual:/@storybook/builder-vite/storybook-stories.js';
 const statsPath = 'preview-stats.json';
 
 const log = { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() };
@@ -86,6 +87,27 @@ describe('getDependentStoryFiles', () => {
         id: CSF_GLOB,
         name: CSF_GLOB,
         reasons: [{ moduleName: './storybook-stories.js' }],
+      },
+    ];
+    const ctx = getContext();
+    const res = await getDependentStoryFiles(ctx, { modules }, statsPath, changedFiles);
+    expect(res).toEqual({
+      './src/foo.stories.js': ['src/foo.stories.js'],
+    });
+  });
+
+  it('detects direct changes to CSF files, vite', async () => {
+    const changedFiles = ['src/foo.stories.js'];
+    const modules = [
+      {
+        id: './src/foo.stories.js',
+        name: './src/foo.stories.js',
+        reasons: [{ moduleName: VITE_ENTRY }],
+      },
+      {
+        id: VITE_ENTRY,
+        name: VITE_ENTRY,
+        reasons: [{ moduleName: '/virtual:/@storybook/builder-vite/vite-app.js' }],
       },
     ];
     const ctx = getContext();

--- a/bin-src/lib/getDependentStoryFiles.ts
+++ b/bin-src/lib/getDependentStoryFiles.ts
@@ -31,9 +31,6 @@ const isUserModule = (mod: Module | Reason) =>
 // already contains forward slashes, because that's what git yields even on Windows.
 const posix = (localPath: string) => localPath.split(path.sep).filter(Boolean).join(path.posix.sep);
 
-/** Strips off query params added by rollup/vite to ids, to make paths compatible for comparison with git */
-const stripQueryParams = (filePath: string): string => filePath.split('?')[0];
-
 /**
  * Converts a module path found in the webpack stats to be relative to the (git) root path. Module
  * paths can be relative (`./module.js`) or absolute (`/path/to/project/module.js`). The webpack
@@ -42,11 +39,9 @@ const stripQueryParams = (filePath: string): string => filePath.split('?')[0];
  */
 export function normalizePath(posixPath: string, rootPath: string, baseDir = '') {
   if (!posixPath) return posixPath;
-  // TODO: this might break webpack, which seems to send regex instead of posixPath...
-  const strippedPath = stripQueryParams(posixPath);
-  return path.posix.isAbsolute(strippedPath)
-    ? path.posix.relative(rootPath, strippedPath)
-    : path.posix.join(baseDir, strippedPath);
+  return path.posix.isAbsolute(posixPath)
+    ? path.posix.relative(rootPath, posixPath)
+    : path.posix.join(baseDir, posixPath);
 }
 
 /**

--- a/bin-src/lib/getDependentStoryFiles.ts
+++ b/bin-src/lib/getDependentStoryFiles.ts
@@ -215,8 +215,8 @@ export async function getDependentStoryFiles(
     reasonsById[id].filter(untrace).forEach((reason) => traceName(reason, tracePath));
   }
   const affectedModules = Object.fromEntries(
-    // Chromatic seems to require a `./path/to/story/file.js` format
-    Array.from(affectedModuleIds).map((id) => [`./${normalize(String(id))}`, files(namesById[id])])
+    // The id will be compared against the result of the stories' `.parameters.filename` values (stories retrieved from getStoriesJsonData())
+    Array.from(affectedModuleIds).map((id) => [String(id), files(namesById[id])])
   );
 
   if (ctx.options.traceChanged) {

--- a/bin-src/lib/getDependentStoryFiles.ts
+++ b/bin-src/lib/getDependentStoryFiles.ts
@@ -67,12 +67,9 @@ export async function getDependentStoryFiles(
   const baseDir = storybookBaseDir ? posix(storybookBaseDir) : path.posix.relative(rootPath, '');
 
   // Convert a "webpack path" (relative to storybookBaseDir) to a "git path" (relative to repository root)
-  const normalize = (posixPath: string) => {
-    // Do not try to normalize virtual paths
-    if (posixPath.startsWith('/virtual:')) return posixPath;
-
-    return normalizePath(posixPath, rootPath, baseDir); // e.g. `src/file.js` (no ./ prefix)
-  };
+  // e.g. `src/file.js` (no ./ prefix). Vite virtual paths are ignored.
+  const normalize = (posixPath: string) =>
+    posixPath.startsWith('/virtual:') ? posixPath : normalizePath(posixPath, rootPath, baseDir);
 
   const storybookDir = normalize(posix(storybookConfigDir));
   const staticDirs = staticDir.map((dir: string) => normalize(posix(dir)));


### PR DESCRIPTION
I'm on a mission to use turbosnap in my own project, which is built using storybook-builder-vite.  It's going to take a few different pieces:

- A rollup plugin to generate something similar to `preview-stats.json` from webpack.  
- Some changes to storybook-builder-vite (https://github.com/eirslett/storybook-builder-vite/pull/239)
- A few tweaks here to chromatic, to account for a few differences between webpack and vite.