### PR TITLE
[Action] Add support for new issue_comment event

### DIFF
--- a/action-src/main.ts
+++ b/action-src/main.ts
@@ -54,7 +54,8 @@ const getBuildInfo = (event: typeof context) => {
         slug: repository.full_name,
       };
     }
-    case 'workflow_dispatch': {
+    case 'workflow_dispatch':
+    case 'issue_comment': {
       return {
         sha: event.sha,
         branch: event.ref.replace('refs/heads/', ''),

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chromatic",
-  "version": "6.16.0-canary.4",
+  "version": "6.16.0-next.0",
   "description": "Automate visual testing across browsers. Gather UI feedback. Versioned documentation.",
   "keywords": [
     "storybook-addon",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chromatic",
-  "version": "6.16.0-canary.0",
+  "version": "6.16.0-canary.3",
   "description": "Automate visual testing across browsers. Gather UI feedback. Versioned documentation.",
   "keywords": [
     "storybook-addon",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chromatic",
-  "version": "6.16.0-canary.3",
+  "version": "6.16.0-canary.4",
   "description": "Automate visual testing across browsers. Gather UI feedback. Versioned documentation.",
   "keywords": [
     "storybook-addon",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chromatic",
-  "version": "6.15.0",
+  "version": "6.16.0-canary.0",
   "description": "Automate visual testing across browsers. Gather UI feedback. Versioned documentation.",
   "keywords": [
     "storybook-addon",


### PR DESCRIPTION
This PR adds support for the following events
- `issue_comment`: This will allow the Github action to run if the user specifies the issue_comment event in their action. If the user specifies this event, the Chromatic Github action will run anytime someone creates a comment on an issue or pull request.

If a user only wants to run Chromatic on pull request comments, they will have to do something like this below.
```
on: issue_comment
jobs:
  chromatic-deployment:
    runs-on: ubuntu-latest
    if: ${{ github.event.issue.pull_request }}
    steps:
      - uses: actions/checkout@v1
      - name: Install dependencies
        run: yarn
      - name: Publish to Chromatic
        uses: chromaui/action@v1
        with:
          projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
```