### PR TITLE
Add `--repository-slug` flag to CLI, and `repositorySlug` + `branchName` options to Action

### DIFF
--- a/action-src/main.ts
+++ b/action-src/main.ts
@@ -136,30 +136,30 @@ async function run() {
 
   try {
     // Remember to keep this list in sync with ../action.yml
-    const projectToken = getInput('projectToken') || getInput('appCode'); // backwards compatibility
-    const workingDir = getInput('workingDir') || getInput('workingDirectory');
+    const allowConsoleErrors = getInput('allowConsoleErrors');
+    const autoAcceptChanges = getInput('autoAcceptChanges');
     const buildScriptName = getInput('buildScriptName');
-    const skip = getInput('skip');
+    const debug = getInput('debug');
+    const diagnostics = getInput('diagnostics');
     const dryRun = getInput('dryRun');
+    const exitOnceUploaded = getInput('exitOnceUploaded');
+    const exitZeroOnChanges = getInput('exitZeroOnChanges');
+    const externals = getInput('externals');
     const forceRebuild = getInput('forceRebuild');
-    const storybookBaseDir = getInput('storybookBaseDir');
-    const storybookConfigDir = getInput('storybookConfigDir');
+    const ignoreLastBuildOnBranch = getInput('ignoreLastBuildOnBranch');
     const only = getInput('only');
     const onlyChanged = getInput('onlyChanged');
-    const onlyStoryNames = getInput('onlyStoryNames');
     const onlyStoryFiles = getInput('onlyStoryFiles');
-    const externals = getInput('externals');
-    const untraced = getInput('untraced');
-    const traceChanged = getInput('traceChanged');
-    const diagnostics = getInput('diagnostics');
-    const debug = getInput('debug');
-    const storybookBuildDir = getInput('storybookBuildDir');
+    const onlyStoryNames = getInput('onlyStoryNames');
     const preserveMissing = getInput('preserveMissing');
-    const autoAcceptChanges = getInput('autoAcceptChanges');
-    const allowConsoleErrors = getInput('allowConsoleErrors');
-    const exitZeroOnChanges = getInput('exitZeroOnChanges');
-    const exitOnceUploaded = getInput('exitOnceUploaded');
-    const ignoreLastBuildOnBranch = getInput('ignoreLastBuildOnBranch');
+    const projectToken = getInput('projectToken') || getInput('appCode'); // backwards compatibility
+    const skip = getInput('skip');
+    const storybookBaseDir = getInput('storybookBaseDir');
+    const storybookBuildDir = getInput('storybookBuildDir');
+    const storybookConfigDir = getInput('storybookConfigDir');
+    const traceChanged = getInput('traceChanged');
+    const untraced = getInput('untraced');
+    const workingDir = getInput('workingDir') || getInput('workingDirectory');
     const zip = getInput('zip');
 
     process.env.CHROMATIC_SHA = sha;
@@ -172,32 +172,32 @@ async function run() {
     process.chdir(path.join(process.cwd(), workingDir || ''));
 
     const output = await runChromatic({
-      projectToken,
-      workingDir: maybe(workingDir),
+      allowConsoleErrors: maybe(allowConsoleErrors, false),
+      autoAcceptChanges: maybe(autoAcceptChanges),
       buildScriptName: maybe(buildScriptName),
-      diagnostics: maybe(diagnostics),
       debug: maybe(debug),
-      skip: maybe(skip),
+      diagnostics: maybe(diagnostics),
       dryRun: maybe(dryRun),
+      exitOnceUploaded: maybe(exitOnceUploaded, false),
+      exitZeroOnChanges: maybe(exitZeroOnChanges, true),
+      externals: maybe(externals),
       forceRebuild: maybe(forceRebuild),
+      fromCI: true,
+      ignoreLastBuildOnBranch: maybe(ignoreLastBuildOnBranch),
+      interactive: false,
       only: maybe(only),
       onlyChanged: maybe(onlyChanged),
-      onlyStoryNames: maybe(onlyStoryNames),
       onlyStoryFiles: maybe(onlyStoryFiles),
-      externals: maybe(externals),
-      untraced: maybe(untraced),
+      onlyStoryNames: maybe(onlyStoryNames),
+      preserveMissing: maybe(preserveMissing),
+      projectToken,
+      skip: maybe(skip),
       storybookBaseDir: maybe(storybookBaseDir),
+      storybookBuildDir: maybe(storybookBuildDir),
       storybookConfigDir: maybe(storybookConfigDir),
       traceChanged: maybe(traceChanged),
-      storybookBuildDir: maybe(storybookBuildDir),
-      fromCI: true,
-      interactive: false,
-      preserveMissing: maybe(preserveMissing),
-      autoAcceptChanges: maybe(autoAcceptChanges),
-      exitZeroOnChanges: maybe(exitZeroOnChanges, true),
-      exitOnceUploaded: maybe(exitOnceUploaded, false),
-      allowConsoleErrors: maybe(allowConsoleErrors, false),
-      ignoreLastBuildOnBranch: maybe(ignoreLastBuildOnBranch),
+      untraced: maybe(untraced),
+      workingDir: maybe(workingDir),
       zip: maybe(zip, false),
     });
 

--- a/action-src/main.ts
+++ b/action-src/main.ts
@@ -164,6 +164,7 @@ async function run() {
     const workingDir = getInput('workingDir') || getInput('workingDirectory');
     const zip = getInput('zip');
 
+    process.env.CHROMATIC_ACTION = 'true';
     process.env.CHROMATIC_SHA = sha;
     process.env.CHROMATIC_BRANCH = branchName || branch;
     process.env.CHROMATIC_SLUG = repositorySlug || slug;

--- a/action-src/main.ts
+++ b/action-src/main.ts
@@ -138,6 +138,7 @@ async function run() {
     // Remember to keep this list in sync with ../action.yml
     const allowConsoleErrors = getInput('allowConsoleErrors');
     const autoAcceptChanges = getInput('autoAcceptChanges');
+    const branchName = getInput('branchName');
     const buildScriptName = getInput('buildScriptName');
     const debug = getInput('debug');
     const diagnostics = getInput('diagnostics');
@@ -153,6 +154,7 @@ async function run() {
     const onlyStoryNames = getInput('onlyStoryNames');
     const preserveMissing = getInput('preserveMissing');
     const projectToken = getInput('projectToken') || getInput('appCode'); // backwards compatibility
+    const repositorySlug = getInput('repositorySlug');
     const skip = getInput('skip');
     const storybookBaseDir = getInput('storybookBaseDir');
     const storybookBuildDir = getInput('storybookBuildDir');
@@ -163,8 +165,8 @@ async function run() {
     const zip = getInput('zip');
 
     process.env.CHROMATIC_SHA = sha;
-    process.env.CHROMATIC_BRANCH = branch;
-    process.env.CHROMATIC_SLUG = slug;
+    process.env.CHROMATIC_BRANCH = branchName || branch;
+    process.env.CHROMATIC_SLUG = repositorySlug || slug;
     if (mergeCommit) {
       process.env.CHROMATIC_PULL_REQUEST_SHA = mergeCommit;
     }
@@ -174,6 +176,7 @@ async function run() {
     const output = await runChromatic({
       allowConsoleErrors: maybe(allowConsoleErrors, false),
       autoAcceptChanges: maybe(autoAcceptChanges),
+      branchName: maybe(branchName),
       buildScriptName: maybe(buildScriptName),
       debug: maybe(debug),
       diagnostics: maybe(diagnostics),
@@ -191,6 +194,7 @@ async function run() {
       onlyStoryNames: maybe(onlyStoryNames),
       preserveMissing: maybe(preserveMissing),
       projectToken,
+      repositorySlug: maybe(repositorySlug),
       skip: maybe(skip),
       storybookBaseDir: maybe(storybookBaseDir),
       storybookBuildDir: maybe(storybookBuildDir),

--- a/action.yml
+++ b/action.yml
@@ -6,35 +6,41 @@ branding:
   color: 'orange'
 
 inputs:
-  token:
-    description: 'Your github token'
-    required: false
-  projectToken:
-    description: 'Your chromatic project token'
-    required: true
-  workingDir:
-    description: 'Working directory for the package.json file'
+  allowConsoleErrors:
+    description: 'Do not exit when runtime errors occur in storybook'
     required: false
   appCode:
     description: 'Deprecated, please use projectToken instead'
     required: false
+  autoAcceptChanges:
+    description: 'Automatically accept all changes in chromatic: boolean or branchname'
+    required: false
   buildScriptName:
     description: 'The npm script that builds your Storybook [build-storybook]'
     required: false
-  skip:
-    description: 'Skip Chromatic tests, but mark the commit as passing'
+  debug:
+    description: 'Output verbose debugging information.'
+    required: false
+  diagnostics:
+    description: 'Write process context information to chromatic-diagnostics.json'
     required: false
   dryRun:
     description: 'Run without actually publishing to Chromatic'
     required: false
+  exitOnceUploaded:
+    description: 'Exit with 0 once the built version has been sent to chromatic: boolean or branchname'
+    required: false
+  exitZeroOnChanges:
+    description: 'Positive exit of action even when there are changes: boolean or branchname'
+    required: false
+  externals:
+    description: 'Disable TurboSnap when any of these files have changed since the baseline build'
+    required: false
   forceRebuild:
     description: 'Do not skip build when a rebuild is detected'
     required: false
-  storybookBaseDir:
-    description: 'Relative path from repository root to Storybook project root'
-    required: false
-  storybookConfigDir:
-    description: 'Relative path from where you run Chromatic to your Storybook config directory'
+  ignoreLastBuildOnBranch:
+    description: 'Do not use the last build on this branch as a baseline if it is no longer in history (i.e. branch was rebased)'
     required: false
   only:
     description: 'Deprecated, replaced by onlyStoryNames'
@@ -48,41 +54,35 @@ inputs:
   onlyStoryFiles:
     description: 'Only run a single story or a subset of stories by their filename(s)'
     required: false
-  externals:
-    description: 'Disable TurboSnap when any of these files have changed since the baseline build'
+  preserveMissing:
+    description: 'Deprecated, use onlyChanged, onlyStoryNames or onlyStoryFiles instead'
     required: false
-  untraced:
-    description: 'Disregard these files and their dependencies when tracing dependent stories for TurboSnap'
+  projectToken:
+    description: 'Your chromatic project token'
+    required: true
+  skip:
+    description: 'Skip Chromatic tests, but mark the commit as passing'
     required: false
-  traceChanged:
-    description: 'Print dependency trace for changed files to affected story files; set to "expanded" to list individual modules'
-    required: false
-  diagnostics:
-    description: 'Write process context information to chromatic-diagnostics.json'
-    required: false
-  debug:
-    description: 'Output verbose debugging information.'
+  storybookBaseDir:
+    description: 'Relative path from repository root to Storybook project root'
     required: false
   storybookBuildDir:
     description: 'Provide a directory with your built storybook; use if you have already built your storybook'
     required: false
-  preserveMissing:
-    description: 'Deprecated, use onlyChanged, onlyStoryNames or onlyStoryFiles instead'
+  storybookConfigDir:
+    description: 'Relative path from where you run Chromatic to your Storybook config directory'
     required: false
-  autoAcceptChanges:
-    description: 'Automatically accept all changes in chromatic: boolean or branchname'
+  token:
+    description: 'Your github token'
     required: false
-  allowConsoleErrors:
-    description: 'Do not exit when runtime errors occur in storybook'
+  traceChanged:
+    description: 'Print dependency trace for changed files to affected story files; set to "expanded" to list individual modules'
     required: false
-  exitZeroOnChanges:
-    description: 'Positive exit of action even when there are changes: boolean or branchname'
+  untraced:
+    description: 'Disregard these files and their dependencies when tracing dependent stories for TurboSnap'
     required: false
-  exitOnceUploaded:
-    description: 'Exit with 0 once the built version has been sent to chromatic: boolean or branchname'
-    required: false
-  ignoreLastBuildOnBranch:
-    description: 'Do not use the last build on this branch as a baseline if it is no longer in history (i.e. branch was rebased)'
+  workingDir:
+    description: 'Working directory for the package.json file'
     required: false
   zip:
     description: 'Publish your Storybook to Chromatic as a single zip file instead of individual content files'

--- a/action.yml
+++ b/action.yml
@@ -15,11 +15,14 @@ inputs:
   autoAcceptChanges:
     description: 'Automatically accept all changes in chromatic: boolean or branchname'
     required: false
+  branchName:
+    description: 'Override the branch name'
+    required: false
   buildScriptName:
     description: 'The npm script that builds your Storybook [build-storybook]'
     required: false
   debug:
-    description: 'Output verbose debugging information.'
+    description: 'Output verbose debugging information'
     required: false
   diagnostics:
     description: 'Write process context information to chromatic-diagnostics.json'
@@ -60,6 +63,9 @@ inputs:
   projectToken:
     description: 'Your chromatic project token'
     required: true
+  repositorySlug:
+    description: 'Override the repository slug (e.g. ownerName/repositoryName)'
+    required: false
   skip:
     description: 'Skip Chromatic tests, but mark the commit as passing'
     required: false

--- a/bin-src/git/getCommitAndBranch.ts
+++ b/bin-src/git/getCommitAndBranch.ts
@@ -117,14 +117,8 @@ export default async function getCommitAndBranch(
     slug = GITHUB_REPOSITORY;
   }
 
-  const {
-    isCi,
-    service: ciService,
-    prBranch,
-    branch: ciBranch,
-    commit: ciCommit,
-    slug: ciSlug,
-  } = envCi();
+  const { isCi, service, prBranch, branch: ciBranch, commit: ciCommit, slug: ciSlug } = envCi();
+  const ciService = process.env.CHROMATIC_ACTION ? 'chromaui/action' : service;
   slug = slug || ciSlug;
 
   // On certain CI systems, a branch is not checked out

--- a/bin-src/lib/getOptions.test.ts
+++ b/bin-src/lib/getOptions.test.ts
@@ -89,6 +89,34 @@ describe('getOptions', () => {
     expect(getOptions(getContext(['--branch-name', 'my/branch']))).toMatchObject({
       branchName: 'my/branch',
     });
+    expect(getOptions(getContext(['--branch-name', 'owner:my/branch']))).toMatchObject({
+      branchName: 'my/branch',
+      ownerName: 'owner',
+    });
+  });
+
+  it('allows you to specify the repository slug', async () => {
+    expect(getOptions(getContext(['--repository-slug', 'owner/repo']))).toMatchObject({
+      ownerName: 'owner',
+      repositorySlug: 'owner/repo',
+    });
+  });
+
+  it('checks whether branch name and repository slug contain a conflicting owner name', async () => {
+    expect(
+      getOptions(
+        getContext(['--branch-name', 'owner:my/branch', '--repository-slug', 'owner/repo'])
+      )
+    ).toMatchObject({
+      branchName: 'my/branch',
+      ownerName: 'owner',
+      repositorySlug: 'owner/repo',
+    });
+    expect(() =>
+      getOptions(
+        getContext(['--branch-name', 'owner:my/branch', '--repository-slug', 'another/repo'])
+      )
+    ).toThrow('Invalid value for --branch-name and/or --repository-slug');
   });
 
   it('supports arrays, removing empty values', async () => {

--- a/bin-src/lib/getOptions.ts
+++ b/bin-src/lib/getOptions.ts
@@ -4,24 +4,18 @@ import { Context, Options } from '../types';
 import dependentOption from '../ui/messages/errors/dependentOption';
 import duplicatePatchBuild from '../ui/messages/errors/duplicatePatchBuild';
 import incompatibleOptions from '../ui/messages/errors/incompatibleOptions';
-import invalidExitOnceUploaded from '../ui/messages/errors/invalidExitOnceUploaded';
 import invalidOnlyStoryNames from '../ui/messages/errors/invalidOnlyStoryNames';
-import invalidOnlyChanged from '../ui/messages/errors/invalidOnlyChanged';
 import invalidPatchBuild from '../ui/messages/errors/invalidPatchBuild';
 import invalidReportPath from '../ui/messages/errors/invalidReportPath';
 import invalidSingularOptions from '../ui/messages/errors/invalidSingularOptions';
 import missingBuildScriptName from '../ui/messages/errors/missingBuildScriptName';
 import missingProjectToken from '../ui/messages/errors/missingProjectToken';
 import deprecatedOption from '../ui/messages/warnings/deprecatedOption';
-import getStorybookConfiguration from './getStorybookConfiguration';
 
 const takeLast = (input: string | string[]) =>
   Array.isArray(input) ? input[input.length - 1] : input;
 
 const ensureArray = (input: string | string[]) => (Array.isArray(input) ? input : [input]);
-
-const resolveHomeDir = (filepath: string) =>
-  filepath && filepath.startsWith('~') ? path.join(process.env.HOME, filepath.slice(1)) : filepath;
 
 const trueIfSet = <T>(value: T) => ((value as unknown) === '' ? true : value);
 const undefinedIfEmpty = <T>(array: T[]) => {

--- a/bin-src/lib/getOptions.ts
+++ b/bin-src/lib/getOptions.ts
@@ -45,7 +45,12 @@ export default function getOptions({ argv, env, flags, log, packageJson }: Conte
     dryRun: !!flags.dryRun,
     forceRebuild: trueIfSet(flags.forceRebuild),
     verbose: !!flags.debug,
-    interactive: !flags.debug && !fromCI && !!flags.interactive && !!process.stdout.isTTY,
+    interactive:
+      !fromCI &&
+      !flags.debug &&
+      !!flags.interactive &&
+      !!process.stdout.isTTY &&
+      process.env.NODE_ENV !== 'test',
     junitReport: trueIfSet(flags.junitReport),
     zip: flags.zip,
 

--- a/bin-src/lib/getOptions.ts
+++ b/bin-src/lib/getOptions.ts
@@ -8,6 +8,7 @@ import invalidOnlyStoryNames from '../ui/messages/errors/invalidOnlyStoryNames';
 import invalidOwnerName from '../ui/messages/errors/invalidOwnerName';
 import invalidPatchBuild from '../ui/messages/errors/invalidPatchBuild';
 import invalidReportPath from '../ui/messages/errors/invalidReportPath';
+import invalidRepositorySlug from '../ui/messages/errors/invalidRepositorySlug';
 import invalidSingularOptions from '../ui/messages/errors/invalidSingularOptions';
 import missingBuildScriptName from '../ui/messages/errors/missingBuildScriptName';
 import missingProjectToken from '../ui/messages/errors/missingProjectToken';
@@ -28,7 +29,7 @@ export default function getOptions({ argv, env, flags, log, packageJson }: Conte
   const fromCI = !!flags.ci || !!process.env.CI;
   const [patchHeadRef, patchBaseRef] = (flags.patchBuild || '').split('...').filter(Boolean);
   const [branchName, branchOwner] = (flags.branchName || '').split(':').reverse();
-  const [repositoryOwner] = flags.repositorySlug ? flags.repositorySlug.split('/') : [];
+  const [repositoryOwner, repositoryName, ...rest] = flags.repositorySlug?.split('/') || [];
 
   const options: Options = {
     projectToken: takeLast(flags.projectToken || flags.appCode) || env.CHROMATIC_PROJECT_TOKEN, // backwards compatibility
@@ -83,6 +84,10 @@ export default function getOptions({ argv, env, flags, log, packageJson }: Conte
 
   if (!options.projectToken) {
     throw new Error(missingProjectToken());
+  }
+
+  if (repositoryOwner && (!repositoryName || rest.length)) {
+    throw new Error(invalidRepositorySlug());
   }
 
   if (branchOwner && repositoryOwner && branchOwner !== repositoryOwner) {

--- a/bin-src/lib/getPrebuiltStorybookMetadata.ts
+++ b/bin-src/lib/getPrebuiltStorybookMetadata.ts
@@ -3,13 +3,10 @@ import { Context } from '../types';
 import { builders } from './builders';
 import { supportedAddons } from './supportedAddons';
 import { viewLayers } from './viewLayers';
-import packageDoesNotExist from '../ui/messages/errors/noViewLayerPackage';
-import { resolvePackageJson } from './getStorybookMetadata';
-import { timeout } from './promises';
 
-/* 
+/*
   In Storybook 6.5+, when building a Storybook, a project.json file is generated,
-  containing metadata (sb builder, addons, viewLayer and viewLayer version) for the 
+  containing metadata (sb builder, addons, viewLayer and viewLayer version) for the
   particular setup.
 */
 

--- a/bin-src/lib/parseArgs.ts
+++ b/bin-src/lib/parseArgs.ts
@@ -31,6 +31,7 @@ export default function parseArgs(argv: string[]) {
       --only-story-files <filepath>             Only run a single story or a subset of stories by their filename(s). Specify the full path to the story file relative to the root of your Storybook project. Globs are supported via picomatch. This flag can be specified multiple times.
       --only-story-names <storypath>            Only run a single story or a subset of stories. Story paths typically look like "Path/To/Story". Globs are supported via picomatch. This flag can be specified multiple times.
       --patch-build <headbranch...basebranch>   Create a patch build to fix a missing PR comparison.
+      --repository-slug <slug>                  Override the repository slug. Only meant to be used for unsupported CI integrations and fixing cross-fork PR comparisons. Format: <ownerName>/<repoName>.
       --skip [branch]                           Skip Chromatic tests, but mark the commit as passing. Avoids blocking PRs due to required merge checks. Only for [branch], if specified. Globs are supported via picomatch.
       --storybook-base-dir <dirname>            Relative path from repository root to Storybook project root. Use with --only-changed and --storybook-build-dir when running Chromatic from a different directory than your Storybook.
       --storybook-config-dir <dirname>          Relative path from where you run Chromatic to your Storybook config directory ('.storybook'). Use with --only-changed and --storybook-build-dir when using a custom --config-dir (-c) flag for Storybook. [.storybook]
@@ -78,6 +79,7 @@ export default function parseArgs(argv: string[]) {
         onlyStoryFiles: { type: 'string', isMultiple: true },
         onlyStoryNames: { type: 'string', isMultiple: true },
         patchBuild: { type: 'string' },
+        repositorySlug: { type: 'string' },
         skip: { type: 'string' },
         storybookBaseDir: { type: 'string' },
         storybookConfigDir: { type: 'string' },

--- a/bin-src/tasks/gitInfo.ts
+++ b/bin-src/tasks/gitInfo.ts
@@ -52,7 +52,14 @@ interface LastBuildQueryResult {
 }
 
 export const setGitInfo = async (ctx: Context, task: Task) => {
-  const { branchName, patchBaseRef, fromCI: ci, interactive } = ctx.options;
+  const {
+    branchName,
+    ownerName,
+    repositorySlug,
+    patchBaseRef,
+    fromCI: ci,
+    interactive,
+  } = ctx.options;
 
   ctx.git = {
     version: await getVersion(),
@@ -68,8 +75,9 @@ export const setGitInfo = async (ctx: Context, task: Task) => {
     );
   }
 
-  if (ctx.git.slug && ctx.options.ownerName) {
-    ctx.git.slug = ctx.git.slug.replace(/[^/]+/, ctx.options.ownerName);
+  if (ownerName) {
+    ctx.git.branch = ctx.git.branch.replace(/[^:]+:/, '');
+    ctx.git.slug = repositorySlug || ctx.git.slug?.replace(/[^/]+/, ownerName);
   }
 
   const { branch, commit, slug } = ctx.git;

--- a/bin-src/types.ts
+++ b/bin-src/types.ts
@@ -23,6 +23,7 @@ export interface Flags {
   onlyStoryFiles?: string[];
   onlyStoryNames?: string[];
   patchBuild?: string;
+  repositorySlug?: string;
   skip?: string;
   storybookBaseDir?: string;
   storybookConfigDir?: string;
@@ -81,6 +82,7 @@ export interface Options {
   storybookConfigDir: Flags['storybookConfigDir'];
 
   ownerName: string;
+  repositorySlug: Flags['repositorySlug'];
   branchName: string;
   patchHeadRef: string;
   patchBaseRef: string;

--- a/bin-src/ui/messages/errors/fetchError.stories.ts
+++ b/bin-src/ui/messages/errors/fetchError.stories.ts
@@ -11,7 +11,8 @@ export const FetchError = () =>
     {
       error: {
         name: 'FetchError',
-        // @ts-expect-error This seems to sometimes be required, sometimes disallowed.
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore This seems to sometimes be required, sometimes disallowed.
         [Symbol.toStringTag]: 'FetchError',
         message:
           'request to https://index.chromatic.com/graphql failed, reason: connect ECONNREFUSED',

--- a/bin-src/ui/messages/errors/fetchError.stories.ts
+++ b/bin-src/ui/messages/errors/fetchError.stories.ts
@@ -11,7 +11,6 @@ export const FetchError = () =>
     {
       error: {
         name: 'FetchError',
-        [Symbol.toStringTag]: 'FetchError',
         message:
           'request to https://index.chromatic.com/graphql failed, reason: connect ECONNREFUSED',
         type: 'system',

--- a/bin-src/ui/messages/errors/fetchError.stories.ts
+++ b/bin-src/ui/messages/errors/fetchError.stories.ts
@@ -11,6 +11,8 @@ export const FetchError = () =>
     {
       error: {
         name: 'FetchError',
+        // @ts-expect-error This seems to sometimes be required, sometimes disallowed.
+        [Symbol.toStringTag]: 'FetchError',
         message:
           'request to https://index.chromatic.com/graphql failed, reason: connect ECONNREFUSED',
         type: 'system',

--- a/bin-src/ui/messages/errors/invalidOwnerName.stories.ts
+++ b/bin-src/ui/messages/errors/invalidOwnerName.stories.ts
@@ -1,0 +1,7 @@
+import invalidOwnerName from './invalidOwnerName';
+
+export default {
+  title: 'CLI/Messages/Errors',
+};
+
+export const InvalidOwnerName = () => invalidOwnerName();

--- a/bin-src/ui/messages/errors/invalidOwnerName.stories.ts
+++ b/bin-src/ui/messages/errors/invalidOwnerName.stories.ts
@@ -4,4 +4,4 @@ export default {
   title: 'CLI/Messages/Errors',
 };
 
-export const InvalidOwnerName = () => invalidOwnerName();
+export const InvalidOwnerName = () => invalidOwnerName('branchOwner', 'repoOwner');

--- a/bin-src/ui/messages/errors/invalidOwnerName.ts
+++ b/bin-src/ui/messages/errors/invalidOwnerName.ts
@@ -6,5 +6,5 @@ import { error } from '../../components/icons';
 export default (branchOwner: string, repoOwner: string) =>
   dedent(chalk`
     ${error} Invalid value for {bold --branch-name and/or --repository-slug}
-    The owner name prefix '${branchOwner}' on the branch does not match the repository slug '${repoOwner}'.
+    The branch owner name prefix '${branchOwner}' does not match the repository owner '${repoOwner}'.
   `);

--- a/bin-src/ui/messages/errors/invalidOwnerName.ts
+++ b/bin-src/ui/messages/errors/invalidOwnerName.ts
@@ -1,0 +1,10 @@
+import chalk from 'chalk';
+import { dedent } from 'ts-dedent';
+
+import { error } from '../../components/icons';
+
+export default (branchOwner: string, repoOwner: string) =>
+  dedent(chalk`
+    ${error} Invalid value for {bold --branch-name and/or --repository-slug}
+    The owner name prefix '${branchOwner}' on the branch does not match the repository slug '${repoOwner}'.
+  `);

--- a/bin-src/ui/messages/errors/invalidOwnerName.ts
+++ b/bin-src/ui/messages/errors/invalidOwnerName.ts
@@ -5,6 +5,6 @@ import { error } from '../../components/icons';
 
 export default (branchOwner: string, repoOwner: string) =>
   dedent(chalk`
-    ${error} Invalid value for {bold --branch-name and/or --repository-slug}
+    ${error} Invalid value for {bold --branch-name} and/or {bold --repository-slug}
     The branch owner name prefix '${branchOwner}' does not match the repository owner '${repoOwner}'.
   `);

--- a/bin-src/ui/messages/errors/invalidRepositorySlug.stories.ts
+++ b/bin-src/ui/messages/errors/invalidRepositorySlug.stories.ts
@@ -1,0 +1,7 @@
+import invalidRepositorySlug from './invalidRepositorySlug';
+
+export default {
+  title: 'CLI/Messages/Errors',
+};
+
+export const InvalidRepositorySlug = () => invalidRepositorySlug();

--- a/bin-src/ui/messages/errors/invalidRepositorySlug.ts
+++ b/bin-src/ui/messages/errors/invalidRepositorySlug.ts
@@ -1,0 +1,11 @@
+import chalk from 'chalk';
+import { dedent } from 'ts-dedent';
+
+import { error } from '../../components/icons';
+
+export default () =>
+  dedent(chalk`
+    ${error} Invalid value for {bold --repository-slug}
+    The value must be in the format {bold <ownerName>/<repositoryName>}
+    You can typically find this in the URL of your repository.
+  `);

--- a/bin-src/ui/messages/errors/invalidRepositorySlug.ts
+++ b/bin-src/ui/messages/errors/invalidRepositorySlug.ts
@@ -6,6 +6,6 @@ import { error } from '../../components/icons';
 export default () =>
   dedent(chalk`
     ${error} Invalid value for {bold --repository-slug}
-    The value must be in the format {bold <ownerName>/<repositoryName>}
+    The value must be in the format {bold ownerName/repositoryName}
     You can typically find this in the URL of your repository.
   `);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chromatic",
-  "version": "6.14.0",
+  "version": "6.15.0-canary.0",
   "description": "Automate visual testing across browsers. Gather UI feedback. Versioned documentation.",
   "keywords": [
     "storybook-addon",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chromatic",
-  "version": "6.15.0-canary.0",
+  "version": "6.15.0",
   "description": "Automate visual testing across browsers. Gather UI feedback. Versioned documentation.",
   "keywords": [
     "storybook-addon",


### PR DESCRIPTION
This allows customers to override the repository owner and/or name through either the `repositorySlug` flag/option, or the `branchName` flag/option, whichever is more convenient. Either of them can affect the `ownerName`, which is used to determine whether a build originates from a fork.

We didn't previously expose the `branchName` option on the GitHub Action, now we do.

For example:
- `repositorySlug: "chromaui/chromatic"` sets the owner name to `chromaui` and repository name to `chromatic`
- `branchName: "chromaui:feature"` sets the owner name to `chromaui` and the branch name to `feature`.

If both specify an owner name, they must match.