### PR TITLE
Add configFile option to GitHub Action 

### DIFF
--- a/action-src/main.ts
+++ b/action-src/main.ts
@@ -93,6 +93,7 @@ async function run() {
     const autoAcceptChanges = getInput('autoAcceptChanges');
     const branchName = getInput('branchName');
     const buildScriptName = getInput('buildScriptName');
+    const configFile = getInput('configFile');
     const debug = getInput('debug');
     const diagnosticsFile = getInput('diagnosticsFile') || getInput('diagnostics');
     const dryRun = getInput('dryRun');
@@ -137,6 +138,7 @@ async function run() {
         autoAcceptChanges: maybe(autoAcceptChanges),
         branchName: maybe(branchName),
         buildScriptName: maybe(buildScriptName),
+        configFile: maybe(configFile),
         debug: maybe(debug),
         diagnosticsFile: maybe(diagnosticsFile),
         dryRun: maybe(dryRun),

--- a/action.yml
+++ b/action.yml
@@ -21,6 +21,9 @@ inputs:
   buildScriptName:
     description: 'The npm script that builds your Storybook [build-storybook]'
     required: false
+  configFile:
+    description: 'Path from where to load the Chromatic config JSON file.'
+    required: false
   debug:
     description: 'Output verbose debugging information'
     required: false


### PR DESCRIPTION
The Chromatic CLI can receive a `--config-file` configuration option.

This change exposes that same option in the GitHub action.