### PR TITLE
Add `experimental_abortSignal` to Node API to allow canceling builds

### DIFF
--- a/node-src/lib/tasks.ts
+++ b/node-src/lib/tasks.ts
@@ -26,6 +26,7 @@ export const createTask = ({
 
     // eslint-disable-next-line no-restricted-syntax
     for (const step of steps) {
+      ctx.options.experimental_abortSignal?.throwIfAborted();
       // eslint-disable-next-line no-await-in-loop
       await step(ctx, task);
     }

--- a/node-src/main.test.ts
+++ b/node-src/main.test.ts
@@ -1,7 +1,6 @@
 import { Readable } from 'stream';
 import execaDefault from 'execa';
 import { confirm } from 'node-ask';
-import treeKill from 'tree-kill';
 import fetchDefault from 'node-fetch';
 import dns from 'dns';
 
@@ -223,10 +222,6 @@ jest.mock('node-fetch', () =>
     },
   }))
 );
-
-jest.mock('tree-kill');
-
-const kill = <jest.MockedFunction<typeof treeKill>>treeKill;
 
 const mockStatsFile = Readable.from([
   JSON.stringify({

--- a/node-src/main.test.ts
+++ b/node-src/main.test.ts
@@ -415,6 +415,15 @@ it('should exit with code 0 when the current branch is skipped', async () => {
   expect(ctx.exitCode).toBe(0);
 });
 
+it('should exit with code 6 and stop the build when abortSignal is aborted', async () => {
+  const abortSignal = AbortSignal.abort(new Error('Build canceled'));
+  const ctx = getContext(['--project-token=asdf1234']);
+  ctx.extraOptions = { experimental_abortSignal: abortSignal };
+  await runBuild(ctx);
+  expect(ctx.exitCode).toBe(6);
+  expect(uploadFiles).not.toHaveBeenCalled();
+});
+
 it('calls out to npm build script passed and uploads files', async () => {
   const ctx = getContext(['--project-token=asdf1234', '--build-script-name=build-storybook']);
   await runBuild(ctx);

--- a/node-src/runBuild.ts
+++ b/node-src/runBuild.ts
@@ -1,12 +1,14 @@
 import Listr from 'listr';
 
 import GraphQLClient from './io/GraphQLClient';
+import { getConfiguration } from './lib/getConfiguration';
 import getOptions from './lib/getOptions';
 import NonTTYRenderer from './lib/NonTTYRenderer';
 import { exitCodes, setExitCode } from './lib/setExitCode';
 import { rewriteErrorMessage } from './lib/utils';
 import getTasks from './tasks';
-import { Context, Options } from './types';
+import { Context } from './types';
+import buildCanceled from './ui/messages/errors/buildCanceled';
 import fatalError from './ui/messages/errors/fatalError';
 import fetchError from './ui/messages/errors/fetchError';
 import graphqlError from './ui/messages/errors/graphqlError';
@@ -15,7 +17,6 @@ import runtimeError from './ui/messages/errors/runtimeError';
 import taskError from './ui/messages/errors/taskError';
 import intro from './ui/messages/info/intro';
 import { endActivity } from './ui/components/activity';
-import { getConfiguration } from './lib/getConfiguration';
 
 export async function runBuild(ctx: Context) {
   ctx.log.info('');
@@ -64,6 +65,11 @@ export async function runBuild(ctx: Context) {
       if (err.message.startsWith('Cannot run a build with no stories')) {
         setExitCode(ctx, exitCodes.BUILD_NO_STORIES);
         throw rewriteErrorMessage(err, missingStories(ctx));
+      }
+      if (ctx.extraOptions.experimental_abortSignal?.aborted) {
+        ctx.userError = true;
+        setExitCode(ctx, exitCodes.BUILD_WAS_CANCELED);
+        throw rewriteErrorMessage(err, buildCanceled());
       }
       throw rewriteErrorMessage(err, taskError(ctx, err));
     } finally {

--- a/node-src/runBuild.ts
+++ b/node-src/runBuild.ts
@@ -66,7 +66,7 @@ export async function runBuild(ctx: Context) {
         setExitCode(ctx, exitCodes.BUILD_NO_STORIES);
         throw rewriteErrorMessage(err, missingStories(ctx));
       }
-      if (ctx.extraOptions.experimental_abortSignal?.aborted) {
+      if (ctx.options.experimental_abortSignal?.aborted) {
         setExitCode(ctx, exitCodes.BUILD_WAS_CANCELED, true);
         throw rewriteErrorMessage(err, buildCanceled());
       }

--- a/node-src/runBuild.ts
+++ b/node-src/runBuild.ts
@@ -83,17 +83,16 @@ export async function runBuild(ctx: Context) {
     }
   } catch (error) {
     const errors = [].concat(error); // GraphQLClient might throw an array of errors
+    const formattedError = fatalError(ctx, errors);
 
-    if (errors.length) {
-      const formattedError = fatalError(ctx, errors);
-      ctx.options.experimental_onTaskError?.(ctx, {
-        formattedError,
-        originalError: errors[0],
-      });
-      if (!ctx.userError) {
-        ctx.log.info('');
-        ctx.log.error(formattedError);
-      }
+    ctx.options.experimental_onTaskError?.(ctx, {
+      formattedError,
+      originalError: errors[0],
+    });
+
+    if (!ctx.userError) {
+      ctx.log.info('');
+      ctx.log.error(formattedError);
     }
 
     if (!ctx.exitCode) {

--- a/node-src/tasks/build.test.ts
+++ b/node-src/tasks/build.test.ts
@@ -129,6 +129,7 @@ describe('buildStorybook', () => {
       spawnParams: { command: 'npm run build:storybook --script-args' },
       env: { STORYBOOK_BUILD_TIMEOUT: 1000 },
       log: { debug: jest.fn() },
+      options: {},
     } as any;
     await buildStorybook(ctx);
     expect(ctx.buildLogFile).toMatch(/build-storybook\.log$/);

--- a/node-src/tasks/build.ts
+++ b/node-src/tasks/build.ts
@@ -84,7 +84,6 @@ export const buildStorybook = async (ctx: Context) => {
     subprocess = execa.command(command, { stdio: [null, logFile, logFile] });
     await Promise.race([subprocess, timeoutAfter(ctx.env.STORYBOOK_BUILD_TIMEOUT)]);
   } catch (e) {
-    endActivity(ctx);
     abortSignal?.throwIfAborted();
 
     const buildLog = fs.readFileSync(ctx.buildLogFile, 'utf8');

--- a/node-src/tasks/build.ts
+++ b/node-src/tasks/build.ts
@@ -69,7 +69,7 @@ export const buildStorybook = async (ctx: Context) => {
     logFile.on('error', reject);
   });
 
-  const { experimental_abortSignal: abortSignal } = ctx.extraOptions;
+  const { experimental_abortSignal: abortSignal } = ctx.options;
 
   try {
     const { command } = ctx.spawnParams;

--- a/node-src/types.ts
+++ b/node-src/types.ts
@@ -108,6 +108,9 @@ export interface Options {
 
   /** A callback that is called at the completion of each task */
   experimental_onTaskComplete?: (ctx: Context) => void;
+
+  /** An AbortSignal that terminates the build if aborted */
+  experimental_abortSignal?: AbortSignal;
 }
 
 export { Configuration };

--- a/node-src/ui/components/activity.ts
+++ b/node-src/ui/components/activity.ts
@@ -4,18 +4,18 @@ import { Context, Task } from '../../types';
 const renderLoop = (ctx: Context, render: (frame: number) => void) => {
   const interval = ctx.options.interactive ? 100 : ctx.env.CHROMATIC_OUTPUT_INTERVAL;
   const maxFrames = ctx.env.CHROMATIC_TIMEOUT / interval;
-  let done = false;
+
+  let timeout: NodeJS.Timeout;
   const tick = (frame = 0) => {
     render(frame);
-    if (!done && frame < maxFrames) {
-      setTimeout(() => tick(frame + 1), interval);
+    if (frame < maxFrames) {
+      timeout = setTimeout(() => tick(frame + 1), interval);
     }
   };
+
   tick();
   return {
-    end() {
-      done = true;
-    },
+    end: () => clearTimeout(timeout),
   };
 };
 

--- a/node-src/ui/messages/errors/buildCanceled.stories.ts
+++ b/node-src/ui/messages/errors/buildCanceled.stories.ts
@@ -1,0 +1,7 @@
+import buildCanceled from './buildCanceled';
+
+export default {
+  title: 'CLI/Messages/Errors',
+};
+
+export const BuildCanceled = () => buildCanceled();

--- a/node-src/ui/messages/errors/buildCanceled.ts
+++ b/node-src/ui/messages/errors/buildCanceled.ts
@@ -1,0 +1,10 @@
+import chalk from 'chalk';
+import { dedent } from 'ts-dedent';
+
+import { error } from '../../components/icons';
+
+export default () =>
+  dedent(chalk`
+    ${error} {bold Build canceled}
+    The build was canceled before it completed.
+  `);

--- a/package.json
+++ b/package.json
@@ -185,7 +185,6 @@
     "string-argv": "^0.3.1",
     "strip-ansi": "6.0.0",
     "tmp-promise": "3.0.2",
-    "tree-kill": "^1.2.2",
     "ts-dedent": "^1.0.0",
     "ts-loader": "^9.2.5",
     "ts-node": "^10.9.1",


### PR DESCRIPTION
Aborting the AbortSignal will gracefully cancel the build process. This will only work so long as the build isn't fully published yet, because at that point it's handed off to the capture cloud which doesn't yet support cancellation.

The build-storybook process is actually terminated. The upload should also be terminated (TODO).