### PR TITLE
Test extended timeout for custom registry

### DIFF
--- a/node-src/lib/checkForUpdates.ts
+++ b/node-src/lib/checkForUpdates.ts
@@ -25,7 +25,7 @@ export default async function checkForUpdates(ctx: InitialContext) {
     }
 
     const pkgUrl = new URL(ctx.pkg.name, registryUrl).href;
-    const res = await withTimeout(ctx.http.fetch(pkgUrl), 5000); // If not fetched within 5 seconds, nevermind.
+    const res = await withTimeout(ctx.http.fetch(pkgUrl), 30000); // If not fetched within 30 seconds, nevermind.
     const { 'dist-tags': distTags = {} } = (await res.json()) as any;
     if (!semver.valid(distTags.latest)) {
       ctx.log.warn(`Invalid dist-tag 'latest' returned from registry; skipping update check`);


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>7.5.5--canary.850.6672019080.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@7.5.5--canary.850.6672019080.0
  # or 
  yarn add chromatic@7.5.5--canary.850.6672019080.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
