### PR TITLE
Move all depenendencies to dev deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,11 +81,7 @@
   "resolutions": {
     "any-observable": "^0.5.1"
   },
-  "dependencies": {
-    "@discoveryjs/json-ext": "^0.5.7",
-    "@storybook/csf-tools": "^7.0.12",
-    "snyk-nodejs-lockfile-parser": "^1.49.0"
-  },
+  "dependencies": {},
   "devDependencies": {
     "@actions/core": "^1.10.0",
     "@actions/github": "^5.0.0",
@@ -96,8 +92,10 @@
     "@babel/preset-env": "^7.15.0",
     "@babel/preset-typescript": "^7.15.0",
     "@babel/runtime": "^7.15.3",
+    "@discoveryjs/json-ext": "^0.5.7",
     "@storybook/addon-essentials": "^6.5.6",
     "@storybook/builder-webpack5": "^6.5.6",
+    "@storybook/csf-tools": "^7.0.12",
     "@storybook/eslint-config-storybook": "^3.1.2",
     "@storybook/linter-config": "^3.1.2",
     "@storybook/manager-webpack5": "^6.5.6",
@@ -161,6 +159,7 @@
     "read-pkg-up": "^7.0.1",
     "semver": "^7.3.5",
     "slash": "^3.0.0",
+    "snyk-nodejs-lockfile-parser": "^1.49.0",
     "sort-package-json": "1.50.0",
     "string-argv": "^0.3.1",
     "strip-ansi": "6.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chromatic",
-  "version": "6.19.3-next.0",
+  "version": "6.19.4-canary.0",
   "description": "Automate visual testing across browsers. Gather UI feedback. Versioned documentation.",
   "keywords": [
     "storybook-addon",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chromatic",
-  "version": "6.19.2",
+  "version": "6.19.3-next.0",
   "description": "Automate visual testing across browsers. Gather UI feedback. Versioned documentation.",
   "keywords": [
     "storybook-addon",


### PR DESCRIPTION
I'm not sure why these utilities were in deps, no dev deps. I think that TSUP will never bundle deps, whereas maybe previously webpack would happily bundle everything? Not sure.