### PR TITLE
Update stats process to use stream

### DIFF
--- a/bin-src/tasks/read-stats-file.ts
+++ b/bin-src/tasks/read-stats-file.ts
@@ -1,0 +1,7 @@
+import { parseChunked } from '@discoveryjs/json-ext';
+import { createReadStream } from 'fs-extra';
+import { Stats } from '../types';
+
+export const readStatsFile = async (filePath: string): Promise<Stats> => {
+  return parseChunked(createReadStream(filePath));
+};

--- a/bin-src/tasks/upload.test.ts
+++ b/bin-src/tasks/upload.test.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs-extra';
 import progressStream from 'progress-stream';
 
-import * as trimStatsFile from '../trim-stats-file';
+import * as readStatsFile from './read-stats-file';
 import { getDependentStoryFiles as dependentStoryFiles } from '../lib/getDependentStoryFiles';
 import { validateFiles, traceChangedFiles, uploadStorybook } from './upload';
 
@@ -91,7 +91,7 @@ describe('validateFiles', () => {
 });
 
 describe('traceChangedFiles', () => {
-  jest.spyOn(trimStatsFile, 'readStatsFile').mockReturnValueOnce(Promise.resolve(undefined));
+  jest.spyOn(readStatsFile, 'readStatsFile').mockReturnValueOnce(Promise.resolve(undefined));
 
   it('sets onlyStoryFiles on context', async () => {
     const deps = { 123: ['./example.stories.js'] };

--- a/bin-src/tasks/upload.test.ts
+++ b/bin-src/tasks/upload.test.ts
@@ -1,6 +1,7 @@
 import * as fs from 'fs-extra';
 import progressStream from 'progress-stream';
 
+import * as trimStatsFile from '../trim-stats-file';
 import { getDependentStoryFiles as dependentStoryFiles } from '../lib/getDependentStoryFiles';
 import { validateFiles, traceChangedFiles, uploadStorybook } from './upload';
 
@@ -90,6 +91,8 @@ describe('validateFiles', () => {
 });
 
 describe('traceChangedFiles', () => {
+  jest.spyOn(trimStatsFile, 'readStatsFile').mockReturnValueOnce(Promise.resolve(undefined));
+
   it('sets onlyStoryFiles on context', async () => {
     const deps = { 123: ['./example.stories.js'] };
     getDependentStoryFiles.mockResolvedValueOnce(deps);

--- a/bin-src/tasks/upload.test.ts
+++ b/bin-src/tasks/upload.test.ts
@@ -1,13 +1,13 @@
 import * as fs from 'fs-extra';
 import progressStream from 'progress-stream';
 
-import * as readStatsFile from './read-stats-file';
 import { getDependentStoryFiles as dependentStoryFiles } from '../lib/getDependentStoryFiles';
 import { validateFiles, traceChangedFiles, uploadStorybook } from './upload';
 
 jest.mock('fs-extra');
 jest.mock('progress-stream');
 jest.mock('../lib/getDependentStoryFiles');
+jest.mock('./read-stats-file');
 
 const getDependentStoryFiles = <jest.MockedFunction<typeof dependentStoryFiles>>dependentStoryFiles;
 const createReadStream = <jest.MockedFunction<typeof fs.createReadStream>>fs.createReadStream;
@@ -91,8 +91,6 @@ describe('validateFiles', () => {
 });
 
 describe('traceChangedFiles', () => {
-  jest.spyOn(readStatsFile, 'readStatsFile').mockReturnValueOnce(Promise.resolve(undefined));
-
   it('sets onlyStoryFiles on context', async () => {
     const deps = { 123: ['./example.stories.js'] };
     getDependentStoryFiles.mockResolvedValueOnce(deps);

--- a/bin-src/tasks/upload.ts
+++ b/bin-src/tasks/upload.ts
@@ -29,7 +29,7 @@ import {
 } from '../ui/tasks/upload';
 import { Context, Task } from '../types';
 import { exitCodes, setExitCode } from '../lib/setExitCode';
-import { readStatsFile } from '../trim-stats-file';
+import { readStatsFile } from './read-stats-file';
 
 const GetUploadUrlsMutation = `
   mutation GetUploadUrlsMutation($paths: [String!]!) {

--- a/bin-src/tasks/upload.ts
+++ b/bin-src/tasks/upload.ts
@@ -29,6 +29,7 @@ import {
 } from '../ui/tasks/upload';
 import { Context, Task } from '../types';
 import { exitCodes, setExitCode } from '../lib/setExitCode';
+import { readStatsFile } from '../trim-stats-file';
 
 const GetUploadUrlsMutation = `
   mutation GetUploadUrlsMutation($paths: [String!]!) {
@@ -154,7 +155,7 @@ export const traceChangedFiles = async (ctx: Context, task: Task) => {
   const statsPath = join(ctx.sourceDir, ctx.fileInfo.statsPath);
   const { changedFiles } = ctx.git;
   try {
-    const stats = await fs.readJson(statsPath);
+    const stats = await readStatsFile(statsPath);
     const onlyStoryFiles = await getDependentStoryFiles(ctx, stats, statsPath, changedFiles);
     if (onlyStoryFiles) {
       ctx.onlyStoryFiles = onlyStoryFiles;

--- a/bin-src/trace.ts
+++ b/bin-src/trace.ts
@@ -1,7 +1,7 @@
 import meow from 'meow';
 import { getDependentStoryFiles } from './lib/getDependentStoryFiles';
 import { Context } from './types';
-import { readStatsFile } from './trim-stats-file';
+import { readStatsFile } from './tasks/read-stats-file';
 
 /**
  * Utility to trace a set of changed file paths to dependent story files using a Webpack stats file.

--- a/bin-src/trace.ts
+++ b/bin-src/trace.ts
@@ -1,7 +1,7 @@
-import fs from 'fs-extra';
 import meow from 'meow';
 import { getDependentStoryFiles } from './lib/getDependentStoryFiles';
 import { Context } from './types';
+import { readStatsFile } from './trim-stats-file';
 
 /**
  * Utility to trace a set of changed file paths to dependent story files using a Webpack stats file.
@@ -85,7 +85,7 @@ export async function main(argv: string[]) {
       traceChanged: flags.mode || true,
     },
   } as any;
-  const stats = await fs.readJson(flags.statsFile);
+  const stats = await readStatsFile(flags.statsFile);
   const changedFiles = input.map((f) => f.replace(/^\.\//, ''));
 
   await getDependentStoryFiles(ctx, stats, flags.statsFile, changedFiles);

--- a/bin-src/trim-stats-file.test.ts
+++ b/bin-src/trim-stats-file.test.ts
@@ -1,7 +1,7 @@
 /* eslint-disable prettier/prettier */
 import mockfs from 'mock-fs'
 
-import { readStatsFile } from './trim-stats-file';
+import { readStatsFile } from './tasks/read-stats-file';
 // eslint-disable-next-line jest/no-mocks-import
 import * as trimmedFile from './__mocks__/previewStatsJson/preview-stats.trimmed.json';
 

--- a/bin-src/trim-stats-file.ts
+++ b/bin-src/trim-stats-file.ts
@@ -1,5 +1,5 @@
 import { parseChunked } from '@discoveryjs/json-ext';
-import { createReadStream, outputFile } from 'fs-extra';
+import { createReadStream, outputFile, existsSync } from 'fs-extra';
 import { Stats } from './types';
 
 const dedupe = <T>(arr: T[]) => Array.from(new Set(arr));
@@ -8,8 +8,12 @@ const isUserCode = ({ name, moduleName = name }: { name?: string; moduleName?: s
   !moduleName.startsWith('(webpack)') &&
   !moduleName.match(/(node_modules|webpack\/runtime)\//);
 
-export const readStatsFile = async (filePath: string): Promise<Stats> =>
-  parseChunked(createReadStream(filePath));
+export const readStatsFile = async (filePath: string): Promise<Stats> => {
+  if (existsSync(filePath)) {
+    return parseChunked(createReadStream(filePath));
+  }
+  return undefined;
+};
 
 /**
  * Utility to trim down a `preview-stats.json` file to the bare minimum, so that it can be used to

--- a/bin-src/trim-stats-file.ts
+++ b/bin-src/trim-stats-file.ts
@@ -1,16 +1,11 @@
-import { parseChunked } from '@discoveryjs/json-ext';
-import { createReadStream, outputFile, existsSync } from 'fs-extra';
-import { Stats } from './types';
+import { outputFile } from 'fs-extra';
+import { readStatsFile } from './tasks/read-stats-file';
 
 const dedupe = <T>(arr: T[]) => Array.from(new Set(arr));
 const isUserCode = ({ name, moduleName = name }: { name?: string; moduleName?: string }) =>
   moduleName &&
   !moduleName.startsWith('(webpack)') &&
   !moduleName.match(/(node_modules|webpack\/runtime)\//);
-
-export const readStatsFile = async (filePath: string): Promise<Stats> => {
-  return parseChunked(createReadStream(filePath));
-};
 
 /**
  * Utility to trim down a `preview-stats.json` file to the bare minimum, so that it can be used to

--- a/bin-src/trim-stats-file.ts
+++ b/bin-src/trim-stats-file.ts
@@ -9,10 +9,7 @@ const isUserCode = ({ name, moduleName = name }: { name?: string; moduleName?: s
   !moduleName.match(/(node_modules|webpack\/runtime)\//);
 
 export const readStatsFile = async (filePath: string): Promise<Stats> => {
-  if (existsSync(filePath)) {
-    return parseChunked(createReadStream(filePath));
-  }
-  return undefined;
+  return parseChunked(createReadStream(filePath));
 };
 
 /**


### PR DESCRIPTION
This builds off of the changes to the `trim-stats-file`.
We are now moving to change all instances of the stats file to use `readStatsFile` which will read stats files from a stream.
This will allow handling larger stats files and avoid hitting a file size limit.