### PR TITLE
Disable log files by default, allow them to be configured via options

### DIFF
--- a/node-src/index.ts
+++ b/node-src/index.ts
@@ -161,7 +161,9 @@ export async function runAll(ctx: InitialContext) {
     ctx.configuration = await getConfiguration(
       ctx.extraOptions?.configFile || ctx.flags.configFile
     );
-    (ctx as Context).options = getOptions(ctx);
+    const options = getOptions(ctx);
+    (ctx as Context).options = options;
+    ctx.log.setLogFile(options.logFile);
     setExitCode(ctx, exitCodes.OK);
   } catch (e) {
     return onError(e);

--- a/node-src/lib/getConfiguration.ts
+++ b/node-src/lib/getConfiguration.ts
@@ -15,7 +15,7 @@ const configurationSchema = z
     untraced: z.array(z.string()),
     externals: z.array(z.string()),
     debug: z.boolean(),
-    diagnostics: z.boolean(),
+    diagnosticFile: z.union([z.string(), z.boolean()]),
     junitReport: z.union([z.string(), z.boolean()]),
     zip: z.boolean(),
     autoAcceptChanges: z.union([z.string(), z.boolean()]),
@@ -29,6 +29,8 @@ const configurationSchema = z
     storybookBuildDir: z.string(),
     storybookBaseDir: z.string(),
     storybookConfigDir: z.string(),
+    storybookLogFile: z.union([z.string(), z.boolean()]),
+    logFile: z.union([z.string(), z.boolean()]),
     uploadMetadata: z.boolean(),
   })
   .partial()

--- a/node-src/lib/getOptions.ts
+++ b/node-src/lib/getOptions.ts
@@ -20,12 +20,13 @@ const takeLast = (input: string | string[]) =>
 const ensureArray = (input: string | string[]) => (Array.isArray(input) ? input : [input]);
 
 const trueIfSet = <T>(value: T) => ((value as unknown) === '' ? true : value);
+const defaultIfSet = <T>(value: T, fallback: T) => ((value as unknown) === '' ? fallback : value);
 const undefinedIfEmpty = <T>(array: T[]) => {
   const filtered = array.filter(Boolean);
   return filtered.length ? filtered : undefined;
 };
 
