### PR TITLE
Expose `repositoryRootDir`, `configFile` and fix `diagnosticsFile`

### DIFF
--- a/node-src/index.ts
+++ b/node-src/index.ts
@@ -92,7 +92,7 @@ export async function run({
   flags?: Flags;
   options?: Partial<Options>;
 }): Promise<Output> {
-  const { sessionId = uuid(), env = getEnv(), log = createLogger() } = extraOptions;
+  const { sessionId = uuid(), env = getEnv(), log = createLogger() } = extraOptions || {};
 
   const pkgInfo = await readPkgUp({ cwd: process.cwd() });
   if (!pkgInfo) {

--- a/node-src/index.ts
+++ b/node-src/index.ts
@@ -264,7 +264,7 @@ export type GitInfo = {
   uncommittedHash: string;
   userEmail: string;
   userEmailHash: string;
-  repositoryRoot: string;
+  repositoryRootDir: string;
 };
 
 export async function getGitInfo(): Promise<GitInfo> {
@@ -278,7 +278,7 @@ export async function getGitInfo(): Promise<GitInfo> {
   const commitInfo = await getCommit();
   const userEmail = await getUserEmail();
   const userEmailHash = emailHash(userEmail);
-  const repositoryRoot = await getRepositoryRoot();
+  const repositoryRootDir = await getRepositoryRoot();
 
   const [ownerName, repoName, ...rest] = slug ? slug.split('/') : [];
   const isValidSlug = !!ownerName && !!repoName && !rest.length;
@@ -291,7 +291,7 @@ export async function getGitInfo(): Promise<GitInfo> {
     uncommittedHash,
     userEmail,
     userEmailHash,
-    repositoryRoot,
+    repositoryRootDir,
   };
 }
 

--- a/node-src/index.ts
+++ b/node-src/index.ts
@@ -3,7 +3,14 @@ import Listr from 'listr';
 import readPkgUp from 'read-pkg-up';
 import { v4 as uuid } from 'uuid';
 
-import { getBranch, getCommit, getSlug, getUncommittedHash, getUserEmail } from './git/git';
+import {
+  getBranch,
+  getCommit,
+  getRepositoryRoot,
+  getSlug,
+  getUncommittedHash,
+  getUserEmail,
+} from './git/git';
 import GraphQLClient from './io/GraphQLClient';
 import HTTPClient from './io/HTTPClient';
 import LoggingRenderer from './lib/LoggingRenderer';
@@ -257,6 +264,7 @@ export type GitInfo = {
   uncommittedHash: string;
   userEmail: string;
   userEmailHash: string;
+  repositoryRoot: string;
 };
 
 export async function getGitInfo(): Promise<GitInfo> {
@@ -264,12 +272,13 @@ export async function getGitInfo(): Promise<GitInfo> {
   try {
     slug = await getSlug();
   } catch {
-    slug = ''
+    slug = '';
   }
   const branch = await getBranch();
   const commitInfo = await getCommit();
   const userEmail = await getUserEmail();
   const userEmailHash = emailHash(userEmail);
+  const repositoryRoot = await getRepositoryRoot();
 
   const [ownerName, repoName, ...rest] = slug ? slug.split('/') : [];
   const isValidSlug = !!ownerName && !!repoName && !rest.length;
@@ -282,6 +291,7 @@ export async function getGitInfo(): Promise<GitInfo> {
     uncommittedHash,
     userEmail,
     userEmailHash,
+    repositoryRoot,
   };
 }
 

--- a/node-src/lib/getConfiguration.test.ts
+++ b/node-src/lib/getConfiguration.test.ts
@@ -45,6 +45,7 @@ it('reads configuration successfully', async () => {
   );
 
   expect(await getConfiguration()).toEqual({
+    configFile: 'chromatic.config.json',
     projectId: 'project-id',
     projectToken: 'project-token',
 

--- a/node-src/lib/getConfiguration.test.ts
+++ b/node-src/lib/getConfiguration.test.ts
@@ -22,7 +22,7 @@ it('reads configuration successfully', async () => {
       untraced: ['untraced'],
       externals: ['externals'],
       debug: true,
-      diagnosticFile: 'diagnostic-file',
+      diagnosticsFile: 'diagnostics-file',
       fileHashing: true,
       junitReport: 'junit-report',
       zip: true,
@@ -54,7 +54,7 @@ it('reads configuration successfully', async () => {
     untraced: ['untraced'],
     externals: ['externals'],
     debug: true,
-    diagnosticFile: 'diagnostic-file',
+    diagnosticsFile: 'diagnostics-file',
     fileHashing: true,
     junitReport: 'junit-report',
     zip: true,
@@ -80,7 +80,7 @@ it('handles other side of union options', async () => {
   mockedReadFile.mockReturnValue(
     JSON.stringify({
       onlyChanged: true,
-      diagnosticFile: true,
+      diagnosticsFile: true,
       junitReport: true,
       autoAcceptChanges: true,
       exitZeroOnChanges: true,
@@ -93,7 +93,7 @@ it('handles other side of union options', async () => {
 
   expect(await getConfiguration()).toEqual({
     onlyChanged: true,
-    diagnosticFile: true,
+    diagnosticsFile: true,
     junitReport: true,
     autoAcceptChanges: true,
     exitZeroOnChanges: true,

--- a/node-src/lib/getConfiguration.test.ts
+++ b/node-src/lib/getConfiguration.test.ts
@@ -92,6 +92,7 @@ it('handles other side of union options', async () => {
   );
 
   expect(await getConfiguration()).toEqual({
+    configFile: 'chromatic.config.json',
     onlyChanged: true,
     diagnosticsFile: true,
     junitReport: true,

--- a/node-src/lib/getConfiguration.ts
+++ b/node-src/lib/getConfiguration.ts
@@ -15,7 +15,7 @@ const configurationSchema = z
     untraced: z.array(z.string()),
     externals: z.array(z.string()),
     debug: z.boolean(),
-    diagnosticFile: z.union([z.string(), z.boolean()]),
+    diagnosticsFile: z.union([z.string(), z.boolean()]),
     fileHashing: z.boolean().default(true),
     junitReport: z.union([z.string(), z.boolean()]),
     zip: z.boolean(),

--- a/node-src/lib/getConfiguration.ts
+++ b/node-src/lib/getConfiguration.ts
@@ -42,12 +42,14 @@ const configurationSchema = z
 
 export type Configuration = z.infer<typeof configurationSchema>;
 
-export async function getConfiguration(configFile?: string) {
+export async function getConfiguration(
+  configFile?: string
+): Promise<Configuration & { configFile?: string }> {
   const usedConfigFile = configFile || 'chromatic.config.json';
   try {
     const rawJson = readFileSync(usedConfigFile, 'utf8');
-
-    return configurationSchema.parse(JSON.parse(rawJson));
+    const configuration = configurationSchema.parse(JSON.parse(rawJson));
+    return { configFile: usedConfigFile, ...configuration };
   } catch (err) {
     // Config file does not exist
     if (err.message.match(/ENOENT/)) {


### PR DESCRIPTION
- Add `repositoryRootDir` field to `getGitInfo` return value
- Add `configFile` field to `getConfiguration` return value
- Rename `diagnosticFile` to `diagnosticsFile` in configuration schema (misspelling)
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>10.8.0--canary.913.7802580624.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@10.8.0--canary.913.7802580624.0
  # or 
  yarn add chromatic@10.8.0--canary.913.7802580624.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
