### PR TITLE
Configure auto with `prerelease` setting and update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,13 +71,14 @@ We use `auto` to automate the release process. Versions are bumped, tags are cre
 
 Additionally, a PR **may** have exactly one of these labels:
 
-- `release` creates a `latest` rather than a `next` release (see below)
+- `release` creates a `latest` rather than a `next` release on npm
+- `next-release` creates a `next` rather than a `latest` release on npm
 - `skip-release` does not create a release at all
 
 We have three types of releases:
 
 - `latest` releases are the general audience production releases, used by most people. Automatically created when merging a PR with the `release` label.
-- `next` releases should be valid, working releases that can potentially be used by early adopters of new features, for example to handle a support request. Automatically created when merging a PR without the `release` and `skip-release` labels.
+- `next` releases should be valid, working releases that can potentially be used by early adopters of new features, for example to handle a support request. Automatically created when merging a PR with the `next-release` label.
 - `canary` releases are intended for testing purposes and should not be used in production, as they may only work against a staging or dev environment. Automatically created on every PR, but does not auto-publush the GitHub Action.
 
 > For GitHub Actions, we publish `chromaui/action-next` and `chromaui/action-canary`. The latter is only published manually, rather than for every PR.

--- a/package.json
+++ b/package.json
@@ -213,7 +213,8 @@
       "released"
     ],
     "shipit": {
-      "onlyGraduateWithReleaseLabel": true
+      "onlyGraduateWithReleaseLabel": true,
+      "prerelease": true
     }
   },
   "docs": "https://www.chromatic.com/docs/cli",


### PR DESCRIPTION
Releasing a `next` version wasn't quite working as expected. Seems like it needs the `prerelease` setting as well.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>7.5.4--canary.847.6655142677.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@7.5.4--canary.847.6655142677.0
  # or 
  yarn add chromatic@7.5.4--canary.847.6655142677.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
