### PR TITLE
Add `experimental_abortSignal` to Node API to allow canceling builds

### DIFF
--- a/node-src/lib/tasks.ts
+++ b/node-src/lib/tasks.ts
@@ -25,6 +25,7 @@ export const createTask = ({
     ctx.options.experimental_onTaskStart?.({ ...ctx });
 
     for (const step of steps) {
+      ctx.options.experimental_abortSignal?.throwIfAborted();
       await step(ctx, task);
     }
 

--- a/node-src/main.test.ts
+++ b/node-src/main.test.ts
@@ -421,6 +421,15 @@ it('should exit with code 0 when the current branch is skipped', async () => {
   expect(ctx.exitCode).toBe(0);
 });
 
+it('should exit with code 6 and stop the build when abortSignal is aborted', async () => {
+  const abortSignal = AbortSignal.abort(new Error('Build canceled'));
+  const ctx = getContext(['--project-token=asdf1234']);
+  ctx.extraOptions = { experimental_abortSignal: abortSignal };
+  await runBuild(ctx);
+  expect(ctx.exitCode).toBe(6);
+  expect(uploadFiles).not.toHaveBeenCalled();
+});
+
 it('calls out to npm build script passed and uploads files', async () => {
   const ctx = getContext(['--project-token=asdf1234', '--build-script-name=build-storybook']);
   await runBuild(ctx);

--- a/node-src/runBuild.ts
+++ b/node-src/runBuild.ts
@@ -1,12 +1,14 @@
 import Listr from 'listr';
 
 import GraphQLClient from './io/GraphQLClient';
+import { getConfiguration } from './lib/getConfiguration';
 import getOptions from './lib/getOptions';
 import NonTTYRenderer from './lib/NonTTYRenderer';
 import { exitCodes, setExitCode } from './lib/setExitCode';
 import { rewriteErrorMessage } from './lib/utils';
 import getTasks from './tasks';
 import { Context } from './types';
+import buildCanceled from './ui/messages/errors/buildCanceled';
 import fatalError from './ui/messages/errors/fatalError';
 import fetchError from './ui/messages/errors/fetchError';
 import graphqlError from './ui/messages/errors/graphqlError';
@@ -15,7 +17,6 @@ import runtimeError from './ui/messages/errors/runtimeError';
 import taskError from './ui/messages/errors/taskError';
 import intro from './ui/messages/info/intro';
 import { endActivity } from './ui/components/activity';
-import { getConfiguration } from './lib/getConfiguration';
 
 export async function runBuild(ctx: Context) {
   ctx.log.info('');
@@ -64,6 +65,10 @@ export async function runBuild(ctx: Context) {
       if (err.message.startsWith('Cannot run a build with no stories')) {
         setExitCode(ctx, exitCodes.BUILD_NO_STORIES);
         throw rewriteErrorMessage(err, missingStories(ctx));
+      }
+      if (ctx.options.experimental_abortSignal?.aborted) {
+        setExitCode(ctx, exitCodes.BUILD_WAS_CANCELED, true);
+        throw rewriteErrorMessage(err, buildCanceled());
       }
       throw rewriteErrorMessage(err, taskError(ctx, err));
     } finally {

--- a/node-src/tasks/build.ts
+++ b/node-src/tasks/build.ts
@@ -69,22 +69,15 @@ export const buildStorybook = async (ctx: Context) => {
     logFile.on('error', reject);
   });
 
-  const { experimental_abortSignal: abortSignal } = ctx.options;
-
+  const { experimental_abortSignal: signal } = ctx.options;
   try {
     const { command } = ctx.spawnParams;
     ctx.log.debug('Using spawnParams:', JSON.stringify(ctx.spawnParams, null, 2));
 
-    let subprocess = null;
-    if (abortSignal) {
-      abortSignal.onabort = () => {
-        subprocess?.kill('SIGTERM', { forceKillAfterTimeout: 2000 });
-      };
-    }
-    subprocess = execaCommand(command, { stdio: [null, logFile, logFile] });
+    const subprocess = execaCommand(command, { stdio: [null, logFile, logFile], signal });
     await Promise.race([subprocess, timeoutAfter(ctx.env.STORYBOOK_BUILD_TIMEOUT)]);
   } catch (e) {
-    abortSignal?.throwIfAborted();
+    signal?.throwIfAborted();
 
     const buildLog = readFileSync(ctx.buildLogFile, 'utf8');
     ctx.log.error(buildFailed(ctx, e, buildLog));

--- a/node-src/types.ts
+++ b/node-src/types.ts
@@ -108,6 +108,9 @@ export interface Options {
 
   /** A callback that is called at the completion of each task */
   experimental_onTaskComplete?: (ctx: Context) => void;
+
+  /** An AbortSignal that terminates the build if aborted */
+  experimental_abortSignal?: AbortSignal;
 }
 
 export { Configuration };

--- a/node-src/ui/components/activity.ts
+++ b/node-src/ui/components/activity.ts
@@ -4,18 +4,18 @@ import { Context, Task } from '../../types';
 const renderLoop = (ctx: Context, render: (frame: number) => void) => {
   const interval = ctx.options.interactive ? 100 : ctx.env.CHROMATIC_OUTPUT_INTERVAL;
   const maxFrames = ctx.env.CHROMATIC_TIMEOUT / interval;
-  let done = false;
+
+  let timeout: NodeJS.Timeout;
   const tick = (frame = 0) => {
     render(frame);
-    if (!done && frame < maxFrames) {
-      setTimeout(() => tick(frame + 1), interval);
+    if (frame < maxFrames) {
+      timeout = setTimeout(() => tick(frame + 1), interval);
     }
   };
+
   tick();
   return {
-    end() {
-      done = true;
-    },
+    end: () => clearTimeout(timeout),
   };
 };
 

--- a/node-src/ui/messages/errors/buildCanceled.stories.ts
+++ b/node-src/ui/messages/errors/buildCanceled.stories.ts
@@ -1,0 +1,7 @@
+import buildCanceled from './buildCanceled';
+
+export default {
+  title: 'CLI/Messages/Errors',
+};
+
+export const BuildCanceled = () => buildCanceled();

--- a/node-src/ui/messages/errors/buildCanceled.ts
+++ b/node-src/ui/messages/errors/buildCanceled.ts
@@ -1,0 +1,10 @@
+import chalk from 'chalk';
+import { dedent } from 'ts-dedent';
+
+import { error } from '../../components/icons';
+
+export default () =>
+  dedent(chalk`
+    ${error} {bold Build canceled}
+    The build was canceled before it completed.
+  `);


### PR DESCRIPTION
Supersedes #820 

Aborting the AbortSignal will gracefully cancel the build process. This will only work so long as the build isn't fully published yet, because at that point it's handed off to the capture cloud which doesn't yet support cancellation.

The build-storybook process is actually terminated. The upload should also be terminated (TODO).