### PR TITLE
Updated the check for untraced

### DIFF
--- a/node-src/tasks/upload.ts
+++ b/node-src/tasks/upload.ts
@@ -170,7 +170,7 @@ export const traceChangedFiles = async (ctx: Context, task: Task) => {
     } else {
       ctx.log.warn(`Could not retrieve dependency changes from lockfiles; checking package.json`);
       const changedPackageFiles = await findChangedPackageFiles(packageManifestChanges);
-      if (changedPackageFiles.length > 0) {
+      if (changedPackageFiles.length > 0 && !ctx.untracedFiles) {
         ctx.turboSnap.bailReason = { changedPackageFiles };
         ctx.log.warn(bailFile({ turboSnap: ctx.turboSnap }));
         return;


### PR DESCRIPTION
We need to check if the package files are untraced during uploading.
We only set the TurboSnap bail reason.

We already check in dependendStoryFiles if we can't trace the dependencies.
https://github.com/chromaui/chromatic-cli/blob/c92d97705a9b8a4951c9b60613dba9d26c83db3c/node-src/lib/getDependentStoryFiles.ts#L208-L216
So we could remove that Bail reason and continue processing the changed files.

This would cover us on package changes without traced dependencies.
https://github.com/chromaui/chromatic-cli/blob/c92d97705a9b8a4951c9b60613dba9d26c83db3c/node-src/tasks/upload.ts#L180
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>7.3.1--canary.834.743db4e.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@7.3.1--canary.834.743db4e.0
  # or 
  yarn add chromatic@7.3.1--canary.834.743db4e.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
