### PR TITLE
Enable bash mode for globs when matching branches with picomatch

### DIFF
--- a/bin-src/tasks/gitInfo.test.ts
+++ b/bin-src/tasks/gitInfo.test.ts
@@ -80,6 +80,21 @@ describe('setGitInfo', () => {
     expect(ctx.git.replacementBuildIds).toEqual([]);
   });
 
+  it('sets changedFiles on a branch name containing a slash', async () => {
+    getCommitAndBranch.mockResolvedValue({
+      ...commitInfo,
+      branch: 'something/else',
+    });
+    getBaselineBuilds.mockResolvedValue([{ commit: '012qwes' } as any]);
+    getChangedFilesWithReplacement.mockResolvedValue({
+      changedFiles: ['styles/main.scss', 'lib/utils.js'],
+    });
+    const ctx = { log, options: { onlyChanged: '!(main)' }, client } as any;
+    await setGitInfo(ctx, {} as any);
+    expect(ctx.git.changedFiles).toEqual(['styles/main.scss', 'lib/utils.js']);
+    expect(ctx.git.replacementBuildIds).toEqual([]);
+  });
+
   it('sets replacementBuildIds when found', async () => {
     getBaselineBuilds.mockResolvedValue([{ id: 'rebased', commit: '012qwes' } as any]);
     getChangedFilesWithReplacement.mockResolvedValue({

--- a/bin-src/tasks/gitInfo.ts
+++ b/bin-src/tasks/gitInfo.ts
@@ -74,7 +74,7 @@ export const setGitInfo = async (ctx: Context, task: Task) => {
   const { branch, commit, slug } = ctx.git;
 
   ctx.git.matchesBranch = (glob: true | string) =>
-    typeof glob === 'string' && glob.length ? picomatch(glob)(branch) : !!glob;
+    typeof glob === 'string' && glob.length ? picomatch(glob, { bash: true })(branch) : !!glob;
 
   if (ctx.git.matchesBranch(ctx.options.skip)) {
     transitionTo(skippingBuild)(ctx, task);


### PR DESCRIPTION
Several customers have reported that using the `--only-changed` flag with a glob (e.g. `"!(main)"`) doesn't work properly if they are running Chromatic on a branch that has a forward slash in its name (e.g. "andrew/feature"). In these scenarios, TurboSnap is disabled and the customers are producing far more snapshots than they expected.

It turns out that picomatch, the package being used to match branch names against the given glob, is strict about how it uses forward slashes. By default, a catch-all glob like "*" will **not** match a string with a forward slash, like "andrew/feature". You must use something like "**" to catch the afore-mentioned branch along with other simpler branch names.

By enabling the `bash` configuration option, we tell picomatch to follow bash matching rules more strictly, treating single stars more like globstars. This fixes our issue with branch names containing forward slashes, though there might be performance implications. More info on that here: https://github.com/micromatch/picomatch#matching-behavior-vs-bash.