### PR TITLE
Dealing with URL Params in stats file module names

### DIFF
--- a/bin-src/lib/getDependentStoryFiles.test.ts
+++ b/bin-src/lib/getDependentStoryFiles.test.ts
@@ -185,6 +185,38 @@ describe('getDependentStoryFiles', () => {
     });
   });
 
+  it('detects indirect changes to CSF files, angular css resource', async () => {
+    const changedFiles = ['src/foo.css'];
+    const modules = [
+      {
+        id: null,
+        name: './src/foo.css?ngResource ',
+        reasons: [{ moduleName: './src/foo.component.ts' }],
+      },
+      {
+        id: './src/foo.component.ts',
+        name: './src/foo.component.ts + 1 modules',
+        modules: [{ name: './src/foo.component.ts' }, { name: './src/foo.css?ngResource' }],
+        reasons: [{ moduleName: './src/foo.stories.ts' }],
+      },
+      {
+        id: './src/foo.stories.ts',
+        name: './src/foo.stories.ts',
+        reasons: [{ moduleName: CSF_GLOB }],
+      },
+      {
+        id: CSF_GLOB,
+        name: CSF_GLOB,
+        reasons: [{ moduleName: './.storybook/generated-stories-entry.js' }],
+      },
+    ];
+    const ctx = getContext();
+    const res = await getDependentStoryFiles(ctx, { modules }, statsPath, changedFiles);
+    expect(res).toEqual({
+      './src/foo.stories.ts': ['src/foo.stories.ts'],
+    });
+  });
+
   it('detects indirect changes to CSF files in a single module chunk', async () => {
     const changedFiles = ['src/foo.js'];
     const modules = [

--- a/bin-src/lib/getDependentStoryFiles.ts
+++ b/bin-src/lib/getDependentStoryFiles.ts
@@ -70,8 +70,8 @@ export async function getDependentStoryFiles(
   // Convert a "webpack path" (relative to storybookBaseDir) to a "git path" (relative to repository root)
   // e.g. `./src/file.js` => `path/to/storybook/src/file.js`
   const normalize = (posixPath: string) => {
-    const CSF_REGEX = /.\/src.*?sync/g;
-    const URL_PARAM_REGEX = /(\?.*)|(#.*)/g;
+    const CSF_REGEX = /\s+sync\s+/g;
+    const URL_PARAM_REGEX = /(\?.*)/g;
     let newPath = normalizePath(posixPath, rootPath, baseDir);
     // This regex test is to ensure file names do not include url parmeters
     // or match the CSF glob we get back in the stats file. We added this because

--- a/bin-src/lib/getDependentStoryFiles.ts
+++ b/bin-src/lib/getDependentStoryFiles.ts
@@ -99,6 +99,10 @@ export async function getDependentStoryFiles(
     .filter((mod) => isUserModule(mod))
     .forEach((mod) => {
       let { name } = mod;
+      // This regex test is to ensure file names do not include url parmeters
+      // or match the CSF glob we get back in the stats file. We added this because
+      // CSS/SCSS files were getting ?ngResource appended on the end of file names
+      // in the stats file.
       if (URL_PARAM_REGEX.test(mod.name) && !CSF_REGEX.test(mod.name)) {
         [name] = mod.name.replace(URL_PARAM_REGEX, '');
       }

--- a/bin-src/lib/getDependentStoryFiles.ts
+++ b/bin-src/lib/getDependentStoryFiles.ts
@@ -93,13 +93,14 @@ export async function getDependentStoryFiles(
   const namesById: Record<number, string> = {};
   const reasonsById: Record<number, string[]> = {};
   const csfGlobsByName: Record<string, true> = {};
-
+  const CSF_REGEX = /.\/src.*?sync/g;
+  const URL_PARAM_REGEX = /(\?.*)|(#.*)/g;
   stats.modules
     .filter((mod) => isUserModule(mod))
     .forEach((mod) => {
       let { name } = mod;
-      if (mod.name.includes('?ngResource')) {
-        [name] = mod.name.split('?');
+      if (URL_PARAM_REGEX.test(mod.name) && !CSF_REGEX.test(mod.name)) {
+        [name] = mod.name.replace(URL_PARAM_REGEX, '');
       }
       const normalizedName = normalize(name);
       modulesByName[normalizedName] = mod;
@@ -107,8 +108,13 @@ export async function getDependentStoryFiles(
 
       if (mod.modules) {
         mod.modules.forEach((m) => {
-          modulesByName[normalize(m.name.includes('?ngResource') ? m.name.split('?')[0] : m.name)] =
-            mod;
+          modulesByName[
+            normalize(
+              URL_PARAM_REGEX.test(m.name) && !CSF_REGEX.test(m.name)
+                ? m.name.replace(URL_PARAM_REGEX, '')
+                : m.name
+            )
+          ] = mod;
         });
       }
 

--- a/bin-src/lib/getDependentStoryFiles.ts
+++ b/bin-src/lib/getDependentStoryFiles.ts
@@ -110,8 +110,7 @@ export async function getDependentStoryFiles(
   stats.modules
     .filter((mod) => isUserModule(mod))
     .forEach((mod) => {
-      const { name } = mod;
-      const normalizedName = normalize(name);
+      const normalizedName = normalize(mod.name);
       modulesByName[normalizedName] = mod;
       namesById[mod.id] = normalizedName;
 

--- a/bin-src/lib/getDependentStoryFiles.ts
+++ b/bin-src/lib/getDependentStoryFiles.ts
@@ -97,13 +97,18 @@ export async function getDependentStoryFiles(
   stats.modules
     .filter((mod) => isUserModule(mod))
     .forEach((mod) => {
-      const normalizedName = normalize(mod.name);
+      let { name } = mod;
+      if (mod.name.includes('?ngResource')) {
+        [name] = mod.name.split('?');
+      }
+      const normalizedName = normalize(name);
       modulesByName[normalizedName] = mod;
       namesById[mod.id] = normalizedName;
 
       if (mod.modules) {
         mod.modules.forEach((m) => {
-          modulesByName[normalize(m.name)] = mod;
+          modulesByName[normalize(m.name.includes('?ngResource') ? m.name.split('?')[0] : m.name)] =
+            mod;
         });
       }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chromatic",
-  "version": "6.10.2-next.0",
+  "version": "6.10.2-next.1",
   "description": "Automate visual testing across browsers. Gather UI feedback. Versioned documentation.",
   "keywords": [
     "storybook-addon",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chromatic",
-  "version": "6.10.2-next.1",
+  "version": "6.10.2-next.2",
   "description": "Automate visual testing across browsers. Gather UI feedback. Versioned documentation.",
   "keywords": [
     "storybook-addon",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,15 +1,12 @@
 {
   "exclude": ["node_modules"],
   "compilerOptions": {
-    "target": "es5",
+    "target": "ES6",
     "module": "commonjs",
     "moduleResolution": "node",
     "noImplicitAny": false,
     "esModuleInterop": true,
     "resolveJsonModule": true,
-    "types": [
-      "jest",
-      "webpack-env"
-    ]
+    "types": ["jest", "webpack-env"]
   }
 }


### PR DESCRIPTION
If the name of a module in the Webpack Stats file has a URL parameter (e.g. ?ngResource) in it, it causes an issue with tracing the file. This PR resolves the issue.