### PR TITLE
Fix changelog for 9.0.0 and update auto config to prevent issue in the future

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,27 +1,12 @@
-# v8.0.0 (Fri Nov 10 2023)
-
-#### 💥 Breaking Change
-
-- Drop official support for Node 14/16 [#839](https://github.com/chromaui/chromatic-cli/pull/839) ([@ghengeveld](https://github.com/ghengeveld))
+# v9.0.0 (Fri Nov 10 2023)
 
 #### 🚀 Enhancement
 
 - Support `projectId` + `userToken` as alternative to `projectToken` for auth [#852](https://github.com/chromaui/chromatic-cli/pull/852) ([@ghengeveld](https://github.com/ghengeveld))
-- Merge Group (Queues) GitHub Action Event Support [#825](https://github.com/chromaui/chromatic-cli/pull/825) ([@mhemmings](https://github.com/mhemmings) [@thafryer](https://github.com/thafryer))
 
-#### 🐛 Bug Fix
+#### Authors: 1
 
-- Bump browserify-sign from 4.2.1 to 4.2.2 [#848](https://github.com/chromaui/chromatic-cli/pull/848) ([@dependabot[bot]](https://github.com/dependabot[bot]))
-- Bump semver from 7.3.5 to 7.5.2 [#778](https://github.com/chromaui/chromatic-cli/pull/778) ([@dependabot[bot]](https://github.com/dependabot[bot]))
-- Bump browserify-sign from 4.2.1 to 4.2.2 in /subdir [#849](https://github.com/chromaui/chromatic-cli/pull/849) ([@dependabot[bot]](https://github.com/dependabot[bot]) [@thafryer](https://github.com/thafryer))
-- Configure auto with `prerelease` setting and update readme [#847](https://github.com/chromaui/chromatic-cli/pull/847) ([@ghengeveld](https://github.com/ghengeveld))
-
-#### Authors: 4
-
-- [@dependabot[bot]](https://github.com/dependabot[bot])
 - Gert Hengeveld ([@ghengeveld](https://github.com/ghengeveld))
-- Jarel Fryer ([@thafryer](https://github.com/thafryer))
-- Mark Hemmings ([@mhemmings](https://github.com/mhemmings))
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -203,11 +203,7 @@
     "plugins": [
       "npm",
       "released"
-    ],
-    "shipit": {
-      "onlyGraduateWithReleaseLabel": true,
-      "prerelease": true
-    }
+    ]
   },
   "docs": "https://www.chromatic.com/docs/cli",
   "storybook": {


### PR DESCRIPTION
Auto messed up the last release, probably due to the `prerelease` setting. Let's get rid of it and disable `onlyGraduateWithReleaseLabel` as well, because it's not working as advertised. We can make do without any `next` releases.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>9.0.1--canary.854.6826342859.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@9.0.1--canary.854.6826342859.0
  # or 
  yarn add chromatic@9.0.1--canary.854.6826342859.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
