### PR TITLE
If you supply options you don't need to supply them all

### DIFF
--- a/node-src/index.ts
+++ b/node-src/index.ts
@@ -45,7 +45,7 @@ export async function run({
 }: {
   argv?: string[];
   flags?: Flags;
-  options?: Options;
+  options?: Partial<Options>;
 }): Promise<Output> {
   const sessionId = uuid();
   const env = getEnv();
@@ -100,7 +100,7 @@ export async function run({
   };
 }
 
-export async function runAll(ctx, options?: Options) {
+export async function runAll(ctx, options?: Partial<Options>) {
   // Run these in parallel; neither should ever reject
   await Promise.all([runBuild(ctx, options), checkForUpdates(ctx)]);
 

--- a/node-src/runBuild.ts
+++ b/node-src/runBuild.ts
@@ -16,7 +16,7 @@ import taskError from './ui/messages/errors/taskError';
 import intro from './ui/messages/info/intro';
 import { endActivity } from './ui/components/activity';
 
-export async function runBuild(ctx: Context, extraOptions?: Options) {
+export async function runBuild(ctx: Context, extraOptions?: Partial<Options>) {
   ctx.log.info('');
   ctx.log.info(intro(ctx));
 


### PR DESCRIPTION
I mistyped this, leading to an [unnecessary `as any` in the addon.](https://github.com/chromaui/addon-visual-tests/blob/ab11ced8628671c4ddbb495f9038d0d999cef3da/src/index.ts#L77)