### PR TITLE
Add `onTaskError` option to report errors to node consumers

### DIFF
--- a/node-src/main.test.ts
+++ b/node-src/main.test.ts
@@ -356,7 +356,10 @@ it('passes options error to onTaskError', async () => {
 
   await expect(ctx.options.onTaskError).toHaveBeenCalledWith(
     expect.anything(), // Context
-    expect.stringContaining('Missing project token') // Long formatted error fatalError https://github.com/chromaui/chromatic-cli/blob/217e77671179748eb4ddb8becde78444db93d067/node-src/ui/messages/errors/fatalError.ts#L11
+    expect.objectContaining({
+      formattedError: expect.stringContaining('Missing project token'), // Long formatted error fatalError https://github.com/chromaui/chromatic-cli/blob/217e77671179748eb4ddb8becde78444db93d067/node-src/ui/messages/errors/fatalError.ts#L11
+      originalError: expect.anything(), // No jest matcher for an error.
+    })
   );
 });
 

--- a/node-src/main.test.ts
+++ b/node-src/main.test.ts
@@ -343,6 +343,23 @@ it('fails on missing project token', async () => {
   expect(ctx.testLogger.errors[0]).toMatch(/Missing project token/);
 });
 
+// Note this tests options errors, but not fatal task or runtime errors.
+it('passes options error to onTaskError', async () => {
+  const ctx = getContext([]);
+  ctx.options = {
+    onTaskError: jest.fn(),
+  } as any;
+
+  ctx.options.onTaskError = jest.fn();
+  ctx.env.CHROMATIC_PROJECT_TOKEN = '';
+  await runBuild(ctx);
+
+  await expect(ctx.options.onTaskError).toHaveBeenCalledWith(
+    expect.anything(), // Context
+    expect.stringContaining('Missing project token') // Long formatted error fatalError https://github.com/chromaui/chromatic-cli/blob/217e77671179748eb4ddb8becde78444db93d067/node-src/ui/messages/errors/fatalError.ts#L11
+  );
+});
+
 it('runs in simple situations', async () => {
   const ctx = getContext(['--project-token=asdf1234']);
   await runBuild(ctx);

--- a/node-src/main.test.ts
+++ b/node-src/main.test.ts
@@ -331,6 +331,7 @@ const getContext = (
     },
     packagePath: '',
     statsPath: 'preview-stats.json',
+    options: {},
     ...parseArgs(argv),
   } as any;
 };
@@ -358,7 +359,7 @@ it('passes options error to onTaskError', async () => {
     expect.anything(), // Context
     expect.objectContaining({
       formattedError: expect.stringContaining('Missing project token'), // Long formatted error fatalError https://github.com/chromaui/chromatic-cli/blob/217e77671179748eb4ddb8becde78444db93d067/node-src/ui/messages/errors/fatalError.ts#L11
-      originalError: expect.anything(), // No jest matcher for an error.
+      originalError: expect.any(Error),
     })
   );
 });

--- a/node-src/runBuild.ts
+++ b/node-src/runBuild.ts
@@ -26,7 +26,7 @@ export async function runBuild(ctx: Context, extraOptions?: Partial<Options>) {
   } catch (e) {
     ctx.log.info('');
     ctx.log.error(fatalError(ctx, [e]));
-    ctx.options.onTaskError?.(ctx, fatalError(ctx, [e]));
+    ctx.options.onTaskError?.(ctx, { formattedError: fatalError(ctx, [e]), originalError: e });
     setExitCode(ctx, exitCodes.INVALID_OPTIONS, true);
     return;
   }
@@ -72,7 +72,10 @@ export async function runBuild(ctx: Context, extraOptions?: Partial<Options>) {
     }
   } catch (error) {
     const errors = [].concat(error); // GraphQLClient might throw an array of errors
-    ctx.options.onTaskError?.(ctx, fatalError(ctx, errors));
+    ctx.options.onTaskError?.(ctx, {
+      formattedError: fatalError(ctx, errors),
+      originalError: error,
+    });
 
     if (errors.length && !ctx.userError) {
       ctx.log.info('');

--- a/node-src/runBuild.ts
+++ b/node-src/runBuild.ts
@@ -75,6 +75,7 @@ export async function runBuild(ctx: Context, extraOptions?: Partial<Options>) {
     if (errors.length && !ctx.userError) {
       ctx.log.info('');
       ctx.log.error(fatalError(ctx, errors));
+      ctx.options.onTaskError?.(ctx, fatalError(ctx, errors));
     }
 
     if (!ctx.exitCode) {

--- a/node-src/runBuild.ts
+++ b/node-src/runBuild.ts
@@ -26,6 +26,7 @@ export async function runBuild(ctx: Context, extraOptions?: Partial<Options>) {
   } catch (e) {
     ctx.log.info('');
     ctx.log.error(fatalError(ctx, [e]));
+    ctx.options.onTaskError?.(ctx, fatalError(ctx, [e]));
     setExitCode(ctx, exitCodes.INVALID_OPTIONS, true);
     return;
   }
@@ -71,11 +72,11 @@ export async function runBuild(ctx: Context, extraOptions?: Partial<Options>) {
     }
   } catch (error) {
     const errors = [].concat(error); // GraphQLClient might throw an array of errors
+    ctx.options.onTaskError?.(ctx, fatalError(ctx, errors));
 
     if (errors.length && !ctx.userError) {
       ctx.log.info('');
       ctx.log.error(fatalError(ctx, errors));
-      ctx.options.onTaskError?.(ctx, fatalError(ctx, errors));
     }
 
     if (!ctx.exitCode) {

--- a/node-src/types.ts
+++ b/node-src/types.ts
@@ -92,8 +92,11 @@ export interface Options {
   onTaskComplete?: (ctx: Context) => void;
 
   /** A callback that is called if a task fails */
-  onTaskError?: (ctx: Context, error: Error | Error[] | string) => void;
-  
+  onTaskError?: (
+    ctx: Context,
+    { formattedError, originalError }: { formattedError: string; originalError: Error | Error[] }
+  ) => void;
+
   /** A callback that is called during tasks that have incremental progress */
   onTaskProgress?: (
     ctx: Context,

--- a/node-src/types.ts
+++ b/node-src/types.ts
@@ -90,6 +90,9 @@ export interface Options {
 
   /** A callback that is called at the completion of each task */
   onTaskComplete?: (ctx: Context) => void;
+
+  /** A callback that is called if a task fails */
+  onTaskError?: (ctx: Context, error: Error | Error[] | string) => void;
 }
 
 export interface Context {


### PR DESCRIPTION
Adds an option that receives an error when options or task fails. Consumes the same fatalError message that would be logged to CLI for a user error.