### PR TITLE
Add missing `skip` option to configuration schema

### DIFF
--- a/node-src/lib/getConfiguration.ts
+++ b/node-src/lib/getConfiguration.ts
@@ -26,6 +26,7 @@ const configurationSchema = z
 
     buildScriptName: z.string(),
     outputDir: z.string(),
+    skip: z.union([z.string(), z.boolean()]),
 
     storybookBuildDir: z.string(),
     storybookBaseDir: z.string(),


### PR DESCRIPTION
This option was documented and supposed to be available, but was omitted in the configuration schema. This adds the option so it can be used through `chromatic.config.json`.