### PR TITLE
clean up debug log as it's too much noise

### DIFF
--- a/node-src/lib/getDependentStoryFiles.ts
+++ b/node-src/lib/getDependentStoryFiles.ts
@@ -234,10 +234,6 @@ export async function getDependentStoryFiles(
     const normalizedName = namesById.get(id);
     if (shouldBail(normalizedName)) return;
 
-    ctx.log.debug('Trace file...');
-    ctx.log.debug(name);
-    ctx.log.debug(id || 'no moduleId found for this file');
-
     if (!id || !reasonsById.get(id) || checkedIds[id]) return;
     // Queue this id for tracing
     toCheck.push([id, [...tracePath, id]]);
@@ -248,8 +244,10 @@ export async function getDependentStoryFiles(
     }
   }
 
-  ctx.log.debug('Traced files...');
-  ctx.log.debug(tracedFiles);
+  if (ctx.options.traceChanged) {
+    ctx.log.debug('Traced files...');
+    ctx.log.debug(tracedFiles);
+  }
 
   // First, check the files that have changed according to git
   tracedFiles.forEach((posixPath) => traceName(posixPath));
@@ -267,8 +265,10 @@ export async function getDependentStoryFiles(
     Array.from(affectedModuleIds).map((id) => [String(id), files(namesById.get(id))])
   );
 
-  ctx.log.debug('Affected modules...');
-  ctx.log.debug(affectedModules);
+  if (ctx.options.traceChanged) {
+    ctx.log.debug('Affected modules...');
+    ctx.log.debug(affectedModules);
+  }
 
   if (ctx.options.traceChanged) {
     ctx.log.info(


### PR DESCRIPTION
The trace output in the debug logs results in too much noise and is not helpful.
I want to remove the log for the traced file so the debug log is functional again.

I ran this command `yarn chromatic trace -m expanded node-src/ui/components/activity.ts` to verify the `traceChanged` logic doesn't throw any errors.

I also ran this command without `-m expanded` and confirmed the trace logs no longer appear.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>10.9.3--canary.919.7845683347.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@10.9.3--canary.919.7845683347.0
  # or 
  yarn add chromatic@10.9.3--canary.919.7845683347.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
