### PR TITLE
Fix TurboSnap support for Storybook in a subdirectory

### DIFF
--- a/bin-src/lib/getDependentStoryFiles.ts
+++ b/bin-src/lib/getDependentStoryFiles.ts
@@ -83,6 +83,8 @@ export async function getDependentStoryFiles(
     `generated-stories-entry.js`,
     // v6 store with .cjs extension (SB 6.5)
     'generated-stories-entry.cjs',
+    // v6 store with subdirectory (SB 6.4)
+    `${baseDir}/generated-stories-entry.js`,
     // v7 store (SB >= 6.4)
     `storybook-stories.js`,
     // vite builder

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chromatic",
-  "version": "6.5.1",
+  "version": "6.5.2-canary.0",
   "description": "Automate visual testing across browsers. Gather UI feedback. Versioned documentation.",
   "keywords": [
     "storybook-addon",


### PR DESCRIPTION
## Related

* https://github.com/chromaui/chromatic-cli/issues/486

## Current status

* I'm developing in Monorepo
* I'm managing Storybook in a sub directory of my git root directory.
* Storybook 6.4.19
* Chromatic CLI v6.4.3

example

```
repo/
├── .git
└── sub
    ├── .storybook
    ├── assets
    │   └── js
    │       └── components
    │           └── Button
    │               ├── index.stories.tsx
    │               └── index.tsx
    ├── package.json
    └── yarn.lock
```

## Problem

* When I run TurboSnap on v6.4.3, I get the following error message
  * ```
    Did not find any CSF globs in preview-stats.json
    ```
* In the current configuration, it doesn't seem to be able to find the dependent story files well

## Solution

* When I looked at the output stats file, I found that the entry file was in the format `${baseDir}/generated-stories-entry.js`, so I fixed it that way
  * However, I didn't know why it was in this format

## About this PR

* It's actually working well for my project, but I don't consider this PR to be perfect
* I created this PR in the hope that it will help somebody

## Logs

Some parts have been modified

<details>
<summary>Console log with TurboSnap enabled</summary>

```
Chromatic CLI v6.4.3
https://www.chromatic.com/docs/cli

Authenticating with Chromatic
    → Connecting to https://index.chromatic.com
Authenticated with Chromatic
    → Using project token '********8969'
Retrieving git information
Found 1 changed files:
  sub/assets/js/components/pages/top/IdentificationNotice/IdentificationNoticeExpired/index.tsx
Retrieved git information
    → Commit 'f4f5162' on branch 'turbo-snap'; found 1 parent build and 1 changed file
Collecting Storybook metadata
Collected Storybook metadata
    → Storybook 6.4.19 for React; supported addons found: Docs, Essentials, Viewport
Building your Storybook
    → Running command: /private/var/folders/l_/xkbfxbz12h54zlzfhf1d9pj40000gp/T/xfs-bdbf7468/yarn run --silent build-storybook --output-dir /var/folders/l_/xkbfxbz12h54zlzfhf1d9pj40000gp/T/chromatic--4643-b5qxu2wdjtgI --webpack-stats-json /var/folders/l_/xkbfxbz12h54zlzfhf1d9pj40000gp/T/chromatic--4643-b5qxu2wdjtgI
Storybook built in 48 seconds
    → View build log at /Users/sh-suzuki/Documents/repo/sub/build-storybook.log
Publish your built Storybook
    → Validating Storybook files
Retrieving story files affected by recent changes
    → Traversing dependencies for 1 file that changed since the last build
Found affected story files:
  sub/assets/js/components/pages/m/top/index.stories.tsx [./assets/js/components/pages/m/top/index.stories.tsx]
  sub/assets/js/components/pages/m/top/index.tsx [./assets/js/components/pages/m/top/index.stories.tsx]
  **omissions**
Retrieved story files affected by recent changes
    → Found 2 story files affected by recent changes
Publishing your built Storybook
    → Retrieving target location
    → Starting publish
Publish complete in 4 minutes 21 seconds
    → View your Storybook at **omissions**
Verifying your Storybook
    → This may take a few minutes
Starting partial build
    → Snapshots will be limited to 2 story files affected by recent changes
✔ TurboSnap enabled
Capturing 8 snapshots and skipping 175 snapshots.
Started build 22
    → View build details at **omissions**
Running 8 tests affected by recent changes (skipping 175 tests)
    → This may take a few minutes
✔ Build 22 passed!
No visual changes were found in this build.
ℹ View build details at **omissions**
Build 22 completed
    → Tested 183 stories across 61 components; captured 8 snapshots in 28 seconds
Generating build report
    → Collecting build information
ℹ Wrote JUnit XML report to /Users/sh-suzuki/Documents/repo/sub/chromatic-build.xml
Generated build report
    → View report at /Users/sh-suzuki/Documents/repo/sub/chromatic-build.xml
```

</details>
