### PR TITLE
Allow `traceChanged` in Chromatic config spec

### DIFF
--- a/node-src/lib/getConfiguration.test.ts
+++ b/node-src/lib/getConfiguration.test.ts
@@ -17,6 +17,7 @@ it('reads configuration successfully', async () => {
       projectToken: 'project-token',
 
       onlyChanged: 'only-changed',
+      traceChanged: 'expanded',
       onlyStoryFiles: ['only-story-files'],
       onlyStoryNames: ['only-story-names'],
       untraced: ['untraced'],
@@ -50,6 +51,7 @@ it('reads configuration successfully', async () => {
     projectToken: 'project-token',
 
     onlyChanged: 'only-changed',
+    traceChanged: 'expanded',
     onlyStoryFiles: ['only-story-files'],
     onlyStoryNames: ['only-story-names'],
     untraced: ['untraced'],
@@ -81,6 +83,7 @@ it('handles other side of union options', async () => {
   mockedReadFile.mockReturnValue(
     JSON.stringify({
       onlyChanged: true,
+      traceChanged: true,
       diagnosticsFile: true,
       junitReport: true,
       autoAcceptChanges: true,
@@ -95,6 +98,7 @@ it('handles other side of union options', async () => {
   expect(await getConfiguration()).toEqual({
     configFile: 'chromatic.config.json',
     onlyChanged: true,
+    traceChanged: true,
     diagnosticsFile: true,
     junitReport: true,
     autoAcceptChanges: true,

--- a/node-src/lib/getConfiguration.ts
+++ b/node-src/lib/getConfiguration.ts
@@ -12,6 +12,7 @@ const configurationSchema = z
     onlyChanged: z.union([z.string(), z.boolean()]),
     onlyStoryFiles: z.array(z.string()),
     onlyStoryNames: z.array(z.string()),
+    traceChanged: z.union([z.string(), z.boolean()]),
     untraced: z.array(z.string()),
     externals: z.array(z.string()),
     debug: z.boolean(),


### PR DESCRIPTION
Add missing `traceChanged` config option to Chromatic config spec.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>10.9.1--canary.916.7821376194.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@10.9.1--canary.916.7821376194.0
  # or 
  yarn add chromatic@10.9.1--canary.916.7821376194.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
