### PR TITLE
Increase number of commits checked for squash merge

### DIFF
--- a/node-src/git/getParentCommits.test.ts
+++ b/node-src/git/getParentCommits.test.ts
@@ -732,7 +732,7 @@ describe('getParentCommits', () => {
       expectCommitsToEqualNames(parentCommits, ['A'], repository);
     });
 
-    it(`deals with situations where squashed branches themselves have squash merge commits`, async () => {
+    it(`does not find parents for commits on a squashed branch that are themselves squash merge commits`, async () => {
       // []: has build, <>: is squash merge, (): current commit
       //
       //       [F]        [branch2]

--- a/node-src/git/getParentCommits.test.ts
+++ b/node-src/git/getParentCommits.test.ts
@@ -51,7 +51,7 @@ function createClient({
 }
 
 function expectCommitsToEqualNames(hashes, names, { commitMap }) {
-  return expect(hashes).toEqual(names.map((n) => commitMap[n].hash));
+  return expect(hashes).toEqual(names.map((name) => commitMap[name]?.hash || name));
 }
 
 async function checkoutCommit(name, branch, { dirname, runGit, commitMap }) {

--- a/node-src/git/getParentCommits.test.ts
+++ b/node-src/git/getParentCommits.test.ts
@@ -687,10 +687,22 @@ describe('getParentCommits', () => {
 
     // it(`deals with situations where squashed branches have no builds`)
 
+    //       [X]
+    //     /    \
+    //    P - Q - R
+    //  /
+    //[A] - B - C - M
+
     // it(`deals with situations where squashed branches no longer exist in the repo but have a build`)
 
     // it(`deals with situations where squashed branches no longer exist in the repo and have no build`)
 
     // it(`deals with situations where squashed branches themselves have squash merge commits`)
+
+    // P -[Q]
+    //  \
+    //   X - [Y] -<Z>   (squash merge of Q)
+    //    \
+    //      A -    -   <M> (squash merge of Z)
   });
 });

--- a/node-src/git/getParentCommits.test.ts
+++ b/node-src/git/getParentCommits.test.ts
@@ -752,7 +752,6 @@ describe('getParentCommits', () => {
       const git = { branch: 'main', ...(await getCommit()) };
 
       const parentCommits = await getParentCommits({ client, log, git, options } as any);
-      // This is A and not B because we do not know anything about the deleted branch and its commits
       expectCommitsToEqualNames(parentCommits, ['MISSING', 'A'], repository);
     });
 

--- a/node-src/git/getParentCommits.ts
+++ b/node-src/git/getParentCommits.ts
@@ -8,11 +8,7 @@ import { localBuildsSpecifier } from '../lib/localBuildsSpecifier';
 export const FETCH_N_INITIAL_BUILD_COMMITS = 20;
 
 const FirstCommittedAtQuery = gql`
-  query FirstCommittedAtQuery(
-    $commit: String!
-    $branch: String!
-    $localBuilds: LocalBuildsSpecifierInput!
-  ) {
+  query FirstCommittedAtQuery($branch: String!, $localBuilds: LocalBuildsSpecifierInput!) {
     app {
       firstBuild(sortByCommittedAt: true, localBuilds: $localBuilds) {
         committedAt
@@ -20,11 +16,6 @@ const FirstCommittedAtQuery = gql`
       lastBuild(branch: $branch, sortByCommittedAt: true, localBuilds: $localBuilds) {
         commit
         committedAt
-      }
-      pullRequest(mergeInfo: { commit: $commit, baseRefName: $branch }) {
-        lastHeadBuild {
-          commit
-        }
       }
     }
   }
@@ -37,11 +28,6 @@ interface FirstCommittedAtQueryResult {
     lastBuild: {
       commit: string;
       committedAt: number;
-    };
-    pullRequest: {
-      lastHeadBuild: {
-        commit: string;
-      };
     };
   };
 }
@@ -56,6 +42,27 @@ const HasBuildsWithCommitsQuery = gql`
 interface HasBuildsWithCommitsQueryResult {
   app: {
     hasBuildsWithCommits: string[];
+  };
+}
+
+const IsMergeCommitQuery = gql`
+  query IsMergeCommitQuery($commit: String!, $branch: String!) {
+    app {
+      pullRequest(mergeInfo: { commit: $commit, baseRefName: $branch }) {
+        lastHeadBuild {
+          commit
+        }
+      }
+    }
+  }
+`;
+interface IsMergeCommitQueryResult {
+  app: {
+    pullRequest: {
+      lastHeadBuild: {
+        commit: string;
+      };
+    };
   };
 }
 
@@ -102,32 +109,18 @@ async function nextCommits(
   const commits = (await execGitCommand(command)).split('\n').filter(Boolean);
   log.debug(`command output: ${commits}`);
 
-  return (
-    commits
-      // No sense in checking commits we already know about
-      .filter((c) => !commitsWithBuilds.includes(c))
-      .filter((c) => !commitsWithoutBuilds.includes(c))
-      .slice(0, limit)
-  );
-}
+  // Later on we want to know which commits we visited on the way to finding the ancestor commits
+  // The output of the above rev-list commit includes possibly commits with builds so filter them.
+  // NOTE: this list can include irrelevant commits during earlier iterations of step() when we
+  // don't yet have an accurate list of commitsWithBuilds, however we only use it in the final step.
+  const visitedCommitsWithoutBuilds = commits.filter((c) => !commitsWithBuilds.includes(c));
 
-// Which of the listed commits are "maximally descendent":
-// ie c in commits such that there are no descendents of c in commits.
-async function maximallyDescendentCommits({ log }: Pick<Context, 'log'>, commits: string[]) {
-  if (commits.length === 0) {
-    return commits;
-  }
+  // No sense in checking commits we already know about
+  const candidateCommits = visitedCommitsWithoutBuilds
+    .filter((c) => !commitsWithoutBuilds.includes(c))
+    .slice(0, limit);
 
-  // <commit>^@ expands to all parents of commit
-  const parentCommits = commits.map((c) => `"${c}^@"`);
-  // List the tree from <commits> not including the tree from <parentCommits>
-  // This just filters any commits that are ancestors of other commits
-  const command = `git rev-list ${commitsForCLI(commits)} --not ${commitsForCLI(parentCommits)}`;
-  log.debug(`running ${command}`);
-  const maxCommits = (await execGitCommand(command)).split('\n').filter(Boolean);
-  log.debug(`command output: ${maxCommits}`);
-
-  return maxCommits;
+  return { visitedCommitsWithoutBuilds, candidateCommits };
 }
 
 // Exponentially iterate `limit` up to infinity to find a "covering" set of commits with builds
@@ -143,23 +136,25 @@ async function step(
     commitsWithBuilds: string[];
     commitsWithoutBuilds: string[];
   }
-): Promise<string[]> {
+) {
   log.debug(`step: checking ${limit} up to ${firstCommittedAtSeconds}`);
   log.debug(`step: commitsWithBuilds: ${commitsWithBuilds}`);
   log.debug(`step: commitsWithoutBuilds: ${commitsWithoutBuilds}`);
 
-  const candidateCommits = await nextCommits({ log }, limit, {
+  const { candidateCommits, visitedCommitsWithoutBuilds } = await nextCommits({ log }, limit, {
     firstCommittedAtSeconds,
     commitsWithBuilds,
     commitsWithoutBuilds,
   });
 
-  log.debug(`step: candidateCommits: ${candidateCommits}`);
+  log.debug(
+    `step: candidateCommits: ${candidateCommits}, visitedCommitsWithoutBuilds: ${visitedCommitsWithoutBuilds}`
+  );
 
   // No more commits uncovered commitsWithBuilds!
   if (candidateCommits.length === 0) {
     log.debug('step: no candidateCommits; we are done');
-    return commitsWithBuilds;
+    return { commitsWithBuilds, commitsWithoutBuilds, visitedCommitsWithoutBuilds };
   }
 
   const {
@@ -181,6 +176,25 @@ async function step(
   });
 }
 
+// Which of the listed commits are "maximally descendent":
+// ie c in commits such that there are no descendents of c in commits.
+async function maximallyDescendentCommits({ log }: Pick<Context, 'log'>, commits: string[]) {
+  if (commits.length === 0) {
+    return commits;
+  }
+
+  // <commit>^@ expands to all parents of commit
+  const parentCommits = commits.map((c) => `"${c}^@"`);
+  // List the tree from <commits> not including the tree from <parentCommits>
+  // This just filters any commits that are ancestors of other commits
+  const command = `git rev-list ${commitsForCLI(commits)} --not ${commitsForCLI(parentCommits)}`;
+  log.debug(`running ${command}`);
+  const maxCommits = (await execGitCommand(command)).split('\n').filter(Boolean);
+  log.debug(`command output: ${maxCommits}`);
+
+  return maxCommits;
+}
+
 export async function getParentCommits(
   { options, client, git, log }: Context,
   { ignoreLastBuildOnBranch = false } = {}
@@ -190,16 +204,11 @@ export async function getParentCommits(
   // Include the latest build from this branch as an ancestor of the current build
   const { app } = await client.runQuery<FirstCommittedAtQueryResult>(
     FirstCommittedAtQuery,
-    { branch, commit, localBuilds: localBuildsSpecifier({ options, git }) },
+    { branch, localBuilds: localBuildsSpecifier({ options, git }) },
     { retries: 5 } // This query requires a request to an upstream provider which may fail
   );
-  const { firstBuild, lastBuild, pullRequest } = app;
-  log.debug(
-    `App firstBuild: %o, lastBuild: %o, pullRequest: %o`,
-    firstBuild,
-    lastBuild,
-    pullRequest
-  );
+  const { firstBuild, lastBuild } = app;
+  log.debug(`App firstBuild: %o, lastBuild: %o`, firstBuild, lastBuild);
 
   if (!firstBuild) {
     log.debug('App has no builds, returning []');
@@ -233,29 +242,12 @@ export async function getParentCommits(
     }
   }
 
-  // Add the most recent build on a (merged) branch as a parent if we think this was the commit that
-  // merged the pull request.
-  // @see https://www.chromatic.com/docs/branching-and-baselines#squash-and-rebase-merging
-  if (pullRequest && pullRequest.lastHeadBuild) {
-    if (await commitExists(pullRequest.lastHeadBuild.commit)) {
-      log.debug(
-        `Adding merged PR build commit ${pullRequest.lastHeadBuild.commit} to commits with builds`
-      );
-      initialCommitsWithBuilds.push(pullRequest.lastHeadBuild.commit);
-    } else {
-      log.debug(
-        `Merged PR build commit ${pullRequest.lastHeadBuild.commit} not in index, blindly appending to parents`
-      );
-      extraParentCommits.push(pullRequest.lastHeadBuild.commit);
-    }
-  }
-
   // Get a "covering" set of commits that have builds. This is a set of commits
   // such that any ancestor of HEAD is either:
   //   - in commitsWithBuilds
   //   - an ancestor of a commit in commitsWithBuilds
   //   - has no build
-  const commitsWithBuilds = await step(
+  const { commitsWithBuilds } = await step(
     { options, client, log, git },
     FETCH_N_INITIAL_BUILD_COMMITS,
     {
@@ -265,9 +257,75 @@ export async function getParentCommits(
     }
   );
 
+  // Check if the current commit is a merge commit
+  const {
+    app: { pullRequest },
+  } = await client.runQuery<IsMergeCommitQueryResult>(
+    IsMergeCommitQuery,
+    { commit, branch },
+    { retries: 5 } // This query requires a request to an upstream provider which may fail
+  );
+
+  // Add the most recent build on a (merged) branch as a parent if we think this was the commit that
+  // merged the pull request.
+  // @see https://www.chromatic.com/docs/branching-and-baselines#squash-and-rebase-merging
+  // let shouldRecurse = false;
+  if (pullRequest && pullRequest.lastHeadBuild) {
+    if (await commitExists(pullRequest.lastHeadBuild.commit)) {
+      log.debug(
+        `Adding merged PR build commit ${pullRequest.lastHeadBuild.commit} to commits with builds`
+      );
+      commitsWithBuilds.push(pullRequest.lastHeadBuild.commit);
+      // shouldRecurse = true;
+    } else {
+      log.debug(
+        `Merged PR build commit ${pullRequest.lastHeadBuild.commit} not in index, blindly appending to parents`
+      );
+      extraParentCommits.push(pullRequest.lastHeadBuild.commit);
+    }
+  }
+
+  // let finalCommitsWithBuilds = commitsWithBuilds;
+  // if (shouldRecurse) {
+  //   const { commitsWithBuilds: secondCommitsWithBuilds, visitedCommitsWithoutBuilds } = await step(
+  //     { options, client, log, git },
+  //     FETCH_N_INITIAL_BUILD_COMMITS,
+  //     {
+  //       firstCommittedAtSeconds: firstBuild.committedAt && firstBuild.committedAt / 1000,
+  //       commitsWithBuilds: commitsWithBuilds,
+  //       commitsWithoutBuilds,
+  //     }
+  //   );
+  //   finalCommitsWithBuilds = secondCommitsWithBuilds;
+  // }
+
+  // 1. Add new App.pullRequests(mergeInfo) resolver
+  // const extraPrs = runQuery(`app {
+  //       pullRequests(mergeInfo: $mergeInfos) {
+  //         lastHeadBuild {
+  //           commit
+  //         }
+  //       }
+  //     }`, { mergeInfos: mergeInfoFromTraversedCommits(traversedCommits) });
+  //
+
+  //   let shouldRecurse = false;
+  //   extraPrs.forEach(pr => {
+  //     if (await commitExists(pullRequest.lastCommit)) {
+  //       commitsWithBuilds.push(pullRequest.lastCommit);
+  //       shouldRecurse = true;
+  //     } else {
+  //       extraParentCommits.push(pullRequest.lastHeadBuild.commit);
+  //     }
+  //   });
+  //
+  // if (shouldRecurse) goto 258
+
   log.debug(`Final commitsWithBuilds: ${commitsWithBuilds}`);
 
   // For any pair A,B of builds, there is no point in using B if it is an ancestor of A.
   const descendentCommits = await maximallyDescendentCommits({ log }, commitsWithBuilds);
-  return extraParentCommits.concat(descendentCommits);
+
+  const ancestorCommits = extraParentCommits.concat(descendentCommits);
+  return ancestorCommits;
 }

--- a/node-src/git/getParentCommits.ts
+++ b/node-src/git/getParentCommits.ts
@@ -46,9 +46,9 @@ interface HasBuildsWithCommitsQueryResult {
 }
 
 const MergeCommitsQuery = gql`
-  query MergeCommitsQuery($mergeInfos: [MergedInfoInput]!) {
+  query MergeCommitsQuery($mergeInfoList: [MergedInfoInput]!) {
     app {
-      mergedPullRequests(mergeInfos: $mergeInfos) {
+      mergedPullRequests(mergeInfoList: $mergeInfoList) {
         lastHeadBuild {
           commit
         }
@@ -257,12 +257,12 @@ export async function getParentCommits(
     }
   );
 
-  const mergeInfos = visitedCommitsWithoutBuilds.map((commit) => {
+  const mergeInfoList = visitedCommitsWithoutBuilds.map((commit) => {
     return { commit, baseRefName: branch };
   });
   const { app: { mergedPullRequests } } = await client.runQuery<MergeCommitsQueryResult>(
     MergeCommitsQuery,
-    { mergeInfos },
+    { mergeInfoList },
     { retries: 5 } // This query requires a request to an upstream provider which may fail
   );
 

--- a/node-src/git/getParentCommits.ts
+++ b/node-src/git/getParentCommits.ts
@@ -262,7 +262,7 @@ export async function getParentCommits(
   });
   const { app: { mergedPullRequests } } = await client.runQuery<MergeCommitsQueryResult>(
     MergeCommitsQuery,
-    { mergeInfoList },
+    { mergeInfoList: mergeInfoList.slice(0, 100) }, // Limit amount sent in API call
     { retries: 5 } // This query requires a request to an upstream provider which may fail
   );
 

--- a/node-src/git/mocks/double-loop.ts
+++ b/node-src/git/mocks/double-loop.ts
@@ -1,0 +1,23 @@
+// A
+// | \
+// B  C
+// |  | \
+// D  E  F
+// |  | /
+// G  H
+// | /
+// I
+
+// [commit, parent(s)]
+export default [
+  // prettier-ignore
+  ['A', false],
+  ['B', 'A'],
+  ['C', 'A'],
+  ['D', 'B'],
+  ['E', 'C'],
+  ['F', 'C'],
+  ['G', 'D'],
+  ['H', 'E'],
+  ['I', ['G', 'H']],
+];

--- a/node-src/git/mocks/mock-index.ts
+++ b/node-src/git/mocks/mock-index.ts
@@ -43,9 +43,9 @@ const mocks = {
       hasBuildsWithCommits: commits.filter((commit) => !!builds.find((b) => b.commit === commit)),
     },
   }),
-  MergeCommitsQuery: (builds: Build[], prs: PR[], { mergeInfos }: { mergeInfos: MergeInfo[] }) => {
+  MergeCommitsQuery: (builds: Build[], prs: PR[], { mergeInfoList }: { mergeInfoList: MergeInfo[] }) => {
     const mergedPrs = [];
-    for (const mergeInfo of mergeInfos) {
+    for (const mergeInfo of mergeInfoList) {
       const pr = prs.find((p) => p.mergeCommitHash === mergeInfo.commit);
       const prLastBuild = pr && lastBuildOnBranch(builds, pr.headBranch);
       mergedPrs.push({

--- a/node-src/git/mocks/mock-index.ts
+++ b/node-src/git/mocks/mock-index.ts
@@ -65,8 +65,16 @@ const mocks = {
 
 export default function createMockIndex({ commitMap }, buildDescriptions, prDescriptions = []) {
   const builds = buildDescriptions.map(([name, branch], index) => {
-    const { hash, committedAt: committedAtSeconds } = commitMap[name];
-    const committedAt = parseInt(committedAtSeconds, 10) * 1000;
+    let hash, committedAt;
+    if (commitMap[name]) {
+      const commitInfo = commitMap[name];
+      hash = commitInfo.hash;
+      committedAt = parseInt(commitInfo.committedAt, 10) * 1000;
+    } else {
+      // Allow for test cases with a commit that is no longer in the history
+      hash = name;
+      committedAt = Date.now();
+    }
 
     const number = index + 1;
     return {


### PR DESCRIPTION
When a Chromatic build is run on a squashed merge commit, there's no way to determine the source branch to look for ancestor builds since the git history is lost during the squash. To get around this, we try to query the git provider for a PR that resulted in the squashed commit, which will give us the information we need. 

We're currently only doing this lookup on the commit that a build is running on. This change increases the number of parent commits that we try to do the lookup on.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>10.0.1--canary.866.7107771516.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@10.0.1--canary.866.7107771516.0
  # or 
  yarn add chromatic@10.0.1--canary.866.7107771516.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
