### PR TITLE
Update action to use node16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -135,4 +135,4 @@ outputs:
 
 runs:
   main: action/main.js
-  using: node12
+  using: node16


### PR DESCRIPTION
Node 12 actions are deprecated. This update the node version used to `node16`