### PR TITLE
get the builder name and version via the mainConfig for SB v7+

### DIFF
--- a/bin-src/lib/getStorybookMetadata.ts
+++ b/bin-src/lib/getStorybookMetadata.ts
@@ -181,35 +181,12 @@ export const getStorybookMetadata = async (ctx: Context) => {
   const r = typeof __non_webpack_require__ !== 'undefined' ? __non_webpack_require__ : require;
   const mainConfig = await r(path.resolve(configDir, 'main'));
 
-  let addons = {};
-  try {
-    addons = await findAddons(ctx, mainConfig);
-  } catch (e) {
-    ctx.log.info('Unable to determine addons used in this project', e);
-  }
-
-  let configFlags = {};
-  try {
-    configFlags = await findConfigFlags(ctx);
-  } catch (e) {
-    ctx.log.info('Unable to determine config flags used in this project', e);
-  }
-
-  let viewLayer = {};
-  try {
-    viewLayer = await findViewlayer(ctx);
-  } catch (e) {
-    ctx.log.info('Unable to determine viewLayer used in this project', e);
-  }
-
-  let builder = {};
-  try {
-    builder = await findBuilder(mainConfig);
-  } catch (e) {
-    ctx.log.info('Unable to determine builder based in this project', e);
-  }
-  return [addons, configFlags, viewLayer, builder].reduce(
-    (acc, obj) => Object.assign(acc, obj),
-    {}
-  );
+  const info = await Promise.allSettled([
+    findAddons(ctx, mainConfig),
+    findConfigFlags(ctx),
+    findViewlayer(ctx),
+    findBuilder(mainConfig),
+  ]);
+  ctx.log.debug(info);
+  return info.reduce((acc, obj) => Object.assign(acc, obj), {});
 };

--- a/bin-src/lib/getStorybookMetadata.ts
+++ b/bin-src/lib/getStorybookMetadata.ts
@@ -151,7 +151,7 @@ const findConfigFlags = async ({ options, packageJson }) => {
 };
 
 export const findBuilder = async (mainConfig) => {
-  if (mainConfig?.framework) {
+  if (mainConfig?.framework?.name) {
     const sbV7BuilderName = mainConfig.framework.name;
 
     return Promise.race([

--- a/bin-src/lib/getStorybookMetadata.ts
+++ b/bin-src/lib/getStorybookMetadata.ts
@@ -181,12 +181,35 @@ export const getStorybookMetadata = async (ctx: Context) => {
   const r = typeof __non_webpack_require__ !== 'undefined' ? __non_webpack_require__ : require;
   const mainConfig = await r(path.resolve(configDir, 'main'));
 
-  const info = await Promise.all([
-    findAddons(ctx, mainConfig),
-    findConfigFlags(ctx),
-    findViewlayer(ctx),
-    findBuilder(mainConfig),
-  ]);
-  ctx.log.debug(info);
-  return info.reduce((acc, obj) => Object.assign(acc, obj), {});
+  let addons = {};
+  try {
+    addons = await findAddons(ctx, mainConfig);
+  } catch (e) {
+    ctx.log.info('Unable to determine addons used in this project', e);
+  }
+
+  let configFlags = {};
+  try {
+    configFlags = await findConfigFlags(ctx);
+  } catch (e) {
+    ctx.log.info('Unable to determine config flags used in this project', e);
+  }
+
+  let viewLayer = {};
+  try {
+    viewLayer = await findViewlayer(ctx);
+  } catch (e) {
+    ctx.log.info('Unable to determine viewLayer used in this project', e);
+  }
+
+  let builder = {};
+  try {
+    builder = await findBuilder(mainConfig);
+  } catch (e) {
+    ctx.log.info('Unable to determine builder based in this project', e);
+  }
+  return [addons, configFlags, viewLayer, builder].reduce(
+    (acc, obj) => Object.assign(acc, obj),
+    {}
+  );
 };

--- a/bin-src/lib/getStorybookMetadata.ts
+++ b/bin-src/lib/getStorybookMetadata.ts
@@ -151,6 +151,17 @@ const findConfigFlags = async ({ options, packageJson }) => {
 };
 
 export const findBuilder = async (mainConfig) => {
+  if (mainConfig?.framework) {
+    const sbV7BuilderName = mainConfig.framework.name;
+
+    return Promise.race([
+      resolvePackageJson(sbV7BuilderName)
+        .then((json) => ({ builder: { name: sbV7BuilderName, packageVersion: json.version } }))
+        .catch(() => Promise.reject(new Error(packageDoesNotExist(sbV7BuilderName)))),
+      timeout(10000),
+    ]);
+  }
+
   let name = 'webpack4'; // default builder in Storybook v6
   if (mainConfig?.core?.builder) {
     const { builder } = mainConfig.core;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chromatic",
-  "version": "6.17.3",
+  "version": "6.17.4-next.0",
   "description": "Automate visual testing across browsers. Gather UI feedback. Versioned documentation.",
   "keywords": [
     "storybook-addon",


### PR DESCRIPTION
Our telemetry reports storybook_version = null for a large proportion of our build events. It turns out these are SB v7 build events and the findBuilder function was erroring out causing the entire metadata Promise.all to fail. This PR updates the logic for finding the builder which should restore the telemetry overall.