### PR TITLE
add interactionTestFailuresCount to github action output

### DIFF
--- a/action-src/main.ts
+++ b/action-src/main.ts
@@ -88,6 +88,7 @@ interface Output {
   testCount: number;
   changeCount: number;
   errorCount: number;
+  interactionTestFailuresCount: number;
   actualTestCount: number;
   actualCaptureCount: number;
   inheritedCaptureCount: number;
@@ -122,6 +123,7 @@ async function runChromatic(options): Promise<Output> {
     testCount: ctx.build?.testCount,
     changeCount: ctx.build?.changeCount,
     errorCount: ctx.build?.errorCount,
+    interactionTestFailuresCount: ctx.build?.interactionTestFailuresCount,
     actualTestCount: ctx.build?.actualTestCount,
     actualCaptureCount: ctx.build?.actualCaptureCount,
     inheritedCaptureCount: ctx.build?.inheritedCaptureCount,

--- a/action.yml
+++ b/action.yml
@@ -128,6 +128,8 @@ outputs:
     description: 'The number of tests with visual changes, including any inherited changes (e.g. due to TurboSnap)'
   errorCount:
     description: 'The number of tests with error(s), including any inherited errors (e.g. due to TurboSnap)'
+  interactionTestFailuresCount:
+    description: 'The number of stories with interaction test failures'
   actualCaptureCount:
     description: 'The number of captured snapshots'
   inheritedCaptureCount:


### PR DESCRIPTION
This is a follow on to #651 so that we also include this info in the github action output