### PR TITLE
Pass `gitUserEmailHash` up with new builds and use `localBuilds` filter in baseline calculations

### DIFF
--- a/node-src/git/getBaselineBuilds.ts
+++ b/node-src/git/getBaselineBuilds.ts
@@ -1,11 +1,16 @@
 import gql from 'fake-tag';
 
 import { Context } from '../types';
+import { localBuildsSpecifier } from '../lib/localBuildsSpecifier';
 
 const BaselineCommitsQuery = gql`
-  query BaselineCommitsQuery($branch: String!, $parentCommits: [String!]!, $creatorEmail: String!) {
+  query BaselineCommitsQuery(
+    $branch: String!
+    $parentCommits: [String!]!
+    $localBuilds: LocalBuildsSpecifierInput!
+  ) {
     app {
-      baselineBuilds(branch: $branch, parentCommits: $parentCommits, creatorEmail: $creatorEmail) {
+      baselineBuilds(branch: $branch, parentCommits: $parentCommits, localBuilds: $localBuilds) {
         id
         number
         status(legacy: false)
@@ -30,13 +35,13 @@ interface BaselineCommitsQueryResult {
 }
 
 export async function getBaselineBuilds(
-  { client, git: { creatorEmail } }: Pick<Context, 'client' | 'git'>,
+  ctx: Pick<Context, 'options' | 'client' | 'git'>,
   { branch, parentCommits }: { branch: string; parentCommits: string[] }
 ) {
-  const { app } = await client.runQuery<BaselineCommitsQueryResult>(BaselineCommitsQuery, {
+  const { app } = await ctx.client.runQuery<BaselineCommitsQueryResult>(BaselineCommitsQuery, {
     branch,
     parentCommits,
-    creatorEmail,
+    localBuilds: localBuildsSpecifier(ctx),
   });
   return app.baselineBuilds;
 }

--- a/node-src/git/getBaselineBuilds.ts
+++ b/node-src/git/getBaselineBuilds.ts
@@ -3,9 +3,9 @@ import gql from 'fake-tag';
 import { Context } from '../types';
 
 const BaselineCommitsQuery = gql`
-  query BaselineCommitsQuery($branch: String!, $parentCommits: [String!]!) {
+  query BaselineCommitsQuery($branch: String!, $parentCommits: [String!]!, $creatorEmail: String!) {
     app {
-      baselineBuilds(branch: $branch, parentCommits: $parentCommits) {
+      baselineBuilds(branch: $branch, parentCommits: $parentCommits, creatorEmail: $creatorEmail) {
         id
         number
         status(legacy: false)
@@ -30,12 +30,13 @@ interface BaselineCommitsQueryResult {
 }
 
 export async function getBaselineBuilds(
-  { client }: Pick<Context, 'client'>,
+  { client, git: { creatorEmail } }: Pick<Context, 'client' | 'git'>,
   { branch, parentCommits }: { branch: string; parentCommits: string[] }
 ) {
   const { app } = await client.runQuery<BaselineCommitsQueryResult>(BaselineCommitsQuery, {
     branch,
     parentCommits,
+    creatorEmail,
   });
   return app.baselineBuilds;
 }

--- a/node-src/git/getParentCommits.test.ts
+++ b/node-src/git/getParentCommits.test.ts
@@ -64,6 +64,7 @@ async function checkoutCommit(name, branch, { dirname, runGit, commitMap }) {
 }
 
 const log = { debug: jest.fn() };
+const options = {};
 
 // This is built in from TypeScript 4.5
 type Awaited<T> = T extends Promise<infer U> ? U : T;
@@ -96,7 +97,7 @@ describe('getParentCommits', () => {
     const client = createClient({ repository, builds: [] });
     const git = { branch: 'main', ...(await getCommit()) };
 
-    const parentCommits = await getParentCommits({ client, log, git } as any);
+    const parentCommits = await getParentCommits({ client, log, git, options } as any);
     expectCommitsToEqualNames(parentCommits, [], repository);
   });
 
@@ -109,7 +110,7 @@ describe('getParentCommits', () => {
     const client = createClient({ repository, builds: [['F', 'main']] });
     const git = { branch: 'main', ...(await getCommit()) };
 
-    const parentCommits = await getParentCommits({ client, log, git } as any);
+    const parentCommits = await getParentCommits({ client, log, git, options } as any);
     expectCommitsToEqualNames(parentCommits, ['F'], repository);
   });
 
@@ -122,7 +123,7 @@ describe('getParentCommits', () => {
     const client = createClient({ repository, builds: [['B', 'main']] });
     const git = { branch: 'main', ...(await getCommit()) };
 
-    const parentCommits = await getParentCommits({ client, log, git } as any);
+    const parentCommits = await getParentCommits({ client, log, git, options } as any);
     expectCommitsToEqualNames(parentCommits, ['B'], repository);
   });
 
@@ -141,7 +142,7 @@ describe('getParentCommits', () => {
     });
     const git = { branch: 'main', ...(await getCommit()) };
 
-    const parentCommits = await getParentCommits({ client, log, git } as any);
+    const parentCommits = await getParentCommits({ client, log, git, options } as any);
     expectCommitsToEqualNames(parentCommits, ['E', 'D'], repository);
   });
 
@@ -163,7 +164,7 @@ describe('getParentCommits', () => {
     });
     const git = { branch: 'main', ...(await getCommit()) };
 
-    const parentCommits = await getParentCommits({ client, log, git } as any);
+    const parentCommits = await getParentCommits({ client, log, git, options } as any);
     expectCommitsToEqualNames(parentCommits, ['D', 'C', 'B'], repository);
   });
 
@@ -182,7 +183,7 @@ describe('getParentCommits', () => {
     });
     const git = { branch: 'main', ...(await getCommit()) };
 
-    const parentCommits = await getParentCommits({ client, log, git } as any);
+    const parentCommits = await getParentCommits({ client, log, git, options } as any);
     expectCommitsToEqualNames(parentCommits, ['C', 'B'], repository);
   });
 
