### PR TITLE
Redact `userToken` in diagnostics and fatal error output

### DIFF
--- a/node-src/lib/utils.ts
+++ b/node-src/lib/utils.ts
@@ -56,3 +56,11 @@ export const matchesFile = (glob: string, filepath: string) => {
 
 export const isPackageManifestFile = (filePath: string) =>
   [/^package\.json$/, /\/package\.json$/].some((re) => re.test(filePath));
+
+export const redact = <T>(value: T, ...fields: string[]): T => {
+  if (value === null || typeof value !== 'object') return value;
+  if (Array.isArray(value)) return value.map((item) => redact(item, ...fields)) as T;
+  const obj = { ...value };
+  for (const key in obj) obj[key] = fields.includes(key) ? undefined : redact(obj[key], ...fields);
+  return obj;
+};

--- a/node-src/lib/writeChromaticDiagnostics.test.ts
+++ b/node-src/lib/writeChromaticDiagnostics.test.ts
@@ -16,10 +16,12 @@ describe('getDiagnostics', () => {
     const ctx = {
       build: { number: 1, reportToken: 'foo' },
       flags: { projectToken: 'bar' },
+      extraOptions: { userToken: 'baz' },
     };
     expect(getDiagnostics(ctx as any)).toEqual({
       build: { number: 1, reportToken: undefined },
       flags: { projectToken: undefined },
+      extraOptions: { userToken: undefined },
     });
   });
 });

--- a/node-src/lib/writeChromaticDiagnostics.ts
+++ b/node-src/lib/writeChromaticDiagnostics.ts
@@ -2,23 +2,16 @@ import jsonfile from 'jsonfile';
 
 import { Context } from '..';
 import wroteReport from '../ui/messages/info/wroteReport';
+import { redact } from './utils';
 
 const { writeFile } = jsonfile;
 
 export const CHROMATIC_DIAGNOSTICS_FILE = 'chromatic-diagnostics.json';
 
-const redact = <T>(value: T, ...fields: string[]): T => {
-  if (value === null || typeof value !== 'object') return value;
-  if (Array.isArray(value)) return value.map((item) => redact(item, ...fields)) as T;
-  const obj = { ...value };
-  for (const key in obj) obj[key] = fields.includes(key) ? undefined : redact(obj[key], ...fields);
-  return obj;
-};
-
 export function getDiagnostics(ctx: Context) {
   // Drop some fields that are not useful to have and redact sensitive fields
   const { argv, client, env, help, http, log, pkg, title, ...rest } = ctx;
-  const data = redact(rest, 'projectToken', 'reportToken');
+  const data = redact(rest, 'projectToken', 'reportToken', 'userToken');
 
   // Sort top-level fields alphabetically
   return Object.keys(data)

--- a/node-src/ui/messages/errors/fatalError.stories.ts
+++ b/node-src/ui/messages/errors/fatalError.stories.ts
@@ -29,6 +29,11 @@ const context = {
   },
   options: {
     buildScriptName: 'build:storybook',
+    reportToken: 'thiswillberedacted',
+  },
+  extraOptions: {
+    userToken:
+      'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c',
   },
   runtimeMetadata: {
     nodePlatform: 'darwin',

--- a/node-src/ui/messages/errors/fatalError.ts
+++ b/node-src/ui/messages/errors/fatalError.ts
@@ -5,6 +5,7 @@ import { dedent } from 'ts-dedent';
 
 import { Context, InitialContext } from '../../..';
 import link from '../../components/link';
+import { redact } from '../../../lib/utils';
 
 const buildFields = ({ id, number, webUrl }) => ({ id, number, webUrl });
 
@@ -30,31 +31,37 @@ export default function fatalError(
     build,
     buildCommand,
   } = ctx;
-  const debugInfo = {
-    timestamp,
-    sessionId,
-    gitVersion: git && git.version,
-    nodePlatform: process.platform,
-    nodeVersion: process.versions.node,
-    ...runtimeMetadata,
-    packageName: pkg.name,
-    packageVersion: pkg.version,
-    ...(storybook ? { storybook } : {}),
-    flags,
-    ...(extraOptions && { extraOptions }),
-    ...(configuration && { configuration }),
-    ...('options' in ctx && ctx.options?.buildScriptName
-      ? { buildScript: scripts[ctx.options.buildScriptName] }
-      : {}),
-    ...(buildCommand && { buildCommand }),
-    exitCode,
-    exitCodeKey,
-    errorType: errors.map((err) => err.name).join('\n'),
-    errorMessage: stripAnsi(errors[0].message.split('\n')[0].trim()),
-    ...(isolatorUrl ? { isolatorUrl } : {}),
-    ...(cachedUrl ? { cachedUrl } : {}),
-    ...(build && { build: buildFields(build) }),
-  };
+
+  const debugInfo = redact(
+    {
+      timestamp,
+      sessionId,
+      gitVersion: git && git.version,
+      nodePlatform: process.platform,
+      nodeVersion: process.versions.node,
+      ...runtimeMetadata,
+      packageName: pkg.name,
+      packageVersion: pkg.version,
+      ...(storybook ? { storybook } : {}),
+      flags,
+      ...(extraOptions && { extraOptions }),
+      ...(configuration && { configuration }),
+      ...('options' in ctx && ctx.options?.buildScriptName
+        ? { buildScript: scripts[ctx.options.buildScriptName] }
+        : {}),
+      ...(buildCommand && { buildCommand }),
+      exitCode,
+      exitCodeKey,
+      errorType: errors.map((err) => err.name).join('\n'),
+      errorMessage: stripAnsi(errors[0].message.split('\n')[0].trim()),
+      ...(isolatorUrl ? { isolatorUrl } : {}),
+      ...(cachedUrl ? { cachedUrl } : {}),
+      ...(build && { build: buildFields(build) }),
+    },
+    'projectToken',
+    'reportToken',
+    'userToken'
+  );
 
   const stacktraces = errors.map((err) => err.stack).filter(Boolean);
   return [


### PR DESCRIPTION
Redacts secret tokens in both diagnostics and fatal error output. We already had a `redact` function for this, I just moved it to utils for reuse and added `userToken` to the list of redacted fields.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>9.0.1--canary.859.6904794945.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@9.0.1--canary.859.6904794945.0
  # or 
  yarn add chromatic@9.0.1--canary.859.6904794945.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
