### PR TITLE
Support pinning GitHub Action to major or patch version

### DIFF
--- a/.github/workflows/chromatic-main-and-prs.yml
+++ b/.github/workflows/chromatic-main-and-prs.yml
@@ -18,7 +18,7 @@ jobs:
           node-version: lts/*
       - name: install
         run: yarn install --frozen-lockfile
-      - uses: chromaui/action@v1
+      - uses: chromaui/action@latest
         with:
           # 👇 Chromatic projectToken, refer to the manage page to obtain it.
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}

--- a/.github/workflows/chromatic-prod.yml
+++ b/.github/workflows/chromatic-prod.yml
@@ -13,7 +13,7 @@ jobs:
           node-version: lts/*
       - name: install
         run: yarn install --frozen-lockfile
-      - uses: chromaui/action-next@v1
+      - uses: chromaui/action@latest
         with:
           exitOnceUploaded: true
           onlyChanged: true

--- a/.github/workflows/chromatic-staging.yml
+++ b/.github/workflows/chromatic-staging.yml
@@ -13,7 +13,7 @@ jobs:
           node-version: lts/*
       - name: install
         run: yarn install --frozen-lockfile
-      - uses: chromaui/action-canary@v7.2.x
+      - uses: chromaui/action-canary@latest
         with:
           exitOnceUploaded: true
           onlyChanged: true

--- a/.github/workflows/chromatic-staging.yml
+++ b/.github/workflows/chromatic-staging.yml
@@ -13,7 +13,7 @@ jobs:
           node-version: lts/*
       - name: install
         run: yarn install --frozen-lockfile
-      - uses: chromaui/action-canary@v1
+      - uses: chromaui/action-canary@v7.2.x
         with:
           exitOnceUploaded: true
           onlyChanged: true

--- a/README.md
+++ b/README.md
@@ -81,20 +81,18 @@ We use `auto` to automate the release process. Versions are bumped, tags are cre
 
 Additionally, a PR **may** have exactly one of these labels:
 
-- `release` creates a `latest` rather than a `next` release on npm
-- `next-release` creates a `next` rather than a `latest` release on npm
-- `skip-release` does not create a release at all
+- `release` creates a `latest` release on npm
+- `skip-release` does not create a release at all (changes roll into the next release)
 
-We have three types of releases:
+We have two types of releases:
 
 - `latest` releases are the general audience production releases, used by most people. Automatically created when merging a PR with the `release` label.
-- `next` releases should be valid, working releases that can potentially be used by early adopters of new features, for example to handle a support request. Automatically created when merging a PR with the `next-release` label.
-- `canary` releases are intended for testing purposes and should not be used in production, as they may only work against a staging or dev environment. Automatically created on every PR, but does not auto-publush the GitHub Action.
+- `canary` releases are intended for testing purposes and should not be used in production, as they may only work against a staging or dev environment. Automatically created on every PR, but does not auto-publish the GitHub Action.
 
-> For GitHub Actions, we publish `chromaui/action-next` and `chromaui/action-canary`. The latter is only published manually, rather than for every PR.
+> For GitHub Actions, we may manually publish `chromaui/action-canary`.
 
 A script is provided to manually publish the GitHub Action, though it's typically only necessary for `action-canary` releases:
 
 ```sh
-yarn publish-action <canary|next|latest>
+yarn publish-action <canary|latest>
 ```

--- a/scripts/publish-action.mjs
+++ b/scripts/publish-action.mjs
@@ -4,6 +4,11 @@ import cpy from 'cpy';
 import { $ } from 'execa';
 import tmp from 'tmp-promise';
 
+const copy = (globs, ...args) => {
+  console.info(`📦 Copying:\n   - ${globs.join('\n   - ')}`);
+  return cpy(globs, ...args);
+};
+
 const publishAction = async ({ major, version, repo }) => {
   const dryRun = process.argv.includes('--dry-run');
 
@@ -11,13 +16,10 @@ const publishAction = async ({ major, version, repo }) => {
 
   const { path, cleanup } = await tmp.dir({ unsafeCleanup: true, prefix: `chromatic-action-` });
 
-  const copy = (globs, opts) => {
-    console.info(`📦 Copying:\n   - ${globs.join('\n   - ')}`);
-    return cpy(globs, path, opts);
-  };
-
-  await copy(['action/*.js', 'action/*.json', 'action.yml', 'package.json'], { parents: true });
-  await copy(['action-src/CHANGELOG.md', 'action-src/LICENSE', 'action-src/README.md']);
+  await copy(['action/*.js', 'action/*.json', 'action.yml', 'package.json'], path, {
+    parents: true, // keep directory structure (i.e. action dir)
+  });
+  await copy(['action-src/CHANGELOG.md', 'action-src/LICENSE', 'action-src/README.md'], path);
 
   const $$ = (strings, ...args) => {
     console.info(strings.reduce((acc, s, i) => `${acc}${s}${args[i] || ''}`, '🏃 '));

--- a/scripts/publish-action.mjs
+++ b/scripts/publish-action.mjs
@@ -12,7 +12,10 @@ const publishAction = async ({ major, version, repo }) => {
   console.info(`✅ Publishing ${version} to ${repo} ${dryRun ? '(dry run)' : ''}`);
 
   const { path, cleanup } = await tmp.dir({ unsafeCleanup: true, prefix: `chromatic-action-` });
-  const run = (cmd) => command(cmd, { cwd: path });
+  const run = (cmd) => {
+    if (dryRun) console.log(`👉 ${cmd}`);
+    return command(cmd, { cwd: path });
+  };
 
   await cpy(['action/*.js', 'action/*.json', 'action.yml', 'package.json'], path, {
     parents: true,


### PR DESCRIPTION
This adds two additional tags when publishing the GitHub Action: `v*` and `v*.*.*` (e.g. `v9` and `v9.1.0`) besides the `latest` and `v1` (deprecated) tag we already have. This allows GitHub Action users to pin the CLI version to either a major release (which auto-upgrades but avoids breaking changes) or a patch release (which disables automatic upgrades altogether).

The release script still creates and force-pushes an entirely new repository without history, which means the commits for older tags will no longer exist in history. However, GitHub does retain these commits ([demonstrated here](https://github.com/chromaui/action-canary/commit/2ca473d66f1e2ba85e8c5f0b9d48dacb57d91c20)) and running the Action which such a version works normally ([demonstrated here](https://github.com/chromaui/chromatic-cli/actions/runs/7016961505/job/19089252689)).

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>9.1.1--canary.863.7017242588.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@9.1.1--canary.863.7017242588.0
  # or 
  yarn add chromatic@9.1.1--canary.863.7017242588.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
