### PR TITLE
Use `CHROMATIC_PROJECT_TOKEN` environment variable rather than hardcoded value

### DIFF
--- a/.github/workflows/chromatic-prod.yml
+++ b/.github/workflows/chromatic-prod.yml
@@ -20,7 +20,7 @@ jobs:
           traceChanged: true
           diagnostics: true
         env:
-          CHROMATIC_PROJECT_TOKEN: gcaw1ai2dgo
+          CHROMATIC_PROJECT_TOKEN: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
       - uses: actions/upload-artifact@v2
         if: always()
         with:

--- a/.github/workflows/chromatic-staging.yml
+++ b/.github/workflows/chromatic-staging.yml
@@ -20,7 +20,7 @@ jobs:
           traceChanged: true
           diagnostics: true
         env:
-          CHROMATIC_PROJECT_TOKEN: 253df72b53d2
+          CHROMATIC_PROJECT_TOKEN: ${{ secrets.STAGING_CHROMATIC_PROJECT_TOKEN }}
           CHROMATIC_INDEX_URL: https://index.staging-chromatic.com
           LOG_LEVEL: debug
       - uses: actions/upload-artifact@v2

--- a/.github/workflows/smoke-test-action.yml
+++ b/.github/workflows/smoke-test-action.yml
@@ -21,4 +21,4 @@ jobs:
         env:
           LOG_LEVEL: debug
           DEBUG: chromatic-cli
-          CHROMATIC_PROJECT_TOKEN: 47c20821d2c2
+          CHROMATIC_PROJECT_TOKEN: ${{ secrets.SMOKE_TESTS_CHROMATIC_PROJECT_TOKEN }}

--- a/.github/workflows/smoke-test-node-api.yml
+++ b/.github/workflows/smoke-test-node-api.yml
@@ -17,4 +17,4 @@ jobs:
         env:
           LOG_LEVEL: debug
           DEBUG: chromatic-cli
-          CHROMATIC_PROJECT_TOKEN: 47c20821d2c2
+          CHROMATIC_PROJECT_TOKEN: ${{ secrets.SMOKE_TESTS_CHROMATIC_PROJECT_TOKEN }}

--- a/.github/workflows/smoke-test-node14.yml
+++ b/.github/workflows/smoke-test-node14.yml
@@ -21,4 +21,4 @@ jobs:
         env:
           LOG_LEVEL: debug
           DEBUG: chromatic-cli
-          CHROMATIC_PROJECT_TOKEN: 47c20821d2c2
+          CHROMATIC_PROJECT_TOKEN: ${{ secrets.SMOKE_TESTS_CHROMATIC_PROJECT_TOKEN }}

--- a/.github/workflows/smoke-test-node16.yml
+++ b/.github/workflows/smoke-test-node16.yml
@@ -22,4 +22,4 @@ jobs:
         env:
           LOG_LEVEL: debug
           DEBUG: chromatic-cli
-          CHROMATIC_PROJECT_TOKEN: 47c20821d2c2
+          CHROMATIC_PROJECT_TOKEN: ${{ secrets.SMOKE_TESTS_CHROMATIC_PROJECT_TOKEN }}

--- a/.github/workflows/smoke-test-npx.yml
+++ b/.github/workflows/smoke-test-npx.yml
@@ -21,4 +21,4 @@ jobs:
         env:
           LOG_LEVEL: debug
           DEBUG: chromatic-cli
-          CHROMATIC_PROJECT_TOKEN: 47c20821d2c2
+          CHROMATIC_PROJECT_TOKEN: ${{ secrets.SMOKE_TESTS_CHROMATIC_PROJECT_TOKEN }}

--- a/.github/workflows/smoke-test-windows.yml
+++ b/.github/workflows/smoke-test-windows.yml
@@ -21,4 +21,4 @@ jobs:
         env:
           LOG_LEVEL: debug
           DEBUG: chromatic-cli
-          CHROMATIC_PROJECT_TOKEN: 47c20821d2c2
+          CHROMATIC_PROJECT_TOKEN: ${{ secrets.SMOKE_TESTS_CHROMATIC_PROJECT_TOKEN }}

--- a/.github/workflows/smoke-test-yarn-berry.yml
+++ b/.github/workflows/smoke-test-yarn-berry.yml
@@ -18,4 +18,4 @@ jobs:
         env:
           LOG_LEVEL: debug
           DEBUG: chromatic-cli
-          CHROMATIC_PROJECT_TOKEN: 47c20821d2c2
+          CHROMATIC_PROJECT_TOKEN: ${{ secrets.SMOKE_TESTS_CHROMATIC_PROJECT_TOKEN }}

--- a/.github/workflows/smoke-test-yarn-canary.yml
+++ b/.github/workflows/smoke-test-yarn-canary.yml
@@ -19,4 +19,4 @@ jobs:
         env:
           LOG_LEVEL: debug
           DEBUG: chromatic-cli
-          CHROMATIC_PROJECT_TOKEN: 47c20821d2c2
+          CHROMATIC_PROJECT_TOKEN: ${{ secrets.SMOKE_TESTS_CHROMATIC_PROJECT_TOKEN }}

--- a/.github/workflows/smoke-test-yarn-classic.yml
+++ b/.github/workflows/smoke-test-yarn-classic.yml
@@ -18,4 +18,4 @@ jobs:
         env:
           LOG_LEVEL: debug
           DEBUG: chromatic-cli
-          CHROMATIC_PROJECT_TOKEN: 47c20821d2c2
+          CHROMATIC_PROJECT_TOKEN: ${{ secrets.SMOKE_TESTS_CHROMATIC_PROJECT_TOKEN }}

--- a/.github/workflows/smoke-test-yarn.yml
+++ b/.github/workflows/smoke-test-yarn.yml
@@ -17,4 +17,4 @@ jobs:
         env:
           LOG_LEVEL: debug
           DEBUG: chromatic-cli
-          CHROMATIC_PROJECT_TOKEN: 47c20821d2c2
+          CHROMATIC_PROJECT_TOKEN: ${{ secrets.SMOKE_TESTS_CHROMATIC_PROJECT_TOKEN }}


### PR DESCRIPTION
This brings our project setup in line with our general advice to not hardcode project tokens.

Before we merge this, Azure Pipelines needs to be configured with the env var.

We should cycle our token once this PR is merged.