### PR TITLE
Rename `--only` to `--only-story-names` but keep it as a deprecated alias

### DIFF
--- a/action-src/main.ts
+++ b/action-src/main.ts
@@ -129,6 +129,7 @@ async function run() {
     const storybookConfigDir = getInput('storybookConfigDir');
     const only = getInput('only');
     const onlyChanged = getInput('onlyChanged');
+    const onlyStoryNames = getInput('onlyStoryNames');
     const externals = getInput('externals');
     const untraced = getInput('untraced');
     const traceChanged = getInput('traceChanged');
@@ -170,6 +171,7 @@ async function run() {
       forceRebuild: maybe(forceRebuild),
       only: maybe(only),
       onlyChanged: maybe(onlyChanged),
+      onlyStoryNames: maybe(onlyStoryNames),
       externals: maybe(externals),
       untraced: maybe(untraced),
       storybookBaseDir: maybe(storybookBaseDir),

--- a/action.yml
+++ b/action.yml
@@ -43,10 +43,13 @@ inputs:
     description: 'Relative path from where you run Chromatic to your Storybook config directory'
     required: false
   only:
-    description: 'Only run a single story or a subset of stories'
+    description: 'Deprecated, use onlyStoryNames instead'
     required: false
   onlyChanged:
     description: 'Enables TurboSnap: Only run stories affected by files changed since the baseline build'
+    required: false
+  onlyStoryNames:
+    description: 'Only run a single story or a subset of stories by their name'
     required: false
   externals:
     description: 'Disable TurboSnap when any of these files have changed since the baseline build'

--- a/action.yml
+++ b/action.yml
@@ -43,7 +43,7 @@ inputs:
     description: 'Relative path from where you run Chromatic to your Storybook config directory'
     required: false
   only:
-    description: 'Deprecated, use onlyStoryNames instead'
+    description: 'Deprecated, replaced by onlyStoryNames'
     required: false
   onlyChanged:
     description: 'Enables TurboSnap: Only run stories affected by files changed since the baseline build'
@@ -88,7 +88,7 @@ inputs:
     description: 'Storybook is already running at (external) url (implies -S)'
     required: false
   preserveMissing:
-    description: '[Deprecated] Pass the baselines forward and treat all missing stories as “preserved” without re-capturing them'
+    description: 'Deprecated, use onlyChanged, onlyStoryNames or onlyStoryFiles instead'
     required: false
   autoAcceptChanges:
     description: 'Automatically accept all changes in chromatic: boolean or branchname'

--- a/bin-src/lib/getOptions.ts
+++ b/bin-src/lib/getOptions.ts
@@ -5,7 +5,7 @@ import dependentOption from '../ui/messages/errors/dependentOption';
 import duplicatePatchBuild from '../ui/messages/errors/duplicatePatchBuild';
 import incompatibleOptions from '../ui/messages/errors/incompatibleOptions';
 import invalidExitOnceUploaded from '../ui/messages/errors/invalidExitOnceUploaded';
-import invalidOnly from '../ui/messages/errors/invalidOnly';
+import invalidOnlyStoryNames from '../ui/messages/errors/invalidOnlyStoryNames';
 import invalidOnlyChanged from '../ui/messages/errors/invalidOnlyChanged';
 import invalidPatchBuild from '../ui/messages/errors/invalidPatchBuild';
 import invalidReportPath from '../ui/messages/errors/invalidReportPath';
@@ -41,8 +41,8 @@ export default function getOptions({ argv, env, flags, log, packageJson }: Conte
   const options: Options = {
     projectToken: takeLast(flags.projectToken || flags.appCode) || env.CHROMATIC_PROJECT_TOKEN, // backwards compatibility
 
-    only: flags.only,
     onlyChanged: trueIfSet(flags.onlyChanged),
+    onlyStoryNames: undefinedIfEmpty(ensureArray(flags.onlyStoryNames || flags.only)),
     untraced: undefinedIfEmpty(ensureArray(flags.untraced)),
     externals: undefinedIfEmpty(ensureArray(flags.externals)),
     traceChanged: trueIfSet(flags.traceChanged),
@@ -105,8 +105,8 @@ export default function getOptions({ argv, env, flags, log, packageJson }: Conte
     }
   }
 
-  if (flags.only && !/[\w*]\/[\w*]/.test(flags.only)) {
-    throw new Error(invalidOnly());
+  if (options.onlyStoryNames?.some((glob) => !/[\w*]\/[\w*]/.test(glob))) {
+    throw new Error(invalidOnlyStoryNames());
   }
 
   const { storybookBuildDir, exec } = options;
@@ -126,8 +126,8 @@ export default function getOptions({ argv, env, flags, log, packageJson }: Conte
     throw new Error(invalidSingularOptions(foundSingularOpts.map((key) => singularOpts[key])));
   }
 
-  if (options.only && options.onlyChanged) {
-    throw new Error(invalidSingularOptions(['--only', '--only-changed']));
+  if (options.onlyChanged && options.onlyStoryNames) {
+    throw new Error(invalidSingularOptions(['--only-changed', '--only-story-names']));
   }
 
   if (options.untraced && !options.onlyChanged) {
@@ -163,7 +163,12 @@ export default function getOptions({ argv, env, flags, log, packageJson }: Conte
     throw new Error(invalidReportPath());
   }
 
-  if (options.preserveMissingSpecs) {
+  if (flags.only) {
+    log.info('');
+    log.info(deprecatedOption({ flag: 'only', replacement: 'onlyStoryNames' }));
+  }
+
+  if (flags.preserveMissing) {
     log.info('');
     log.info(deprecatedOption({ flag: 'preserveMissing' }));
   }

--- a/bin-src/lib/parseArgs.ts
+++ b/bin-src/lib/parseArgs.ts
@@ -28,6 +28,7 @@ export default function parseArgs(argv: string[]) {
       --externals <filepath>                    Disable TurboSnap when any of these files have changed since the baseline build. Globs are supported via picomatch. This flag can be specified multiple times. Requires --only-changed.
       --ignore-last-build-on-branch <branch>    Do not use the last build on this branch as a baseline if it is no longer in history (i.e. branch was rebased). Globs are supported via picomatch.
       --only-changed [branch]                   Enables TurboSnap: Only run stories affected by files changed since the baseline build. Only for [branch], if specified. Globs are supported via picomatch. All other snapshots will be inherited from the prior commit.
+      --only-story-names <storypath>            Only run a single story or a subset of stories. Story paths typically look like "Path/To/Story". Globs are supported via picomatch. This flag can be specified multiple times.
       --patch-build <headbranch...basebranch>   Create a patch build to fix a missing PR comparison.
       --skip [branch]                           Skip Chromatic tests, but mark the commit as passing. Avoids blocking PRs due to required merge checks. Only for [branch], if specified. Globs are supported via picomatch.
       --storybook-base-dir <dirname>            Relative path from repository root to Storybook project root. Use with --only-changed and --storybook-build-dir when running Chromatic from a different directory than your Storybook.
@@ -43,7 +44,6 @@ export default function parseArgs(argv: string[]) {
       --junit-report [filepath]     Write build results to a JUnit XML file. {buildNumber} will be replaced with the actual build number. [chromatic-build-{buildNumber}.xml]
       --list                        List available stories. This requires running a full build.
       --no-interactive              Don't ask interactive questions about your setup and don't overwrite output. Always true in non-TTY environments.
-      --only <storypath>            Only run a single story or a subset of stories. Story paths typically look like "Path/To/Story". Globs are supported via picomatch. This option implies --preserve-missing.
       --trace-changed [mode]        Print dependency trace for changed files to affected story files. Set to "expanded" to list individual modules. Requires --only-changed.
 
     Deprecated options
@@ -58,6 +58,7 @@ export default function parseArgs(argv: string[]) {
       --storybook-key <path>        Use with --storybook-https. Auto detected from the npm script when using --script-name.
       --storybook-ca <ca>           Use with --storybook-https. Auto detected from the npm script when using --script-name.
       --storybook-url, -u <url>     Run against an online Storybook at some URL. This implies --do-not-start.
+      --only                        Superceded by --only-story-names.
       --preserve-missing            Treat missing stories as unchanged rather than deleted when comparing to the baseline.
     `,
     {
@@ -81,8 +82,8 @@ export default function parseArgs(argv: string[]) {
         exitZeroOnChanges: { type: 'string' },
         externals: { type: 'string', isMultiple: true },
         ignoreLastBuildOnBranch: { type: 'string' },
-        only: { type: 'string' },
         onlyChanged: { type: 'string' },
+        onlyStoryNames: { type: 'string', isMultiple: true },
         patchBuild: { type: 'string' },
         skip: { type: 'string' },
         storybookBaseDir: { type: 'string' },
@@ -112,6 +113,7 @@ export default function parseArgs(argv: string[]) {
         storybookCert: { type: 'string' },
         storybookKey: { type: 'string' },
         storybookCa: { type: 'string' },
+        only: { type: 'string' },
         preserveMissing: { type: 'boolean' },
       },
     }

--- a/bin-src/types.ts
+++ b/bin-src/types.ts
@@ -19,8 +19,8 @@ export interface Flags {
   exitZeroOnChanges?: string;
   externals?: string[];
   ignoreLastBuildOnBranch?: string;
-  only?: string;
   onlyChanged?: string;
+  onlyStoryNames?: string[];
   patchBuild?: string;
   skip?: string;
   storybookBaseDir?: string;
@@ -50,14 +50,15 @@ export interface Flags {
   storybookCert?: string;
   storybookKey?: string;
   storybookCa?: string;
+  only?: string;
   preserveMissing?: boolean;
 }
 
 export interface Options {
   projectToken: string;
 
-  only: Flags['only'];
   onlyChanged: true | string;
+  onlyStoryNames: Flags['onlyStoryNames'];
   untraced: Flags['untraced'];
   externals: Flags['externals'];
   traceChanged: true | string;

--- a/bin-src/ui/messages/errors/invalidOnly.stories.ts
+++ b/bin-src/ui/messages/errors/invalidOnly.stories.ts
@@ -1,7 +1,0 @@
-import invalidOnly from './invalidOnly';
-
-export default {
-  title: 'CLI/Messages/Errors',
-};
-
-export const InvalidOnly = () => invalidOnly();

--- a/bin-src/ui/messages/errors/invalidOnlyStoryNames.stories.ts
+++ b/bin-src/ui/messages/errors/invalidOnlyStoryNames.stories.ts
@@ -1,0 +1,7 @@
+import invalidOnlyStoryNames from './invalidOnlyStoryNames';
+
+export default {
+  title: 'CLI/Messages/Errors',
+};
+
+export const InvalidOnlyStoryNames = () => invalidOnlyStoryNames();

--- a/bin-src/ui/messages/errors/invalidOnlyStoryNames.ts
+++ b/bin-src/ui/messages/errors/invalidOnlyStoryNames.ts
@@ -5,7 +5,7 @@ import { error } from '../../components/icons';
 
 export default () =>
   dedent(chalk`
-    ${error} Invalid {bold --only}
+    ${error} Invalid {bold --only-story-names}
     Value must be provided in the form {bold 'Path/To/MyStory'}.
     Globbing is supported, for example: 'Pages/**'
   `);

--- a/bin-src/ui/messages/info/listingStories.ts
+++ b/bin-src/ui/messages/info/listingStories.ts
@@ -9,13 +9,15 @@ interface Spec {
 }
 
 const snapshotRow = ({ spec }: { spec: Spec }) =>
-  chalk`{dim → }${spec.component.name}:${spec.name}`;
+  chalk`{dim → }${spec.component.name}/${spec.name}`;
 
 export default (snapshots: { spec: Spec }[]) =>
   dedent(chalk`
     {bold Listing available stories:}
     ${snapshots.map(snapshotRow).join('\n')}
 
-    ${info} Use {bold --only} to run a build for a specific component or story.
-    Globs are supported, for example: {bold --only "${snapshots[0].spec.component.name}:*"}
+    ${info} Use {bold --only-story-names} to run a build for a specific component or story.
+    Globs are supported, for example: {bold --only-story-names "${
+      snapshots[0].spec.component.name
+    }/**"}
   `);

--- a/bin-src/ui/messages/warnings/deprecatedOption.ts
+++ b/bin-src/ui/messages/warnings/deprecatedOption.ts
@@ -12,8 +12,8 @@ const snakify = (option: string) => `--${option.replace(/[A-Z]/g, '-$&').toLower
 export default ({ flag, replacement }: { flag: keyof Flags; replacement?: keyof Flags }) =>
   dedent(chalk`
     ${warning} {bold Using deprecated option: ${snakify(flag)}}
-    This option ${
-      replacement ? chalk`was superceded by {bold ${snakify(replacement)}}` : 'is deprecated'
+    This option is ${
+      replacement ? chalk`superceded by {bold ${snakify(replacement)}}` : 'deprecated'
     } and may be removed in a future release.
     Refer to the changelog for more information: ${link(changelogUrl)}
   `);

--- a/bin-src/ui/messages/warnings/deprecatedOption.ts
+++ b/bin-src/ui/messages/warnings/deprecatedOption.ts
@@ -7,9 +7,13 @@ import link from '../../components/link';
 
 const changelogUrl = 'https://github.com/chromaui/chromatic-cli/blob/main/CHANGELOG.md';
 
-export default ({ flag }: { flag: keyof Flags }) =>
+const snakify = (option: string) => `--${option.replace(/[A-Z]/g, '-$&').toLowerCase()}`;
+
+export default ({ flag, replacement }: { flag: keyof Flags; replacement?: keyof Flags }) =>
   dedent(chalk`
-    ${warning} {bold Using deprecated option: ${flag}}
-    This option is deprecated and may be removed in a future release.
+    ${warning} {bold Using deprecated option: ${snakify(flag)}}
+    This option ${
+      replacement ? chalk`was superceded by {bold ${snakify(replacement)}}` : 'is deprecated'
+    } and may be removed in a future release.
     Refer to the changelog for more information: ${link(changelogUrl)}
   `);

--- a/bin-src/ui/tasks/snapshot.stories.ts
+++ b/bin-src/ui/tasks/snapshot.stories.ts
@@ -50,7 +50,7 @@ export const PendingOnlyChanged = () =>
 
 export const PendingOnlyStoryNames = () =>
   pending(
-    { build: { ...build, actualTestCount: 8 }, options: { onlyStoryNames: 'Pages/**' } } as any,
+    { build: { ...build, actualTestCount: 8 }, options: { onlyStoryNames: ['Pages/**'] } } as any,
     { cursor: 6 }
   );
 

--- a/bin-src/ui/tasks/snapshot.stories.ts
+++ b/bin-src/ui/tasks/snapshot.stories.ts
@@ -43,15 +43,16 @@ export const Pending = () =>
     label: 'ComponentName › StoryName',
   });
 
-export const PendingOnly = () =>
-  pending({ build: { ...build, actualTestCount: 8 }, options: { only: 'Pages/**' } } as any, {
-    cursor: 6,
-  });
-
 export const PendingOnlyChanged = () =>
   pending({ build: { ...build, actualTestCount: 8 }, options, onlyStoryFiles: {} } as any, {
     cursor: 6,
   });
+
+export const PendingOnlyStoryNames = () =>
+  pending(
+    { build: { ...build, actualTestCount: 8 }, options: { onlyStoryNames: 'Pages/**' } } as any,
+    { cursor: 6 }
+  );
 
 export const BuildPassed = () => buildPassed({ build, now, startedAt } as any);
 

--- a/bin-src/ui/tasks/snapshot.ts
+++ b/bin-src/ui/tasks/snapshot.ts
@@ -42,7 +42,9 @@ export const stats = ({
 export const pending = (ctx: Context, { cursor = 0, label = '' } = {}) => {
   const { build, options, onlyStoryFiles } = ctx;
   const { errors, tests, skips } = stats(ctx);
-  const matching = options.only ? ` for stories matching '${options.only}'` : '';
+  const matching = options.onlyStoryNames
+    ? ` for stories matching '${options.onlyStoryNames}'`
+    : '';
   const affected = onlyStoryFiles ? ' affected by recent changes' : '';
   const skipping = build.testCount > build.actualTestCount ? ` (skipping ${skips})` : '';
   const percentage = Math.round((cursor / build.actualTestCount) * 100);

--- a/bin-src/ui/tasks/snapshot.ts
+++ b/bin-src/ui/tasks/snapshot.ts
@@ -43,7 +43,7 @@ export const pending = (ctx: Context, { cursor = 0, label = '' } = {}) => {
   const { build, options, onlyStoryFiles } = ctx;
   const { errors, tests, skips } = stats(ctx);
   const matching = options.onlyStoryNames
-    ? ` for stories matching '${options.onlyStoryNames}'`
+    ? ` for stories matching '${options.onlyStoryNames.join(', ')}'`
     : '';
   const affected = onlyStoryFiles ? ' affected by recent changes' : '';
   const skipping = build.testCount > build.actualTestCount ? ` (skipping ${skips})` : '';

--- a/bin-src/ui/tasks/verify.stories.ts
+++ b/bin-src/ui/tasks/verify.stories.ts
@@ -3,8 +3,8 @@ import {
   initial,
   dryRun,
   pending,
-  runOnly,
   runOnlyFiles,
+  runOnlyNames,
   success,
   failed,
   publishFailed,
@@ -29,12 +29,13 @@ export const Pending = () => pending();
 
 export const PublishFailed = () => publishFailed();
 
-export const RunOnly = () => runOnly({ options: { only: 'MyComponent/MyStory' } } as any);
-
 export const RunOnlyFiles = () =>
   runOnlyFiles({
     onlyStoryFiles: Object.fromEntries(Array.from({ length: 12 }, (_, i) => [i])),
   } as any);
+
+export const RunOnlyNames = () =>
+  runOnlyNames({ options: { onlyStoryNames: 'MyComponent/MyStory' } } as any);
 
 export const Started = () => success({ build } as any);
 
@@ -44,4 +45,5 @@ export const ContinueSetup = () => success({ isOnboarding: true, build } as any)
 
 export const NoStories = () => failed({ options: {} } as any);
 
-export const NoMatches = () => failed({ options: { only: 'MyComponent/MyStory' } } as any);
+export const NoMatches = () =>
+  failed({ options: { onlyStoryNames: 'MyComponent/MyStory' } } as any);

--- a/bin-src/ui/tasks/verify.stories.ts
+++ b/bin-src/ui/tasks/verify.stories.ts
@@ -35,7 +35,7 @@ export const RunOnlyFiles = () =>
   } as any);
 
 export const RunOnlyNames = () =>
-  runOnlyNames({ options: { onlyStoryNames: 'MyComponent/MyStory' } } as any);
+  runOnlyNames({ options: { onlyStoryNames: ['MyComponent/**'] } } as any);
 
 export const Started = () => success({ build } as any);
 
@@ -46,4 +46,4 @@ export const ContinueSetup = () => success({ isOnboarding: true, build } as any)
 export const NoStories = () => failed({ options: {} } as any);
 
 export const NoMatches = () =>
-  failed({ options: { onlyStoryNames: 'MyComponent/MyStory' } } as any);
+  failed({ options: { onlyStoryNames: ['MyComponent/MyStory'] } } as any);

--- a/bin-src/ui/tasks/verify.ts
+++ b/bin-src/ui/tasks/verify.ts
@@ -23,18 +23,18 @@ export const publishFailed = () => ({
   output: 'Failed to publish build',
 });
 
-export const runOnly = (ctx: Context) => ({
-  status: 'pending',
-  title: 'Starting partial build',
-  output: `Snapshots will be limited to stories matching '${ctx.options.only}'`,
-});
-
 export const runOnlyFiles = (ctx: Context) => ({
   status: 'pending',
   title: 'Starting partial build',
   output: `Snapshots will be limited to ${
     Object.keys(ctx.onlyStoryFiles).length
   } story files affected by recent changes`,
+});
+
+export const runOnlyNames = (ctx: Context) => ({
+  status: 'pending',
+  title: 'Starting partial build',
+  output: `Snapshots will be limited to stories matching ${ctx.options.onlyStoryNames.join(', ')}`,
 });
 
 export const success = (ctx: Context) => ({
@@ -48,7 +48,7 @@ export const success = (ctx: Context) => ({
 export const failed = (ctx: Context) => ({
   status: 'error',
   title: 'Verifying your Storybook',
-  output: ctx.options.only
-    ? 'Cannot run a build with no stories. Change or omit the --only predicate.'
+  output: ctx.options.onlyStoryNames
+    ? 'Cannot run a build with no stories. Change or omit the --only-story-names predicate.'
     : 'Cannot run a build with no stories. Please add some stories!',
 });


### PR DESCRIPTION
<img width="890" alt="Screen Shot 2022-08-17 at 15 44 05" src="https://user-images.githubusercontent.com/321738/185149757-1feca8fe-4726-4114-bfee-0654d77591cc.png">

Contrary to `--only`, `--only-story-names` can be specified multiple times.
