### PR TITLE
Display full error message when storybookBaseDir is invalid

### DIFF
--- a/node-src/lib/checkStorybookBaseDir.ts
+++ b/node-src/lib/checkStorybookBaseDir.ts
@@ -37,7 +37,7 @@ export async function checkStorybookBaseDir(ctx: Context, stats: Stats) {
       })
     );
   } catch (err) {
-    ctx.log.debug('No modules from stats file found in:', storybookBaseDir);
+    ctx.log.error(invalidStorybookBaseDir());
     setExitCode(ctx, exitCodes.INVALID_OPTIONS, true);
     throw new Error(invalidStorybookBaseDir());
   }

--- a/node-src/tasks/upload.test.ts
+++ b/node-src/tasks/upload.test.ts
@@ -58,7 +58,7 @@ const readFileSyncMock = vi.mocked(readFileSync);
 const statSyncMock = vi.mocked(statSync);
 
 const env = { CHROMATIC_RETRIES: 2, CHROMATIC_OUTPUT_INTERVAL: 0 };
-const log = { info: vi.fn(), warn: vi.fn(), debug: vi.fn() };
+const log = { info: vi.fn(), warn: vi.fn(), debug: vi.fn(), error: vi.fn() };
 const http = { fetch: vi.fn() };
 
 afterEach(() => {


### PR DESCRIPTION
The CLI is supposed to spit out an error message like this:

```
✖ TurboSnap disabled until base directory is set correctly
The base directory allows TurboSnap to trace files.
Set the --storybook-base-dir option as the relative path from the repository root to the Storybook project root.
Run @chromatic-com/turbosnap-helper to get your base directory value.
```

But only the last line is showing unless the debug flag is enabled. This change fixes that.

QA by running this on a project using `--only-changed` and an invalid `--storybook-base-dir`.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>11.0.3--canary.932.8166399273.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@11.0.3--canary.932.8166399273.0
  # or 
  yarn add chromatic@11.0.3--canary.932.8166399273.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
