### PR TITLE
Add "package.json" to exports map

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
       "types": "./isChromatic.d.ts",
       "require": "./isChromatic.js",
       "import": "./isChromatic.mjs"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "main": "isChromatic.js",
   "module": "isChromatic.mjs",


### PR DESCRIPTION
Storybook telemetry uses the package.json to determine the installed version of packages. Because the Chromatic CLI now has an exports map, but it does not contain package.json as an entry point, Storybook fails to read it, and therefore the version in the metadata is `null`. This PR fixes that!

Before:
<img width="329" alt="image" src="https://github.com/chromaui/chromatic-cli/assets/1671563/5d4ab0e0-f41e-4dda-b504-c7abff43e39b">

After:
<img width="591" alt="image" src="https://github.com/chromaui/chromatic-cli/assets/1671563/e378f20f-2883-4bd2-9f8b-ad02d1049592">

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>10.5.1--canary.900.7652337120.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@10.5.1--canary.900.7652337120.0
  # or 
  yarn add chromatic@10.5.1--canary.900.7652337120.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
