### PR TITLE
Support `env`, `sessionId` and `log` options via Node API

### DIFF
--- a/node-src/index.ts
+++ b/node-src/index.ts
@@ -85,9 +85,7 @@ export async function run({
   flags?: Flags;
   options?: Partial<Options>;
 }): Promise<Output> {
-  const sessionId = uuid();
-  const env = getEnv();
-  const log = createLogger();
+  const { sessionId = uuid(), env = getEnv(), log = createLogger() } = this.options;
 
   const pkgInfo = await readPkgUp({ cwd: process.cwd() });
   if (!pkgInfo) {
@@ -281,3 +279,5 @@ export async function getGitInfo(): Promise<GitInfo> {
 }
 
 export { getConfiguration } from './lib/getConfiguration';
+
+export { Logger } from './lib/log';

--- a/node-src/index.ts
+++ b/node-src/index.ts
@@ -85,7 +85,7 @@ export async function run({
   flags?: Flags;
   options?: Partial<Options>;
 }): Promise<Output> {
-  const { sessionId = uuid(), env = getEnv(), log = createLogger() } = this.options;
+  const { sessionId = uuid(), env = getEnv(), log = createLogger() } = extraOptions;
 
   const pkgInfo = await readPkgUp({ cwd: process.cwd() });
   if (!pkgInfo) {

--- a/node-src/types.ts
+++ b/node-src/types.ts
@@ -130,6 +130,15 @@ export interface Options extends Configuration {
 
   /** An AbortSignal that terminates the build if aborted */
   experimental_abortSignal?: AbortSignal;
+
+  /** Logger object */
+  log?: Logger;
+
+  /** Sessiond Id */
+  sessionId?: string;
+
+  /** Environment variables */
+  env?: Env;
 }
 
 export { Configuration };


### PR DESCRIPTION
This PR will allow for "sessionid", "env" and "log" to be supplied to the node-interface via the options-object.
This as suggested by Gerrit.