### PR TITLE
Remove after-release script

### DIFF
--- a/package.json
+++ b/package.json
@@ -206,14 +206,14 @@
     "zod": "^3.22.2"
   },
   "peerDependencies": {
-    "chromatic-playwright": "^0.4.0 || ^1.0.0",
-    "chromatic-cypress": "^0.4.0 || ^1.0.0"
+    "chromatic-cypress": "^0.4.0 || ^1.0.0",
+    "chromatic-playwright": "^0.4.0 || ^1.0.0"
   },
   "peerDependenciesMeta": {
-    "chromatic-playwright": {
+    "chromatic-cypress": {
       "optional": true
     },
-    "chromatic-cypress": {
+    "chromatic-playwright": {
       "optional": true
     }
   },
@@ -228,13 +228,7 @@
     },
     "plugins": [
       "npm",
-      "released",
-      [
-        "exec",
-        {
-          "afterShipIt": "yarn run publish-action"
-        }
-      ]
+      "released"
     ]
   },
   "docs": "https://www.chromatic.com/docs/cli",


### PR DESCRIPTION
Temporarily disables releasing to GitHub Actions.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>10.6.1--canary.906.7674628239.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@10.6.1--canary.906.7674628239.0
  # or 
  yarn add chromatic@10.6.1--canary.906.7674628239.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
