### PR TITLE
Disconnect Preserve missing from `--only-story-names` flag

### DIFF
--- a/bin-src/lib/getOptions.ts
+++ b/bin-src/lib/getOptions.ts
@@ -60,7 +60,7 @@ export default function getOptions({ argv, env, flags, log, packageJson }: Conte
     exitOnceUploaded: trueIfSet(flags.exitOnceUploaded),
     ignoreLastBuildOnBranch: flags.ignoreLastBuildOnBranch,
     // deprecated
-    preserveMissingSpecs: flags.preserveMissing || !!flags.only || !!flags.onlyStoryNames?.length,
+    preserveMissingSpecs: flags.preserveMissing || !!flags.only,
     originalArgv: argv,
 
     buildScriptName: flags.buildScriptName,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chromatic",
-  "version": "6.17.2",
+  "version": "6.17.3-next.0",
   "description": "Automate visual testing across browsers. Gather UI feedback. Versioned documentation.",
   "keywords": [
     "storybook-addon",


### PR DESCRIPTION
Only Story Names was using preserve missing in the background. This updates the CLI so that the CLI flag no causes preserveMissingSpecs to be set.