@@ -204,7 +205,7 @@ describe('getParentCommits', () => {
     });
     const git = { branch: 'main', ...(await getCommit()) };
 
-    const parentCommits = await getParentCommits({ client, log, git } as any);
+    const parentCommits = await getParentCommits({ client, log, git, options } as any);
     expectCommitsToEqualNames(parentCommits, ['B'], repository);
   });
 
@@ -227,7 +228,7 @@ describe('getParentCommits', () => {
     });
     const git = { branch: 'main', ...(await getCommit()) };
 
-    const parentCommits = await getParentCommits({ client, log, git } as any);
+    const parentCommits = await getParentCommits({ client, log, git, options } as any);
     expectCommitsToEqualNames(parentCommits, ['E', 'D'], repository);
   });
 
@@ -242,7 +243,7 @@ describe('getParentCommits', () => {
     const client = createClient({ repository, builds: [['C', 'main']] });
     const git = { branch: 'main', ...(await getCommit()) };
 
-    const parentCommits = await getParentCommits({ client, log, git } as any);
+    const parentCommits = await getParentCommits({ client, log, git, options } as any);
     expectCommitsToEqualNames(parentCommits, ['C'], repository);
   });
 
@@ -265,7 +266,7 @@ describe('getParentCommits', () => {
     });
     const git = { branch: 'main', ...(await getCommit()) };
 
-    const parentCommits = await getParentCommits({ client, log, git } as any);
+    const parentCommits = await getParentCommits({ client, log, git, options } as any);
     expectCommitsToEqualNames(parentCommits, ['D'], repository);
   });
 
@@ -284,7 +285,7 @@ describe('getParentCommits', () => {
     });
     const git = { branch: 'main', ...(await getCommit()) };
 
-    const parentCommits = await getParentCommits({ client, log, git } as any);
+    const parentCommits = await getParentCommits({ client, log, git, options } as any);
     expectCommitsToEqualNames(parentCommits, ['C'], repository);
   });
 
@@ -297,7 +298,7 @@ describe('getParentCommits', () => {
     const client = createClient({ repository, builds: [['D', 'branch']] });
     const git = { branch: 'main', ...(await getCommit()) };
 
-    const parentCommits = await getParentCommits({ client, log, git } as any);
+    const parentCommits = await getParentCommits({ client, log, git, options } as any);
     expectCommitsToEqualNames(parentCommits, [], repository);
   });
 
@@ -310,7 +311,7 @@ describe('getParentCommits', () => {
     const client = createClient({ repository, builds: [['E', 'branch']] });
     const git = { branch: 'main', ...(await getCommit()) };
 
-    const parentCommits = await getParentCommits({ client, log, git } as any);
+    const parentCommits = await getParentCommits({ client, log, git, options } as any);
     expectCommitsToEqualNames(parentCommits, [], repository);
   });
 
@@ -323,7 +324,7 @@ describe('getParentCommits', () => {
     const client = createClient({ repository, builds: [['B', 'branch']] });
     const git = { branch: 'main', ...(await getCommit()) };
 
-    const parentCommits = await getParentCommits({ client, log, git } as any);
+    const parentCommits = await getParentCommits({ client, log, git, options } as any);
     expectCommitsToEqualNames(parentCommits, [], repository);
   });
 
