### PR TITLE
revert retrieval of storybook metadata via yarn.

### DIFF
--- a/bin-src/lib/getStorybookInfo.test.ts
+++ b/bin-src/lib/getStorybookInfo.test.ts
@@ -72,15 +72,9 @@ describe('getStorybookInfo', () => {
   it('throws on missing package', async () => {
     const ctx = getContext({ packageJson: { dependencies: VUE } });
     await expect(getStorybookInfo(ctx)).resolves.toEqual({
-      addons: [
-        {
-          name: 'essentials',
-          packageName: '@storybook/addon-essentials',
-          packageVersion: '6.5.5',
-        },
-      ],
-      version: '6.5.5',
-      viewLayer: 'react',
+      addons: [],
+      version: null,
+      viewLayer: null,
     });
   });
 
@@ -114,30 +108,18 @@ describe('getStorybookInfo', () => {
     it('throws on invalid value', async () => {
       const ctx = getContext({ env: { CHROMATIC_STORYBOOK_VERSION: '3.2.1' } });
       await expect(getStorybookInfo(ctx)).resolves.toEqual({
-        addons: [
-          {
-            name: 'essentials',
-            packageName: '@storybook/addon-essentials',
-            packageVersion: '6.5.5',
-          },
-        ],
-        version: '6.5.5',
-        viewLayer: 'react',
+        addons: [],
+        version: null,
+        viewLayer: null,
       });
     });
 
     it('throws on unsupported viewlayer', async () => {
       const ctx = getContext({ env: { CHROMATIC_STORYBOOK_VERSION: '@storybook/native@3.2.1' } });
       await expect(getStorybookInfo(ctx)).resolves.toEqual({
-        addons: [
-          {
-            name: 'essentials',
-            packageName: '@storybook/addon-essentials',
-            packageVersion: '6.5.5',
-          },
-        ],
-        version: '6.5.5',
-        viewLayer: 'react',
+        addons: [],
+        version: null,
+        viewLayer: null,
       });
     });
   });

--- a/bin-src/lib/getStorybookInfo.ts
+++ b/bin-src/lib/getStorybookInfo.ts
@@ -136,10 +136,7 @@ export default async function getStorybookInfo(
     const info = await Promise.all([findAddons(ctx), findConfigFlags(ctx), findViewlayer(ctx)]);
     return info.reduce((acc, obj) => Object.assign(acc, obj), {});
   } catch (e) {
-    const result = await getInstalledStorybookInfo();
-    if (result.viewLayer) {
-      return result;
-    }
+    ctx.log.debug(e);
     return { viewLayer: null, version: null, addons: [] };
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chromatic",
-  "version": "6.5.5-canary.5",
+  "version": "6.5.5",
   "description": "Automate visual testing across browsers. Gather UI feedback. Versioned documentation.",
   "keywords": [
     "storybook-addon",


### PR DESCRIPTION
Revert change to get storybook metadata using yarn.

https://linear.app/chromaui/issue/AP-1542/storybook-metadata-missing-regression