### PR TITLE
Prevent non-string or null message in timestamp logging from causing exit code 254 during build.

### DIFF
--- a/node-src/lib/log.ts
+++ b/node-src/lib/log.ts
@@ -29,7 +29,7 @@ const withTime = (messages: string[], color = false) => {
   if (messages.every((message) => /^\s*$/.test(message))) return messages;
   let time = new Date().toISOString().slice(11, 23);
   if (color) time = chalk.dim(time);
-  return [time + ' ', ...messages.map((msg) => msg.replace(/\n/g, `\n              `))];
+  return [time + ' ', ...messages.map((msg) => typeof msg === 'string' ? msg.replace(/\n/g, `\n              `) : msg)];
 };
 
 type LogType = 'error' | 'warn' | 'info' | 'debug';


### PR DESCRIPTION
Prevent non-string or null message from causing exit code 254 during build.