@@ -345,7 +346,7 @@ describe('getParentCommits', () => {
     });
     const git = { branch: 'main', ...(await getCommit()) };
 
-    const parentCommits = await getParentCommits({ client, log, git } as any);
+    const parentCommits = await getParentCommits({ client, log, git, options } as any);
     expectCommitsToEqualNames(parentCommits, [], repository);
   });
 
@@ -358,7 +359,7 @@ describe('getParentCommits', () => {
     const client = createClient({ repository, builds: [['D', 'main']] });
     const git = { branch: 'main', ...(await getCommit()) };
 
-    const parentCommits = await getParentCommits({ client, log, git } as any);
+    const parentCommits = await getParentCommits({ client, log, git, options } as any);
     expectCommitsToEqualNames(parentCommits, ['D'], repository);
   });
 
@@ -371,7 +372,7 @@ describe('getParentCommits', () => {
     const client = createClient({ repository, builds: [['z', 'branch']] });
     const git = { branch: 'main', ...(await getCommit()) };
 
-    const parentCommits = await getParentCommits({ client, log, git } as any);
+    const parentCommits = await getParentCommits({ client, log, git, options } as any);
     expectCommitsToEqualNames(parentCommits, [], repository);
   });
 
@@ -384,7 +385,7 @@ describe('getParentCommits', () => {
     const client = createClient({ repository, builds: [['A', 'branch']] });
     const git = { branch: 'main', ...(await getCommit()) };
 
-    const parentCommits = await getParentCommits({ client, log, git } as any);
+    const parentCommits = await getParentCommits({ client, log, git, options } as any);
     expectCommitsToEqualNames(parentCommits, ['A'], repository);
   });
 
@@ -410,7 +411,7 @@ describe('getParentCommits', () => {
     };
     const git = { branch: 'branch', ...(await getCommit()) };
 
-    const parentCommits = await getParentCommits({ client, log, git } as any);
+    const parentCommits = await getParentCommits({ client, log, git, options } as any);
     expectCommitsToEqualNames(parentCommits, ['A'], repository);
   });
 
@@ -434,7 +435,7 @@ describe('getParentCommits', () => {
     });
     const git = { branch: 'branch', ...(await getCommit()) };
 
-    const parentCommits = await getParentCommits({ client, log, git } as any);
+    const parentCommits = await getParentCommits({ client, log, git, options } as any);
     expectCommitsToEqualNames(parentCommits, ['D'], repository);
   });
 
@@ -458,7 +459,7 @@ describe('getParentCommits', () => {
     });
     const git = { branch: 'branch', ...(await getCommit()) };
 
-    const parentCommits = await getParentCommits({ client, log, git } as any);
+    const parentCommits = await getParentCommits({ client, log, git, options } as any);
     expectCommitsToEqualNames(parentCommits, ['D'], repository);
   });
 
@@ -482,7 +483,7 @@ describe('getParentCommits', () => {
     });
     const git = { branch: 'branch', ...(await getCommit()) };
 
-    const parentCommits = await getParentCommits({ client, log, git } as any);
+    const parentCommits = await getParentCommits({ client, log, git, options } as any);
     expectCommitsToEqualNames(parentCommits, ['C'], repository);
   });
 
@@ -505,7 +506,7 @@ describe('getParentCommits', () => {
     });
     const git = { branch: 'branch', ...(await getCommit()) };
 
-    const parentCommits = await getParentCommits({ client, log, git } as any, {
+    const parentCommits = await getParentCommits({ client, log, git, options } as any, {
       ignoreLastBuildOnBranch: true,
     });
     expectCommitsToEqualNames(parentCommits, ['C'], repository);
@@ -537,7 +538,7 @@ describe('getParentCommits', () => {
     });
     const git = { branch: 'branch', ...(await getCommit()) };
 
-    const parentCommits = await getParentCommits({ client, log, git } as any);
+    const parentCommits = await getParentCommits({ client, log, git, options } as any);
     expect(parentCommits).toEqual([Zhash, repository.commitMap.C.hash]);
   });
 
@@ -562,7 +563,7 @@ describe('getParentCommits', () => {
     });
     const git = { branch: 'branch', ...(await getCommit()) };
 
-    const parentCommits = await getParentCommits({ client, log, git } as any);
+    const parentCommits = await getParentCommits({ client, log, git, options } as any);
     expectCommitsToEqualNames(parentCommits, ['B'], repository);
   });
 
