### PR TITLE
Add `skipUpdateCheck` option

### DIFF
--- a/node-src/lib/checkForUpdates.ts
+++ b/node-src/lib/checkForUpdates.ts
@@ -10,6 +10,11 @@ const withTimeout = <T>(promise: Promise<T>, ms: number): Promise<T> =>
   Promise.race([promise, rejectIn(ms)]);
 
 export default async function checkForUpdates(ctx: InitialContext) {
+  if (ctx.extraOptions.skipUpdateCheck === true) {
+    ctx.log.info(`Skipping update check`);
+    return;
+  }
+
   if (!semver.valid(ctx.pkg.version)) {
     ctx.log.warn(`Invalid semver version in package.json: ${ctx.pkg.version}`);
     return;

--- a/node-src/lib/checkForUpdates.ts
+++ b/node-src/lib/checkForUpdates.ts
@@ -10,7 +10,7 @@ const withTimeout = <T>(promise: Promise<T>, ms: number): Promise<T> =>
   Promise.race([promise, rejectIn(ms)]);
 
 export default async function checkForUpdates(ctx: InitialContext) {
-  if (ctx.extraOptions.skipUpdateCheck === true) {
+  if (ctx.options.skipUpdateCheck === true) {
     ctx.log.info(`Skipping update check`);
     return;
   }

--- a/node-src/lib/getOptions.ts
+++ b/node-src/lib/getOptions.ts
@@ -125,6 +125,7 @@ export default function getOptions({
       defaultIfSet(flags.diagnostics && '', DEFAULT_DIAGNOSTICS_FILE), // for backwards compatibility
     junitReport: defaultIfSet(flags.junitReport, DEFAULT_REPORT_FILE),
     zip: flags.zip,
+    skipUpdateCheck: flags.skipUpdateCheck,
 
     autoAcceptChanges: trueIfSet(flags.autoAcceptChanges),
     exitZeroOnChanges: trueIfSet(flags.exitZeroOnChanges),

--- a/node-src/lib/getOptions.ts
+++ b/node-src/lib/getOptions.ts
@@ -69,6 +69,7 @@ export default function getOptions({
     forceRebuild: undefined,
     junitReport: undefined,
     zip: undefined,
+    skipUpdateCheck: undefined,
 
     ignoreLastBuildOnBranch: undefined,
     preserveMissingSpecs: undefined,

--- a/node-src/lib/parseArgs.ts
+++ b/node-src/lib/parseArgs.ts
@@ -39,7 +39,7 @@ export default function parseArgs(argv: string[]) {
       --storybook-config-dir <dirname>          Relative path from where you run Chromatic to your Storybook config directory ('.storybook'). Use with --only-changed and --storybook-build-dir when using a custom --config-dir (-c) flag for Storybook. [.storybook]
       --untraced <filepath>                     Disregard these files and their dependencies when tracing dependent stories for TurboSnap. Globs are supported via picomatch. This flag can be specified multiple times. Requires --only-changed.
       --zip                                     Publish your Storybook to Chromatic as a single zip file instead of individual content files.
-      --skipUpdateCheck                         Skip checking for Chromatic update.
+      --skip-update-check                       Skip checking for available Chromatic package update.
 
     Debug options
       --debug                          Output verbose debugging information. This option implies --no-interactive, --diagnostics-file, --log-file.

--- a/node-src/lib/parseArgs.ts
+++ b/node-src/lib/parseArgs.ts
@@ -39,6 +39,7 @@ export default function parseArgs(argv: string[]) {
       --storybook-config-dir <dirname>          Relative path from where you run Chromatic to your Storybook config directory ('.storybook'). Use with --only-changed and --storybook-build-dir when using a custom --config-dir (-c) flag for Storybook. [.storybook]
       --untraced <filepath>                     Disregard these files and their dependencies when tracing dependent stories for TurboSnap. Globs are supported via picomatch. This flag can be specified multiple times. Requires --only-changed.
       --zip                                     Publish your Storybook to Chromatic as a single zip file instead of individual content files.
+      --skipUpdateCheck                         Skip checking for Chromatic update.
 
     Debug options
       --debug                          Output verbose debugging information. This option implies --no-interactive, --diagnostics-file, --log-file.

--- a/node-src/types.ts
+++ b/node-src/types.ts
@@ -37,6 +37,7 @@ export interface Flags {
   storybookConfigDir?: string;
   untraced?: string[];
   zip?: boolean;
+  skipUpdateCheck?: boolean;
 
   // Debug options
   debug?: boolean;
@@ -140,6 +141,8 @@ export interface Options extends Configuration {
 
   /** Environment variables */
   env?: Env;
+
+  skipUpdateCheck: Flags['skipUpdateCheck'];
 }
 
 export { Configuration };


### PR DESCRIPTION
Added option (--skipUpdateCheck) to not check for an updated version of Chromatic. We have over a 100 of Storybook instances which we check with Chromatic. Our private NPM-registry-feed (Azure DevOps artifacts) does not support retrieving the version-info and triggers an error. Having these errors clutters our CI-logs.

This is a non-breaking change and can be marked as #patch