### PR TITLE
Increase timeout on Storybook Verify

### DIFF
--- a/.github/workflows/chromatic-main-and-prs.yml
+++ b/.github/workflows/chromatic-main-and-prs.yml
@@ -13,6 +13,9 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
       - name: install
         run: yarn install --frozen-lockfile
       - uses: chromaui/action@v1

--- a/.github/workflows/chromatic-prod.yml
+++ b/.github/workflows/chromatic-prod.yml
@@ -8,6 +8,9 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
       - name: install
         run: yarn install --frozen-lockfile
       - uses: chromaui/action-next@v1

--- a/.github/workflows/chromatic-staging.yml
+++ b/.github/workflows/chromatic-staging.yml
@@ -8,6 +8,9 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
       - name: install
         run: yarn install --frozen-lockfile
       - uses: chromaui/action-canary@v1

--- a/.github/workflows/smoke-test-action.yml
+++ b/.github/workflows/smoke-test-action.yml
@@ -5,7 +5,12 @@ jobs:
   self-test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
       - run: yarn
       - run: yarn build
       - uses: ./

--- a/.github/workflows/smoke-test-node14.yml
+++ b/.github/workflows/smoke-test-node14.yml
@@ -10,7 +10,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-node@v2
         with:
-          node-version: '12'
+          node-version: '14'
       - run: yarn
       - run: yarn build
       - uses: ./

--- a/.github/workflows/smoke-test-npx.yml
+++ b/.github/workflows/smoke-test-npx.yml
@@ -7,8 +7,10 @@ jobs:
     steps:
       - uses: actions/setup-node@v1
         with:
-          node-version: '14.x'
-      - uses: actions/checkout@v1
+          node-version: '16.x'
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - name: install
         run: yarn && git status --porcelain
       - name: prep package

--- a/.github/workflows/smoke-test-windows.yml
+++ b/.github/workflows/smoke-test-windows.yml
@@ -7,8 +7,10 @@ jobs:
     steps:
       - uses: actions/setup-node@v1
         with:
-          node-version: '14.x'
-      - uses: actions/checkout@v1
+          node-version: '16.x'
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - name: install
         run: yarn
       - name: prep package

--- a/.github/workflows/smoke-test-yarn-berry.yml
+++ b/.github/workflows/smoke-test-yarn-berry.yml
@@ -7,8 +7,10 @@ jobs:
     steps:
       - uses: actions/setup-node@v1
         with:
-          node-version: '14.x'
-      - uses: actions/checkout@v1
+          node-version: '16.x'
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - run: yarn install
       - run: yarn set version berry
       - name: run chromatic

--- a/.github/workflows/smoke-test-yarn-canary.yml
+++ b/.github/workflows/smoke-test-yarn-canary.yml
@@ -7,8 +7,10 @@ jobs:
     steps:
       - uses: actions/setup-node@v1
         with:
-          node-version: '14.x'
-      - uses: actions/checkout@v1
+          node-version: '16.x'
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - run: yarn install
       - run: yarn set version berry
       - run: yarn set version canary

--- a/.github/workflows/smoke-test-yarn-classic.yml
+++ b/.github/workflows/smoke-test-yarn-classic.yml
@@ -7,8 +7,10 @@ jobs:
     steps:
       - uses: actions/setup-node@v1
         with:
-          node-version: '14.x'
-      - uses: actions/checkout@v1
+          node-version: '16.x'
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - run: yarn install
       - run: yarn set version 1.x.x
       - name: run chromatic

--- a/.github/workflows/smoke-test-yarn.yml
+++ b/.github/workflows/smoke-test-yarn.yml
@@ -5,7 +5,12 @@ jobs:
   self-test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
       - run: yarn
       - run: yarn bundle:bin
       - run: yarn chromatic --build-script-name build-test-storybook --exit-zero-on-changes --force-rebuild

--- a/bin-src/lib/getEnv.ts
+++ b/bin-src/lib/getEnv.ts
@@ -27,7 +27,7 @@ const {
   CHROMATIC_DNS_SERVERS = '',
   CHROMATIC_DNS_FAILOVER_SERVERS = '1.1.1.1, 8.8.8.8', // Cloudflare, Google
   LOGGLY_CUSTOMER_TOKEN = 'b5e26204-cdc5-4c78-a9cc-c69eb7fabad3',
-  STORYBOOK_VERIFY_TIMEOUT = String(2 * 60 * 1000),
+  STORYBOOK_VERIFY_TIMEOUT = String(3 * 60 * 1000),
   STORYBOOK_BUILD_TIMEOUT = String(10 * 60 * 1000),
   HTTPS_PROXY = process.env.https_proxy,
   HTTP_PROXY = process.env.http_proxy,


### PR DESCRIPTION
The Verify task essentially waits on the extract process to finish in Chromatic. However, it seems that there has been a delay in the background task processing. Hopefully, this creates some room until the Platform team can adjust the background task processing.