### PR TITLE
Restore prepublish script to fix smoke tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "lint": "yarn lint:js .storybook bin-src test-stories ./isChromatic.js ./isChromatic.mjs",
     "lint:js": "cross-env NODE_ENV=production eslint --fix --cache --cache-location=.cache/eslint --ext .js,.json,.mjs,.ts,.cjs --report-unused-disable-directives",
     "lint:package": "sort-package-json",
-    "prerelease": "npm run build",
+    "prepublish": "npm run build",
     "release": "node scripts/release.js",
     "trace": "node -r esm bin-src/trace.js",
     "trim-stats": "node -r esm bin-src/trim-stats-file.js",

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -75,7 +75,10 @@ const publishAction = async ({ repo, tag, version }) => {
     throw new Error("Invalid tag, expecting one of 'canary', 'next', 'latest'");
   }
 
-  if (bump !== 'action') {
+  if (bump === 'action') {
+    // We need to build the action manually if we're not publishing to npm
+    await command('npm run bundle:action');
+  } else {
     const { version: currentVersion } = await readJSON(join(__dirname, '../package.json'));
     const [, , , currentTag] = currentVersion.match(/^([0-9]+\.[0-9]+\.[0-9]+)(-(\w+)\.\d+)?$/);
 


### PR DESCRIPTION
And implement another way to ensure we build when only publishing the action