### PR TITLE
Force `NODE_ENV=production` for Storybook builds through the CLI

### DIFF
--- a/node-src/tasks/build.ts
+++ b/node-src/tasks/build.ts
@@ -64,7 +64,11 @@ export const buildStorybook = async (ctx: Context) => {
     ctx.log.debug('Running build command:', ctx.buildCommand);
     ctx.log.debug('Runtime metadata:', JSON.stringify(ctx.runtimeMetadata, null, 2));
 
-    const subprocess = execaCommand(ctx.buildCommand, { stdio: [null, logFile, logFile], signal });
+    const subprocess = execaCommand(ctx.buildCommand, {
+      stdio: [null, logFile, logFile],
+      signal,
+      env: { NODE_ENV: 'production' },
+    });
     await Promise.race([subprocess, timeoutAfter(ctx.env.STORYBOOK_BUILD_TIMEOUT)]);
   } catch (e) {
     signal?.throwIfAborted();


### PR DESCRIPTION
It seems this can get set to `development` when builds are spawned from the Visual Tests addon. There's no reason to build in dev, AFAIK.

I guess technically this might be a breaking change, not sure.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>9.1.1--canary.865.7041382024.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@9.1.1--canary.865.7041382024.0
  # or 
  yarn add chromatic@9.1.1--canary.865.7041382024.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
