### PR TITLE
Finer-grained TurboSnap: Determines dependent story files based on package.json dependency version changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,8 @@
   },
   "dependencies": {
     "@discoveryjs/json-ext": "^0.5.7",
-    "@types/webpack-env": "^1.17.0"
+    "@types/webpack-env": "^1.17.0",
+    "parse-diff": "^0.9.0"
   },
   "devDependencies": {
     "@actions/core": "^1.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10676,6 +10676,11 @@ parse-asn1@^5.0.0, parse-asn1@^5.1.5:
     pbkdf2 "^3.0.3"
     safe-buffer "^5.1.1"
 
+parse-diff@^0.9.0:
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/parse-diff/-/parse-diff-0.9.0.tgz#2e71b5dc5d8f4b9c19c471fd6325646dc9f21724"
+  integrity sha512-Jn+VZORAezkfOXR6B40EZcXxdJBamtgBpfeoFH6hxD+p0e74nVaCL9SWlQj1ggc8b6AexgPKlDiiE0CMMZDSbQ==
+
 parse-entities@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/parse-entities/-/parse-entities-2.0.0.tgz#53c6eb5b9314a1f4ec99fa0fdf7ce01ecda0cbe8"


### PR DESCRIPTION
Note: Code is pretty rough, this is more to get the approach out there for review (I need to add tests, get better variable names, move things around, etc).

I have an initial approach (thanks @ghengeveld for pairing on this) for keeping TurboSnap enabled when a dependency version in a `package.json` file changes. This will enable us to avoid bailing if a change happens to a package file or a lockfile. We may eventually look in lockfiles for changes, but the same pattern should apply.

Adds dependency [`parse-diff`](https://www.npmjs.com/package/parse-diff) to make it easier to tell what lines actually changed.

To test:
 - Create a placeholder repo with a storybook and Chromatic project, using TurboSnap
 - yarn link this repo to that project
 - Add a dependency to a component in that project
 - Commit and run a build
 - Tweak the dependency in package.json (doesn't matter for now if it's valid)
 - (without committing) run another build (temporary thing)
 - Verify that the story/stories for the component using that dependency is snapshotted, but nothing else

