### PR TITLE
Update buildHasErrors with interaction test failure specific messaging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 6.10.2 - 2022-10-11
+# 6.10.2 - 2022-10-19
 
 - [651](https://github.com/chromaui/chromatic-cli/pull/651) Update buildHasErrors with interaction test failure specific messaging
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # 6.10.2 - 2022-10-11
 
+- [651](https://github.com/chromaui/chromatic-cli/pull/651) Update buildHasErrors with interaction test failure specific messaging
+
+# 6.10.2 - 2022-10-11
+
 - [649](https://github.com/chromaui/chromatic-cli/pull/649) Fix TurboSnap for module names containing URL params in stats file
 - [650](https://github.com/chromaui/chromatic-cli/pull/650) Ensure all GitHub Action outputs are exposed
 

--- a/bin-src/tasks/verify.ts
+++ b/bin-src/tasks/verify.ts
@@ -91,6 +91,7 @@ interface StartedBuildQueryResult {
   };
 }
 
+// these fields must be part of authorizedBuildFieldsViaAppCode in the public api
 const VerifyBuildQuery = `
   query VerifyBuildQuery($number: Int!) {
     app {

--- a/bin-src/tasks/verify.ts
+++ b/bin-src/tasks/verify.ts
@@ -106,6 +106,7 @@ const VerifyBuildQuery = `
         actualTestCount: testCount(statuses: [IN_PROGRESS])
         actualCaptureCount
         inheritedCaptureCount
+        interactionTestFailuresCount
         webUrl
         cachedUrl
         browsers {

--- a/bin-src/types.ts
+++ b/bin-src/types.ts
@@ -214,6 +214,7 @@ export interface Context {
     testCount: number;
     changeCount: number;
     errorCount: number;
+    interactionTestFailuresCount: number;
     inProgressCount?: number;
     autoAcceptChanges: boolean;
     wasLimited?: boolean;

--- a/bin-src/ui/messages/errors/buildHasErrors.stories.ts
+++ b/bin-src/ui/messages/errors/buildHasErrors.stories.ts
@@ -12,3 +12,22 @@ export const BuildHasErrors = () =>
     },
     exitCode: 1,
   });
+export const BuildHasErrorsAndInteractionTestFailure = () =>
+  buildHasErrors({
+    build: {
+      errorCount: 2,
+      interactionTestFailuresCount: 1,
+      webUrl: 'https://www.chromatic.com/build?appId=59c59bd0183bd100364e1d57&number=42',
+    },
+    exitCode: 1,
+  });
+
+export const BuildHasOnlyInteractionTestFailure = () =>
+  buildHasErrors({
+    build: {
+      errorCount: 2,
+      interactionTestFailuresCount: 2,
+      webUrl: 'https://www.chromatic.com/build?appId=59c59bd0183bd100364e1d57&number=42',
+    },
+    exitCode: 1,
+  });

--- a/bin-src/ui/messages/errors/buildHasErrors.ts
+++ b/bin-src/ui/messages/errors/buildHasErrors.ts
@@ -9,19 +9,15 @@ export default ({ build, exitCode }) => {
   const { errorCount, interactionTestFailuresCount, webUrl } = build;
   const hasInteractionTestFailures = interactionTestFailuresCount > 0;
   const hasOtherErrors = errorCount - interactionTestFailuresCount > 0;
+  const failedTests = pluralize('failed test', interactionTestFailuresCount, true);
 
   let errorMessage;
 
   if (hasInteractionTestFailures && hasOtherErrors) {
     const errors = pluralize('build error', errorCount - interactionTestFailuresCount, true);
-
-    errorMessage = `Encountered ${errors} and ${pluralize(
-      'failed test',
-      interactionTestFailuresCount,
-      true
-    )}`;
+    errorMessage = `Encountered ${errors} and ${failedTests}`;
   } else if (hasInteractionTestFailures) {
-    errorMessage = `Encountered ${pluralize('failed test', interactionTestFailuresCount, true)}`;
+    errorMessage = `Encountered ${failedTests}`;
   } else {
     const errors = pluralize('build error', errorCount, true);
     errorMessage = `Encountered ${errors}`;

--- a/bin-src/ui/messages/errors/buildHasErrors.ts
+++ b/bin-src/ui/messages/errors/buildHasErrors.ts
@@ -2,14 +2,34 @@ import chalk from 'chalk';
 import pluralize from 'pluralize';
 import { dedent } from 'ts-dedent';
 
-import { error, info } from '../../components/icons';
+import { error as errorIcon, info as infoIcon } from '../../components/icons';
 import link from '../../components/link';
 
 export default ({ build, exitCode }) => {
-  const errors = pluralize('build error', build.errorCount, true);
+  const { errorCount, interactionTestFailuresCount, webUrl } = build;
+  const hasInteractionTestFailures = interactionTestFailuresCount > 0;
+  const hasOtherErrors = errorCount - interactionTestFailuresCount > 0;
+
+  let errorMessage;
+
+  if (hasInteractionTestFailures && hasOtherErrors) {
+    const errors = pluralize('build error', errorCount - interactionTestFailuresCount, true);
+
+    errorMessage = `Encountered ${errors} and ${pluralize(
+      'failed test',
+      interactionTestFailuresCount,
+      true
+    )}`;
+  } else if (hasInteractionTestFailures) {
+    errorMessage = `Encountered ${pluralize('failed test', interactionTestFailuresCount, true)}`;
+  } else {
+    const errors = pluralize('build error', errorCount, true);
+    errorMessage = `Encountered ${errors}`;
+  }
+
   return dedent(chalk`
-    ${error} {bold Encountered ${errors}}: failing with exit code ${exitCode}
+    ${errorIcon} {bold ${errorMessage}}: failing with exit code ${exitCode}
     Pass {bold --allow-console-errors} to succeed this command regardless of runtime build errors.
-    ${info} Review the errors at ${link(build.webUrl)}
+    ${infoIcon} Review the errors at ${link(webUrl)}
   `);
 };

--- a/bin-src/ui/messages/errors/buildHasErrors.ts
+++ b/bin-src/ui/messages/errors/buildHasErrors.ts
@@ -1,7 +1,6 @@
 import chalk from 'chalk';
 import pluralize from 'pluralize';
 import { dedent } from 'ts-dedent';
-
 import { error as errorIcon, info as infoIcon } from '../../components/icons';
 import link from '../../components/link';
 


### PR DESCRIPTION
This PR includes 
* Updating the test storybook to 6.5.12 and adding an interaction test
* Requesting an additional field on Build for the verify step which helps to show more accurate interaction test failure messaging in buildHasErrors
![image](https://user-images.githubusercontent.com/1164060/195418938-8eb417cf-2fbb-4a84-ad17-fb0da2700b1c.png)
