### PR TITLE
Reintroduce `uploadBuild` mutation, running in batches

### DIFF
--- a/node-src/index.test.ts
+++ b/node-src/index.test.ts
@@ -98,14 +98,16 @@ vi.mock('node-fetch', () => ({
       }
 
       if (query?.match('PublishBuildMutation')) {
-        if (variables.input.isolatorUrl.startsWith('http://throw-an-error')) {
-          throw new Error('fetch error');
-        }
-        publishedBuild = { id: variables.id, ...variables.input };
+        publishedBuild = {
+          id: variables.id,
+          ...variables.input,
+          storybookUrl: 'https://5d67dc0374b2e300209c41e7-pfkaemtlit.chromatic.com/',
+        };
         return {
           data: {
             publishBuild: {
               status: 'PUBLISHED',
+              storybookUrl: 'https://5d67dc0374b2e300209c41e7-pfkaemtlit.chromatic.com/',
             },
           },
         };
@@ -132,8 +134,8 @@ vi.mock('node-fetch', () => ({
                 status: 'IN_PROGRESS',
                 specCount: 1,
                 componentCount: 1,
+                storybookUrl: 'https://5d67dc0374b2e300209c41e7-pfkaemtlit.chromatic.com/',
                 webUrl: 'http://test.com',
-                cachedUrl: 'https://5d67dc0374b2e300209c41e7-pfkaemtlit.chromatic.com/iframe.html',
                 ...mockBuildFeatures,
                 app: {
                   account: {
@@ -193,7 +195,8 @@ vi.mock('node-fetch', () => ({
         };
       }
 
-      if (query?.match('GetUploadUrlsMutation')) {
+      if (query?.match('UploadBuildMutation') || query?.match('UploadMetadataMutation')) {
+        const key = query?.match('UploadBuildMutation') ? 'uploadBuild' : 'uploadMetadata';
         const contentTypes = {
           html: 'text/html',
           js: 'text/javascript',
@@ -202,13 +205,17 @@ vi.mock('node-fetch', () => ({
         };
         return {
           data: {
-            getUploadUrls: {
-              domain: 'https://chromatic.com',
-              urls: variables.paths.map((path: string) => ({
-                path,
-                url: `https://cdn.example.com/${path}`,
-                contentType: contentTypes[path.split('.').at(-1)],
-              })),
+            [key]: {
+              info: {
+                targets: variables.files.map(({ filePath }) => ({
+                  contentType: contentTypes[filePath.split('.').at(-1)],
+                  fileKey: '',
+                  filePath,
+                  formAction: 'https://s3.amazonaws.com',
+                  formFields: {},
+                })),
+              },
+              userErrors: [],
             },
           },
         };
@@ -405,7 +412,7 @@ it('runs in simple situations', async () => {
     storybookViewLayer: 'viewLayer',
     committerEmail: 'test@test.com',
     committerName: 'tester',
-    isolatorUrl: `https://chromatic.com/iframe.html`,
+    storybookUrl: 'https://5d67dc0374b2e300209c41e7-pfkaemtlit.chromatic.com/',
   });
 });
 
@@ -462,20 +469,24 @@ it('calls out to npm build script passed and uploads files', async () => {
     expect.any(Object),
     [
       {
-        contentHash: 'hash',
         contentLength: 42,
         contentType: 'text/html',
+        fileKey: '',
+        filePath: 'iframe.html',
+        formAction: 'https://s3.amazonaws.com',
+        formFields: {},
         localPath: expect.stringMatching(/\/iframe\.html$/),
         targetPath: 'iframe.html',
-        targetUrl: 'https://cdn.example.com/iframe.html',
       },
       {
-        contentHash: 'hash',
         contentLength: 42,
         contentType: 'text/html',
+        fileKey: '',
+        filePath: 'index.html',
+        formAction: 'https://s3.amazonaws.com',
+        formFields: {},
         localPath: expect.stringMatching(/\/index\.html$/),
         targetPath: 'index.html',
-        targetUrl: 'https://cdn.example.com/index.html',
       },
     ],
     expect.any(Function)
@@ -491,20 +502,24 @@ it('skips building and uploads directly with storybook-build-dir', async () => {
     expect.any(Object),
     [
       {
-        contentHash: 'hash',
         contentLength: 42,
         contentType: 'text/html',
+        fileKey: '',
+        filePath: 'iframe.html',
+        formAction: 'https://s3.amazonaws.com',
+        formFields: {},
         localPath: expect.stringMatching(/\/iframe\.html$/),
         targetPath: 'iframe.html',
-        targetUrl: 'https://cdn.example.com/iframe.html',
       },
       {
-        contentHash: 'hash',
         contentLength: 42,
         contentType: 'text/html',
+        fileKey: '',
+        filePath: 'index.html',
+        formAction: 'https://s3.amazonaws.com',
+        formFields: {},
         localPath: expect.stringMatching(/\/index\.html$/),
         targetPath: 'index.html',
-        targetUrl: 'https://cdn.example.com/index.html',
       },
     ],
     expect.any(Function)
@@ -699,32 +714,44 @@ it('should upload metadata files if --upload-metadata is passed', async () => {
   expect(upload.mock.calls.at(-1)[1]).toEqual(
     expect.arrayContaining([
       {
-        localPath: '.storybook/main.js',
-        targetPath: '.chromatic/main.js',
         contentLength: 518,
         contentType: 'text/javascript',
-        targetUrl: 'https://cdn.example.com/.chromatic/main.js',
+        fileKey: '',
+        filePath: '.chromatic/main.js',
+        formAction: 'https://s3.amazonaws.com',
+        formFields: {},
+        localPath: '.storybook/main.js',
+        targetPath: '.chromatic/main.js',
       },
       {
-        localPath: 'storybook-out/preview-stats.trimmed.json',
-        targetPath: '.chromatic/preview-stats.trimmed.json',
         contentLength: 457,
         contentType: 'application/json',
-        targetUrl: 'https://cdn.example.com/.chromatic/preview-stats.trimmed.json',
+        fileKey: '',
+        filePath: '.chromatic/preview-stats.trimmed.json',
+        formAction: 'https://s3.amazonaws.com',
+        formFields: {},
+        localPath: 'storybook-out/preview-stats.trimmed.json',
+        targetPath: '.chromatic/preview-stats.trimmed.json',
       },
       {
-        localPath: '.storybook/preview.js',
-        targetPath: '.chromatic/preview.js',
         contentLength: 1338,
         contentType: 'text/javascript',
-        targetUrl: 'https://cdn.example.com/.chromatic/preview.js',
+        fileKey: '',
+        filePath: '.chromatic/preview.js',
+        formAction: 'https://s3.amazonaws.com',
+        formFields: {},
+        localPath: '.storybook/preview.js',
+        targetPath: '.chromatic/preview.js',
       },
       {
-        localPath: expect.any(String),
-        targetPath: '.chromatic/index.html',
         contentLength: expect.any(Number),
         contentType: 'text/html',
-        targetUrl: 'https://cdn.example.com/.chromatic/index.html',
+        fileKey: '',
+        filePath: '.chromatic/index.html',
+        formAction: 'https://s3.amazonaws.com',
+        formFields: {},
+        localPath: expect.any(String),
+        targetPath: '.chromatic/index.html',
       },
     ])
   );

--- a/node-src/index.ts
+++ b/node-src/index.ts
@@ -120,7 +120,7 @@ export async function run({
     code: ctx.exitCode,
     url: ctx.build?.webUrl,
     buildUrl: ctx.build?.webUrl,
-    storybookUrl: ctx.build?.cachedUrl?.replace(/iframe\.html.*$/, ''),
+    storybookUrl: ctx.build?.storybookUrl,
     specCount: ctx.build?.specCount,
     componentCount: ctx.build?.componentCount,
     testCount: ctx.build?.testCount,

--- a/node-src/lib/compress.ts
+++ b/node-src/lib/compress.ts
@@ -24,7 +24,7 @@ export default async function makeZipFile(ctx: Context, files: FileDesc[]) {
     archive.pipe(sink);
 
     files.forEach(({ localPath, targetPath: name }) => {
-      ctx.log.debug({ name }, 'Adding file to zip archive');
+      ctx.log.debug(`Adding to zip archive: ${name}`);
       archive.append(createReadStream(localPath), { name });
     });
 

--- a/node-src/lib/upload.ts
+++ b/node-src/lib/upload.ts
@@ -1,112 +1,199 @@
 import makeZipFile from './compress';
-import { Context, FileDesc, TargetedFile } from '../types';
+import { Context, FileDesc, TargetInfo } from '../types';
 import { uploadZip, waitForUnpack } from './uploadZip';
 import { uploadFiles } from './uploadFiles';
+import { maxFileCountExceeded } from '../ui/messages/errors/maxFileCountExceeded';
+import { maxFileSizeExceeded } from '../ui/messages/errors/maxFileSizeExceeded';
 
-const GetUploadUrlsMutation = `
-  mutation GetUploadUrlsMutation($buildId: ObjID, $paths: [String!]!) {
-    getUploadUrls(buildId: $buildId, paths: $paths) {
-      domain
-      urls {
-        path
-        url
-        contentType
+const UploadBuildMutation = `
+  mutation UploadBuildMutation($buildId: ObjID!, $files: [FileUploadInput!]!, $zip: Boolean) {
+    uploadBuild(buildId: $buildId, files: $files, zip: $zip) {
+      info {
+        targets {
+          contentType
+          fileKey
+          filePath
+          formAction
+          formFields
+        }
+        zipTarget {
+          contentType
+          fileKey
+          filePath
+          formAction
+          formFields
+          sentinelUrl
+        }
+      }
+      userErrors {
+        __typename
+        ... on UserError {
+          message
+        }
+        ... on MaxFileCountExceededError {
+          maxFileCount
+          fileCount
+        }
+        ... on MaxFileSizeExceededError {
+          maxFileSize
+          filePaths
+        }
       }
     }
   }
 `;
-interface GetUploadUrlsMutationResult {
-  getUploadUrls: {
-    domain: string;
-    urls: {
-      path: string;
-      url: string;
-      contentType: string;
+
+interface UploadBuildMutationResult {
+  uploadBuild: {
+    info?: {
+      targets: TargetInfo[];
+      zipTarget?: TargetInfo & { sentinelUrl: string };
+    };
+    userErrors: (
+      | {
+          __typename: 'UserError';
+          message: string;
+        }
+      | {
+          __typename: 'MaxFileCountExceededError';
+          message: string;
+          maxFileCount: number;
+          fileCount: number;
+        }
+      | {
+          __typename: 'MaxFileSizeExceededError';
+          message: string;
+          maxFileSize: number;
+          filePaths: string[];
+        }
+    )[];
+  };
+}
+
+export async function uploadBuild(
+  ctx: Context,
+  files: FileDesc[],
+  options: {
+    onStart?: () => void;
+    onProgress?: (progress: number, total: number) => void;
+    onComplete?: (uploadedBytes: number, uploadedFiles: number) => void;
+    onError?: (error: Error, path?: string) => void;
+  } = {}
+) {
+  const { uploadBuild } = await ctx.client.runQuery<UploadBuildMutationResult>(
+    UploadBuildMutation,
+    {
+      buildId: ctx.announcedBuild.id,
+      files: files.map(({ contentLength, targetPath }) => ({
+        contentLength,
+        filePath: targetPath,
+      })),
+      zip: ctx.options.zip,
+    }
+  );
+
+  if (uploadBuild.userErrors.length) {
+    uploadBuild.userErrors.forEach((e) => {
+      if (e.__typename === 'MaxFileCountExceededError') {
+        ctx.log.error(maxFileCountExceeded(e));
+      } else if (e.__typename === 'MaxFileSizeExceededError') {
+        ctx.log.error(maxFileSizeExceeded(e));
+      } else {
+        ctx.log.error(e.message);
+      }
+    });
+    return options.onError?.(new Error('Upload rejected due to user error'));
+  }
+
+  const targets = uploadBuild.info.targets.map((target) => {
+    const file = files.find((f) => f.targetPath === target.filePath);
+    return { ...file, ...target };
+  });
+
+  if (!targets.length) {
+    ctx.log.debug('No new files to upload, continuing');
+    return options.onComplete?.(0, 0);
+  }
+
+  options.onStart?.();
+
+  const total = targets.reduce((acc, { contentLength }) => acc + contentLength, 0);
+  if (uploadBuild.info.zipTarget) {
+    try {
+      const { path, size } = await makeZipFile(ctx, targets);
+      const compressionRate = (total - size) / total;
+      ctx.log.debug(`Compression reduced upload size by ${Math.round(compressionRate * 100)}%`);
+
+      const target = { ...uploadBuild.info.zipTarget, contentLength: size, localPath: path };
+      await uploadZip(ctx, target, (progress) => options.onProgress?.(progress, size));
+      await waitForUnpack(ctx, target.sentinelUrl);
+      return options.onComplete?.(size, targets.length);
+    } catch (err) {
+      ctx.log.debug({ err }, 'Error uploading zip, falling back to uploading individual files');
+    }
+  }
+
+  try {
+    await uploadFiles(ctx, targets, (progress) => options.onProgress?.(progress, total));
+    return options.onComplete?.(total, targets.length);
+  } catch (e) {
+    return options.onError?.(e, files.some((f) => f.localPath === e.message) && e.message);
+  }
+}
+
+const UploadMetadataMutation = `
+  mutation UploadMetadataMutation($buildId: ObjID!, $files: [FileUploadInput!]!) {
+    uploadMetadata(buildId: $buildId, files: $files) {
+      info {
+        targets {
+          contentType
+          fileKey
+          filePath
+          formAction
+          formFields
+        }
+      }
+      userErrors {
+        ... on UserError {
+          message
+        }
+      }
+    }
+  }
+`;
+
+interface UploadMetadataMutationResult {
+  uploadMetadata: {
+    info?: {
+      targets: TargetInfo[];
+    };
+    userErrors: {
+      message: string;
     }[];
   };
 }
 
-const GetZipUploadUrlMutation = `
-  mutation GetZipUploadUrlMutation($buildId: ObjID) {
-    getZipUploadUrl(buildId: $buildId) {
-      domain
-      url
-      sentinelUrl
+export async function uploadMetadata(ctx: Context, files: FileDesc[]) {
+  const { uploadMetadata } = await ctx.client.runQuery<UploadMetadataMutationResult>(
+    UploadMetadataMutation,
+    {
+      buildId: ctx.announcedBuild.id,
+      files: files.map(({ contentLength, targetPath }) => ({
+        contentLength,
+        filePath: targetPath,
+      })),
     }
-  }
-`;
-interface GetZipUploadUrlMutationResult {
-  getZipUploadUrl: {
-    domain: string;
-    url: string;
-    sentinelUrl: string;
-  };
-}
-
-export async function uploadAsIndividualFiles(
-  ctx: Context,
-  files: FileDesc[],
-  options: {
-    onStart?: () => void;
-    onProgress?: (progress: number, total: number) => void;
-    onComplete?: (uploadedBytes: number, domain?: string) => void;
-    onError?: (error: Error, path?: string) => void;
-  } = {}
-) {
-  const { getUploadUrls } = await ctx.client.runQuery<GetUploadUrlsMutationResult>(
-    GetUploadUrlsMutation,
-    { buildId: ctx.announcedBuild.id, paths: files.map(({ targetPath }) => targetPath) }
   );
-  const { domain, urls } = getUploadUrls;
-  const targets = urls.map<TargetedFile>(({ path, url, contentType }) => {
-    const file = files.find((f) => f.targetPath === path);
-    return { ...file, contentType, targetUrl: url };
-  });
-  const total = targets.reduce((acc, { contentLength }) => acc + contentLength, 0);
 
-  options.onStart?.();
-
-  try {
-    await uploadFiles(ctx, targets, (progress) => options.onProgress?.(progress, total));
-  } catch (e) {
-    return options.onError?.(e, files.some((f) => f.localPath === e.message) && e.message);
+  if (uploadMetadata.info) {
+    const targets = uploadMetadata.info.targets.map((target) => {
+      const file = files.find((f) => f.targetPath === target.filePath);
+      return { ...file, ...target };
+    });
+    await uploadFiles(ctx, targets);
   }
 
-  options.onComplete?.(total, domain);
-}
-
-export async function uploadAsZipFile(
-  ctx: Context,
-  files: FileDesc[],
-  options: {
-    onStart?: () => void;
-    onProgress?: (progress: number, total: number) => void;
-    onComplete?: (uploadedBytes: number, domain?: string) => void;
-    onError?: (error: Error, path?: string) => void;
-  } = {}
-) {
-  const originalSize = files.reduce((acc, { contentLength }) => acc + contentLength, 0);
-  const zipped = await makeZipFile(ctx, files);
-  const { path, size } = zipped;
-
-  if (size > originalSize) throw new Error('Zip file is larger than individual files');
-  ctx.log.debug(`Compression reduced upload size by ${originalSize - size} bytes`);
-
-  const { getZipUploadUrl } = await ctx.client.runQuery<GetZipUploadUrlMutationResult>(
-    GetZipUploadUrlMutation,
-    { buildId: ctx.announcedBuild.id }
-  );
-  const { domain, url, sentinelUrl } = getZipUploadUrl;
-
-  options.onStart?.();
-
-  try {
-    await uploadZip(ctx, path, url, size, (progress) => options.onProgress?.(progress, size));
-  } catch (e) {
-    return options.onError?.(e, path);
+  if (uploadMetadata.userErrors.length) {
+    uploadMetadata.userErrors.forEach((e) => ctx.log.warn(e.message));
   }
-
-  await waitForUnpack(ctx, sentinelUrl);
-
-  options.onComplete?.(size, domain);
 }

--- a/node-src/lib/upload.ts
+++ b/node-src/lib/upload.ts
@@ -5,6 +5,9 @@ import { uploadFiles } from './uploadFiles';
 import { maxFileCountExceeded } from '../ui/messages/errors/maxFileCountExceeded';
 import { maxFileSizeExceeded } from '../ui/messages/errors/maxFileSizeExceeded';
 
+// This limit is imposed by the uploadBuild mutation
+const MAX_FILES_PER_REQUEST = 1000;
+
 const UploadBuildMutation = `
   mutation UploadBuildMutation($buildId: ObjID!, $files: [FileUploadInput!]!, $zip: Boolean) {
     uploadBuild(buildId: $buildId, files: $files, zip: $zip) {
@@ -80,62 +83,86 @@ export async function uploadBuild(
     onError?: (error: Error, path?: string) => void;
   } = {}
 ) {
-  const { uploadBuild } = await ctx.client.runQuery<UploadBuildMutationResult>(
-    UploadBuildMutation,
-    {
-      buildId: ctx.announcedBuild.id,
-      files: files.map(({ contentLength, targetPath }) => ({
-        contentLength,
-        filePath: targetPath,
-      })),
-      zip: ctx.options.zip,
-    }
-  );
+  ctx.uploadedBytes = 0;
+  ctx.uploadedFiles = 0;
 
-  if (uploadBuild.userErrors.length) {
-    uploadBuild.userErrors.forEach((e) => {
-      if (e.__typename === 'MaxFileCountExceededError') {
-        ctx.log.error(maxFileCountExceeded(e));
-      } else if (e.__typename === 'MaxFileSizeExceededError') {
-        ctx.log.error(maxFileSizeExceeded(e));
-      } else {
-        ctx.log.error(e.message);
+  const targets: (TargetInfo & FileDesc)[] = [];
+  let zipTarget: (TargetInfo & { sentinelUrl: string }) | undefined;
+
+  const batches = files.reduce<typeof files[]>((acc, file, fileIndex) => {
+    const batchIndex = Math.floor(fileIndex / MAX_FILES_PER_REQUEST);
+    if (!acc[batchIndex]) acc[batchIndex] = [];
+    acc[batchIndex].push(file);
+    return acc;
+  }, []);
+
+  // The uploadBuild mutation has to run in batches to avoid hitting request/response payload limits
+  // or running out of memory. These run sequentially to avoid too many concurrent requests.
+  // The uploading itself still happens without batching, since it has its own concurrency limiter.
+  for (const batch of batches) {
+    const { uploadBuild } = await ctx.client.runQuery<UploadBuildMutationResult>(
+      UploadBuildMutation,
+      {
+        buildId: ctx.announcedBuild.id,
+        files: batch.map(({ contentLength, targetPath }) => ({
+          contentLength,
+          filePath: targetPath,
+        })),
+        zip: ctx.options.zip,
       }
-    });
-    return options.onError?.(new Error('Upload rejected due to user error'));
-  }
+    );
 
-  const targets = uploadBuild.info.targets.map((target) => {
-    const file = files.find((f) => f.targetPath === target.filePath);
-    return { ...file, ...target };
-  });
+    if (uploadBuild.userErrors.length) {
+      uploadBuild.userErrors.forEach((e) => {
+        if (e.__typename === 'MaxFileCountExceededError') {
+          ctx.log.error(maxFileCountExceeded(e));
+        } else if (e.__typename === 'MaxFileSizeExceededError') {
+          ctx.log.error(maxFileSizeExceeded(e));
+        } else {
+          ctx.log.error(e.message);
+        }
+      });
+      return options.onError?.(new Error('Upload rejected due to user error'));
+    }
+
+    targets.push(
+      ...uploadBuild.info.targets.map((target) => {
+        const file = batch.find((f) => f.targetPath === target.filePath);
+        return { ...file, ...target };
+      })
+    );
+    zipTarget = uploadBuild.info.zipTarget;
+  }
 
   if (!targets.length) {
     ctx.log.debug('No new files to upload, continuing');
-    return options.onComplete?.(0, 0);
+    return;
   }
 
-  options.onStart?.();
+  // Uploading zero-length files is valid, so this might add up to 0.
+  const totalBytes = targets.reduce((sum, { contentLength }) => sum + contentLength, 0);
 
-  const total = targets.reduce((acc, { contentLength }) => acc + contentLength, 0);
-  if (uploadBuild.info.zipTarget) {
+  if (zipTarget) {
     try {
       const { path, size } = await makeZipFile(ctx, targets);
-      const compressionRate = (total - size) / total;
+      const compressionRate = totalBytes && (totalBytes - size) / totalBytes;
       ctx.log.debug(`Compression reduced upload size by ${Math.round(compressionRate * 100)}%`);
 
-      const target = { ...uploadBuild.info.zipTarget, contentLength: size, localPath: path };
+      const target = { ...zipTarget, contentLength: size, localPath: path };
       await uploadZip(ctx, target, (progress) => options.onProgress?.(progress, size));
       await waitForUnpack(ctx, target.sentinelUrl);
-      return options.onComplete?.(size, targets.length);
+      ctx.uploadedBytes += size;
+      ctx.uploadedFiles += targets.length;
+      return;
     } catch (err) {
       ctx.log.debug({ err }, 'Error uploading zip, falling back to uploading individual files');
     }
   }
 
   try {
-    await uploadFiles(ctx, targets, (progress) => options.onProgress?.(progress, total));
-    return options.onComplete?.(total, targets.length);
+    await uploadFiles(ctx, targets, (progress) => options.onProgress?.(progress, totalBytes));
+    ctx.uploadedBytes += totalBytes;
+    ctx.uploadedFiles += targets.length;
   } catch (e) {
     return options.onError?.(e, files.some((f) => f.localPath === e.message) && e.message);
   }

--- a/node-src/lib/uploadFiles.ts
+++ b/node-src/lib/uploadFiles.ts
@@ -1,25 +1,25 @@
 import retry from 'async-retry';
+import { filesize } from 'filesize';
+import FormData from 'form-data';
 import { createReadStream } from 'fs';
 import pLimit from 'p-limit';
 import progress from 'progress-stream';
-import { Context, TargetedFile } from '../types';
+import { Context, FileDesc, TargetInfo } from '../types';
 
 export async function uploadFiles(
   ctx: Context,
-  files: TargetedFile[],
-  onProgress: (progress: number) => void
+  targets: (FileDesc & TargetInfo)[],
+  onProgress?: (progress: number) => void
 ) {
   const { experimental_abortSignal: signal } = ctx.options;
   const limitConcurrency = pLimit(10);
   let totalProgress = 0;
 
   await Promise.all(
-    files.map(({ localPath, targetUrl, contentType, contentLength }) => {
+    targets.map(({ contentLength, filePath, formAction, formFields, localPath }) => {
       let fileProgress = 0; // The bytes uploaded for this this particular file
 
-      ctx.log.debug(
-        `Uploading ${contentLength} bytes of ${contentType} for '${localPath}' to '${targetUrl}'`
-      );
+      ctx.log.debug(`Uploading ${filePath} (${filesize(contentLength)})`);
 
       return limitConcurrency(() =>
         retry(
@@ -33,37 +33,34 @@ export async function uploadFiles(
             progressStream.on('progress', ({ delta }) => {
               fileProgress += delta; // We upload multiple files so we only care about the delta
               totalProgress += delta;
-              onProgress(totalProgress);
+              onProgress?.(totalProgress);
+            });
+
+            const formData = new FormData();
+            Object.entries(formFields).forEach(([k, v]) => formData.append(k, v));
+            formData.append('file', createReadStream(localPath).pipe(progressStream), {
+              knownLength: contentLength,
             });
 
             const res = await ctx.http.fetch(
-              targetUrl,
-              {
-                method: 'PUT',
-                body: createReadStream(localPath).pipe(progressStream),
-                headers: {
-                  'content-type': contentType,
-                  'content-length': contentLength.toString(),
-                  'cache-control': 'max-age=31536000',
-                },
-                signal,
-              },
+              formAction,
+              { body: formData, method: 'POST', signal },
               { retries: 0 } // already retrying the whole operation
             );
 
             if (!res.ok) {
-              ctx.log.debug(`Uploading '${localPath}' failed: %O`, res);
+              ctx.log.debug(`Uploading ${localPath} failed: %O`, res);
               throw new Error(localPath);
             }
-            ctx.log.debug(`Uploaded '${localPath}'.`);
+            ctx.log.debug(`Uploaded ${filePath} (${filesize(contentLength)})`);
           },
           {
             retries: ctx.env.CHROMATIC_RETRIES,
             onRetry: (err: Error) => {
               totalProgress -= fileProgress;
               fileProgress = 0;
-              ctx.log.debug('Retrying upload %s, %O', targetUrl, err);
-              onProgress(totalProgress);
+              ctx.log.debug('Retrying upload for %s, %O', localPath, err);
+              onProgress?.(totalProgress);
             },
           }
         )

--- a/node-src/lib/uploadZip.ts
+++ b/node-src/lib/uploadZip.ts
@@ -1,8 +1,10 @@
 import retry from 'async-retry';
+import { filesize } from 'filesize';
+import FormData from 'form-data';
 import { createReadStream } from 'fs';
 import { Response } from 'node-fetch';
 import progress from 'progress-stream';
-import { Context } from '../types';
+import { Context, TargetInfo } from '../types';
 
 // A sentinel file is created by a zip-unpack lambda within the Chromatic infrastructure once the
 // uploaded zip is fully extracted. The contents of this file will consist of 'OK' if the process
@@ -11,15 +13,14 @@ const SENTINEL_SUCCESS_VALUE = 'OK';
 
 export async function uploadZip(
   ctx: Context,
-  path: string,
-  url: string,
-  contentLength: number,
+  target: TargetInfo & { contentLength: number; localPath: string; sentinelUrl: string },
   onProgress: (progress: number) => void
 ) {
   const { experimental_abortSignal: signal } = ctx.options;
+  const { contentLength, filePath, formAction, formFields, localPath } = target;
   let totalProgress = 0;
 
-  ctx.log.debug(`Uploading ${contentLength} bytes for '${path}' to '${url}'`);
+  ctx.log.debug(`Uploading ${filePath} (${filesize(contentLength)})`);
 
   return retry(
     async (bail) => {
@@ -34,31 +35,29 @@ export async function uploadZip(
         onProgress(totalProgress);
       });
 
+      const formData = new FormData();
+      Object.entries(formFields).forEach(([k, v]) => formData.append(k, v));
+      formData.append('file', createReadStream(localPath).pipe(progressStream), {
+        knownLength: contentLength,
+      });
+
       const res = await ctx.http.fetch(
-        url,
-        {
-          method: 'PUT',
-          body: createReadStream(path).pipe(progressStream),
-          headers: {
-            'content-type': 'application/zip',
-            'content-length': contentLength.toString(),
-          },
-          signal,
-        },
+        formAction,
+        { body: formData, method: 'POST', signal },
         { retries: 0 } // already retrying the whole operation
       );
 
       if (!res.ok) {
-        ctx.log.debug(`Uploading '${path}' failed: %O`, res);
-        throw new Error(path);
+        ctx.log.debug(`Uploading ${localPath} failed: %O`, res);
+        throw new Error(localPath);
       }
-      ctx.log.debug(`Uploaded '${path}'.`);
+      ctx.log.debug(`Uploaded ${filePath} (${filesize(contentLength)})`);
     },
     {
       retries: ctx.env.CHROMATIC_RETRIES,
       onRetry: (err: Error) => {
         totalProgress = 0;
-        ctx.log.debug('Retrying upload %s, %O', url, err);
+        ctx.log.debug('Retrying upload for %s, %O', localPath, err);
         onProgress(totalProgress);
       },
     }

--- a/node-src/tasks/report.ts
+++ b/node-src/tasks/report.ts
@@ -2,7 +2,6 @@ import reportBuilder from 'junit-report-builder';
 import path from 'path';
 
 import { createTask, transitionTo } from '../lib/tasks';
-import { baseStorybookUrl } from '../lib/utils';
 import { Context } from '../types';
 import wroteReport from '../ui/messages/info/wroteReport';
 import { initial, pending, success } from '../ui/tasks/report';
@@ -13,8 +12,8 @@ const ReportQuery = `
       build(number: $buildNumber) {
         number
         status(legacy: false)
+        storybookUrl
         webUrl
-        cachedUrl
         createdAt
         completedAt
         tests {
@@ -44,8 +43,8 @@ interface ReportQueryResult {
     build: {
       number: number;
       status: string;
+      storybookUrl: string;
       webUrl: string;
-      cachedUrl: string;
       createdAt: number;
       completedAt: number;
       tests: {
@@ -94,7 +93,7 @@ export const generateReport = async (ctx: Context) => {
     .property('buildNumber', build.number)
     .property('buildStatus', build.status)
     .property('buildUrl', build.webUrl)
-    .property('storybookUrl', baseStorybookUrl(build.cachedUrl));
+    .property('storybookUrl', build.storybookUrl);
 
   build.tests.forEach(({ status, result, spec, parameters, mode }) => {
     const testSuffixName = mode.name || `[${parameters.viewport}px]`;

--- a/node-src/tasks/storybookInfo.test.ts
+++ b/node-src/tasks/storybookInfo.test.ts
@@ -7,8 +7,8 @@ vi.mock('../lib/getStorybookInfo');
 
 const getStorybookInfo = vi.mocked(storybookInfo);
 
-describe('startStorybook', () => {
-  it('starts the app and sets the isolatorUrl on context', async () => {
+describe('storybookInfo', () => {
+  it('retrieves Storybook metadata and sets it on context', async () => {
     const storybook = { version: '1.0.0', viewLayer: 'react', addons: [] };
     getStorybookInfo.mockResolvedValue(storybook);
 

--- a/node-src/tasks/upload.ts
+++ b/node-src/tasks/upload.ts
@@ -203,13 +203,11 @@ export const uploadStorybook = async (ctx: Context, task: Task) => {
   if (ctx.skip) return;
   transitionTo(starting)(ctx, task);
 
-  const files = ctx.fileInfo.paths
-    .map((path) => ({
-      contentLength: ctx.fileInfo.lengths.find(({ knownAs }) => knownAs === path).contentLength,
-      localPath: join(ctx.sourceDir, path),
-      targetPath: path,
-    }))
-    .filter((f) => f.contentLength);
+  const files = ctx.fileInfo.paths.map((path) => ({
+    contentLength: ctx.fileInfo.lengths.find(({ knownAs }) => knownAs === path).contentLength,
+    localPath: join(ctx.sourceDir, path),
+    targetPath: path,
+  }));
 
   await uploadBuild(ctx, files, {
     onProgress: throttle(

--- a/node-src/tasks/verify.test.ts
+++ b/node-src/tasks/verify.test.ts
@@ -29,13 +29,7 @@ describe('publishBuild', () => {
 
     expect(client.runQuery).toHaveBeenCalledWith(
       expect.stringMatching(/PublishBuildMutation/),
-      {
-        input: {
-          cachedUrl: ctx.cachedUrl,
-          isolatorUrl: ctx.isolatorUrl,
-          turboSnapStatus: 'UNUSED',
-        },
-      },
+      { input: { turboSnapStatus: 'UNUSED' } },
       { headers: { Authorization: `Bearer report-token` }, retries: 3 }
     );
     expect(ctx.announcedBuild).toEqual({ ...announcedBuild, ...publishedBuild });
@@ -51,7 +45,6 @@ describe('verifyBuild', () => {
     git: { version: 'whatever', matchesBranch: () => false },
     pkg: { version: '1.0.0' },
     storybook: { version: '2.0.0', viewLayer: 'react', addons: [] },
-    isolatorUrl: 'https://tunnel.chromaticqa.com/',
     announcedBuild: { number: 1, reportToken: 'report-token' },
   };
 
@@ -109,7 +102,7 @@ describe('verifyBuild', () => {
         build: {
           number: 1,
           status: 'IN_PROGRESS',
-          cachedUrl: 'https://5d67dc0374b2e300209c41e7-pfkaemtlit.chromatic.com/iframe.html',
+          storybookUrl: 'https://5d67dc0374b2e300209c41e7-pfkaemtlit.chromatic.com/',
           features: { uiTests: true, uiReview: false },
           app: { account: {} },
           wasLimited: true,
@@ -130,7 +123,7 @@ describe('verifyBuild', () => {
         build: {
           number: 1,
           status: 'IN_PROGRESS',
-          cachedUrl: 'https://5d67dc0374b2e300209c41e7-pfkaemtlit.chromatic.com/iframe.html',
+          storybookUrl: 'https://5d67dc0374b2e300209c41e7-pfkaemtlit.chromatic.com/',
           features: { uiTests: true, uiReview: false },
           app: { account: { exceededThreshold: true } },
           wasLimited: true,
@@ -151,7 +144,7 @@ describe('verifyBuild', () => {
         build: {
           number: 1,
           status: 'IN_PROGRESS',
-          cachedUrl: 'https://5d67dc0374b2e300209c41e7-pfkaemtlit.chromatic.com/iframe.html',
+          storybookUrl: 'https://5d67dc0374b2e300209c41e7-pfkaemtlit.chromatic.com/',
           features: { uiTests: true, uiReview: false },
           app: { account: { paymentRequired: true } },
           wasLimited: true,
@@ -172,7 +165,7 @@ describe('verifyBuild', () => {
         build: {
           number: 1,
           status: 'IN_PROGRESS',
-          cachedUrl: 'https://5d67dc0374b2e300209c41e7-pfkaemtlit.chromatic.com/iframe.html',
+          storybookUrl: 'https://5d67dc0374b2e300209c41e7-pfkaemtlit.chromatic.com/',
           features: { uiTests: false, uiReview: false },
           app: { account: { paymentRequired: true } },
           wasLimited: true,

--- a/node-src/tasks/verify.ts
+++ b/node-src/tasks/verify.ts
@@ -26,15 +26,19 @@ const PublishBuildMutation = `
     publishBuild(id: $id, input: $input) {
       # no need for legacy:false on PublishedBuild.status
       status
+      storybookUrl
     }
   }
 `;
 interface PublishBuildMutationResult {
-  publishBuild: Context['announcedBuild'];
+  publishBuild: {
+    status: string;
+    storybookUrl: string;
+  };
 }
 
 export const publishBuild = async (ctx: Context) => {
-  const { cachedUrl, isolatorUrl, turboSnap } = ctx;
+  const { turboSnap } = ctx;
   const { id, reportToken } = ctx.announcedBuild;
   const { replacementBuildIds } = ctx.git;
   const { onlyStoryNames, onlyStoryFiles = ctx.onlyStoryFiles } = ctx.options;
@@ -51,8 +55,6 @@ export const publishBuild = async (ctx: Context) => {
     {
       id,
       input: {
-        cachedUrl,
-        isolatorUrl,
         ...(onlyStoryFiles && { onlyStoryFiles }),
         ...(onlyStoryNames && { onlyStoryNames: [].concat(onlyStoryNames) }),
         ...(replacementBuildIds && { replacementBuildIds }),
@@ -66,12 +68,15 @@ export const publishBuild = async (ctx: Context) => {
   );
 
   ctx.announcedBuild = { ...ctx.announcedBuild, ...publishedBuild };
+  ctx.storybookUrl = publishedBuild.storybookUrl;
 
   // Queueing the extract may have failed
   if (publishedBuild.status === 'FAILED') {
     setExitCode(ctx, exitCodes.BUILD_FAILED, false);
     throw new Error(publishFailed().output);
   }
+
+  ctx.log.info(storybookPublished(ctx));
 };
 
 const StartedBuildQuery = `
@@ -111,7 +116,6 @@ const VerifyBuildQuery = `
         inheritedCaptureCount
         interactionTestFailuresCount
         webUrl
-        cachedUrl
         browsers {
           browser
         }
@@ -161,7 +165,7 @@ interface VerifyBuildQueryResult {
 }
 
 export const verifyBuild = async (ctx: Context, task: Task) => {
-  const { client, isolatorUrl } = ctx;
+  const { client } = ctx;
   const { list, onlyStoryNames, onlyStoryFiles = ctx.onlyStoryFiles } = ctx.options;
   const { matchesBranch } = ctx.git;
 
@@ -175,6 +179,7 @@ export const verifyBuild = async (ctx: Context, task: Task) => {
   }
 
   const waitForBuildToStart = async () => {
+    const { storybookUrl } = ctx;
     const { number, reportToken } = ctx.announcedBuild;
     const variables = { number };
     const options = { headers: { Authorization: `Bearer ${reportToken}` } };
@@ -183,7 +188,7 @@ export const verifyBuild = async (ctx: Context, task: Task) => {
       app: { build },
     } = await client.runQuery<StartedBuildQueryResult>(StartedBuildQuery, variables, options);
     if (build.failureReason) {
-      ctx.log.warn(brokenStorybook({ ...build, isolatorUrl }));
+      ctx.log.warn(brokenStorybook({ ...build, storybookUrl }));
       setExitCode(ctx, exitCodes.STORYBOOK_BROKEN, true);
       throw new Error(publishFailed().output);
     }

--- a/node-src/types.ts
+++ b/node-src/types.ts
@@ -223,8 +223,7 @@ export interface Context {
     };
     mainConfigFilePath?: string;
   };
-  isolatorUrl: string;
-  cachedUrl: string;
+  storybookUrl?: string;
   announcedBuild: {
     id: string;
     number: number;
@@ -241,7 +240,7 @@ export interface Context {
     number: number;
     status: string;
     webUrl: string;
-    cachedUrl: string;
+    storybookUrl: string;
     reportToken?: string;
     inheritedCaptureCount: number;
     actualCaptureCount: number;
@@ -294,7 +293,7 @@ export interface Context {
   buildLogFile?: string;
   fileInfo?: {
     paths: string[];
-    hashes: Record<Context['fileInfo']['paths'][number], string>;
+    hashes?: Record<Context['fileInfo']['paths'][number], string>;
     statsPath: string;
     lengths: {
       knownAs: string;
@@ -304,6 +303,7 @@ export interface Context {
     total: number;
   };
   uploadedBytes?: number;
+  uploadedFiles?: number;
   turboSnap?: Partial<{
     unavailable?: boolean;
     rootPath: string;
@@ -354,13 +354,15 @@ export interface Stats {
 }
 
 export interface FileDesc {
-  contentHash?: string;
   contentLength: number;
   localPath: string;
   targetPath: string;
 }
 
-export interface TargetedFile extends FileDesc {
+export interface TargetInfo {
   contentType: string;
-  targetUrl: string;
+  fileKey: string;
+  filePath: string;
+  formAction: string;
+  formFields: { [key: string]: string };
 }

--- a/node-src/ui/messages/errors/brokenStorybook.stories.ts
+++ b/node-src/ui/messages/errors/brokenStorybook.stories.ts
@@ -15,6 +15,6 @@ ReferenceError: foo is not defined
     at https://61b0a4b8ebf0e344c2aa231c-nsoaxcirhi.capture.dev-chromatic.com/main.72ad6d7a.iframe.bundle.js:1:47
 `;
 
-const isolatorUrl = 'https://61b0a4b8ebf0e344c2aa231c-wdooytetbw.dev-chromatic.com';
+const storybookUrl = 'https://61b0a4b8ebf0e344c2aa231c-wdooytetbw.dev-chromatic.com/';
 
-export const BrokenStorybook = () => brokenStorybook({ failureReason, isolatorUrl });
+export const BrokenStorybook = () => brokenStorybook({ failureReason, storybookUrl });

--- a/node-src/ui/messages/errors/brokenStorybook.ts
+++ b/node-src/ui/messages/errors/brokenStorybook.ts
@@ -1,16 +1,15 @@
 import chalk from 'chalk';
 import { dedent } from 'ts-dedent';
 
-import { baseStorybookUrl } from '../../../lib/utils';
 import { error } from '../../components/icons';
 import link from '../../components/link';
 
-export default ({ failureReason, isolatorUrl }) =>
+export default ({ failureReason, storybookUrl }) =>
   `${dedent(chalk`
     ${error} {bold Failed to extract stories from your Storybook}
     This is usually a problem with your published Storybook, not with Chromatic.
 
     Build and open your Storybook locally and check the browser console for errors.
-    Visit your published Storybook at ${link(baseStorybookUrl(isolatorUrl))}
+    Visit your published Storybook at ${link(storybookUrl)}
     The following error was encountered while running your Storybook:
   `)}\n\n${failureReason.trim()}`;

--- a/node-src/ui/messages/errors/fatalError.stories.ts
+++ b/node-src/ui/messages/errors/fatalError.stories.ts
@@ -47,10 +47,10 @@ const context = {
   build: {
     id: '5ec5069ae0d35e0022b6a9cc',
     number: 42,
+    storybookUrl: 'https://5d67dc0374b2e300209c41e7-pfkaemtlit.chromatic.com/',
     webUrl: 'https://www.chromatic.com/build?appId=5d67dc0374b2e300209c41e7&number=1400',
   },
-  isolatorUrl: 'https://pfkaemtlit.tunnel.chromaticqa.com/iframe.html',
-  cachedUrl: 'https://5d67dc0374b2e300209c41e7-pfkaemtlit.chromatic.com/iframe.html',
+  storybookUrl: 'https://5d67dc0374b2e300209c41e7-pfkaemtlit.chromatic.com/',
 };
 
 const stack = `Error: Oh no!

--- a/node-src/ui/messages/errors/fatalError.ts
+++ b/node-src/ui/messages/errors/fatalError.ts
@@ -7,7 +7,12 @@ import { Context, InitialContext } from '../../..';
 import link from '../../components/link';
 import { redact } from '../../../lib/utils';
 
-const buildFields = ({ id, number, webUrl }) => ({ id, number, webUrl });
+const buildFields = ({ id, number, storybookUrl = undefined, webUrl = undefined }) => ({
+  id,
+  number,
+  ...(storybookUrl && { storybookUrl }),
+  ...(webUrl && { webUrl }),
+});
 
 export default function fatalError(
   ctx: Context | InitialContext,
@@ -26,9 +31,8 @@ export default function fatalError(
     runtimeMetadata,
     exitCode,
     exitCodeKey,
-    isolatorUrl,
-    cachedUrl,
-    build,
+    announcedBuild,
+    build = announcedBuild,
     buildCommand,
   } = ctx;
 
@@ -54,8 +58,6 @@ export default function fatalError(
       exitCodeKey,
       errorType: errors.map((err) => err.name).join('\n'),
       errorMessage: stripAnsi(errors[0].message.split('\n')[0].trim()),
-      ...(isolatorUrl ? { isolatorUrl } : {}),
-      ...(cachedUrl ? { cachedUrl } : {}),
       ...(build && { build: buildFields(build) }),
     },
     'projectToken',

--- a/node-src/ui/messages/errors/maxFileCountExceeded.stories.ts
+++ b/node-src/ui/messages/errors/maxFileCountExceeded.stories.ts
@@ -1,0 +1,11 @@
+import { maxFileCountExceeded } from './maxFileCountExceeded';
+
+export default {
+  title: 'CLI/Messages/Errors',
+};
+
+export const MaxFileCountExceeded = () =>
+  maxFileCountExceeded({
+    fileCount: 54_321,
+    maxFileCount: 20_000,
+  });

--- a/node-src/ui/messages/errors/maxFileCountExceeded.ts
+++ b/node-src/ui/messages/errors/maxFileCountExceeded.ts
@@ -1,0 +1,19 @@
+import chalk from 'chalk';
+import { dedent } from 'ts-dedent';
+
+import { error } from '../../components/icons';
+
+export const maxFileCountExceeded = ({
+  fileCount,
+  maxFileCount,
+}: {
+  fileCount: number;
+  maxFileCount: number;
+}) =>
+  dedent(chalk`
+    ${error} {bold Attempted to upload too many files}
+    You're not allowed to upload more than ${maxFileCount} files per build.
+    Your Storybook contains ${fileCount} files. This is a very high number.
+    Do you have files in a static/public directory that shouldn't be there?
+    Contact customer support if you need to increase this limit.
+  `);

--- a/node-src/ui/messages/errors/maxFileSizeExceeded.stories.ts
+++ b/node-src/ui/messages/errors/maxFileSizeExceeded.stories.ts
@@ -1,0 +1,8 @@
+import { maxFileSizeExceeded } from './maxFileSizeExceeded';
+
+export default {
+  title: 'CLI/Messages/Errors',
+};
+
+export const MaxFileSizeExceeded = () =>
+  maxFileSizeExceeded({ filePaths: ['index.js', 'main.js'], maxFileSize: 12345 });

--- a/node-src/ui/messages/errors/maxFileSizeExceeded.ts
+++ b/node-src/ui/messages/errors/maxFileSizeExceeded.ts
@@ -1,0 +1,19 @@
+import chalk from 'chalk';
+import { filesize } from 'filesize';
+import { dedent } from 'ts-dedent';
+
+import { error } from '../../components/icons';
+
+export const maxFileSizeExceeded = ({
+  filePaths,
+  maxFileSize,
+}: {
+  filePaths: string[];
+  maxFileSize: number;
+}) =>
+  dedent(chalk`
+    ${error} {bold Attempted to exceed maximum file size}
+    You're attempting to upload files that exceed the maximum file size of ${filesize(maxFileSize)}.
+    Contact customer support if you need to increase this limit.
+    - ${filePaths.map((path) => path).join('\n- ')}
+  `);

--- a/node-src/ui/messages/info/storybookPublished.stories.ts
+++ b/node-src/ui/messages/info/storybookPublished.stories.ts
@@ -6,6 +6,11 @@ export default {
 
 export const StorybookPublished = () =>
   storybookPublished({
+    storybookUrl: 'https://5d67dc0374b2e300209c41e7-pfkaemtlit.chromatic.com/',
+  } as any);
+
+export const StorybookPrepared = () =>
+  storybookPublished({
     build: {
       actualCaptureCount: undefined,
       actualTestCount: undefined,
@@ -14,6 +19,6 @@ export const StorybookPublished = () =>
       errorCount: undefined,
       componentCount: 5,
       specCount: 8,
-      cachedUrl: 'https://5d67dc0374b2e300209c41e7-pfkaemtlit.chromatic.com/iframe.html',
     },
+    storybookUrl: 'https://5d67dc0374b2e300209c41e7-pfkaemtlit.chromatic.com/',
   } as any);

--- a/node-src/ui/messages/info/storybookPublished.ts
+++ b/node-src/ui/messages/info/storybookPublished.ts
@@ -1,17 +1,23 @@
 import chalk from 'chalk';
 import { dedent } from 'ts-dedent';
 
-import { baseStorybookUrl } from '../../../lib/utils';
 import { Context } from '../../../types';
 import { info, success } from '../../components/icons';
 import link from '../../components/link';
 import { stats } from '../../tasks/snapshot';
 
-export default ({ build }: Pick<Context, 'build'>) => {
-  const { components, stories } = stats({ build });
+export default ({ build, storybookUrl }: Pick<Context, 'build' | 'storybookUrl'>) => {
+  if (build) {
+    const { components, stories } = stats({ build });
+    return dedent(chalk`
+      ${success} {bold Storybook published}
+      We found ${components} with ${stories}.
+      ${info} View your Storybook at ${link(storybookUrl)}
+    `);
+  }
+
   return dedent(chalk`
     ${success} {bold Storybook published}
-    We found ${components} with ${stories}.
-    ${info} View your Storybook at ${link(baseStorybookUrl(build.cachedUrl))}
+    ${info} View your Storybook at ${link(storybookUrl)}
   `);
 };

--- a/node-src/ui/tasks/upload.stories.ts
+++ b/node-src/ui/tasks/upload.stories.ts
@@ -20,9 +20,6 @@ export default {
   decorators: [(storyFn: any) => task(storyFn())],
 };
 
-const isolatorUrl = 'https://5eb48280e78a12aeeaea33cf-kdypokzbrs.chromatic.com/iframe.html';
-// const storybookUrl = 'https://self-hosted-storybook.netlify.app';
-
 export const Initial = () => initial;
 
 export const DryRun = () => dryRun();
@@ -60,6 +57,14 @@ export const Starting = () => starting();
 
 export const Uploading = () => uploading({ percentage: 42 });
 
-export const Success = () => success({ now: 0, startedAt: -54321, isolatorUrl } as any);
+export const Success = () =>
+  success({
+    now: 0,
+    startedAt: -54321,
+    uploadedBytes: 1234567,
+    uploadedFiles: 42,
+  } as any);
+
+export const SuccessNoFiles = () => success({} as any);
 
 export const Failed = () => failed({ path: 'main.9e3e453142da82719bf4.bundle.js' });

--- a/node-src/ui/tasks/upload.stories.ts
+++ b/node-src/ui/tasks/upload.stories.ts
@@ -6,7 +6,6 @@ import {
   hashing,
   initial,
   invalid,
-  preparing,
   starting,
   success,
   traced,
@@ -50,8 +49,6 @@ export const BailedSiblings = () =>
 export const Traced = () => traced({ onlyStoryFiles: Array.from({ length: 5 }) } as any);
 
 export const Hashing = () => hashing();
-
-export const Preparing = () => preparing();
 
 export const Starting = () => starting();
 

--- a/node-src/ui/tasks/upload.ts
+++ b/node-src/ui/tasks/upload.ts
@@ -81,12 +81,6 @@ export const hashing = () => ({
   output: `Calculating file hashes`,
 });
 
-export const preparing = () => ({
-  status: 'pending',
-  title: 'Publishing your built Storybook',
-  output: `Retrieving target location`,
-});
-
 export const starting = () => ({
   status: 'pending',
   title: 'Publishing your built Storybook',

--- a/node-src/ui/tasks/upload.ts
+++ b/node-src/ui/tasks/upload.ts
@@ -1,7 +1,8 @@
+import { filesize } from 'filesize';
 import pluralize from 'pluralize';
 
 import { getDuration } from '../../lib/tasks';
-import { baseStorybookUrl, progressBar, isPackageManifestFile } from '../../lib/utils';
+import { isPackageManifestFile, progressBar } from '../../lib/utils';
 import { Context } from '../../types';
 
 export const initial = {
@@ -98,11 +99,15 @@ export const uploading = ({ percentage }: { percentage: number }) => ({
   output: `${progressBar(percentage)} ${percentage}%`,
 });
 
-export const success = (ctx: Context) => ({
-  status: 'success',
-  title: `Publish complete in ${getDuration(ctx)}`,
-  output: `View your Storybook at ${baseStorybookUrl(ctx.isolatorUrl)}`,
-});
+export const success = (ctx: Context) => {
+  const files = pluralize('file', ctx.uploadedFiles, true);
+  const bytes = filesize(ctx.uploadedBytes || 0);
+  return {
+    status: 'success',
+    title: ctx.uploadedBytes ? `Publish complete in ${getDuration(ctx)}` : `Publish complete`,
+    output: ctx.uploadedBytes ? `Uploaded ${files} (${bytes})` : 'No new files to upload',
+  };
+};
 
 export const failed = ({ path }: { path: string }) => ({
   status: 'error',

--- a/package.json
+++ b/package.json
@@ -150,6 +150,7 @@
     "execa": "^7.2.0",
     "fake-tag": "^2.0.0",
     "filesize": "^10.1.0",
+    "form-data": "^4.0.0",
     "fs-extra": "^10.0.0",
     "https-proxy-agent": "^7.0.2",
     "husky": "^7.0.0",
@@ -202,6 +203,9 @@
   },
   "auto": {
     "baseBranch": "main",
+    "canary": {
+      "force": true
+    },
     "plugins": [
       "npm",
       "released",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7905,6 +7905,15 @@ form-data@^3.0.0:
     combined-stream "^1.0.8"
     mime-types "^2.1.12"
 
+form-data@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.0.tgz#93919daeaf361ee529584b9b31664dc12c9fa452"
+  integrity sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
+    mime-types "^2.1.12"
+
 format@^0.2.0:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/format/-/format-0.2.2.tgz#d6170107e9efdc4ed30c9dc39016df942b5cb58b"


### PR DESCRIPTION
This reintroduces the `uploadBuild` mutation after it was [reverted](https://github.com/chromaui/chromatic-cli/pull/883). It's now limited to sending 1000 files at a time in order to prevent issues with request/response payload size and/or memory limits. To accommodate that constraint, files are now batched in chunks of 1000 and `uploadBuild` runs in a loop.