### PR TITLE
Add change count to buildPassed message if changes exist.

### DIFF
--- a/bin-src/ui/messages/info/buildPassed.stories.ts
+++ b/bin-src/ui/messages/info/buildPassed.stories.ts
@@ -9,6 +9,16 @@ export const BuildPassed = () =>
     build: {
       number: 42,
       webUrl: 'https://www.chromatic.com/build?appId=59c59bd0183bd100364e1d57&number=42',
+      changeCount: 0,
+    },
+  } as any);
+
+export const BuildPassedWithChanges = () =>
+  buildPassed({
+    build: {
+      number: 42,
+      webUrl: 'https://www.chromatic.com/build?appId=59c59bd0183bd100364e1d57&number=42',
+      changeCount: 2,
     },
   } as any);
 

--- a/bin-src/ui/messages/info/buildPassed.ts
+++ b/bin-src/ui/messages/info/buildPassed.ts
@@ -1,5 +1,6 @@
 import chalk from 'chalk';
 import { dedent } from 'ts-dedent';
+import pluralize from 'pluralize';
 import { Context } from '../../../types';
 
 import { info, success } from '../../components/icons';
@@ -8,6 +9,7 @@ import { stats } from '../../tasks/snapshot';
 
 export default ({ build, isOnboarding }: Context) => {
   const { changes, snapshots, components, stories } = stats({ build });
+  const visualChanges = pluralize('visual changes', build.changeCount, true);
   if (isOnboarding) {
     return dedent(chalk`
       ${success} {bold Build passed. Welcome to Chromatic!}
@@ -23,7 +25,7 @@ export default ({ build, isOnboarding }: Context) => {
     `)
     : dedent(chalk`
       ${success} {bold Build ${build.number} passed!}
-      No visual changes were found in this build.
+      ${build.changeCount === 0 ? 'No visual changes' : visualChanges} were found in this build.
       ${info} View build details at ${link(build.webUrl)}
     `);
 };

--- a/bin-src/ui/messages/info/buildPassed.ts
+++ b/bin-src/ui/messages/info/buildPassed.ts
@@ -25,7 +25,7 @@ export default ({ build, isOnboarding }: Context) => {
     `)
     : dedent(chalk`
       ${success} {bold Build ${build.number} passed!}
-      ${build.changeCount === 0 ? 'No visual changes' : visualChanges} were found in this build.
+      ${build.changeCount > 0 ? visualChanges : 'No visual changes'} were found in this build.
       ${info} View build details at ${link(build.webUrl)}
     `);
 };


### PR DESCRIPTION
When using the Github Action, the flag `exitZeroOnChanges` is equal to true when not set explicitly equal to false. So, if the build status is `ACCEPTED`, `PENDING` or `DENIED`, we always return 'No visual changes were found in this build.' even if there was changes. This PR updates the message so if changes are found, the number of changes are shown in action output.