### PR TITLE
fix: normalize storiesEntryFiles in getDependentStoryFiles

### DIFF
--- a/bin-src/lib/getDependentStoryFiles.test.ts
+++ b/bin-src/lib/getDependentStoryFiles.test.ts
@@ -1,5 +1,4 @@
 import chalk from 'chalk';
-
 import { getDependentStoryFiles, normalizePath } from './getDependentStoryFiles';
 import * as git from '../git/git';
 
@@ -69,6 +68,48 @@ describe('getDependentStoryFiles', () => {
       },
     ];
     const ctx = getContext();
+    const res = await getDependentStoryFiles(ctx, { modules }, statsPath, changedFiles);
+    expect(res).toEqual({
+      './src/foo.stories.js': ['src/foo.stories.js'],
+    });
+  });
+
+  it('detects direct changes to CSF files, 6.4 v6 store with storybook config and baseDir', async () => {
+    const changedFiles = ['path/to/project/src/foo.stories.js'];
+    const modules = [
+      {
+        id: './src/foo.stories.js',
+        name: './src/foo.stories.js',
+        reasons: [{ moduleName: CSF_GLOB }],
+      },
+      {
+        id: CSF_GLOB,
+        name: CSF_GLOB,
+        reasons: [{ moduleName: './generated-stories-entry.js' }],
+      },
+    ];
+    const ctx = getContext({ configDir: '.storybook', storybookBaseDir: 'path/to/project' });
+    const res = await getDependentStoryFiles(ctx, { modules }, statsPath, changedFiles);
+    expect(res).toEqual({
+      './src/foo.stories.js': ['path/to/project/src/foo.stories.js'],
+    });
+  });
+
+  it('detects direct changes to CSF files, 6.4 v6 store with storybook config', async () => {
+    const changedFiles = ['src/foo.stories.js'];
+    const modules = [
+      {
+        id: './src/foo.stories.js',
+        name: './src/foo.stories.js',
+        reasons: [{ moduleName: CSF_GLOB }],
+      },
+      {
+        id: CSF_GLOB,
+        name: CSF_GLOB,
+        reasons: [{ moduleName: './generated-stories-entry.js' }],
+      },
+    ];
+    const ctx = getContext({ configDir: '.storybook' });
     const res = await getDependentStoryFiles(ctx, { modules }, statsPath, changedFiles);
     expect(res).toEqual({
       './src/foo.stories.js': ['src/foo.stories.js'],

--- a/bin-src/lib/getDependentStoryFiles.ts
+++ b/bin-src/lib/getDependentStoryFiles.ts
@@ -80,16 +80,16 @@ export async function getDependentStoryFiles(
   // we'll need a different approach to figure out CSF files (maybe the user should pass a glob?).
   const storiesEntryFiles = [
     // v6 store (SB <= 6.3)
-    `${storybookDir}/generated-stories-entry.js`,
+    `${storybookConfigDir}/generated-stories-entry.js`,
     // v6 store with root as config dir (or SB 6.4)
-    `generated-stories-entry.js`,
+    `./generated-stories-entry.js`,
     // v6 store with .cjs extension (SB 6.5)
-    'generated-stories-entry.cjs',
+    `./generated-stories-entry.cjs`,
     // v7 store (SB >= 6.4)
-    `storybook-stories.js`,
+    `./storybook-stories.js`,
     // vite builder
     `/virtual:/@storybook/builder-vite/vite-app.js`,
-  ];
+  ].map((entryFile) => normalize(entryFile));
 
   const modulesByName: Record<string, Module> = {};
   const namesById: Record<number, string> = {};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chromatic",
-  "version": "6.5.0",
+  "version": "6.5.1",
   "description": "Automate visual testing across browsers. Gather UI feedback. Versioned documentation.",
   "keywords": [
     "storybook-addon",


### PR DESCRIPTION
This PR fixes a bug related to situations where Chromatic (Turbosnap enabled) fails with the error "Did not find any CSF globs in preview-stats.json" (https://github.com/chromaui/chromatic-cli/issues/530 and https://github.com/chromaui/chromatic-cli/issues/486 - not sure if these are caused by the same error)

The error occurs if you're using Storybook 6.4 and pass in configDir as something else than '.' to Chromatic, and the reason stems from this array of predefined paths:

```ts
const storiesEntryFiles = [
    // v6 store (SB <= 6.3)
    `${storybookDir}/generated-stories-entry.js`,
    // v6 store with root as config dir (or SB 6.4)
    `generated-stories-entry.js`,
    // v6 store with .cjs extension (SB 6.5)
    'generated-stories-entry.cjs',
    // v7 store (SB >= 6.4)
    `storybook-stories.js`,
    // vite builder
    `/virtual:/@storybook/builder-vite/vite-app.js`,
];
```
  


In this case, `storybookDir` will be resolved as a combination of `baseDir` + `storybookConfigDir` whereas the rest are not. This fix ensures the storiesEntryFiles respects both `storybookBaseDir` and `storybookConfigDir`