### PR TITLE
Add missing `fileHashing` option to GitHub Action

### DIFF
--- a/action-src/main.ts
+++ b/action-src/main.ts
@@ -101,6 +101,7 @@ async function run() {
     const exitOnceUploaded = getInput('exitOnceUploaded');
     const exitZeroOnChanges = getInput('exitZeroOnChanges');
     const externals = getInput('externals');
+    const fileHashing = getInput('fileHashing');
     const forceRebuild = getInput('forceRebuild');
     const ignoreLastBuildOnBranch = getInput('ignoreLastBuildOnBranch');
     const logFile = getInput('logFile');
@@ -148,6 +149,7 @@ async function run() {
         exitOnceUploaded: maybe(exitOnceUploaded, false),
         exitZeroOnChanges: maybe(exitZeroOnChanges, true),
         externals: maybe(externals),
+        fileHashing: maybe(fileHashing, true),
         forceRebuild: maybe(forceRebuild),
         ignoreLastBuildOnBranch: maybe(ignoreLastBuildOnBranch),
         interactive: false,

--- a/action.yml
+++ b/action.yml
@@ -47,6 +47,9 @@ inputs:
   externals:
     description: 'Disable TurboSnap when any of these files have changed since the baseline build'
     required: false
+  fileHashing:
+    description: 'Whether to apply file hashing to skip uploading unchanged files (default: true)'
+    required: false
   forceRebuild:
     description: 'Do not skip build when a rebuild is detected'
     required: false


### PR DESCRIPTION
This adds support for the `fileHashing` option through the GitHub Action. The default value is `true`. Set `fileHashing: false` to disable file hashing (i.e. file upload deduplication).

Note that this flag is only supposed to be used if you run into build errors caused by file hashing / deduplication (e.g. the `copy-files.txt` sentinel files never resolves).