### PR TITLE
Added `onTaskComplete` callback option

### DIFF
--- a/node-src/lib/tasks.ts
+++ b/node-src/lib/tasks.ts
@@ -16,7 +16,7 @@ export const createTask = ({ title, steps, ...config }): Listr.ListrTask<Context
       await step(ctx, task);
     }
 
-    ctx.options.onTaskComplete?.(ctx);
+    ctx.options.onTaskComplete?.({ ...ctx });
   },
   ...config,
 });

--- a/node-src/lib/tasks.ts
+++ b/node-src/lib/tasks.ts
@@ -15,6 +15,8 @@ export const createTask = ({ title, steps, ...config }): Listr.ListrTask<Context
       // eslint-disable-next-line no-await-in-loop
       await step(ctx, task);
     }
+
+    ctx.options.onTaskComplete?.(ctx);
   },
   ...config,
 });

--- a/node-src/types.ts
+++ b/node-src/types.ts
@@ -86,6 +86,9 @@ export interface Options {
   branchName: string;
   patchHeadRef: string;
   patchBaseRef: string;
+
+  /** A callback that is called at the completion of each task */
+  onTaskComplete?: (ctx: Context) => void;
 }
 
 export interface Context {


### PR DESCRIPTION
Telescoping on https://github.com/chromaui/chromatic-cli/pull/755

And ability to pass options to the node API.

This will allow us to get access to the context at the completion of each task, in particular to get the build id at the end of the `announce` task.