### PR TITLE
Omit `inputs` for `workflow_dispatch` event in GitHub Action

### DIFF
--- a/action-src/main.ts
+++ b/action-src/main.ts
@@ -55,20 +55,10 @@ const getBuildInfo = (event: typeof context) => {
       };
     }
     case 'workflow_dispatch': {
-      const { ref, sha } = event.payload.inputs || {};
-
-      if (!ref || !sha) {
-        setFailed(
-          `When triggering via workflow_dispatch, ref & sha are required inputs. See https://github.com/chromaui/action#triggering-from-workflow_dispatch`
-        );
-        return null;
-      }
-
       return {
+        sha: event.sha,
+        branch: event.ref.replace('refs/heads/', ''),
         slug: event.payload.repository.full_name,
-        branch: ref.replace('refs/heads/', ''),
-        ref,
-        sha,
       };
     }
     default: {


### PR DESCRIPTION
The support for `workflow_dispatch` added in #311, but it is a pain to set `inputs` manually.
This should be possible to automate, so I modified the implementation.