### PR TITLE
Be smarter about comparing lock files

### DIFF
--- a/node-src/lib/findChangedDependencies.ts
+++ b/node-src/lib/findChangedDependencies.ts
@@ -64,16 +64,17 @@ export const findChangedDependencies = async (ctx: Context) => {
   const filteredPathPairs = pathPairs
     .map(([manifestPath, lockfilePath]) => {
       const commits = packageMetadataChanges
-        .filter(
-          ({ changedFiles }) =>
-            changedFiles.includes(manifestPath) || changedFiles.includes(lockfilePath)
+        .filter(({ changedFiles }) =>
+          changedFiles.some((file) => file === lockfilePath || file === manifestPath)
         )
         .map(({ commit }) => commit);
 
       return [manifestPath, lockfilePath, commits] as const;
     })
-    .filter(([, , commits]) => commits.length > 0)
-    .filter(([manifestPath]) => !untraced.some((glob) => matchesFile(glob, manifestPath)));
+    .filter(
+      ([manifestPath, , commits]) =>
+        !untraced.some((glob) => matchesFile(glob, manifestPath)) && commits.length > 0
+    );
 
   ctx.log.debug(
     { filteredPathPairs },

--- a/node-src/lib/findChangedDependencies.ts
+++ b/node-src/lib/findChangedDependencies.ts
@@ -13,17 +13,17 @@ const YARN_LOCK = 'yarn.lock';
 // Yields a list of dependency names which have changed since the baseline.
 // E.g. ['react', 'react-dom', '@storybook/react']
 export const findChangedDependencies = async (ctx: Context) => {
-  const { baselineCommits } = ctx.git;
+  const { packageMetadataChanges } = ctx.git;
   const { untraced = [] } = ctx.options;
 
-  if (!baselineCommits.length) {
-    ctx.log.debug('No baseline commits found');
+  if (!packageMetadataChanges.length) {
+    ctx.log.debug('No package metadata changed found');
     return [];
   }
 
   ctx.log.debug(
-    { baselineCommits },
-    `Finding changed dependencies for ${baselineCommits.length} baselines`
+    { packageMetadataChanges },
+    `Finding changed dependencies for ${packageMetadataChanges.length} baselines`
   );
 
   const rootPath = await getRepositoryRoot();
@@ -60,21 +60,36 @@ export const findChangedDependencies = async (ctx: Context) => {
 
   ctx.log.debug({ pathPairs }, `Found ${pathPairs.length} manifest/lockfile pairs to check`);
 
-  const tracedPairs = pathPairs.filter(([manifestPath, lockfilePath]) => {
-    if (untraced.some((glob) => matchesFile(glob, manifestPath))) return false;
-    if (untraced.some((glob) => matchesFile(glob, lockfilePath))) return false;
-    return true;
-  });
-  const untracedCount = pathPairs.length - tracedPairs.length;
-  if (untracedCount) {
-    ctx.log.debug(`Skipping ${untracedCount} manifest/lockfile pairs due to --untraced`);
+  // Now filter out any pairs that don't have git changes, or for which the manifest is untraced
+  const filteredPathPairs = pathPairs
+    .map(([manifestPath, lockfilePath]) => {
+      const commits = packageMetadataChanges
+        .filter(
+          ({ changedFiles }) =>
+            changedFiles.includes(manifestPath) || changedFiles.includes(lockfilePath)
+        )
+        .map(({ commit }) => commit);
+
+      return [manifestPath, lockfilePath, commits] as const;
+    })
+    .filter(([, , commits]) => commits.length > 0)
+    .filter(([manifestPath]) => !untraced.some((glob) => matchesFile(glob, manifestPath)));
+
+  ctx.log.debug(
+    { filteredPathPairs },
+    `Found ${filteredPathPairs.length} manifest/lockfile pairs to diff`
+  );
+
+  // Short circuit
+  if (filteredPathPairs.length === 0) {
+    return [];
   }
 
   // Use a Set so we only keep distinct package names.
   const changedDependencyNames = new Set<string>();
 
   await Promise.all(
-    tracedPairs.map(async ([manifestPath, lockfilePath]) => {
+    filteredPathPairs.map(async ([manifestPath, lockfilePath, commits]) => {
       const headDependencies = await getDependencies(ctx, { rootPath, manifestPath, lockfilePath });
       ctx.log.debug({ manifestPath, lockfilePath, headDependencies }, `Found HEAD dependencies`);
 
@@ -82,7 +97,7 @@ export const findChangedDependencies = async (ctx: Context) => {
       // A change means either the version number is different or the dependency was added/removed.
       // If a manifest or lockfile is missing on the baseline, this throws and we'll end up bailing.
       await Promise.all(
-        baselineCommits.map(async (ref) => {
+        commits.map(async (ref) => {
           const baselineChanges = await compareBaseline(ctx, headDependencies, {
             ref,
             rootPath,

--- a/node-src/lib/findChangedDependencies.ts
+++ b/node-src/lib/findChangedDependencies.ts
@@ -69,7 +69,7 @@ export const findChangedDependencies = async (ctx: Context) => {
         )
         .map(({ commit }) => commit);
 
-      return [manifestPath, lockfilePath, commits] as const;
+      return [manifestPath, lockfilePath, [...new Set(commits)]] as const;
     })
     .filter(
       ([manifestPath, , commits]) =>

--- a/node-src/lib/utils.ts
+++ b/node-src/lib/utils.ts
@@ -53,10 +53,10 @@ export const matchesFile = (glob: string, filepath: string) => {
 };
 
 export const isPackageManifestFile = (filePath: string) =>
-  [/^package\.json$/, /\/package\.json$/].some((re) => re.test(filePath));
+  [/(^|\/)package\.json$/].some((re) => re.test(filePath));
 
 export const isPackageLockFile = (filePath: string) =>
-  [/^package\.json$/, /\/package\.json$/].some((re) => re.test(filePath));
+  [/(^|\/)package-lock\.json$/, /(^|\/)yarn\.lock$/].some((re) => re.test(filePath));
 
 export const isPackageMetadataFile = (filePath: string) =>
   isPackageManifestFile(filePath) || isPackageLockFile(filePath);

--- a/node-src/lib/utils.ts
+++ b/node-src/lib/utils.ts
@@ -55,6 +55,12 @@ export const matchesFile = (glob: string, filepath: string) => {
 export const isPackageManifestFile = (filePath: string) =>
   [/^package\.json$/, /\/package\.json$/].some((re) => re.test(filePath));
 
+export const isPackageLockFile = (filePath: string) =>
+  [/^package\.json$/, /\/package\.json$/].some((re) => re.test(filePath));
+
+export const isPackageMetadataFile = (filePath: string) =>
+  isPackageManifestFile(filePath) || isPackageLockFile(filePath);
+
 export const redact = <T>(value: T, ...fields: string[]): T => {
   if (value === null || typeof value !== 'object') return value;
   if (Array.isArray(value)) return value.map((item) => redact(item, ...fields)) as T;

--- a/node-src/tasks/gitInfo.ts
+++ b/node-src/tasks/gitInfo.ts
@@ -193,9 +193,13 @@ export const setGitInfo = async (ctx: Context, task: Task) => {
       );
 
       // Track changed package manifest files along with the commit they were changed in.
+      const { untraced = [] } = ctx.options;
       ctx.git.packageMetadataChanges = changedFilesWithInfo.flatMap(
         ({ build, changedFiles, replacementBuild }) => {
-          const metadataFiles = changedFiles.filter(isPackageMetadataFile);
+          const metadataFiles = changedFiles
+            .filter((f) => !untraced.some((glob) => matchesFile(glob, f)))
+            .filter(isPackageMetadataFile);
+
           return metadataFiles.length
             ? [{ changedFiles: metadataFiles, commit: replacementBuild?.commit ?? build.commit }]
             : [];

--- a/node-src/tasks/gitInfo.ts
+++ b/node-src/tasks/gitInfo.ts
@@ -6,7 +6,7 @@ import { getParentCommits } from '../git/getParentCommits';
 import { getBaselineBuilds } from '../git/getBaselineBuilds';
 import { exitCodes, setExitCode } from '../lib/setExitCode';
 import { createTask, transitionTo } from '../lib/tasks';
-import { isPackageManifestFile, matchesFile } from '../lib/utils';
+import { isPackageMetadataFile, matchesFile } from '../lib/utils';
 import {
   initial,
   pending,
@@ -193,11 +193,11 @@ export const setGitInfo = async (ctx: Context, task: Task) => {
       );
 
       // Track changed package manifest files along with the commit they were changed in.
-      ctx.git.packageManifestChanges = changedFilesWithInfo.flatMap(
+      ctx.git.packageMetadataChanges = changedFilesWithInfo.flatMap(
         ({ build, changedFiles, replacementBuild }) => {
-          const manifestFiles = changedFiles.filter(isPackageManifestFile);
-          return manifestFiles.length
-            ? [{ changedFiles: manifestFiles, commit: replacementBuild?.commit ?? build.commit }]
+          const metadataFiles = changedFiles.filter(isPackageMetadataFile);
+          return metadataFiles.length
+            ? [{ changedFiles: metadataFiles, commit: replacementBuild?.commit ?? build.commit }]
             : [];
         }
       );

--- a/node-src/tasks/initialize.ts
+++ b/node-src/tasks/initialize.ts
@@ -66,7 +66,7 @@ export const announceBuild = async (ctx: Context) => {
     replacementBuildIds,
     committedAt,
     baselineCommits,
-    packageManifestChanges,
+    packageMetadataChanges,
     gitUserEmail,
     ...commitInfo
   } = ctx.git; // omit some fields;

--- a/node-src/tasks/upload.test.ts
+++ b/node-src/tasks/upload.test.ts
@@ -176,7 +176,7 @@ describe('traceChangedFiles', () => {
     findChangedDependencies.mockRejectedValue(new Error('no lockfile'));
     findChangedPackageFiles.mockResolvedValue(['./package.json']);
 
-    const packageManifestChanges = [{ changedFiles: ['./package.json'], commit: 'abcdef' }];
+    const packageMetadataChanges = [{ changedFiles: ['./package.json'], commit: 'abcdef' }];
     const ctx = {
       env,
       log,
@@ -184,13 +184,13 @@ describe('traceChangedFiles', () => {
       options: {},
       sourceDir: '/static/',
       fileInfo: { statsPath: '/static/preview-stats.json' },
-      git: { changedFiles: ['./example.js', './package.json'], packageManifestChanges },
+      git: { changedFiles: ['./example.js', './package.json'], packageMetadataChanges },
       turboSnap: {},
     } as any;
     await traceChangedFiles(ctx, {} as any);
 
     expect(ctx.turboSnap.bailReason).toEqual({ changedPackageFiles: ['./package.json'] });
-    expect(findChangedPackageFiles).toHaveBeenCalledWith(packageManifestChanges);
+    expect(findChangedPackageFiles).toHaveBeenCalledWith(packageMetadataChanges);
     expect(getDependentStoryFiles).not.toHaveBeenCalled();
   });
 
@@ -200,7 +200,7 @@ describe('traceChangedFiles', () => {
     findChangedPackageFiles.mockResolvedValue([]); // no dependency changes
     getDependentStoryFiles.mockResolvedValue(deps);
 
-    const packageManifestChanges = [{ changedFiles: ['./package.json'], commit: 'abcdef' }];
+    const packageMetadataChanges = [{ changedFiles: ['./package.json'], commit: 'abcdef' }];
     const ctx = {
       env,
       log,
@@ -208,14 +208,14 @@ describe('traceChangedFiles', () => {
       options: {},
       sourceDir: '/static/',
       fileInfo: { statsPath: '/static/preview-stats.json' },
-      git: { changedFiles: ['./example.js', './package.json'], packageManifestChanges },
+      git: { changedFiles: ['./example.js', './package.json'], packageMetadataChanges },
       turboSnap: {},
     } as any;
     await traceChangedFiles(ctx, {} as any);
 
     expect(ctx.turboSnap.bailReason).toBeUndefined();
     expect(ctx.onlyStoryFiles).toStrictEqual(Object.keys(deps));
-    expect(findChangedPackageFiles).toHaveBeenCalledWith(packageManifestChanges);
+    expect(findChangedPackageFiles).toHaveBeenCalledWith(packageMetadataChanges);
   });
 
   it('ignores dependency changes in untraced package.json files (fallback scenario)', async () => {
@@ -224,7 +224,7 @@ describe('traceChangedFiles', () => {
     findChangedPackageFiles.mockResolvedValue([]);
     getDependentStoryFiles.mockResolvedValue(deps);
 
-    const packageManifestChanges = [{ changedFiles: ['./package.json'], commit: 'abcdef' }];
+    const packageMetadataChanges = [{ changedFiles: ['./package.json'], commit: 'abcdef' }];
     const ctx = {
       env,
       log,
@@ -232,7 +232,7 @@ describe('traceChangedFiles', () => {
       options: { untraced: ['package.json'] },
       sourceDir: '/static/',
       fileInfo: { statsPath: '/static/preview-stats.json' },
-      git: { changedFiles: ['./example.js', './package.json'], packageManifestChanges },
+      git: { changedFiles: ['./example.js', './package.json'], packageMetadataChanges },
       turboSnap: {},
     } as any;
     await traceChangedFiles(ctx, {} as any);

--- a/node-src/tasks/upload.test.ts
+++ b/node-src/tasks/upload.test.ts
@@ -172,28 +172,6 @@ describe('traceChangedFiles', () => {
     expect(findChangedPackageFiles).not.toHaveBeenCalled();
   });
 
-  it('does not run package dependency analysis if there are no traced metadata changes', async () => {
-    const deps = { 123: ['./example.stories.js'] };
-    getDependentStoryFiles.mockResolvedValue(deps);
-
-    const packageMetadataChanges = [{ changedFiles: ['./package.json'], commit: 'abcdef' }];
-    const ctx = {
-      env,
-      log,
-      http,
-      options: { untraced: ['package.json'] },
-      sourceDir: '/static/',
-      fileInfo: { statsPath: '/static/preview-stats.json' },
-      git: { changedFiles: ['./example.js', './package.json'], packageMetadataChanges },
-      turboSnap: {},
-    } as any;
-    await traceChangedFiles(ctx, {} as any);
-
-    expect(ctx.onlyStoryFiles).toStrictEqual(Object.keys(deps));
-    expect(findChangedDependencies).not.toHaveBeenCalled();
-    expect(findChangedPackageFiles).not.toHaveBeenCalled();
-  });
-
   it('bails on package.json changes if it fails to retrieve lockfile changes (fallback scenario)', async () => {
     findChangedDependencies.mockRejectedValue(new Error('no lockfile'));
     findChangedPackageFiles.mockResolvedValue(['./package.json']);

--- a/node-src/tasks/upload.test.ts
+++ b/node-src/tasks/upload.test.ts
@@ -170,6 +170,8 @@ describe('traceChangedFiles', () => {
     await traceChangedFiles(ctx, {} as any);
 
     expect(ctx.onlyStoryFiles).toStrictEqual(Object.keys(deps));
+    expect(findChangedDependencies).not.toHaveBeenCalled();
+    expect(findChangedPackageFiles).not.toHaveBeenCalled();
   });
 
   it('bails on package.json changes if it fails to retrieve lockfile changes (fallback scenario)', async () => {

--- a/node-src/tasks/upload.ts
+++ b/node-src/tasks/upload.ts
@@ -111,11 +111,19 @@ export const traceChangedFiles = async (ctx: Context, task: Task) => {
 
   transitionTo(tracing)(ctx, task);
 
+  const { untraced = [] } = ctx.options;
   const { statsPath } = ctx.fileInfo;
   const { changedFiles, packageMetadataChanges } = ctx.git;
+  const tracedMetadataChanges = packageMetadataChanges
+    ?.map(({ changedFiles, commit }) => ({
+      changedFiles: changedFiles.filter((f) => !untraced.some((glob) => matchesFile(glob, f))),
+      commit,
+    }))
+    .filter(({ changedFiles }) => changedFiles.length > 0);
+
   try {
     let changedDependencyNames: void | string[] = [];
-    if (packageMetadataChanges?.length > 0) {
+    if (tracedMetadataChanges?.length > 0) {
       changedDependencyNames = await findChangedDependencies(ctx).catch((err) => {
         const { name, message, stack, code } = err;
         ctx.log.debug({ name, message, stack, code });
@@ -131,17 +139,7 @@ export const traceChangedFiles = async (ctx: Context, task: Task) => {
       } else {
         ctx.log.warn(`Could not retrieve dependency changes from lockfiles; checking package.json`);
 
-        const { untraced = [] } = ctx.options;
-        const tracedPackageManifestChanges = packageMetadataChanges
-          ?.map(({ changedFiles, commit }) => ({
-            changedFiles: changedFiles.filter(
-              (f) => !untraced.some((glob) => matchesFile(glob, f))
-            ),
-            commit,
-          }))
-          .filter(({ changedFiles }) => changedFiles.length > 0);
-
-        const changedPackageFiles = await findChangedPackageFiles(tracedPackageManifestChanges);
+        const changedPackageFiles = await findChangedPackageFiles(tracedMetadataChanges);
         if (changedPackageFiles.length > 0) {
           ctx.turboSnap.bailReason = { changedPackageFiles };
           ctx.log.warn(bailFile({ turboSnap: ctx.turboSnap }));

--- a/node-src/tasks/upload.ts
+++ b/node-src/tasks/upload.ts
@@ -112,7 +112,7 @@ export const traceChangedFiles = async (ctx: Context, task: Task) => {
   transitionTo(tracing)(ctx, task);
 
   const { statsPath } = ctx.fileInfo;
-  const { changedFiles, packageManifestChanges } = ctx.git;
+  const { changedFiles, packageMetadataChanges } = ctx.git;
   try {
     const changedDependencyNames = await findChangedDependencies(ctx).catch((err) => {
       const { name, message, stack, code } = err;
@@ -130,7 +130,7 @@ export const traceChangedFiles = async (ctx: Context, task: Task) => {
       ctx.log.warn(`Could not retrieve dependency changes from lockfiles; checking package.json`);
 
       const { untraced = [] } = ctx.options;
-      const tracedPackageManifestChanges = packageManifestChanges
+      const tracedPackageManifestChanges = packageMetadataChanges
         ?.map(({ changedFiles, commit }) => ({
           changedFiles: changedFiles.filter((f) => !untraced.some((glob) => matchesFile(glob, f))),
           commit,

--- a/node-src/types.ts
+++ b/node-src/types.ts
@@ -210,7 +210,7 @@ export interface Context {
     changedDependencyNames?: string[];
     replacementBuildIds?: [string, string][];
     matchesBranch?: (glob: boolean | string) => boolean;
-    packageManifestChanges?: { changedFiles: string[]; commit: string }[];
+    packageMetadataChanges?: { changedFiles: string[]; commit: string }[];
   };
   storybook: {
     version: string;

--- a/package.json
+++ b/package.json
@@ -232,7 +232,6 @@
     ]
   },
   "docs": "https://www.chromatic.com/docs/cli",
-  "packageManager": "yarn@1.22.19+sha256.732620bac8b1690d507274f025f3c6cfdc3627a84d9642e38a07452cc00e0f2e",
   "storybook": {
     "icon": "https://user-images.githubusercontent.com/263385/101995175-2e087800-3c96-11eb-9a33-9860a1c3ce62.gif",
     "displayName": "Chromatic"

--- a/package.json
+++ b/package.json
@@ -232,6 +232,7 @@
     ]
   },
   "docs": "https://www.chromatic.com/docs/cli",
+  "packageManager": "yarn@1.22.19+sha256.732620bac8b1690d507274f025f3c6cfdc3627a84d9642e38a07452cc00e0f2e",
   "storybook": {
     "icon": "https://user-images.githubusercontent.com/263385/101995175-2e087800-3c96-11eb-9a33-9860a1c3ce62.gif",
     "displayName": "Chromatic"


### PR DESCRIPTION
- Don't consider lockfiles at all if there are no traced changes to package metadata
- Otherwise, after figuring out what lockfile pairs exist, filter out the ones that don't have diffs.

In practice this makes a big difference:
 - With no changes on the Chromatic monorepo it goes from 10-12s to 0s.
 - With only `./package.json` changed, it goes to 1s.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>10.9.0--canary.912.7810229911.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@10.9.0--canary.912.7810229911.0
  # or 
  yarn add chromatic@10.9.0--canary.912.7810229911.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
