### PR TITLE
Added an example for a TurboSnap optimized flow

### DIFF
--- a/.github/workflows/chromatic-main-and-prs.yml
+++ b/.github/workflows/chromatic-main-and-prs.yml
@@ -15,20 +15,15 @@ jobs:
           fetch-depth: 0
       - name: install
         run: yarn install --frozen-lockfile
-      - uses: chromaui/action-next@v1
+      - uses: chromaui/action@v1
         with:
+          # 👇 Chromatic projectToken, refer to the manage page to obtain it.
+          projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
           exitOnceUploaded: true
           onlyChanged: true
           traceChanged: true
           diagnostics: true
-          # Only use this if you notice too many builds with TurboSnap exiting due to a global package.json, package-lock.json, yarn.lock
-          # Typically for use when you have an active repository with lots of rebasing or squash and merge commits
-          # Documentation https://www.chromatic.com/docs/turbosnap#avoid-re-testing-on-changes-to-package-control-files
-          # This pattern will ignore all of the following files (package.json src/app/package.json yarn.lock app/yarn.lock)
-          untraced: |
-            - '**/(package**.json|yarn.lock)'
-        env:
-          CHROMATIC_PROJECT_TOKEN: gcaw1ai2dgo
+          skip: ${{ github.event.pull_request.draft == true }}
       - uses: actions/upload-artifact@v2
         if: always()
         with:

--- a/.github/workflows/chromatic-main-and-prs.yml
+++ b/.github/workflows/chromatic-main-and-prs.yml
@@ -1,4 +1,4 @@
-name: Chromatic
+name: Chromatic Main and Active PRs only
 on:
   push:
     branches:

--- a/.github/workflows/chromatic-main-and-prs.yml
+++ b/.github/workflows/chromatic-main-and-prs.yml
@@ -1,0 +1,38 @@
+name: Chromatic
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types: [assigned, ready_for_review, review_requested]
+
+jobs:
+  chromatic:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: install
+        run: yarn install --frozen-lockfile
+      - uses: chromaui/action-next@v1
+        with:
+          exitOnceUploaded: true
+          onlyChanged: true
+          traceChanged: true
+          diagnostics: true
+          # Only use this if you notice too many builds with TurboSnap exiting due to a global package.json, package-lock.json, yarn.lock
+          # Typically for use when you have an active repository with lots of rebasing or squash and merge commits
+          # Documentation https://www.chromatic.com/docs/turbosnap#avoid-re-testing-on-changes-to-package-control-files
+          # This pattern will ignore all of the following files (package.json src/app/package.json yarn.lock app/yarn.lock)
+          untraced: |
+            - '**/(package**.json|yarn.lock)'
+        env:
+          CHROMATIC_PROJECT_TOKEN: gcaw1ai2dgo
+      - uses: actions/upload-artifact@v2
+        if: always()
+        with:
+          name: chromatic-build-artifacts-${{ github.run_id }}
+          path: |
+            chromatic-diagnostics.json
+            **/build-storybook.log


### PR DESCRIPTION
This PR adds an example yml configuration for when a user wants to really optimize the use of Chromatic with TurboSnap including:
* Disabling full re-builds when a global package file has changed
* Running only on push to main or the default base branch (`main, master, develop`)
* Running only on an active Pull request