### PR TITLE
Improve the failure message when there's only one git commit

### DIFF
--- a/bin-src/ui/messages/errors/gitOneCommit.ts
+++ b/bin-src/ui/messages/errors/gitOneCommit.ts
@@ -14,7 +14,7 @@ export default (isGithubAction = false) =>
         With {bold actions/checkout@v2}, you can enable this by setting 'fetch-depth: 0'.
         ${info} Read more at ${link('https://www.chromatic.com/docs/github-actions')}
       - You've only made a single commit so far. 
-        Chromatic needs an additional commit to be able to detect what's changed. 
+        Please make at least one additional commit to be able to detect what's changed. 
     `)
     : dedent(chalk`
       ${error} {bold Found only one commit}
@@ -23,5 +23,5 @@ export default (isGithubAction = false) =>
         In order for Chromatic to correctly determine baseline commits, we need access to the full Git history graph.
         Refer to your CI provider's documentation for details.
       - You've only made a single commit so far.  
-        Chromatic needs an additional commit to be able to detect what's changed.
+        Please make at least one additional commit to be able to detect what's changed.
     `);

--- a/bin-src/ui/messages/errors/gitOneCommit.ts
+++ b/bin-src/ui/messages/errors/gitOneCommit.ts
@@ -14,7 +14,7 @@ export default (isGithubAction = false) =>
         With {bold actions/checkout@v2}, you can enable this by setting 'fetch-depth: 0'.
         ${info} Read more at ${link('https://www.chromatic.com/docs/github-actions')}
       - You've only made a single commit so far. 
-        Please make at least one additional commit to be able to detect what's changed. 
+        Please make at least one additional commit in order for Chromatic to be able to detect what's changed. 
     `)
     : dedent(chalk`
       ${error} {bold Found only one commit}
@@ -23,5 +23,5 @@ export default (isGithubAction = false) =>
         In order for Chromatic to correctly determine baseline commits, we need access to the full Git history graph.
         Refer to your CI provider's documentation for details.
       - You've only made a single commit so far.  
-        Please make at least one additional commit to be able to detect what's changed.
+        Please make at least one additional commit in order for Chromatic to be able to detect what's changed.
     `);

--- a/bin-src/ui/messages/errors/gitOneCommit.ts
+++ b/bin-src/ui/messages/errors/gitOneCommit.ts
@@ -8,14 +8,20 @@ export default (isGithubAction = false) =>
   isGithubAction
     ? dedent(chalk`
       ${error} {bold Found only one commit}
-      This typically means you've checked out a shallow copy of the Git repository, which {bold actions/checkout@v2} does by default.
-      In order for Chromatic to correctly determine baseline commits, we need access to the full Git history graph.
-      With {bold actions/checkout@v2}, you can enable this by setting 'fetch-depth: 0'.
-      ${info} Read more at ${link('https://www.chromatic.com/docs/github-actions')}
+      This typically means you have ran into one of the following scenarios:
+      - You've checked out a shallow copy of the Git repository, which {bold actions/checkout@v2} does by default.
+        In order for Chromatic to correctly determine baseline commits, we need access to the full Git history graph.
+        With {bold actions/checkout@v2}, you can enable this by setting 'fetch-depth: 0'.
+        ${info} Read more at ${link('https://www.chromatic.com/docs/github-actions')}
+      - You've only made a single commit so far. 
+        Chromatic needs an additional commit to be able to detect what's changed. 
     `)
     : dedent(chalk`
       ${error} {bold Found only one commit}
-      This typically means you've checked out a shallow copy of the Git repository, which some CI systems do by default.
-      In order for Chromatic to correctly determine baseline commits, we need access to the full Git history graph.
-      Refer to your CI provider's documentation for details.
+      This typically means you have ran into one of the following scenarios:
+      - You've checked out a shallow copy of the Git repository, which some CI systems do by default.
+        In order for Chromatic to correctly determine baseline commits, we need access to the full Git history graph.
+        Refer to your CI provider's documentation for details.
+      - You've only made a single commit so far.  
+        Chromatic needs an additional commit to be able to detect what's changed.
     `);


### PR DESCRIPTION
A lot of customers write in to support when their builds fail due to one commit. This ticket is to improve the messaging.