### PR TITLE
downcase the slug so we don't accidentally treat origin as fork

### DIFF
--- a/bin-src/git/git.ts
+++ b/bin-src/git/git.ts
@@ -124,7 +124,8 @@ export async function getVersion() {
 // ignores the `.git` suffix if it exists, so it matches something like `ownername/reponame`.
 export async function getSlug() {
   const result = await execGitCommand(`git config --get remote.origin.url`);
-  const [, slug] = result.match(/([^/:]+\/[^/]+?)(\.git)?$/) || [];
+  const downcasedResult = result.toLowerCase();
+  const [, slug] = downcasedResult.match(/([^/:]+\/[^/]+?)(\.git)?$/) || [];
   return slug;
 }
 


### PR DESCRIPTION
if the slug is capitalized we are accidentally treating it as a fork. Always downcasing the getSlug method should prevent that.
https://linear.app/chromaui/issue/CH-1630/chromatic-cli-slug-isnt-downcased