### PR TITLE
Added initial logging and calls for Storybok directories

### DIFF
--- a/node-src/ui/messages/warnings/missingConfigValues.ts
+++ b/node-src/ui/messages/warnings/missingConfigValues.ts
@@ -1,0 +1,13 @@
+import chalk from 'chalk';
+import { dedent } from 'ts-dedent';
+
+import { warning } from '../../components/icons';
+
+export const missingConfigValues = (storybookDirectories: any[]) =>
+  dedent(chalk`
+        ${warning} We detected 2 or more Storybooks in your repository.
+        For Chromatic and TurboSnap to work properly, please add the following config flags
+        for any subdirectory Storybooks:
+        {bold storybookBaseDir: ${storybookDirectories[1].storybookBaseDir}}.
+        {bold storybookConfigDir: ${storybookDirectories[1].storybookConfigDir}}.
+    `);

--- a/package.json
+++ b/package.json
@@ -148,6 +148,7 @@
     "esm": "^3.2.25",
     "execa": "^7.2.0",
     "fake-tag": "^2.0.0",
+    "fast-glob": "^3.3.2",
     "filesize": "^10.1.0",
     "formdata-node": "^6.0.3",
     "fs-extra": "^10.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7605,6 +7605,17 @@ fast-glob@^3.2.2, fast-glob@^3.2.9:
     merge2 "^1.3.0"
     micromatch "^4.0.4"
 
+fast-glob@^3.3.2:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.3.2.tgz#a904501e57cfdd2ffcded45e99a54fef55e46129"
+  integrity sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==
+  dependencies:
+    "@nodelib/fs.stat" "^2.0.2"
+    "@nodelib/fs.walk" "^1.2.3"
+    glob-parent "^5.1.2"
+    merge2 "^1.3.0"
+    micromatch "^4.0.4"
+
 fast-json-parse@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/fast-json-parse/-/fast-json-parse-1.0.3.tgz#43e5c61ee4efa9265633046b770fb682a7577c4d"


### PR DESCRIPTION
This is a POC for detecting storybook config directories and warning users when the `storybookBaseDir` and `storybookConfigDir` are not set correctly for TurboSnap.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>10.5.1--canary.898.7648887766.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@10.5.1--canary.898.7648887766.0
  # or 
  yarn add chromatic@10.5.1--canary.898.7648887766.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
