### PR TITLE
Trace command errors for package manifest change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 6.11.3 - 2022-10-31
+
+- [670](https://github.com/chromaui/chromatic-cli/pull/670) Trace command errors for package manifest change
+
 # 6.11.2 - 2022-10-26
 
 - [667](https://github.com/chromaui/chromatic-cli/pull/667) Edit package file detection process for the untraced flag

--- a/bin-src/lib/getDependentStoryFiles.ts
+++ b/bin-src/lib/getDependentStoryFiles.ts
@@ -192,7 +192,7 @@ export async function getDependentStoryFiles(
     // If package.json dependencies changed, we still want to use the same TurboSnap bail reason
     // for now.
     // if package.jsons are untraced, don't bail, even when its dependency fields have changed
-  } else if (ctx.git.changedPackageManifests?.length && tracedFiles.filter(isPackageFile).length) {
+  } else if (ctx.git?.changedPackageManifests?.length && tracedFiles.filter(isPackageFile).length) {
     ctx.turboSnap.bailReason = { changedPackageFiles: ctx.git.changedPackageManifests };
   }
 

--- a/bin-src/trace.ts
+++ b/bin-src/trace.ts
@@ -92,7 +92,7 @@ export async function main(argv: string[]) {
   const packageManifestFile = changedFiles.find((item) => isPackageManifestFile(item));
   if (packageManifestFile) {
     throw new Error(
-      'Unable to trace package manifest file as that would require diffing file contents.'
+      `Unable to trace package manifest file (${packageManifestFile}) as that would require diffing file contents.`
     );
   }
 

--- a/bin-src/trace.ts
+++ b/bin-src/trace.ts
@@ -2,6 +2,7 @@ import meow from 'meow';
 import { getDependentStoryFiles } from './lib/getDependentStoryFiles';
 import { Context } from './types';
 import { readStatsFile } from './tasks/read-stats-file';
+import { isPackageManifestFile } from './lib/utils';
 
 /**
  * Utility to trace a set of changed file paths to dependent story files using a Webpack stats file.
@@ -87,6 +88,13 @@ export async function main(argv: string[]) {
   } as any;
   const stats = await readStatsFile(flags.statsFile);
   const changedFiles = input.map((f) => f.replace(/^\.\//, ''));
+
+  const packageManifestFile = changedFiles.find((item) => isPackageManifestFile(item));
+  if (packageManifestFile) {
+    throw new Error(
+      'Unable to trace package manifest file as that would require diffing file contents.'
+    );
+  }
 
   await getDependentStoryFiles(ctx, stats, flags.statsFile, changedFiles);
 }


### PR DESCRIPTION
In #648 we started looking within package manifest files and only bailing from TurboSnap if the change was dependency-related. However the `trace` command was failing because we were looking for info that didn't exist. 

Now we throw an error if a person attempts to trace a package.json file, since we'd need to know the file contents (and not just the file path) to know if that file would cause changes to story files.

New error message:
<img width="632" alt="Screen Shot 2022-10-31 at 4 38 24 PM" src="https://user-images.githubusercontent.com/5875149/199129583-db2fefaa-003d-4b82-a6d9-93b51288b796.png">
