### PR TITLE
Check `onlyStoryNames` is non-empty

### DIFF
--- a/bin-src/lib/getOptions.ts
+++ b/bin-src/lib/getOptions.ts
@@ -62,7 +62,7 @@ export default function getOptions({ argv, env, flags, log, packageJson }: Conte
     exitOnceUploaded: trueIfSet(flags.exitOnceUploaded),
     ignoreLastBuildOnBranch: flags.ignoreLastBuildOnBranch,
     // deprecated
-    preserveMissingSpecs: flags.preserveMissing || !!flags.only || flags.onlyStoryNames.length > 0,
+    preserveMissingSpecs: flags.preserveMissing || !!flags.only || !!flags.onlyStoryNames?.length,
     originalArgv: argv,
 
     buildScriptName: flags.buildScriptName,

--- a/bin-src/lib/getOptions.ts
+++ b/bin-src/lib/getOptions.ts
@@ -61,7 +61,8 @@ export default function getOptions({ argv, env, flags, log, packageJson }: Conte
     exitZeroOnChanges: trueIfSet(flags.exitZeroOnChanges),
     exitOnceUploaded: trueIfSet(flags.exitOnceUploaded),
     ignoreLastBuildOnBranch: flags.ignoreLastBuildOnBranch,
-    preserveMissingSpecs: flags.preserveMissing || !!flags.only || !!flags.onlyStoryNames, // deprecated
+    // deprecated
+    preserveMissingSpecs: flags.preserveMissing || !!flags.only || flags.onlyStoryNames.length > 0,
     originalArgv: argv,
 
     buildScriptName: flags.buildScriptName,


### PR DESCRIPTION
It is always set to an array.

Fix issue introduced in https://github.com/chromaui/chromatic-cli/pull/643