### PR TITLE
Handle redirects when using `--storybook-url`

### DIFF
--- a/bin-src/lib/getOptions.test.ts
+++ b/bin-src/lib/getOptions.test.ts
@@ -81,7 +81,7 @@ describe('getOptions', () => {
   it('picks up default start script', async () => {
     expect(getOptions(getContext(['-s']))).toMatchObject({
       scriptName: 'storybook',
-      url: 'http://localhost:1337/iframe.html',
+      url: 'http://localhost:1337',
       noStart: false,
     });
   });
@@ -95,7 +95,7 @@ describe('getOptions', () => {
   it('allows you to specify alternate script, still picks up port', async () => {
     expect(getOptions(getContext(['--script-name', 'otherStorybook']))).toMatchObject({
       scriptName: 'otherStorybook',
-      url: 'http://localhost:7070/iframe.html',
+      url: 'http://localhost:7070',
       noStart: false,
     });
   });
@@ -105,7 +105,7 @@ describe('getOptions', () => {
       getOptions(getContext(['--script-name', 'notStorybook', '--storybook-port', '6060']))
     ).toMatchObject({
       scriptName: 'notStorybook',
-      url: 'http://localhost:6060/iframe.html',
+      url: 'http://localhost:6060',
     });
   });
 
@@ -120,7 +120,7 @@ describe('getOptions', () => {
       getOptions(getContext(['--exec', 'storybook-command', '--storybook-port', '6060']))
     ).toMatchObject({
       exec: 'storybook-command',
-      url: 'http://localhost:6060/iframe.html',
+      url: 'http://localhost:6060',
     });
   });
 
@@ -169,7 +169,7 @@ describe('getOptions', () => {
   it('allows you to set a URL without path', async () => {
     expect(getOptions(getContext(['--storybook-url', 'https://google.com']))).toMatchObject({
       noStart: true,
-      url: 'https://google.com/iframe.html',
+      url: 'https://google.com',
       createTunnel: false,
     });
   });
@@ -177,7 +177,7 @@ describe('getOptions', () => {
   it('allows you to set a URL with a path', async () => {
     expect(getOptions(getContext(['--storybook-url', 'https://google.com/foo']))).toMatchObject({
       noStart: true,
-      url: 'https://google.com/foo/iframe.html',
+      url: 'https://google.com/foo',
       createTunnel: false,
     });
   });

--- a/bin-src/lib/getOptions.ts
+++ b/bin-src/lib/getOptions.ts
@@ -221,20 +221,11 @@ export default function getOptions({ argv, env, flags, log, packageJson }: Conte
     storybookUrl = `${options.https ? 'https' : 'http'}://localhost:${port}`;
   }
 
-  const parsedUrl = new URL(storybookUrl);
-  const suffix = 'iframe.html';
-  if (!parsedUrl.pathname.endsWith(suffix)) {
-    if (!parsedUrl.pathname.endsWith('/')) {
-      parsedUrl.pathname += '/';
-    }
-    parsedUrl.pathname += suffix;
-  }
-
   return {
     ...options,
     noStart,
     useTunnel: true,
-    url: parsedUrl.href,
+    url: storybookUrl,
     scriptName,
   };
 }

--- a/bin-src/lib/startStorybook.ts
+++ b/bin-src/lib/startStorybook.ts
@@ -3,11 +3,11 @@ import { spawn } from 'cross-spawn';
 import path from 'path';
 import { Context } from '../types';
 
-export async function resolveIsolatorUrl(ctx: Context, url: string) {
+export async function resolveIsolatorUrl(ctx: Context, storybookUrl: string) {
   try {
     // Allow invalid certificates, because we might be running against localhost.
     const options = { proxy: { rejectUnauthorized: false } };
-    const { url: resolvedUrl } = await ctx.http.fetch(url, {}, options);
+    const { url: resolvedUrl } = await ctx.http.fetch(storybookUrl, {}, options);
     const isolatorUrl = resolvedUrl.replace(/index\.html$/, '').replace(/\/?$/, '/iframe.html');
     await ctx.http.fetch(isolatorUrl, {}, options);
     return isolatorUrl;

--- a/bin-src/tasks/start.test.ts
+++ b/bin-src/tasks/start.test.ts
@@ -14,7 +14,6 @@ describe('startStorybook', () => {
       },
     } as any;
     await startStorybook(ctx);
-    expect(ctx.isolatorUrl).toBe(ctx.options.url);
     expect(startApp).toHaveBeenCalledWith(ctx, {
       args: undefined,
       options: { stdio: 'pipe' },


### PR DESCRIPTION
Rather than just assuming `iframe.html` will exist where we expect it to be, actually resolve the provided URL and add `iframe.html` to the resolved (redirected) URL.