### PR TITLE
Added onlyStoryFiles to the github action

### DIFF
--- a/action-src/main.ts
+++ b/action-src/main.ts
@@ -147,6 +147,7 @@ async function run() {
     const only = getInput('only');
     const onlyChanged = getInput('onlyChanged');
     const onlyStoryNames = getInput('onlyStoryNames');
+    const onlyStoryFiles = getInput('onlyStoryFiles');
     const externals = getInput('externals');
     const untraced = getInput('untraced');
     const traceChanged = getInput('traceChanged');
@@ -191,6 +192,7 @@ async function run() {
       only: maybe(only),
       onlyChanged: maybe(onlyChanged),
       onlyStoryNames: maybe(onlyStoryNames),
+      onlyStoryFiles: maybe(onlyStoryFiles),
       externals: maybe(externals),
       untraced: maybe(untraced),
       storybookBaseDir: maybe(storybookBaseDir),

--- a/action.yml
+++ b/action.yml
@@ -51,6 +51,9 @@ inputs:
   onlyStoryNames:
     description: 'Only run a single story or a subset of stories by their name'
     required: false
+  onlyStoryFiles:
+    description: 'Only run a single story or a subset of stories by their filename(s)'
+    required: false
   externals:
     description: 'Disable TurboSnap when any of these files have changed since the baseline build'
     required: false


### PR DESCRIPTION
This PR adds `onlyStoryFiles` as an option for the GitHub Action.

It is included as an option on the [Chromatic CLI docs](https://www.chromatic.com/docs/cli#chromatic-options).