### PR TITLE
Run publish-action script as afterShipIt hook

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,10 +2,10 @@ name: Release
 
 on:
   # PRs have their own canary releases which always run but don't publish the GitHub Action.
+  # Types are configured so this also runs when labels are added or removed.
   # To allow debugging the release process, this does not have a paths filter.
   pull_request:
-    branches:
-      - main
+    types: [opened, synchronize, reopened, labeled, unlabeled]
 
   # Pushes to main trigger a release and publish the GitHub Action. To allow the occasional update
   # to markdown and config files, only changes to actual source code trigger a release.

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "lint": "yarn lint:js .storybook bin-src node-src test-stories ./isChromatic.js ./isChromatic.mjs",
     "lint:js": "cross-env NODE_ENV=production eslint --fix --cache --cache-location=.cache/eslint --ext .js,.json,.mjs,.ts,.cjs --report-unused-disable-directives",
     "lint:package": "sort-package-json",
-    "release": "yarn run build && auto shipit && yarn run publish-action",
+    "release": "yarn run build && auto shipit",
     "publish-action": "./scripts/publish-action.mjs",
     "trace": "./dist/bin.js trace",
     "trim-stats": "./dist/bin.js trim-stats-file",
@@ -108,6 +108,7 @@
     "@actions/core": "^1.10.0",
     "@actions/github": "^5.0.0",
     "@antfu/ni": "^0.21.5",
+    "@auto-it/exec": "^11.0.4",
     "@discoveryjs/json-ext": "^0.5.7",
     "@storybook/addon-essentials": "^6.5.6",
     "@storybook/builder-webpack5": "^6.5.6",
@@ -207,7 +208,13 @@
     },
     "plugins": [
       "npm",
-      "released"
+      "released",
+      [
+        "exec",
+        {
+          "afterShipIt": "yarn run publish-action"
+        }
+      ]
     ]
   },
   "docs": "https://www.chromatic.com/docs/cli",

--- a/yarn.lock
+++ b/yarn.lock
@@ -97,6 +97,18 @@
     typescript-memoize "^1.0.0-alpha.3"
     url-join "^4.0.0"
 
+"@auto-it/exec@^11.0.4":
+  version "11.0.4"
+  resolved "https://registry.yarnpkg.com/@auto-it/exec/-/exec-11.0.4.tgz#97efbc9fbc14f2b777ef874c029a40fda8be7a3e"
+  integrity sha512-n/kB8k/dwci9UeTsLCs8mig8ZQuS2dMHcHlsKXBeM18EmcbGHxDxyaPeMHJsnSlfKNmGtCXhHBHBhGVP18Ia+w==
+  dependencies:
+    "@auto-it/core" "11.0.4"
+    endent "^2.1.0"
+    fp-ts "^2.5.3"
+    fromentries "^1.2.0"
+    io-ts "^2.1.2"
+    tslib "2.1.0"
+
 "@auto-it/npm@11.0.4":
   version "11.0.4"
   resolved "https://registry.yarnpkg.com/@auto-it/npm/-/npm-11.0.4.tgz#67b6bf78fb6d3f814365796f15541b014db73fcb"


### PR DESCRIPTION
Don't run `publish-action` on every merge to main, but only when `shipIt` has run (which depends on the `release` label being present on the PR).

This should prevent another situation where the GitHub Action is released with code that isn't actually supposed to be released yet (merged to main with the `skip-release` label).
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>10.1.1--canary.877.7264235665.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@10.1.1--canary.877.7264235665.0
  # or 
  yarn add chromatic@10.1.1--canary.877.7264235665.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
