### PR TITLE
Add `release` event to GitHub Action

### DIFF
--- a/action-src/main.ts
+++ b/action-src/main.ts
@@ -62,6 +62,13 @@ const getBuildInfo = (event: typeof context) => {
         slug: event.payload.repository.full_name,
       };
     }
+    case 'release': {
+      return {
+        sha: event.sha,
+        branch: event.ref.replace('refs/tags/', ''),
+        slug: event.payload.repository.full_name,
+      };
+    }
     default: {
       setFailed(`${event.eventName} event is not supported in this action`);
       return null;

--- a/action-src/main.ts
+++ b/action-src/main.ts
@@ -65,7 +65,7 @@ const getBuildInfo = (event: typeof context) => {
     case 'release': {
       return {
         sha: event.sha,
-        branch: event.ref.replace('refs/tags/', ''),
+        branch: event.payload.release.target_commitish,
         slug: event.payload.repository.full_name,
       };
     }


### PR DESCRIPTION
In the same vein as #196 and #668, but this time for the `release` event, preventing the following error:

```console
Error: release event is not supported in this action
```