@@ -585,7 +586,7 @@ describe('getParentCommits', () => {
     });
     const git = { branch: 'branch', ...(await getCommit()) };
 
-    const parentCommits = await getParentCommits({ client, log, git } as any);
+    const parentCommits = await getParentCommits({ client, log, git, options } as any);
     expectCommitsToEqualNames(parentCommits, ['E'], repository);
   });
 
@@ -610,7 +611,7 @@ describe('getParentCommits', () => {
     const git = { branch: 'HEAD', ...(await getCommit()) };
 
     // We can pass 'HEAD' as the branch if we fail to find any other branch info from another source
-    const parentCommits = await getParentCommits({ client, log, git } as any);
+    const parentCommits = await getParentCommits({ client, log, git, options } as any);
     expectCommitsToEqualNames(parentCommits, ['C'], repository);
   });
 
@@ -636,7 +637,7 @@ describe('getParentCommits', () => {
       });
       const git = { branch: 'main', ...(await getCommit()) };
 
-      const parentCommits = await getParentCommits({ client, log, git } as any);
+      const parentCommits = await getParentCommits({ client, log, git, options } as any);
       // This doesn't include 'C' as D "covers" it.
       expectCommitsToEqualNames(parentCommits, ['D'], repository);
     });

--- a/node-src/git/getParentCommits.ts
+++ b/node-src/git/getParentCommits.ts
@@ -47,7 +47,7 @@ interface FirstCommittedAtQueryResult {
 }
 
 const HasBuildsWithCommitsQuery = gql`
-  query HasBuildsWithCommitsQuery($commits: [String!]!, $localBuilds: LocalBuildsSpecifierInput!!) {
+  query HasBuildsWithCommitsQuery($commits: [String!]!, $localBuilds: LocalBuildsSpecifierInput!) {
     app {
       hasBuildsWithCommits(commits: $commits, localBuilds: $localBuilds)
     }

--- a/node-src/git/getParentCommits.ts
+++ b/node-src/git/getParentCommits.ts
@@ -8,7 +8,11 @@ import { localBuildsSpecifier } from '../lib/localBuildsSpecifier';
 export const FETCH_N_INITIAL_BUILD_COMMITS = 20;
 
 const FirstCommittedAtQuery = gql`
