### PR TITLE
Allow passing both `buildScriptName` and `storybookBuildDir`

### DIFF
--- a/node-src/lib/getOptions.test.ts
+++ b/node-src/lib/getOptions.test.ts
@@ -115,10 +115,10 @@ describe('getOptions', () => {
     });
   });
 
-  it('throws if you try to pass a build script and a directory', async () => {
+  it('allows you to pass both a build script and a directory', async () => {
     await expect(() =>
-      getOptions(getContext(['-b', '/tmp/dir', '--storybook-build-dir', '/tmp/dir']))
-    ).toThrow(/You can only use one of --build-script-name, --storybook-build-dir/);
+      getOptions(getContext(['-b', 'build:storybook', '--storybook-build-dir', '/tmp/dir']))
+    ).not.toThrow()
   });
 
   it('allows you to specify the branch name', async () => {

--- a/node-src/lib/getOptions.test.ts
+++ b/node-src/lib/getOptions.test.ts
@@ -115,27 +115,10 @@ describe('getOptions', () => {
     });
   });
 
-  it('allows you to pass both a build script and a directory', () => {
-    const context = getContext(['-b', 'build:storybook', '--storybook-build-dir', '/tmp/dir'])
-    const log = context.log as unknown as TestLogger
+  it('allows you to pass both a build script and a directory', async () => {
     expect(() =>
-      getOptions(context)
-    ).not.toThrow()
-
-    expect(log.entries).to.include('Both --build-script-name and --storybook-build-dir are specified as arguments, --build-script-name is ignored when using static storybook builds')
-  });
-
-  it('warns when both buildScriptName and storybookBuildDir are specified in configuration', () => {
-    const context = getContext([])
-    const log = context.log as unknown as TestLogger
-    expect(() =>
-        getOptions({...context, configuration: {
-          buildScriptName: 'other-build-script-name',
-            storybookBuildDir: '/tmp/storybook-prebuilt'
-          }})
-    ).not.toThrow()
-
-    expect(log.entries).to.include('Both buildScriptName and storybookBuildDir are specified in configuration, buildScriptName is ignored when using static storybook builds')
+      getOptions(getContext(['-b', 'build:storybook', '--storybook-build-dir', '/tmp/dir']))
+    ).not.toThrow();
   });
 
   it('allows you to specify the branch name', async () => {

--- a/node-src/lib/getOptions.test.ts
+++ b/node-src/lib/getOptions.test.ts
@@ -122,7 +122,7 @@ describe('getOptions', () => {
       getOptions(context)
     ).not.toThrow()
 
-    expect(log.entries).to.include('Note: Both --build-script-name and --storybook-build-dir are specified as arguments, --build-script-name is ignored when using static storybook builds')
+    expect(log.entries).to.include('Both --build-script-name and --storybook-build-dir are specified as arguments, --build-script-name is ignored when using static storybook builds')
   });
 
   it('warns when both buildScriptName and storybookBuildDir are specified in configuration', () => {

--- a/node-src/lib/getOptions.test.ts
+++ b/node-src/lib/getOptions.test.ts
@@ -115,10 +115,27 @@ describe('getOptions', () => {
     });
   });
 
-  it('allows you to pass both a build script and a directory', async () => {
-    await expect(() =>
-      getOptions(getContext(['-b', 'build:storybook', '--storybook-build-dir', '/tmp/dir']))
+  it('allows you to pass both a build script and a directory', () => {
+    const context = getContext(['-b', 'build:storybook', '--storybook-build-dir', '/tmp/dir'])
+    const log = context.log as unknown as TestLogger
+    expect(() =>
+      getOptions(context)
     ).not.toThrow()
+
+    expect(log.entries).to.include('Note: Both --build-script-name and --storybook-build-dir are specified as arguments, --build-script-name is ignored when using static storybook builds')
+  });
+
+  it('warns when both buildScriptName and storybookBuildDir are specified in configuration', () => {
+    const context = getContext([])
+    const log = context.log as unknown as TestLogger
+    expect(() =>
+        getOptions({...context, configuration: {
+          buildScriptName: 'other-build-script-name',
+            storybookBuildDir: '/tmp/storybook-prebuilt'
+          }})
+    ).not.toThrow()
+
+    expect(log.entries).to.include('Both buildScriptName and storybookBuildDir are specified in configuration, buildScriptName is ignored when using static storybook builds')
   });
 
   it('allows you to specify the branch name', async () => {

--- a/node-src/lib/getOptions.ts
+++ b/node-src/lib/getOptions.ts
@@ -169,9 +169,22 @@ export default function getOptions({
       process.env.NODE_ENV !== 'test',
   };
 
+  const combinedCliOptions = {
+    ...optionsFromFlags,
+    ...extraOptions,
+  }
+
   if (options.debug) {
     log.setLevel('debug');
     log.setInteractive(false);
+  }
+
+  if (combinedCliOptions.buildScriptName && combinedCliOptions.storybookBuildDir){
+    log.info('Both --build-script-name and --storybook-build-dir are specified as arguments, --build-script-name is ignored when using static storybook builds')
+  }
+
+  if (configuration && configuration.buildScriptName && configuration.storybookBuildDir) {
+    log.warn('Both buildScriptName and storybookBuildDir are specified in configuration, buildScriptName is ignored when using static storybook builds')
   }
 
   if (options.debug || options.uploadMetadata) {
@@ -206,7 +219,6 @@ export default function getOptions({
   }
 
   const { storybookBuildDir } = options;
-  let { buildScriptName } = options;
 
   // We can only have one of these arguments
   const singularOpts = {
@@ -275,6 +287,7 @@ export default function getOptions({
   }
 
   const { scripts } = packageJson;
+  let { buildScriptName } = options;
   if (typeof buildScriptName !== 'string') {
     buildScriptName = 'build-storybook';
     if (!scripts[buildScriptName]) {

--- a/node-src/lib/getOptions.ts
+++ b/node-src/lib/getOptions.ts
@@ -169,22 +169,9 @@ export default function getOptions({
       process.env.NODE_ENV !== 'test',
   };
 
-  const combinedCliOptions = {
-    ...optionsFromFlags,
-    ...extraOptions,
-  }
-
   if (options.debug) {
     log.setLevel('debug');
     log.setInteractive(false);
-  }
-
-  if (combinedCliOptions.buildScriptName && combinedCliOptions.storybookBuildDir){
-    log.info('Both --build-script-name and --storybook-build-dir are specified as arguments, --build-script-name is ignored when using static storybook builds')
-  }
-
-  if (configuration && configuration.buildScriptName && configuration.storybookBuildDir) {
-    log.warn('Both buildScriptName and storybookBuildDir are specified in configuration, buildScriptName is ignored when using static storybook builds')
   }
 
   if (options.debug || options.uploadMetadata) {
@@ -219,6 +206,7 @@ export default function getOptions({
   }
 
   const { storybookBuildDir } = options;
+  let { buildScriptName } = options;
 
   // We can only have one of these arguments
   const singularOpts = {
@@ -287,7 +275,6 @@ export default function getOptions({
   }
 
   const { scripts } = packageJson;
-  let { buildScriptName } = options;
   if (typeof buildScriptName !== 'string') {
     buildScriptName = 'build-storybook';
     if (!scripts[buildScriptName]) {

--- a/node-src/lib/getOptions.ts
+++ b/node-src/lib/getOptions.ts
@@ -207,7 +207,6 @@ export default function getOptions({
 
   // We can only have one of these arguments
   const singularOpts = {
-    buildScriptName: '--build-script-name',
     storybookBuildDir: '--storybook-build-dir',
     playwright: '--playwright',
     cypress: '--cypress',


### PR DESCRIPTION
Allows passing both --storybook-build-dir and  --build-script-name

Solves #933 