### PR TITLE
Filter out unsupported addons from sb metadata

### DIFF
--- a/bin-src/__mocks__/unsupportedAddons/project.json
+++ b/bin-src/__mocks__/unsupportedAddons/project.json
@@ -1,0 +1,51 @@
+{
+  "generatedAt": 1654054690474,
+  "builder": {
+    "name": "webpack5"
+  },
+  "hasCustomBabel": false,
+  "hasCustomWebpack": true,
+  "hasStaticDirs": false,
+  "hasStorybookEslint": false,
+  "refCount": 0,
+  "packageManager": {
+    "type": "yarn",
+    "version": "1.22.18"
+  },
+  "features": {
+    "postcss": false
+  },
+  "storybookVersion": "6.5.6",
+  "language": "typescript",
+  "storybookPackages": {
+    "@storybook/addon-essentials": {
+      "version": "6.5.6"
+    },
+    "@storybook/builder-webpack5": {
+      "version": "6.5.6"
+    },
+    "@storybook/eslint-config-storybook": {
+      "version": "3.1.2"
+    },
+    "@storybook/linter-config": {
+      "version": "3.1.2"
+    },
+    "@storybook/manager-webpack5": {
+      "version": "6.5.6"
+    },
+    "@storybook/react": {
+      "version": "6.5.6"
+    }
+  },
+  "framework": {
+    "name": "react"
+  },
+  "addons": {
+    "@storybook/addon-viewport": {
+      "version": "6.5.6"
+    },
+    "storybook-addon-apollo-client": {
+      "version": "4.0.11"
+    }
+  }
+}

--- a/bin-src/lib/getPrebuiltStorybookMetadata.ts
+++ b/bin-src/lib/getPrebuiltStorybookMetadata.ts
@@ -52,11 +52,11 @@ export const getStorybookMetadataFromProjectJson = async (
     version: sbProjectJson.storybookPackages[viewLayerPackage].version ?? null,
     builder,
     addons: Object.entries(sbProjectJson.addons)
+      .filter(([packageName]) => supportedAddons[packageName])
       .map(([packageName, addon]) => ({
         name: supportedAddons[packageName],
         packageName,
         packageVersion: addon.version,
-      }))
-      .filter((addon) => addon.name),
+      })),
   };
 };

--- a/bin-src/lib/getPrebuiltStorybookMetadata.ts
+++ b/bin-src/lib/getPrebuiltStorybookMetadata.ts
@@ -51,10 +51,12 @@ export const getStorybookMetadataFromProjectJson = async (
     viewLayer: sbProjectJson.framework.name ?? null,
     version: sbProjectJson.storybookPackages[viewLayerPackage].version ?? null,
     builder,
-    addons: Object.entries(sbProjectJson.addons).map(([packageName, addon]) => ({
-      name: supportedAddons[packageName],
-      packageName,
-      packageVersion: addon.version,
-    })),
+    addons: Object.entries(sbProjectJson.addons)
+      .map(([packageName, addon]) => ({
+        name: supportedAddons[packageName],
+        packageName,
+        packageVersion: addon.version,
+      }))
+      .filter((addon) => addon.name),
   };
 };

--- a/bin-src/lib/getStorybookConfiguration.ts
+++ b/bin-src/lib/getStorybookConfiguration.ts
@@ -6,9 +6,6 @@ export default function getStorybookConfiguration(
   shortName: string,
   longName?: string
 ) {
-  if (!storybookScript) {
-    return null;
-  }
   const parts = storybookScript.split(/[\s='"]+/);
   let index = parts.indexOf(longName);
   if (index === -1) {

--- a/bin-src/lib/getStorybookConfiguration.ts
+++ b/bin-src/lib/getStorybookConfiguration.ts
@@ -6,6 +6,9 @@ export default function getStorybookConfiguration(
   shortName: string,
   longName?: string
 ) {
+  if (!storybookScript) {
+    return null;
+  }
   const parts = storybookScript.split(/[\s='"]+/);
   let index = parts.indexOf(longName);
   if (index === -1) {

--- a/bin-src/lib/getStorybookInfo.test.ts
+++ b/bin-src/lib/getStorybookInfo.test.ts
@@ -157,5 +157,24 @@ describe('getStorybookInfo', () => {
         builder: null,
       });
     });
+
+    it('does not return unsupported addons in metadata', async () => {
+      const ctx = getContext({
+        options: { storybookBuildDir: 'bin-src/__mocks__/unsupportedAddons' },
+        packageJson: { dependencies: REACT },
+      });
+      await expect(getStorybookInfo(ctx)).resolves.toEqual({
+        addons: [
+          {
+            name: 'viewport',
+            packageName: '@storybook/addon-viewport',
+            packageVersion: '6.5.6',
+          },
+        ],
+        builder: { name: 'webpack5', packageVersion: '6.5.6' },
+        version: '6.5.6',
+        viewLayer: 'react',
+      });
+    });
   });
 });


### PR DESCRIPTION
You can test this by running `yarn test` and reviewing the "getStorybookInfo does not return with --storybook-build-dir unsupported addons in metadata" test.