-  query FirstCommittedAtQuery($commit: String!, $branch: String!, $localBuilds: LocalBuildsSpecifierInput!!) {
+  query FirstCommittedAtQuery(
+    $commit: String!
+    $branch: String!
+    $localBuilds: LocalBuildsSpecifierInput!
+  ) {
     app {
       firstBuild(sortByCommittedAt: true, localBuilds: $localBuilds) {
         committedAt

--- a/node-src/git/git.ts
+++ b/node-src/git/git.ts
@@ -44,6 +44,10 @@ export async function getVersion() {
   return result.replace('git version ', '');
 }
 
+export async function getUserEmail() {
+  return execGitCommand(`git config user.email`);
+}
+
 // The slug consists of the last two parts of the URL, at least for GitHub, GitLab and Bitbucket,
 // and is typically followed by `.git`. The regex matches the last two parts between slashes, and
 // ignores the `.git` suffix if it exists, so it matches something like `ownername/reponame`.

--- a/node-src/index.ts
+++ b/node-src/index.ts
@@ -14,7 +14,7 @@ import checkPackageJson from './lib/checkPackageJson';
 import { writeChromaticDiagnostics } from './lib/writeChromaticDiagnostics';
 import invalidPackageJson from './ui/messages/errors/invalidPackageJson';
 import noPackageJson from './ui/messages/errors/noPackageJson';
-import { getBranch, getCommit, getSlug } from './git/git';
+import { getBranch, getCommit, getSlug, getUserEmail } from './git/git';
 
 /**
  Make keys of `T` outside of `R` optional.
@@ -113,12 +113,14 @@ export async function runAll(ctx, options?: Options) {
 }
 
 export type GitInfo = {
+  userEmail: string;
   branch: string;
   commit: string;
   slug: string;
 };
 
 export async function getGitInfo(): Promise<GitInfo> {
+  const userEmail = await getUserEmail();
   const branch = await getBranch();
   const { commit } = await getCommit();
   const slug = await getSlug();
@@ -126,5 +128,5 @@ export async function getGitInfo(): Promise<GitInfo> {
   const [ownerName, repoName, ...rest] = slug ? slug.split('/') : [];
   const isValidSlug = !!ownerName && !!repoName && !rest.length;
 
-  return { branch, commit, slug: isValidSlug ? slug : '' };
+  return { userEmail, branch, commit, slug: isValidSlug ? slug : '' };
 }

--- a/node-src/index.ts
+++ b/node-src/index.ts
@@ -15,6 +15,7 @@ import { writeChromaticDiagnostics } from './lib/writeChromaticDiagnostics';
 import invalidPackageJson from './ui/messages/errors/invalidPackageJson';
 import noPackageJson from './ui/messages/errors/noPackageJson';
 import { getBranch, getCommit, getSlug, getUserEmail } from './git/git';
+import { emailHash } from './lib/emailHash';
 
 /**
  Make keys of `T` outside of `R` optional.
@@ -114,6 +115,7 @@ export async function runAll(ctx, options?: Options) {
 
 export type GitInfo = {
   userEmail: string;
+  userEmailHash: string;
   branch: string;
   commit: string;
   slug: string;
@@ -121,6 +123,7 @@ export type GitInfo = {
 
 export async function getGitInfo(): Promise<GitInfo> {
   const userEmail = await getUserEmail();
+  const userEmailHash = emailHash(userEmail);
   const branch = await getBranch();
   const { commit } = await getCommit();
   const slug = await getSlug();
@@ -128,5 +131,5 @@ export async function getGitInfo(): Promise<GitInfo> {
   const [ownerName, repoName, ...rest] = slug ? slug.split('/') : [];
   const isValidSlug = !!ownerName && !!repoName && !rest.length;
 
-  return { userEmail, branch, commit, slug: isValidSlug ? slug : '' };
+  return { userEmail, userEmailHash, branch, commit, slug: isValidSlug ? slug : '' };
 }

--- a/node-src/lib/emailHash.ts
+++ b/node-src/lib/emailHash.ts
@@ -1,4 +1,3 @@
-// This is duplicated from https://github.com/chromaui/chromatic/blob/1ceabdd81936b883a2a9ddc804ed13bfa0919c47/services/index/model/lib/emailHash.ts#L1-L7
 import { createHash } from 'crypto';
 
 // Inspired by https://en.gravatar.com/site/implement/hash

--- a/node-src/lib/emailHash.ts
+++ b/node-src/lib/emailHash.ts
@@ -1,0 +1,7 @@
+// This is duplicated from https://github.com/chromaui/chromatic/blob/1ceabdd81936b883a2a9ddc804ed13bfa0919c47/services/index/model/lib/emailHash.ts#L1-L7
+import { createHash } from 'crypto';
+
+// Inspired by https://en.gravatar.com/site/implement/hash
+export function emailHash(email: string) {
+  return createHash('md5').update(email.trim().toLowerCase()).digest('hex');
+}

--- a/node-src/lib/localBuildsSpecifier.ts
+++ b/node-src/lib/localBuildsSpecifier.ts
@@ -1,0 +1,12 @@
+import { Context } from '../types';
+import { emailHash } from './emailHash';
+
+export function localBuildsSpecifier(ctx: Pick<Context, 'options' | 'git'>) {
+  if (ctx.options.isLocalBuild) return { localBuildEmailHash: emailHash(ctx.git.gitUserEmail) };
+
+  // For non local builds, if we have a committer hash, we want only local builds from that person
+  if (ctx.git.committerEmail) return { localBuildEmailHash: emailHash(ctx.git.committerEmail) };
+
+  // If we don't know, we fall back to *no local builds at all*
+  return { isLocalBuild: false };
+}

--- a/node-src/lib/localBuildsSpecifier.ts
+++ b/node-src/lib/localBuildsSpecifier.ts
@@ -4,7 +4,7 @@ import { emailHash } from './emailHash';
 export function localBuildsSpecifier(ctx: Pick<Context, 'options' | 'git'>) {
   if (ctx.options.isLocalBuild) return { localBuildEmailHash: emailHash(ctx.git.gitUserEmail) };
 
-  // For non local builds, if we have a committer hash, we want only local builds from that person
+  // For global builds, we only want local builds from the committer (besides global builds)
   if (ctx.git.committerEmail) return { localBuildEmailHash: emailHash(ctx.git.committerEmail) };
 
   // If we don't know, we fall back to *no local builds at all*

--- a/node-src/main.test.ts
+++ b/node-src/main.test.ts
@@ -354,7 +354,7 @@ it('runs in simple situations', async () => {
     packageVersion: expect.any(String),
     storybookVersion: '5.1.0',
     storybookViewLayer: 'viewLayer',
-    creatorEmail: 'test@test.com',
+    gitUserEmail: 'test@test.com',
     committerEmail: 'test@test.com',
     committerName: 'tester',
     isolatorUrl: `https://chromatic.com/iframe.html`,

--- a/node-src/main.test.ts
+++ b/node-src/main.test.ts
@@ -354,6 +354,7 @@ it('runs in simple situations', async () => {
     packageVersion: expect.any(String),
     storybookVersion: '5.1.0',
     storybookViewLayer: 'viewLayer',
+    creatorEmail: 'test@test.com',
     committerEmail: 'test@test.com',
     committerName: 'tester',
     isolatorUrl: `https://chromatic.com/iframe.html`,

--- a/node-src/main.test.ts
+++ b/node-src/main.test.ts
@@ -265,6 +265,7 @@ jest.mock('./git/git', () => ({
   getChangedFiles: () => Promise.resolve(['src/foo.stories.js']),
   getRepositoryRoot: () => Promise.resolve(process.cwd()),
   getUncommittedHash: () => Promise.resolve('abc123'),
+  getUserEmail: () => Promise.resolve('test@test.com'),
 }));
 
 jest.mock('./git/getParentCommits', () => ({
@@ -355,7 +356,6 @@ it('runs in simple situations', async () => {
     packageVersion: expect.any(String),
     storybookVersion: '5.1.0',
     storybookViewLayer: 'viewLayer',
-    gitUserEmail: 'test@test.com',
     committerEmail: 'test@test.com',
     committerName: 'tester',
     isolatorUrl: `https://chromatic.com/iframe.html`,

--- a/node-src/tasks/gitInfo.test.ts
+++ b/node-src/tasks/gitInfo.test.ts
@@ -28,19 +28,16 @@ const getParentCommits = <jest.MockedFunction<typeof getParentCommitsUnmocked>>(
 
 const log = { info: jest.fn(), warn: jest.fn(), debug: jest.fn() };
 
-const minimalCommitInfo = {
+const commitInfo = {
   commit: '123asdf',
   committedAt: 1640131292,
+  committerName: 'Gert Hengeveld',
+  committerEmail: 'gert@chromatic.com',
   branch: 'something',
   slug: undefined,
   isTravisPrBuild: false,
   fromCI: false,
   ciService: undefined,
-};
-const commitInfo = {
-  ...minimalCommitInfo,
-  committerName: 'Gert Hengeveld',
-  committerEmail: 'gert@chromatic.com',
 };
 
 const client = { runQuery: jest.fn(), setAuthorization: jest.fn() };
@@ -65,31 +62,15 @@ describe('setGitInfo', () => {
       branch: 'something',
       parentCommits: ['asd2344'],
       version: 'Git v1.0.0',
-      creatorEmail: 'gert@chromatic.com',
       slug: 'user/repo',
     });
   });
 
-  it('falls back to unknown when git info cannot be parsed', async () => {
-    getCommitAndBranch.mockResolvedValue(minimalCommitInfo);
-
-    const ctx = { log, options: {}, client } as any;
-    await setGitInfo(ctx, {} as any);
-    expect(ctx.git).toMatchObject({
-      commit: '123asdf',
-      branch: 'something',
-      parentCommits: ['asd2344'],
-      version: 'Git v1.0.0',
-      creatorEmail: 'unknown',
-      slug: 'user/repo',
-    });
-  });
-
-  it('sets creatorEmail to current user for local builds', async () => {
+  it('sets gitUserEmail to current user for local builds', async () => {
     const ctx = { log, options: { isLocalBuild: true }, client } as any;
     await setGitInfo(ctx, {} as any);
     expect(ctx.git).toMatchObject({
-      creatorEmail: 'user@email.com',
+      gitUserEmail: 'user@email.com',
     });
   });
 

--- a/node-src/tasks/gitInfo.ts
+++ b/node-src/tasks/gitInfo.ts
@@ -67,7 +67,10 @@ export const setGitInfo = async (ctx: Context, task: Task) => {
 
   ctx.git = {
     version: await getVersion(),
-    gitUserEmail: await getUserEmail(),
+    gitUserEmail: await getUserEmail().catch((e) => {
+      ctx.log.debug('Failed to retrieve Git user email', e);
+      return null;
+    }),
     ...commitAndBranchInfo,
   };
 

--- a/node-src/tasks/initialize.ts
+++ b/node-src/tasks/initialize.ts
@@ -64,7 +64,7 @@ export const announceBuild = async (ctx: Context) => {
         patchBaseRef,
         patchHeadRef,
         preserveMissingSpecs,
-        gitUserEmailHash: emailHash(gitUserEmail),
+        ...(gitUserEmail && { gitUserEmailHash: emailHash(gitUserEmail) }),
         ...commitInfo,
         committedAt: new Date(committedAt),
         ciVariables: ctx.environment,

--- a/node-src/tasks/initialize.ts
+++ b/node-src/tasks/initialize.ts
@@ -1,3 +1,4 @@
+import { emailHash } from '../lib/emailHash';
 import { createTask, transitionTo } from '../lib/tasks';
 import { Context } from '../types';
 import noAncestorBuild from '../ui/messages/warnings/noAncestorBuild';
@@ -49,6 +50,7 @@ export const announceBuild = async (ctx: Context) => {
     committedAt,
     baselineCommits,
     packageManifestChanges,
+    gitUserEmail,
     ...commitInfo
   } = ctx.git; // omit some fields;
   const { rebuildForBuildId, turboSnap } = ctx;
@@ -62,6 +64,7 @@ export const announceBuild = async (ctx: Context) => {
         patchBaseRef,
         patchHeadRef,
         preserveMissingSpecs,
+        gitUserEmailHash: emailHash(gitUserEmail),
         ...commitInfo,
         committedAt: new Date(committedAt),
         ciVariables: ctx.environment,

--- a/node-src/types.ts
+++ b/node-src/types.ts
@@ -141,13 +141,8 @@ export interface Context {
 
   git: {
     version: string;
-    /**
-     * The creator of the build is:
-     *   - the current user in local builds
-     *   - the creator of the commit in CI builds
-     *   - 'unknown' in CI situations where we cannot read the current commit info.
-     */
-    creatorEmail: string;
+    /** The current user's email as pre git config */
+    gitUserEmail: string;
     branch: string;
     commit: string;
     committerEmail?: string;

--- a/node-src/types.ts
+++ b/node-src/types.ts
@@ -141,8 +141,16 @@ export interface Context {
 
   git: {
     version: string;
+    /**
+     * The creator of the build is:
+     *   - the current user in local builds
+     *   - the creator of the commit in CI builds
+     *   - 'unknown' in CI situations where we cannot read the current commit info.
+     */
+    creatorEmail: string;
     branch: string;
     commit: string;
+    committerEmail?: string;
     committedAt: number;
     slug?: string;
     mergeCommit?: string;

--- a/node-src/ui/messages/errors/gitUserEmailNotFound.stories.ts
+++ b/node-src/ui/messages/errors/gitUserEmailNotFound.stories.ts
@@ -1,0 +1,7 @@
+import gitUserEmailNotFound from './gitUserEmailNotFound';
+
+export default {
+  title: 'CLI/Messages/Errors',
+};
+
+export const GitUserEmailNotFound = () => gitUserEmailNotFound();

--- a/node-src/ui/messages/errors/gitUserEmailNotFound.ts
+++ b/node-src/ui/messages/errors/gitUserEmailNotFound.ts
@@ -1,0 +1,14 @@
+import chalk from 'chalk';
+import { dedent } from 'ts-dedent';
+
+import { error } from '../../components/icons';
+
+export default () =>
+  `${dedent(chalk`
+    ${error} {bold Failed to find the current git user's email}
+    Git email required for Visual Tests addon builds.
+
+    In order to associate your local changes with later CI builds, you need to configure
+    git with the email address you'll commit with.
+    You can do this with \`git config --global user.email YOUR_EMAIL\`
+  `)}`;

--- a/node-src/ui/messages/errors/gitUserEmailNotFound.ts
+++ b/node-src/ui/messages/errors/gitUserEmailNotFound.ts
@@ -2,13 +2,20 @@ import chalk from 'chalk';
 import { dedent } from 'ts-dedent';
 
 import { error } from '../../components/icons';
+import link from '../../components/link';
+
+const localBuildsDocsLink = 'https://www.chromatic.com/docs/addon-visual-tests#local-builds';
 
 export default () =>
   `${dedent(chalk`
     ${error} {bold Failed to find the current git user's email}
-    Git email required for Visual Tests addon builds.
-
+    We were unable to find your git email so this local build
+    will not belong to you and will not affect your future baselines
+    (read more: ${link(localBuildsDocsLink)}).
+    
     In order to associate your local changes with later CI builds, you need to configure
     git with the email address you'll commit with.
     You can do this with \`git config --global user.email YOUR_EMAIL\`
+
+    Once you've done so, please run this build again.
   `)}`;

--- a/node-src/ui/messages/errors/gitUserEmailNotFound.ts
+++ b/node-src/ui/messages/errors/gitUserEmailNotFound.ts
@@ -4,7 +4,8 @@ import { dedent } from 'ts-dedent';
 import { error } from '../../components/icons';
 import link from '../../components/link';
 
-const localBuildsDocsLink = 'https://www.chromatic.com/docs/addon-visual-tests#local-builds';
+const localBuildsDocsLink =
+  'https://www.chromatic.com/docs/branching-and-baselines#what-are-local-builds';
 
 export default () =>
   `${dedent(chalk`

--- a/node-src/ui/messages/errors/gitUserEmailNotFound.ts
+++ b/node-src/ui/messages/errors/gitUserEmailNotFound.ts
@@ -11,12 +11,12 @@ export default () =>
   `${dedent(chalk`
     ${error} {bold Failed to find the current git user's email}
     We were unable to find your git email so this local build
-    will not belong to you and will not affect your future baselines
-    (read more: ${link(localBuildsDocsLink)}).
+    will not belong to you and will not affect your future baselines.
+    Read more: ${link(localBuildsDocsLink)}
     
-    In order to associate your local changes with later CI builds, you need to configure
-    git with the email address you'll commit with.
-    You can do this with \`git config --global user.email YOUR_EMAIL\`
+    In order to associate your local changes with later CI builds, you
+    need to configure git with the email address you'll commit with.
+    You can do this with \`git config --global user.email YOUR_EMAIL\`.
 
     Once you've done so, please run this build again.
   `)}`;

--- a/node-src/ui/messages/warnings/noCommitDetails.ts
+++ b/node-src/ui/messages/warnings/noCommitDetails.ts
@@ -13,6 +13,7 @@ export default ({ ref, sha, env }: BranchRef | CommitRef) => {
       ${warning} {bold Branch '${ref}' does not exist}
       We tried to retrieve its latest commit but couldn't find it in your Git history.
       Falling back to ${sha.slice(0, 7)}, but commit details (date, author) will be missing.
+      We will not be able to retain baselines from builds created by the Visual Tests addon.
       Pull request status updates likely won't work properly.
       Please use our official GitHub Action or forward the pull_request event info to us.
       ${info} Read more at ${link('https://www.chromatic.com/docs/github-actions')}
@@ -24,11 +25,13 @@ export default ({ ref, sha, env }: BranchRef | CommitRef) => {
       We tried to retrieve the commit details but couldn't find it in your Git history.
       Check your {bold ${env}} environment variable.
       Using it anyway, but commit details (date, author) will be missing.
+      We will not be able to retain baselines from builds created by the Visual Tests addon.
     `);
   }
   return dedent(chalk`
     ${warning} {bold Commit ${sha.slice(0, 7)} does not exist}
     We tried to retrieve the commit details but couldn't find it in your Git history.
     Using it anyway, but commit details (date, author) will be missing.
+    We will not be able to retain baselines from builds created by the Visual Tests addon.
   `);
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chromatic",
-  "version": "6.22.0-canary.2",
+  "version": "6.22.0-canary.3",
   "description": "Automate visual testing across browsers. Gather UI feedback. Versioned documentation.",
   "keywords": [
     "storybook-addon",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chromatic",
-  "version": "6.22.0",
+  "version": "6.23.0-canary.0",
   "description": "Automate visual testing across browsers. Gather UI feedback. Versioned documentation.",
   "keywords": [
     "storybook-addon",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chromatic",
-  "version": "6.22.0-canary.1",
+  "version": "6.22.0-canary.2",
   "description": "Automate visual testing across browsers. Gather UI feedback. Versioned documentation.",
   "keywords": [
     "storybook-addon",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chromatic",
-  "version": "6.22.0-canary.0",
+  "version": "6.22.0-canary.1",
   "description": "Automate visual testing across browsers. Gather UI feedback. Versioned documentation.",
   "keywords": [
     "storybook-addon",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chromatic",
-  "version": "6.22.0-canary.3",
+  "version": "6.22.0-canary.4",
   "description": "Automate visual testing across browsers. Gather UI feedback. Versioned documentation.",
   "keywords": [
     "storybook-addon",


### PR DESCRIPTION
Telescoping on https://github.com/chromaui/chromatic-cli/pull/795

We want to mark who created each build[1] so we can filter out local builds created by anyone else apart from the current user.

As such we:

 - Send `gitUserEmaiHash ` as part of the `AnnounceBuild` mutation
 - Send `localBuilds: { localBuildEmailHash: gitUserEmaiHash || committerHash }` as part of all the queries we use for baseline calculations.

This depends on https://github.com/chromaui/chromatic/pull/7576


[1] The creator is the current git user for local builds and the committer otherwise.