### PR TITLE
Fix Storybook published messaging

### DIFF
--- a/.github/workflows/chromatic-prod.yml
+++ b/.github/workflows/chromatic-prod.yml
@@ -19,6 +19,7 @@ jobs:
           onlyChanged: true
           traceChanged: true
           diagnostics: true
+          debug: true
         env:
           CHROMATIC_PROJECT_TOKEN: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
       - uses: actions/upload-artifact@v2

--- a/node-src/tasks/verify.ts
+++ b/node-src/tasks/verify.ts
@@ -75,8 +75,6 @@ export const publishBuild = async (ctx: Context) => {
     setExitCode(ctx, exitCodes.BUILD_FAILED, false);
     throw new Error(publishFailed().output);
   }
-
-  ctx.log.info(storybookPublished(ctx));
 };
 
 const StartedBuildQuery = `
@@ -244,12 +242,13 @@ export const verifyBuild = async (ctx: Context, task: Task) => {
     }
   }
 
+  ctx.log.info(storybookPublished(ctx));
+
   transitionTo(success, true)(ctx, task);
 
   if (list || ctx.isPublishOnly || matchesBranch(ctx.options.exitOnceUploaded)) {
     setExitCode(ctx, exitCodes.OK);
     ctx.skipSnapshots = true;
-    ctx.log.info(storybookPublished(ctx));
   }
 };
 

--- a/node-src/ui/messages/info/storybookPublished.stories.ts
+++ b/node-src/ui/messages/info/storybookPublished.stories.ts
@@ -23,3 +23,18 @@ export const StorybookPrepared = () =>
     },
     storybookUrl: 'https://5d67dc0374b2e300209c41e7-pfkaemtlit.chromatic.com/',
   } as any);
+
+  export const StorybookPreparedWithIncompleteBuild = () =>
+  storybookPublished({
+    build: {
+      actualCaptureCount: undefined,
+      actualTestCount: undefined,
+      testCount: undefined,
+      changeCount: undefined,
+      errorCount: undefined,
+      componentCount: undefined,
+      specCount: undefined,
+      storybookUrl: 'https://5d67dc0374b2e300209c41e7-pfkaemtlit.chromatic.com/',
+    },
+    storybookUrl: 'https://5d67dc0374b2e300209c41e7-pfkaemtlit.chromatic.com/',
+  } as any);

--- a/node-src/ui/messages/info/storybookPublished.ts
+++ b/node-src/ui/messages/info/storybookPublished.ts
@@ -7,11 +7,14 @@ import link from '../../components/link';
 import { stats } from '../../tasks/snapshot';
 
 export default ({ build, storybookUrl }: Pick<Context, 'build' | 'storybookUrl'>) => {
-  if (build) {
-    const { components, stories } = stats({ build });
+  // `ctx.build` is initialized and overwritten in many ways, which means that
+  // this can be any kind of build without component and stories information,
+  // like PASSED builds, for example
+  const buildStats = build ? stats({ build }) : null;
+  if (buildStats?.components && buildStats?.stories) {
     return dedent(chalk`
       ${success} {bold Storybook published}
-      We found ${components} with ${stories}.
+      We found ${buildStats.components} with ${buildStats.stories}.
       ${info} View your Storybook at ${link(storybookUrl)}
     `);
   }

--- a/node-src/ui/messages/info/storybookPublished.ts
+++ b/node-src/ui/messages/info/storybookPublished.ts
@@ -10,11 +10,11 @@ export default ({ build, storybookUrl }: Pick<Context, 'build' | 'storybookUrl'>
   // `ctx.build` is initialized and overwritten in many ways, which means that
   // this can be any kind of build without component and stories information,
   // like PASSED builds, for example
-  const buildStats = build ? stats({ build }) : null;
-  if (buildStats?.components && buildStats?.stories) {
+  if (build?.componentCount && build?.specCount) {
+    const { components, stories } = stats({ build });
     return dedent(chalk`
       ${success} {bold Storybook published}
-      We found ${buildStats.components} with ${buildStats.stories}.
+      We found ${components} with ${stories}.
       ${info} View your Storybook at ${link(storybookUrl)}
     `);
   }


### PR DESCRIPTION
This fixes a couple of issues with the Storybook published messaging.

1. Logging this from the `publishBuild` step meant that sometimes the `ctx.build` used to construct the message was in an early stage (like `PASSED`) without component and story information, resulting in a message like:
```
✔ Storybook published
We found undefined components with undefined stories.
```

2. This is also logged from the `verifyBuild` step under certain conditions (like with `exit-once-uploaded`), resulting in duplicate messaging like:
```
✔ Storybook published
We found undefined components with undefined stories.

✔ Storybook published
We found 19 components with 221 stories.
```

### How to Test
* With the canary version, commit some changes and run builds with various flags including with and without `exit-once-uploaded` and `only-changed`.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>10.9.5--canary.920.7904534893.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@10.9.5--canary.920.7904534893.0
  # or 
  yarn add chromatic@10.9.5--canary.920.7904534893.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
