### PR TITLE
Add Fallback getGitInfo if we cannot find the origin URL

### DIFF
--- a/node-src/index.ts
+++ b/node-src/index.ts
@@ -260,7 +260,12 @@ export type GitInfo = {
 };
 
 export async function getGitInfo(): Promise<GitInfo> {
-  const slug = await getSlug();
+  let slug: string;
+  try {
+    slug = await getSlug();
+  } catch {
+    slug = ''
+  }
   const branch = await getBranch();
   const commitInfo = await getCommit();
   const userEmail = await getUserEmail();


### PR DESCRIPTION
This PR adds a fallback for situations where we cannot get an origin URL to create a project slug. Without this, there's a downstream issue in the Visual Test Addon, where it thinks the project does not have git initialized, but it does. The project does not have an origin set yet.

To QA:
1. Run the tests.
2. Install this addon version (`1.0.4--canary.172.95c7a87.0`) in a repository where Git has been initialized, but there's no origin set yet.
3. Confirm that you see the "Git not detected" message.
4. Then, initialize the repo and make your first commit.
5. Confirm that you **_do not_** see the "Git not detected" message.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>10.7.1--canary.910.7751165821.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@10.7.1--canary.910.7751165821.0
  # or 
  yarn add chromatic@10.7.1--canary.910.7751165821.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
