### PR TITLE
Include all commit info in `GitInfo`

### DIFF
--- a/node-src/index.ts
+++ b/node-src/index.ts
@@ -114,31 +114,34 @@ export async function runAll(ctx, options?: Options) {
 }
 
 export type GitInfo = {
-  userEmail: string;
-  userEmailHash: string;
+  slug: string;
   branch: string;
   commit: string;
-  slug: string;
+  committedAt: number;
+  committerEmail: string;
+  committerName: string;
   uncommittedHash: string;
+  userEmail: string;
+  userEmailHash: string;
 };
 
 export async function getGitInfo(): Promise<GitInfo> {
+  const slug = await getSlug();
+  const branch = await getBranch();
+  const commitInfo = await getCommit();
   const userEmail = await getUserEmail();
   const userEmailHash = emailHash(userEmail);
-  const branch = await getBranch();
-  const { commit } = await getCommit();
-  const slug = await getSlug();
 
   const [ownerName, repoName, ...rest] = slug ? slug.split('/') : [];
   const isValidSlug = !!ownerName && !!repoName && !rest.length;
 
   const uncommittedHash = await getUncommittedHash();
   return {
+    slug: isValidSlug ? slug : '',
+    branch,
+    ...commitInfo,
+    uncommittedHash,
     userEmail,
     userEmailHash,
-    branch,
-    commit,
-    slug: isValidSlug ? slug : '',
-    uncommittedHash,
   };
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chromatic",
-  "version": "6.23.0",
+  "version": "6.24.0-canary.0",
   "description": "Automate visual testing across browsers. Gather UI feedback. Versioned documentation.",
   "keywords": [
     "storybook-addon",


### PR DESCRIPTION
This adds `committedAt`, `committerName` and `committerEmail` to `GitInfo`, so that we can compare the last local commit against the `committedAt` of a build.