### PR TITLE
Add workflow to require certain PR labels before merging

### DIFF
--- a/.github/workflows/check-labels.yml
+++ b/.github/workflows/check-labels.yml
@@ -1,0 +1,18 @@
+name: Check PR Labels
+on:
+  pull_request:
+    types: [opened, labeled, unlabeled, synchronize]
+
+jobs:
+  check-labels:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 20
+      - uses: chromaui/pr-label-checker-action@main
+        with:
+          one-of: |
+            major, minor, patch
+            release, skip-release
+          none-of: DO NOT MERGE


### PR DESCRIPTION
This adds a GitHub workflow for [chromaui/pr-label-checker-action](https://github.com/chromaui/pr-label-checker-action), which I created for this. It's configured to require one of `patch` / `minor` / `major` as well as either `release` or `skip-release` and disallow the `DO NOT MERGE` label.

The purpose of this is to enforce having the necessary labels for `auto` to work properly.