### PR TITLE
Add `--playwright` & `--cypress` flags

### DIFF
--- a/action-src/main.ts
+++ b/action-src/main.ts
@@ -94,6 +94,7 @@ async function run() {
     const branchName = getInput('branchName');
     const buildScriptName = getInput('buildScriptName');
     const configFile = getInput('configFile');
+    const cypress = getInput('cypress');
     const debug = getInput('debug');
     const diagnosticsFile = getInput('diagnosticsFile') || getInput('diagnostics');
     const dryRun = getInput('dryRun');
@@ -107,6 +108,7 @@ async function run() {
     const onlyChanged = getInput('onlyChanged');
     const onlyStoryFiles = getInput('onlyStoryFiles');
     const onlyStoryNames = getInput('onlyStoryNames');
+    const playwright = getInput('playwright');
     const preserveMissing = getInput('preserveMissing');
     const projectToken = getInput('projectToken') || getInput('appCode'); // backwards compatibility
     const repositorySlug = getInput('repositorySlug');
@@ -139,6 +141,7 @@ async function run() {
         branchName: maybe(branchName),
         buildScriptName: maybe(buildScriptName),
         configFile: maybe(configFile),
+        cypress: maybe(cypress),
         debug: maybe(debug),
         diagnosticsFile: maybe(diagnosticsFile),
         dryRun: maybe(dryRun),
@@ -153,6 +156,7 @@ async function run() {
         onlyChanged: maybe(onlyChanged),
         onlyStoryFiles: maybe(onlyStoryFiles),
         onlyStoryNames: maybe(onlyStoryNames),
+        playwright: maybe(playwright),
         preserveMissing: maybe(preserveMissing),
         projectToken,
         repositorySlug: maybe(repositorySlug),

--- a/action.yml
+++ b/action.yml
@@ -23,6 +23,8 @@ inputs:
     required: false
   configFile:
     description: 'Path from where to load the Chromatic config JSON file.'
+  cypress:
+    description: 'Run build against `chromatic-cypress` test archives'
     required: false
   debug:
     description: 'Output verbose debugging information'
@@ -65,6 +67,9 @@ inputs:
     required: false
   onlyStoryFiles:
     description: 'Only run a single story or a subset of stories by their filename(s)'
+    required: false
+  playwright:
+    description: 'Run build against `chromatic-playwright` test archives'
     required: false
   preserveMissing:
     description: 'Deprecated, use onlyChanged, onlyStoryNames or onlyStoryFiles instead'

--- a/node-src/index.ts
+++ b/node-src/index.ts
@@ -27,7 +27,6 @@ import buildCanceled from './ui/messages/errors/buildCanceled';
 import { default as fatalError } from './ui/messages/errors/fatalError';
 import fetchError from './ui/messages/errors/fetchError';
 import graphqlError from './ui/messages/errors/graphqlError';
-import invalidPackageJson from './ui/messages/errors/invalidPackageJson';
 import missingStories from './ui/messages/errors/missingStories';
 import noPackageJson from './ui/messages/errors/noPackageJson';
 import runtimeError from './ui/messages/errors/runtimeError';
@@ -159,15 +158,6 @@ export async function runAll(ctx: InitialContext) {
     const options = getOptions(ctx);
     (ctx as Context).options = options;
     ctx.log.setLogFile(options.logFile);
-
-    const needsScripts = !options.playwright && !options.cypress;
-    if (
-      typeof ctx.packageJson !== 'object' ||
-      (needsScripts && typeof ctx.packageJson.scripts !== 'object')
-    ) {
-      ctx.log.error(invalidPackageJson(ctx.packagePath));
-      process.exit(252);
-    }
 
     setExitCode(ctx, exitCodes.OK);
   } catch (e) {

--- a/node-src/index.ts
+++ b/node-src/index.ts
@@ -97,11 +97,6 @@ export async function run({
   }
 
   const { path: packagePath, packageJson } = pkgInfo;
-  if (typeof packageJson !== 'object' || typeof packageJson.scripts !== 'object') {
-    log.error(invalidPackageJson(packagePath));
-    process.exit(252);
-  }
-
   const ctx: InitialContext = {
     ...parseArgs(argv),
     ...(flags && { flags }),
@@ -164,6 +159,16 @@ export async function runAll(ctx: InitialContext) {
     const options = getOptions(ctx);
     (ctx as Context).options = options;
     ctx.log.setLogFile(options.logFile);
+
+    const needsScripts = !options.playwright && !options.cypress;
+    if (
+      typeof ctx.packageJson !== 'object' ||
+      (needsScripts && typeof ctx.packageJson.scripts !== 'object')
+    ) {
+      ctx.log.error(invalidPackageJson(ctx.packagePath));
+      process.exit(252);
+    }
+
     setExitCode(ctx, exitCodes.OK);
   } catch (e) {
     return onError(e);

--- a/node-src/lib/getConfiguration.ts
+++ b/node-src/lib/getConfiguration.ts
@@ -26,6 +26,7 @@ const configurationSchema = z
 
     buildScriptName: z.string(),
     playwright: z.boolean(),
+    cypress: z.boolean(),
     outputDir: z.string(),
     skip: z.union([z.string(), z.boolean()]),
 

--- a/node-src/lib/getConfiguration.ts
+++ b/node-src/lib/getConfiguration.ts
@@ -25,6 +25,7 @@ const configurationSchema = z
     ignoreLastBuildOnBranch: z.string(),
 
     buildScriptName: z.string(),
+    playwright: z.boolean(),
     outputDir: z.string(),
     skip: z.union([z.string(), z.boolean()]),
 

--- a/node-src/lib/getE2eBinPath.ts
+++ b/node-src/lib/getE2eBinPath.ts
@@ -1,0 +1,18 @@
+import { Context } from '../types';
+import missingDependency from '../ui/messages/errors/missingDependency';
+import { exitCodes, setExitCode } from './setExitCode';
+import { failed } from '../ui/tasks/build';
+
+export function getE2eBinPath(ctx: Context, flag: 'playwright' | 'cypress') {
+  const dependencyName = `chromatic-${flag}`;
+  try {
+    return require.resolve(`${dependencyName}/bin/build-archive-storybook`);
+  } catch (err) {
+    if (err.code === 'MODULE_NOT_FOUND') {
+      ctx.log.error(missingDependency({ dependencyName, flag }));
+      setExitCode(ctx, exitCodes.MISSING_DEPENDENCY, true);
+      throw new Error(failed(ctx).output);
+    }
+    throw err;
+  }
+}

--- a/node-src/lib/getOptions.ts
+++ b/node-src/lib/getOptions.ts
@@ -13,6 +13,7 @@ import invalidSingularOptions from '../ui/messages/errors/invalidSingularOptions
 import missingBuildScriptName from '../ui/messages/errors/missingBuildScriptName';
 import missingProjectToken from '../ui/messages/errors/missingProjectToken';
 import deprecatedOption from '../ui/messages/warnings/deprecatedOption';
+import invalidPackageJson from '../ui/messages/errors/invalidPackageJson';
 
 const takeLast = (input: string | string[]) =>
   Array.isArray(input) ? input[input.length - 1] : input;
@@ -39,6 +40,7 @@ export default function getOptions({
   configuration,
   log,
   packageJson,
+  packagePath,
 }: InitialContext): Options {
   const defaultOptions = {
     projectToken: env.CHROMATIC_PROJECT_TOKEN,
@@ -262,6 +264,11 @@ export default function getOptions({
 
   if (options.playwright || options.cypress) {
     return options;
+  }
+
+  if (typeof packageJson !== 'object' || typeof packageJson.scripts !== 'object') {
+    log.error(invalidPackageJson(packagePath));
+    process.exit(252);
   }
 
   const { scripts } = packageJson;

--- a/node-src/lib/getOptions.ts
+++ b/node-src/lib/getOptions.ts
@@ -72,6 +72,7 @@ export default function getOptions({
 
     buildScriptName: undefined,
     playwright: undefined,
+    cypress: undefined,
     outputDir: undefined,
     allowConsoleErrors: undefined,
     storybookBuildDir: undefined,
@@ -130,6 +131,7 @@ export default function getOptions({
 
     buildScriptName: flags.buildScriptName,
     playwright: trueIfSet(flags.playwright),
+    cypress: trueIfSet(flags.cypress),
     outputDir: takeLast(flags.outputDir),
     allowConsoleErrors: flags.allowConsoleErrors,
     storybookBuildDir: takeLast(flags.storybookBuildDir),
@@ -204,6 +206,8 @@ export default function getOptions({
   const singularOpts = {
     buildScriptName: '--build-script-name',
     storybookBuildDir: '--storybook-build-dir',
+    playwright: '--playwright',
+    cypress: '--cypress',
   };
   const foundSingularOpts = Object.keys(singularOpts).filter((name) => !!options[name]);
 
@@ -256,7 +260,7 @@ export default function getOptions({
     return options;
   }
 
-  if (options.playwright) {
+  if (options.playwright || options.cypress) {
     return options;
   }
 

--- a/node-src/lib/getOptions.ts
+++ b/node-src/lib/getOptions.ts
@@ -71,6 +71,7 @@ export default function getOptions({
     preserveMissingSpecs: undefined,
 
     buildScriptName: undefined,
+    playwright: undefined,
     outputDir: undefined,
     allowConsoleErrors: undefined,
     storybookBuildDir: undefined,
@@ -128,6 +129,7 @@ export default function getOptions({
       flags.preserveMissing || typeof flags.only === 'string' ? true : undefined,
 
     buildScriptName: flags.buildScriptName,
+    playwright: trueIfSet(flags.playwright),
     outputDir: takeLast(flags.outputDir),
     allowConsoleErrors: flags.allowConsoleErrors,
     storybookBuildDir: takeLast(flags.storybookBuildDir),
@@ -251,6 +253,10 @@ export default function getOptions({
 
   // Build Storybook
   if (storybookBuildDir) {
+    return options;
+  }
+
+  if (options.playwright) {
     return options;
   }
 

--- a/node-src/lib/setExitCode.ts
+++ b/node-src/lib/setExitCode.ts
@@ -35,6 +35,7 @@ export const exitCodes = {
   // I/O errors
   FETCH_ERROR: 201,
   GRAPHQL_ERROR: 202,
+  MISSING_DEPENDENCY: 210,
   INVALID_OPTIONS: 254,
 };
 

--- a/node-src/types.ts
+++ b/node-src/types.ts
@@ -16,6 +16,7 @@ export interface Flags {
 
   // E2E options
   playwright?: boolean;
+  cypress?: boolean;
 
   // Chromatic options
   autoAcceptChanges?: string;
@@ -93,7 +94,8 @@ export interface Options extends Configuration {
   originalArgv: string[];
 
   buildScriptName: Flags['buildScriptName'];
-  playwright: Flags['playwright'],
+  playwright: Flags['playwright'];
+  cypress: Flags['cypress'];
   outputDir: string;
   allowConsoleErrors: Flags['allowConsoleErrors'];
   url?: string;

--- a/node-src/types.ts
+++ b/node-src/types.ts
@@ -14,6 +14,9 @@ export interface Flags {
   outputDir?: string[];
   storybookBuildDir?: string[];
 
+  // E2E options
+  playwright?: boolean;
+
   // Chromatic options
   autoAcceptChanges?: string;
   branchName?: string;
@@ -90,6 +93,7 @@ export interface Options extends Configuration {
   originalArgv: string[];
 
   buildScriptName: Flags['buildScriptName'];
+  playwright: Flags['playwright'],
   outputDir: string;
   allowConsoleErrors: Flags['allowConsoleErrors'];
   url?: string;

--- a/node-src/ui/messages/errors/missingDependency.stories.ts
+++ b/node-src/ui/messages/errors/missingDependency.stories.ts
@@ -1,0 +1,8 @@
+import missingDependency from './missingDependency';
+
+export default {
+  title: 'CLI/Messages/Errors',
+};
+
+export const MissingDependency = () =>
+  missingDependency({ dependencyName: 'chromatic-playwright', flag: 'playwright' });

--- a/node-src/ui/messages/errors/missingDependency.ts
+++ b/node-src/ui/messages/errors/missingDependency.ts
@@ -1,0 +1,11 @@
+import chalk from 'chalk';
+import { dedent } from 'ts-dedent';
+import { error, info } from '../../components/icons';
+
+export default ({ dependencyName, flag }: { dependencyName: string; flag: string }) => {
+  return dedent(chalk`
+      ${error} Failed to import \`${dependencyName}\`, is it installed in \`package.json\`?
+
+      ${info} To run \`chromatic --${flag}\` you must have \`${dependencyName}\` installed.
+    `);
+};

--- a/package.json
+++ b/package.json
@@ -196,8 +196,8 @@
     "zod": "^3.22.2"
   },
   "peerDependencies": {
-    "chromatic-playwright": "^0.3.1",
-    "chromatic-cypress": "^0.3.2"
+    "chromatic-playwright": "^1.0.0",
+    "chromatic-cypress": "^1.0.0"
   },
   "peerDependenciesMeta": {
     "chromatic-playwright": {

--- a/package.json
+++ b/package.json
@@ -196,8 +196,8 @@
     "zod": "^3.22.2"
   },
   "peerDependencies": {
-    "chromatic-playwright": "^0.3.1 || ^1.0.0",
-    "chromatic-cypress": "^0.3.2 || ^1.0.0"
+    "chromatic-playwright": "^0.4.0 || ^1.0.0",
+    "chromatic-cypress": "^0.4.0 || ^1.0.0"
   },
   "peerDependenciesMeta": {
     "chromatic-playwright": {

--- a/package.json
+++ b/package.json
@@ -196,8 +196,8 @@
     "zod": "^3.22.2"
   },
   "peerDependencies": {
-    "chromatic-playwright": "^1.0.0",
-    "chromatic-cypress": "^1.0.0"
+    "chromatic-playwright": "^0.3.1 || ^1.0.0",
+    "chromatic-cypress": "^0.3.2 || ^1.0.0"
   },
   "peerDependenciesMeta": {
     "chromatic-playwright": {

--- a/package.json
+++ b/package.json
@@ -195,6 +195,18 @@
     "zen-observable": "^0.8.15",
     "zod": "^3.22.2"
   },
+  "peerDependencies": {
+    "chromatic-playwright": "^0.3.1",
+    "chromatic-cypress": "^0.3.2"
+  },
+  "peerDependenciesMeta": {
+    "chromatic-playwright": {
+      "optional": true
+    },
+    "chromatic-cypress": {
+      "optional": true
+    }
+  },
   "publishConfig": {
     "access": "public",
     "registry": "https://registry.npmjs.org/"


### PR DESCRIPTION
When set, build storybook by directly invoking the binary from `@chromaui/test-archiver`.

This is a POC, we will move this binary into a `chromatic-playwright` package soon.

TODO:
 - [x] Add cypress flag too
 - [x] Ensure the flag works in the action
 - [x] Throw errors if incompatible flags are used
 - [x] Tests

Some notes:
 
 - This won't work if you symlink the `chromatic` package into a test project (due to symlinking and resolution). Probably just use the canary to test it out (`chromatic@10.2.1--canary.882.7460727945.0`)
 
  - For this to work in it's current form, you need to add the following export to the `@chromaui/archive-storybook` `package.json:exports` field:

```
    "./package.json": {
      "require": "./package.json",
      "import": "./package.json"
    }
```

I did this manually inside `node_modules` of my test project for now.

For some reason I couldn't `require.resolve('@chromaui/archive-storybook')` directly. @ndelangen may know more about this.

- We'll want to resolve things in `chromatic-playwright` really, so we'd be adding the export to that package once we setup the monorepo.

- This calls `node path/to/@chromaui/archive-storybook/dist/bin/build-archive-storybook.js -o ...`, which then calls `node path/to/@storybook/cli/dist/bin/storybook.js -c path/to/config`. There might be a way to avoid the double node invocation. Then again, it's probably not a big deal.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>10.5.0--canary.882.7634992282.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@10.5.0--canary.882.7634992282.0
  # or 
  yarn add chromatic@10.5.0--canary.882.7634992282.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
