### PR TITLE
Add turbosnap support for `generated-stories-entry.cjs`

### DIFF
--- a/bin-src/lib/getDependentStoryFiles.test.ts
+++ b/bin-src/lib/getDependentStoryFiles.test.ts
@@ -74,6 +74,27 @@ describe('getDependentStoryFiles', () => {
     });
   });
 
+  it('detects direct changes to CSF files, 6.5 v6 store', async () => {
+    const changedFiles = ['src/foo.stories.js'];
+    const modules = [
+      {
+        id: './src/foo.stories.js',
+        name: './src/foo.stories.js',
+        reasons: [{ moduleName: CSF_GLOB }],
+      },
+      {
+        id: CSF_GLOB,
+        name: CSF_GLOB,
+        reasons: [{ moduleName: './generated-stories-entry.cjs' }],
+      },
+    ];
+    const ctx = getContext();
+    const res = await getDependentStoryFiles(ctx, { modules }, statsPath, changedFiles);
+    expect(res).toEqual({
+      './src/foo.stories.js': ['src/foo.stories.js'],
+    });
+  });
+
   it('detects direct changes to CSF files, 6.4 v7 store', async () => {
     const changedFiles = ['src/foo.stories.js'];
     const modules = [

--- a/bin-src/lib/getDependentStoryFiles.ts
+++ b/bin-src/lib/getDependentStoryFiles.ts
@@ -81,6 +81,8 @@ export async function getDependentStoryFiles(
     `${storybookDir}/generated-stories-entry.js`,
     // v6 store with root as config dir (or SB 6.4)
     `generated-stories-entry.js`,
+    // v6 store with .cjs extension (SB 6.5)
+    'generated-stories-entry.cjs',
     // v7 store (SB >= 6.4)
     `storybook-stories.js`,
   ];


### PR DESCRIPTION
Fixes https://github.com/chromaui/chromatic-cli/issues/519.

Ref: https://github.com/storybookjs/storybook/pull/17486