### PR TITLE
Update logs to check the branch name in CI

### DIFF
--- a/.github/workflows/chromatic-prod.yml
+++ b/.github/workflows/chromatic-prod.yml
@@ -19,6 +19,7 @@ jobs:
           onlyChanged: true
           traceChanged: true
           diagnostics: true
+          debug: true
         env:
           CHROMATIC_PROJECT_TOKEN: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
       - uses: actions/upload-artifact@v2

--- a/.github/workflows/chromatic-staging.yml
+++ b/.github/workflows/chromatic-staging.yml
@@ -19,6 +19,7 @@ jobs:
           onlyChanged: true
           traceChanged: true
           diagnostics: true
+          debug: true
         env:
           CHROMATIC_PROJECT_TOKEN: ${{ secrets.STAGING_CHROMATIC_PROJECT_TOKEN }}
           CHROMATIC_INDEX_URL: https://index.staging-chromatic.com

--- a/.github/workflows/chromatic-staging.yml
+++ b/.github/workflows/chromatic-staging.yml
@@ -13,7 +13,7 @@ jobs:
           node-version: lts/*
       - name: install
         run: yarn install --frozen-lockfile
-      - uses: chromaui/action@v1
+      - uses: chromaui/action@latest
         with:
           exitOnceUploaded: true
           onlyChanged: true

--- a/.github/workflows/chromatic-staging.yml
+++ b/.github/workflows/chromatic-staging.yml
@@ -13,7 +13,7 @@ jobs:
           node-version: lts/*
       - name: install
         run: yarn install --frozen-lockfile
-      - uses: chromaui/action-canary@v1
+      - uses: chromaui/action@v1
         with:
           exitOnceUploaded: true
           onlyChanged: true

--- a/node-src/git/getCommitAndBranch.ts
+++ b/node-src/git/getCommitAndBranch.ts
@@ -52,6 +52,10 @@ export default async function getCommitAndBranch(
   } = process.env;
   const { isCi, service, prBranch, branch: ciBranch, commit: ciCommit, slug: ciSlug } = envCi();
 
+  log.debug('PR Branch: ', prBranch);
+  log.debug('CI Branch: ', ciBranch);
+  log.debug('GITHUB_HEAD_REF: ', GITHUB_HEAD_REF);
+
   const isFromEnvVariable = CHROMATIC_SHA && CHROMATIC_BRANCH; // Our GitHub Action also sets these
   const isTravisPrBuild = TRAVIS_EVENT_TYPE === 'pull_request';
   const isGitHubAction = GITHUB_ACTIONS === 'true';

--- a/node-src/git/getCommitAndBranch.ts
+++ b/node-src/git/getCommitAndBranch.ts
@@ -55,6 +55,7 @@ export default async function getCommitAndBranch(
   log.debug('PR Branch: ', prBranch);
   log.debug('CI Branch: ', ciBranch);
   log.debug('GITHUB_HEAD_REF: ', GITHUB_HEAD_REF);
+  log.debug(envCi());
 
   const isFromEnvVariable = CHROMATIC_SHA && CHROMATIC_BRANCH; // Our GitHub Action also sets these
   const isTravisPrBuild = TRAVIS_EVENT_TYPE === 'pull_request';

--- a/node-src/ui/components/link.ts
+++ b/node-src/ui/components/link.ts
@@ -1,3 +1,4 @@
 import chalk from 'chalk';
 
+// Need to trigger a UI change
 export default (url: string) => chalk.cyan(url);

--- a/node-src/ui/components/link.ts
+++ b/node-src/ui/components/link.ts
@@ -1,4 +1,4 @@
 import chalk from 'chalk';
 
 // Need to trigger a UI change
-export default (url: string) => chalk.cyan(url);
+export default (url: string) => chalk.blue(url);

--- a/package.json
+++ b/package.json
@@ -134,6 +134,7 @@
     "async-retry": "^1.3.3",
     "auto": "^11.0.4",
     "chalk": "^4.1.2",
+    "chromatic": "9.0.1--canary.857.6893274802.0",
     "cpy": "^8.1.2",
     "cross-env": "^7.0.3",
     "cross-spawn": "^7.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5615,6 +5615,11 @@ chownr@^2.0.0:
   resolved "https://registry.yarnpkg.com/chownr/-/chownr-2.0.0.tgz#15bfbe53d2eab4cf70f18a8cd68ebe5b3cb1dece"
   integrity sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==
 
+chromatic@9.0.1--canary.857.6893274802.0:
+  version "9.0.1--canary.857.6893274802.0"
+  resolved "https://registry.yarnpkg.com/chromatic/-/chromatic-9.0.1--canary.857.6893274802.0.tgz#e6138ee88f9797ab000d7b77b338e64c257cb44c"
+  integrity sha512-2IjoDvV5Z5PTcl1VYVuMgA6RwKRMd7xKJL6PIgW1u4zV5gIGTJnLZcF593GbMRM7vXjqtQw0kj+YWzq4pbroFw==
+
 chrome-trace-event@^1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/chrome-trace-event/-/chrome-trace-event-1.0.3.tgz#1015eced4741e15d06664a957dbbf50d041e26ac"


### PR DESCRIPTION
We need to determine if we can get the branch name from CI for a GitHub Merge Queue
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>9.1.1--canary.857.7006504909.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@9.1.1--canary.857.7006504909.0
  # or 
  yarn add chromatic@9.1.1--canary.857.7006504909.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