-const stripUndefined = <T extends Record<string, unknown | undefined>>(object: T) =>
+const stripUndefined = (object: Partial<Options>): Partial<Options> =>
   Object.fromEntries(Object.entries(object).filter(([_, v]) => v !== undefined));
 
 export default function getOptions({
@@ -57,6 +58,7 @@ export default function getOptions({
     externals: undefined,
     traceChanged: undefined,
     list: undefined,
+    logFile: undefined,
     skip: undefined,
     forceRebuild: undefined,
     junitReport: undefined,
@@ -71,6 +73,7 @@ export default function getOptions({
     storybookBuildDir: undefined,
     storybookBaseDir: undefined,
     storybookConfigDir: undefined,
+    storybookLogFile: undefined,
 
     ownerName: undefined,
     repositorySlug: undefined,
@@ -84,6 +87,11 @@ export default function getOptions({
   const [branchName, branchOwner] = (flags.branchName || '').split(':').reverse();
   const [repositoryOwner, repositoryName, ...rest] = flags.repositorySlug?.split('/') || [];
 
+  const DEFAULT_LOG_FILE = 'chromatic.log';
+  const DEFAULT_REPORT_FILE = 'chromatic-build-{buildNumber}.xml';
+  const DEFAULT_DIAGNOSTICS_FILE = 'chromatic-diagnostics.json';
+  const DEFAULT_STORYBOOK_LOG_FILE = 'build-storybook.log';
+
   // We need to strip out undefined because they otherwise they override anyway
   const optionsFromFlags = stripUndefined({
     projectToken: takeLast(flags.projectToken || flags.appCode),
@@ -95,13 +103,16 @@ export default function getOptions({
     externals: undefinedIfEmpty(ensureArray(flags.externals)),
     traceChanged: trueIfSet(flags.traceChanged),
     list: flags.list,
+    logFile: defaultIfSet(flags.logFile, DEFAULT_LOG_FILE),
     fromCI: flags.ci,
     skip: trueIfSet(flags.skip),
     dryRun: flags.dryRun,
     forceRebuild: trueIfSet(flags.forceRebuild),
     debug: flags.debug,
-    diagnostics: flags.diagnostics,
-    junitReport: trueIfSet(flags.junitReport),
+    diagnosticsFile:
+      defaultIfSet(flags.diagnosticsFile, DEFAULT_DIAGNOSTICS_FILE) ||
+      defaultIfSet(flags.diagnostics && '', DEFAULT_DIAGNOSTICS_FILE), // for backwards compatibility
+    junitReport: defaultIfSet(flags.junitReport, DEFAULT_REPORT_FILE),
     zip: flags.zip,
 
     autoAcceptChanges: trueIfSet(flags.autoAcceptChanges),
@@ -118,6 +129,7 @@ export default function getOptions({
     storybookBuildDir: takeLast(flags.storybookBuildDir),
     storybookBaseDir: flags.storybookBaseDir,
     storybookConfigDir: flags.storybookConfigDir,
+    storybookLogFile: defaultIfSet(flags.storybookLogFile, DEFAULT_STORYBOOK_LOG_FILE),
 
     ownerName: branchOwner || repositoryOwner,
     repositorySlug: flags.repositorySlug,
@@ -146,6 +158,13 @@ export default function getOptions({
   if (options.debug) {
     log.setLevel('debug');
     log.setInteractive(false);
+  }
+
+  if (options.uploadMetadata) {
+    // Implicitly enable these options unless they're already enabled or explicitly disabled
+    options.logFile = options.logFile ?? DEFAULT_LOG_FILE;
+    options.diagnosticsFile = options.diagnosticsFile ?? DEFAULT_DIAGNOSTICS_FILE;
+    options.storybookLogFile = options.storybookLogFile ?? DEFAULT_STORYBOOK_LOG_FILE;
   }
 
   if (!options.projectToken) {

--- a/node-src/lib/parseArgs.ts
+++ b/node-src/lib/parseArgs.ts
@@ -41,15 +41,17 @@ export default function parseArgs(argv: string[]) {
       --zip                                     Publish your Storybook to Chromatic as a single zip file instead of individual content files.
 
     Debug options
-      --debug                       Output verbose debugging information. This option implies --no-interactive.
-      --diagnostics                 Write process context information to chromatic-diagnostics.json.
-      --dry-run                     Run without actually publishing to Chromatic.
-      --force-rebuild [branch]      Do not skip build when a rebuild is detected. Only for [branch], if specified. Globs are supported via picomatch.
-      --junit-report [filepath]     Write build results to a JUnit XML file. {buildNumber} will be replaced with the actual build number. [chromatic-build-{buildNumber}.xml]
-      --list                        List available stories. This requires running a full build.
-      --no-interactive              Don't ask interactive questions about your setup and don't overwrite output. Always true in non-TTY environments.
-      --trace-changed [mode]        Print dependency trace for changed files to affected story files. Set to "expanded" to list individual modules. Requires --only-changed.
-      --upload-metadata             Upload Chromatic metadata files as part of the published Storybook. Includes chromatic-diagnostics.json, chromatic.log, and storybook-build.log, among others.
+      --debug                          Output verbose debugging information. This option implies --no-interactive.
+      --diagnostics-file [filepath]    Write process context information to a JSON file. [chromatic-diagnostics.json]
+      --dry-run                        Run without actually publishing to Chromatic.
+      --force-rebuild [branch]         Do not skip build when a rebuild is detected. Only for [branch], if specified. Globs are supported via picomatch.
+      --junit-report [filepath]        Write build results to a JUnit XML file. {buildNumber} will be replaced with the actual build number. [chromatic-build-{buildNumber}.xml]
+      --list                           List available stories. This requires running a full build.
+      --log-file [filepath]            Write log output to a file. [chromatic.log]
+      --no-interactive                 Don't ask interactive questions about your setup and don't overwrite output. Always true in non-TTY environments.
+      --storybook-log-file [filepath]  Write Storybook build output to a file. [storybook-build.log]
+      --trace-changed [mode]           Print dependency trace for changed files to affected story files. Set to "expanded" to list individual modules. Requires --only-changed.
+      --upload-metadata                Upload Chromatic metadata files as part of the published Storybook. Includes diagnostics and log files, among others. This option enables --diagnostics-file, --log-file and --storybook-log-file, unless explicitly disabled via the 'no-' prefix.
 
     Deprecated options
       --app-code <token>            Renamed to --project-token.
@@ -92,18 +94,21 @@ export default function parseArgs(argv: string[]) {
 
         // Debug options
         debug: { type: 'boolean' },
-        diagnostics: { type: 'boolean' },
+        diagnosticsFile: { type: 'string' },
         dryRun: { type: 'boolean' },
         forceRebuild: { type: 'string' },
         junitReport: { type: 'string' },
         list: { type: 'boolean' },
+        logFile: { type: 'string' },
         interactive: { type: 'boolean', default: true },
+        storybookLogFile: { type: 'string' },
         traceChanged: { type: 'string' },
         uploadMetadata: { type: 'boolean' },
 
         // Deprecated options (for JSDOM and tunneled builds, among others)
         allowConsoleErrors: { type: 'boolean' },
         appCode: { type: 'string', alias: 'a', isMultiple: true }, // kept for backwards compatibility
+        diagnostics: { type: 'boolean' },
         only: { type: 'string' },
         preserveMissing: { type: 'boolean' },
       },

--- a/node-src/lib/uploadMetadataFiles.ts
+++ b/node-src/lib/uploadMetadataFiles.ts
@@ -3,15 +3,12 @@ import { basename } from 'path';
 import { withFile } from 'tmp-promise';
 
 import { main as trimStatsFile } from '../../bin-src/trim-stats-file';
-import { STORYBOOK_BUILD_LOG_FILE } from '../tasks/build';
 import { Context, FileDesc } from '../types';
 import metadataHtml from '../ui/html/metadata.html';
 import uploadingMetadata from '../ui/messages/info/uploadingMetadata';
 import { findStorybookConfigFile } from './getStorybookMetadata';
-import { CHROMATIC_LOG_FILE } from './log';
 import { uploadAsIndividualFiles } from './upload';
 import { baseStorybookUrl } from './utils';
-import { CHROMATIC_DIAGNOSTICS_FILE } from './writeChromaticDiagnostics';
 
 const fileSize = (path: string): Promise<number> =>
   new Promise((resolve) => stat(path, (err, stats) => resolve(err ? 0 : stats.size)));
@@ -23,9 +20,9 @@ export async function uploadMetadataFiles(ctx: Context) {
   }
 
   const metadataFiles = [
-    CHROMATIC_DIAGNOSTICS_FILE,
-    CHROMATIC_LOG_FILE,
-    STORYBOOK_BUILD_LOG_FILE,
+    ctx.options.logFile,
+    ctx.options.diagnosticsFile,
+    ctx.options.storybookLogFile,
     await findStorybookConfigFile(ctx, /^main\.[jt]sx?$/).catch(() => null),
     await findStorybookConfigFile(ctx, /^preview\.[jt]sx?$/).catch(() => null),
     ctx.fileInfo?.statsPath && (await trimStatsFile([ctx.fileInfo.statsPath])),

--- a/node-src/lib/writeChromaticDiagnostics.ts
+++ b/node-src/lib/writeChromaticDiagnostics.ts
@@ -5,8 +5,6 @@ import wroteReport from '../ui/messages/info/wroteReport';
 
 const { writeFile } = jsonfile;
 
-export const CHROMATIC_DIAGNOSTICS_FILE = 'chromatic-diagnostics.json';
-
 const redact = <T>(value: T, ...fields: string[]): T => {
   if (value === null || typeof value !== 'object') return value;
   if (Array.isArray(value)) return value.map((item) => redact(item, ...fields)) as T;
@@ -29,8 +27,8 @@ export function getDiagnostics(ctx: Context) {
 // Extract important information from ctx, sort it and output into a json file
 export async function writeChromaticDiagnostics(ctx: Context) {
   try {
-    await writeFile(CHROMATIC_DIAGNOSTICS_FILE, getDiagnostics(ctx), { spaces: 2 });
-    ctx.log.info(wroteReport(CHROMATIC_DIAGNOSTICS_FILE, 'Chromatic diagnostics'));
+    await writeFile(ctx.options.diagnosticsFile, getDiagnostics(ctx), { spaces: 2 });
+    ctx.log.info(wroteReport(ctx.options.diagnosticsFile, 'Chromatic diagnostics'));
   } catch (error) {
     ctx.log.error(error);
   }

--- a/node-src/tasks/build.ts
+++ b/node-src/tasks/build.ts
@@ -12,8 +12,6 @@ import buildFailed from '../ui/messages/errors/buildFailed';
 import { failed, initial, pending, skipped, success } from '../ui/tasks/build';
 import { getPackageManagerRunCommand } from '../lib/getPackageManager';
 
-export const STORYBOOK_BUILD_LOG_FILE = 'build-storybook.log';
-
 export const setSourceDir = async (ctx: Context) => {
   if (ctx.options.outputDir) {
     ctx.sourceDir = ctx.options.outputDir;
@@ -51,7 +49,7 @@ const timeoutAfter = (ms) =>
   new Promise((resolve, reject) => setTimeout(reject, ms, new Error(`Operation timed out`)));
 
 export const buildStorybook = async (ctx: Context) => {
-  ctx.buildLogFile = path.resolve(STORYBOOK_BUILD_LOG_FILE);
+  ctx.buildLogFile = path.resolve(ctx.options.storybookLogFile);
   const logFile = createWriteStream(ctx.buildLogFile);
   await new Promise((resolve, reject) => {
     logFile.on('open', resolve);

--- a/node-src/tasks/report.ts
+++ b/node-src/tasks/report.ts
@@ -75,8 +75,7 @@ export const generateReport = async (ctx: Context) => {
   const { junitReport } = ctx.options;
   const { number: buildNumber, reportToken } = ctx.build;
 
-  const file = junitReport === true ? 'chromatic-build-{buildNumber}.xml' : (junitReport as string);
-  ctx.reportPath = path.resolve(file.replace(/{buildNumber}/g, String(buildNumber)));
+  ctx.reportPath = path.resolve(junitReport.replace(/{buildNumber}/g, String(buildNumber)));
 
   const {
     app: { build },

--- a/node-src/types.ts
+++ b/node-src/types.ts
@@ -36,18 +36,21 @@ export interface Flags {
 
   // Debug options
   debug?: boolean;
-  diagnostics?: boolean;
+  diagnosticsFile?: string;
   dryRun?: boolean;
   forceRebuild?: string;
+  interactive?: boolean;
   junitReport?: string;
   list?: boolean;
-  interactive?: boolean;
+  logFile?: string;
+  storybookLogFile?: string;
   traceChanged?: string;
   uploadMetadata?: boolean;
 
   // Deprecated options (for JSDOM and tunneled builds, among others)
   allowConsoleErrors?: boolean;
   appCode?: string[];
+  diagnostics?: boolean;
   only?: string;
   preserveMissing?: boolean;
 }
@@ -56,6 +59,7 @@ export interface Options {
   projectToken: string;
 
   configFile?: Flags['configFile'];
+  logFile?: Flags['logFile'];
   onlyChanged: boolean | string;
   onlyStoryFiles: Flags['onlyStoryFiles'];
   onlyStoryNames: Flags['onlyStoryNames'];
@@ -68,9 +72,9 @@ export interface Options {
   dryRun: Flags['dryRun'];
   forceRebuild: boolean | string;
   debug: boolean;
-  diagnostics: boolean;
+  diagnosticsFile?: Flags['diagnosticsFile'];
   interactive: boolean;
-  junitReport: boolean | string;
+  junitReport?: Flags['junitReport'];
   uploadMetadata?: Flags['uploadMetadata'];
   zip: Flags['zip'];
 
@@ -89,6 +93,7 @@ export interface Options {
   storybookBuildDir: string;
   storybookBaseDir: Flags['storybookBaseDir'];
   storybookConfigDir: Flags['storybookConfigDir'];
+  storybookLogFile: Flags['storybookLogFile'];
 
   ownerName: string;
   repositorySlug: Flags['repositorySlug'];


### PR DESCRIPTION
This prevents writing `chromatic.log` and `build-storybook.log` by default. Instead these can be enabled via the `logFile` (`--log-file`) and `storybookLogFile` (`--storybook-log-file`) options (boolean or string). A string value can be passed to set a deviating target path (default `chromatic.log` and `build-storybook.log`).

For consistency, `diagnostics` was renamed to `diagnosticsFile` and now accepts a string (target path) as well (besides a boolean). The default is `diagnostics.json`.

`logFile`, `storybookLogFile` and `diagnostics` are automatically enabled when using `uploadMetadata` (`--upload-metadata`) but can be explicitly disabled setting the respective option to `false` (or using `--no-log-file` / `--no-storybook-log-file` / `--no-diagnostics-file`).
