### PR TITLE
Retry queries by default and allow even more retries for `FirstCommittedAtQuery`

### DIFF
--- a/bin-src/git/getParentCommits.ts
+++ b/bin-src/git/getParentCommits.ts
@@ -182,10 +182,11 @@ export async function getParentCommits(
   const { branch, commit, committedAt } = git;
 
   // Include the latest build from this branch as an ancestor of the current build
-  const { app } = await client.runQuery<FirstCommittedAtQueryResult>(FirstCommittedAtQuery, {
-    branch,
-    commit,
-  });
+  const { app } = await client.runQuery<FirstCommittedAtQueryResult>(
+    FirstCommittedAtQuery,
+    { branch, commit },
+    { retries: 5 } // This query requires a request to an upstream provider which may fail
+  );
   const { firstBuild, lastBuild, pullRequest } = app;
   log.debug(
     `App firstBuild: %o, lastBuild: %o, pullRequest: %o`,

--- a/bin-src/io/GraphQLClient.ts
+++ b/bin-src/io/GraphQLClient.ts
@@ -35,7 +35,7 @@ export default class GraphQLClient {
   async runQuery(
     query: string,
     variables: Record<string, any>,
-    { headers = {}, retries = 0 } = {}
+    { headers = {}, retries = 2 } = {}
   ) {
     return retry(
       async (bail) => {


### PR DESCRIPTION
This should deal with network flake and handle brief outages at the upstream Git provider (for up to several minutes).