### PR TITLE
Add configFile option to GitHub Action

### DIFF
--- a/action-src/main.ts
+++ b/action-src/main.ts
@@ -93,6 +93,7 @@ async function run() {
     const autoAcceptChanges = getInput('autoAcceptChanges');
     const branchName = getInput('branchName');
     const buildScriptName = getInput('buildScriptName');
+    const configFile = getInput('configFile');
     const debug = getInput('debug');
     const diagnosticsFile = getInput('diagnosticsFile') || getInput('diagnostics');
     const dryRun = getInput('dryRun');
@@ -137,6 +138,7 @@ async function run() {
         autoAcceptChanges: maybe(autoAcceptChanges),
         branchName: maybe(branchName),
         buildScriptName: maybe(buildScriptName),
+        configFile: maybe(configFile),
         debug: maybe(debug),
         diagnosticsFile: maybe(diagnosticsFile),
         dryRun: maybe(dryRun),

--- a/action.yml
+++ b/action.yml
@@ -21,6 +21,9 @@ inputs:
   buildScriptName:
     description: 'The npm script that builds your Storybook [build-storybook]'
     required: false
+  configFile:
+    description: 'Path from where to load the Chromatic config JSON file.'
+    required: false
   debug:
     description: 'Output verbose debugging information'
     required: false


### PR DESCRIPTION
This is thanks to @wisestuart work here #885 I just had to reopen PR because it was missing the env var to release the update.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>10.2.2--canary.886.7507415488.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@10.2.2--canary.886.7507415488.0
  # or 
  yarn add chromatic@10.2.2--canary.886.7507415488.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
