### PR TITLE
Fix `Unexpected build status: PREPARED` error

### DIFF
--- a/node-src/main.test.ts
+++ b/node-src/main.test.ts
@@ -145,7 +145,7 @@ jest.mock('node-fetch', () =>
       if (query.match('SnapshotBuildQuery')) {
         return {
           data: {
-            app: { build: { status: 'PENDING', changeCount: 1 } },
+            app: { build: { status: 'PENDING', changeCount: 1, completedAt: 1 } },
           },
         };
       }

--- a/node-src/tasks/snapshot.test.ts
+++ b/node-src/tasks/snapshot.test.ts
@@ -24,7 +24,7 @@ describe('takeSnapshots', () => {
 
     client.runQuery.mockReturnValueOnce({ app: { build: { status: 'IN_PROGRESS' } } });
     client.runQuery.mockReturnValueOnce({
-      app: { build: { changeCount: 0, status: 'PASSED' } },
+      app: { build: { changeCount: 0, status: 'PASSED', completedAt: 1 } },
     });
 
     await takeSnapshots(ctx, {} as any);
@@ -34,7 +34,7 @@ describe('takeSnapshots', () => {
       { headers: { Authorization: `Bearer report-token` } }
     );
     expect(client.runQuery).toHaveBeenCalledTimes(2);
-    expect(ctx.build).toEqual({ ...build, changeCount: 0, status: 'PASSED' });
+    expect(ctx.build).toEqual({ ...build, changeCount: 0, status: 'PASSED', completedAt: 1 });
     expect(ctx.exitCode).toBe(0);
   });
 
@@ -53,11 +53,11 @@ describe('takeSnapshots', () => {
 
     client.runQuery.mockReturnValueOnce({ app: { build: { status: 'IN_PROGRESS' } } });
     client.runQuery.mockReturnValueOnce({
-      app: { build: { changeCount: 2, status: 'PENDING' } },
+      app: { build: { changeCount: 2, status: 'PENDING', completedAt: 1 } },
     });
 
     await takeSnapshots(ctx, {} as any);
-    expect(ctx.build).toEqual({ ...build, changeCount: 2, status: 'PENDING' });
+    expect(ctx.build).toEqual({ ...build, changeCount: 2, status: 'PENDING', completedAt: 1 });
     expect(ctx.exitCode).toBe(1);
   });
 
@@ -76,11 +76,11 @@ describe('takeSnapshots', () => {
 
     client.runQuery.mockReturnValueOnce({ app: { build: { status: 'IN_PROGRESS' } } });
     client.runQuery.mockReturnValueOnce({
-      app: { build: { changeCount: 2, status: 'BROKEN' } },
+      app: { build: { changeCount: 2, status: 'BROKEN', completedAt: 1 } },
     });
 
     await takeSnapshots(ctx, {} as any);
-    expect(ctx.build).toEqual({ ...build, changeCount: 2, status: 'BROKEN' });
+    expect(ctx.build).toEqual({ ...build, changeCount: 2, status: 'BROKEN', completedAt: 1 });
     expect(ctx.exitCode).toBe(2);
   });
 
@@ -99,11 +99,11 @@ describe('takeSnapshots', () => {
 
     client.runQuery.mockReturnValueOnce({ app: { build: { status: 'IN_PROGRESS' } } });
     client.runQuery.mockReturnValueOnce({
-      app: { build: { changeCount: 2, status: 'FAILED' } },
+      app: { build: { changeCount: 2, status: 'FAILED', completedAt: 1 } },
     });
 
     await takeSnapshots(ctx, {} as any);
-    expect(ctx.build).toEqual({ ...build, changeCount: 2, status: 'FAILED' });
+    expect(ctx.build).toEqual({ ...build, changeCount: 2, status: 'FAILED', completedAt: 1 });
     expect(ctx.exitCode).toBe(3);
   });
 });

--- a/node-src/types.ts
+++ b/node-src/types.ts
@@ -216,6 +216,7 @@ export interface Context {
     turboSnapEnabled?: boolean;
     wasLimited?: boolean;
     startedAt?: number;
+    completedAt?: number;
     app: {
       manageUrl: string;
       setupUrl: string;


### PR DESCRIPTION
Previously, the CLI could crash if the `waitForBuild` polling happened to return a build while it was `PUBLISHED` or `PREPARED`. These would be considered "complete" (not in progress) but the code that runs after the build is complete (rightfully) does not handle those build statuses. 

I could've updated the status check to take `PUBLISHED` and `PREPARED` into account but it seems more resilient to look at `completedAt` instead.