### PR TITLE
Enable to override commit sha on github action

### DIFF
--- a/action-src/main.ts
+++ b/action-src/main.ts
@@ -93,6 +93,7 @@ async function run() {
     const autoAcceptChanges = getInput('autoAcceptChanges');
     const branchName = getInput('branchName');
     const buildScriptName = getInput('buildScriptName');
+    const commitSha = getInput('commitSha');
     const debug = getInput('debug');
     const diagnostics = getInput('diagnostics');
     const dryRun = getInput('dryRun');
@@ -120,7 +121,7 @@ async function run() {
     const junitReport = getInput('junitReport');
 
     process.env.CHROMATIC_ACTION = 'true';
-    process.env.CHROMATIC_SHA = sha;
+    process.env.CHROMATIC_SHA = commitSha || sha;
     process.env.CHROMATIC_BRANCH = branchName || branch;
     process.env.CHROMATIC_SLUG = repositorySlug || slug;
     if (mergeCommit) {

--- a/action.yml
+++ b/action.yml
@@ -21,6 +21,9 @@ inputs:
   buildScriptName:
     description: 'The npm script that builds your Storybook [build-storybook]'
     required: false
+  commitSha:
+    description: 'Override the commit SHA'
+    required: false
   debug:
     description: 'Output verbose debugging information'
     required: false


### PR DESCRIPTION
This PR enables to override SHA on GitHub Action. This PR is to complement https://github.com/chromaui/chromatic-cli/pull/713.

On the issue_comment event, `github.sha` always refers to the default branch. Therefore, if you want to trigger a chromatic action on a specific PR associated with a particular PR comment, an additional process to fetch both the branch name and sha is required. Currently, you can override the branch name by providing the branchName option, but the sha cannot be overridden. This PR enables it.

The following example shows a way to override a sha with this PR.

```yaml
on: issue_comment
permissions: read-all
jobs:
  publish_chromatic:
    name: Publish to Chromatic
    runs-on: ubuntu-latest
    steps:
      - id: get-branch
        run: |
          input_string=$(gh pr view 8 --repo nobuhikosawai/ga-test --json headRefOid --json headRefName -q '"branch=\(.headRefName) sha=\(.headRefOid)"')
          branch=$(echo "$input_string" | awk -F ' ' '{split($1, a, "="); split($2, b, "="); print a[2]}')
          sha=$(echo "$input_string" | awk -F ' ' '{split($1, a, "="); split($2, b, "="); print b[2]}')
          echo "branch=$branch" >> $GITHUB_OUTPUT
          echo "sha=$sha" >> $GITHUB_OUTPUT
        env:
          REPO: ${{ github.repository }}
          PR_NO: ${{ github.event.issue.number }}
          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
      - uses: actions/checkout@v4
        with:
          fetch-depth: 0
          ref: ${{ steps.get-branch.outputs.branch }}
      - name: Install dependencies
        run: yarn
      - name: Publish to Chromatic
        uses: chromaui/action@v1
        with:
          projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
          branchName: ${{ steps.get-branch.outputs.branch }}
          commitSha: ${{ steps.get-branch.outputs.sha  }}
```