### PR TITLE
Only release 'latest' GitHub Action from `main` branch

### DIFF
--- a/scripts/publish-action.mjs
+++ b/scripts/publish-action.mjs
@@ -57,15 +57,17 @@ const publishAction = async ({ version, repo }) => {
 
   const { default: pkg } = await import('../package.json', { assert: { type: 'json' } });
 
-  const [, major, minor, patch, tag] = pkg.version.match(/(\d+)\.(\d+)\.(\d+)-?(\w+)?/) || [];
+  const [, major, minor, patch, tag] = pkg.version.match(/(\d+)\.(\d+)\.(\d+)-*(\w+)?/) || [];
   if (!major || !minor || !patch) {
     console.error(`❗️ Invalid version: ${pkg.version}`);
     return;
   }
 
+  const { stdout: branch } = await execaCommand('git rev-parse --abbrev-ref HEAD');
+  const defaultTag = branch === 'main' ? 'latest' : 'canary';
   const context = ['canary', 'next', 'latest'].includes(process.argv[2])
     ? process.argv[2]
-    : tag || 'latest';
+    : tag || defaultTag;
 
   switch (context) {
     case 'canary':


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>7.4.1--canary.837.6512947158.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@7.4.1--canary.837.6512947158.0
  # or 
  yarn add chromatic@7.4.1--canary.837.6512947158.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
