### PR TITLE
Fix support for boolean value to `junitReport` option

### DIFF
--- a/node-src/tasks/report.test.ts
+++ b/node-src/tasks/report.test.ts
@@ -1,0 +1,99 @@
+import reportBuilder from 'junit-report-builder';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { generateReport } from './report';
+import path from 'path';
+
+const log = { error: vi.fn(), info: vi.fn() };
+const mockTests = [
+  {
+    status: 'ACCEPTED',
+    result: '',
+    spec: { name: '', component: { name: '' } },
+    parameters: { viewportIsDefault: true, viewport: 1080 },
+    mode: { name: 'Beast Mode' },
+  },
+  {
+    status: 'PENDING',
+    result: '',
+    spec: { name: '', component: { name: '' } },
+    parameters: { viewportIsDefault: true, viewport: 1080 },
+    mode: { name: 'Beast Mode' },
+  },
+  {
+    status: 'DENIED',
+    result: '',
+    spec: { name: '', component: { name: '' } },
+    parameters: { viewportIsDefault: false, viewport: 1080 },
+    mode: { name: 'Beast Mode' },
+  },
+  {
+    status: 'BROKEN',
+    result: '',
+    spec: { name: '', component: { name: '' } },
+    parameters: { viewportIsDefault: true, viewport: 1080 },
+    mode: { name: null },
+  },
+  {
+    status: 'FAILED',
+    result: '',
+    spec: { name: '', component: { name: '' } },
+    parameters: { viewportIsDefault: false, viewport: 1080 },
+    mode: { name: null },
+  },
+];
+
+vi.spyOn(reportBuilder, 'writeTo').mockImplementation(vi.fn());
+
+describe('generateRport', () => {
+  const client = { runQuery: vi.fn(), setAuthorization: vi.fn() };
+  const build = {
+    app: { repository: { provider: 'github' } },
+    number: 1,
+    reportToken: 'report-token',
+  };
+  beforeEach(() => {
+    vi.resetAllMocks();
+    client.runQuery.mockReturnValue({
+      app: {
+        build: {
+          number: 1,
+          status: 'PASSED',
+          createdAt: 0,
+          completedAt: 0,
+          webUrl: 'https://google.com',
+          storybookUrl: 'https://storybook.js.org',
+          tests: mockTests,
+        },
+      },
+    });
+  });
+  it('sucessfully generates report when passed a string', async () => {
+    const ctx = {
+      client,
+      log,
+      options: {
+        junitReport: 'tests-file.xml',
+      },
+      build,
+    } as any;
+    await generateReport(ctx);
+    expect(reportBuilder.writeTo).toHaveBeenCalledWith(
+      path.join(__dirname, '../../tests-file.xml')
+    );
+  });
+
+  it('sucessfully generates report when passed a boolean equal to true', async () => {
+    const ctx = {
+      client,
+      log,
+      options: {
+        junitReport: true,
+      },
+      build,
+    } as any;
+    await generateReport(ctx);
+    expect(reportBuilder.writeTo).toHaveBeenCalledWith(
+      path.join(__dirname, '../../chromatic-build-1.xml')
+    );
+  });
+});

--- a/node-src/tasks/report.ts
+++ b/node-src/tasks/report.ts
@@ -74,7 +74,11 @@ export const generateReport = async (ctx: Context) => {
   const { junitReport } = ctx.options;
   const { number: buildNumber, reportToken } = ctx.build;
 
-  ctx.reportPath = path.resolve(junitReport.replace(/{buildNumber}/g, String(buildNumber)));
+  const file =
+    typeof junitReport === 'boolean' && junitReport
+      ? 'chromatic-build-{buildNumber}.xml'
+      : junitReport;
+  ctx.reportPath = path.resolve(file.replace(/{buildNumber}/g, String(buildNumber)));
 
   const {
     app: { build },


### PR DESCRIPTION
This PR adds the functionality to generate the JUnit report with the default naming scheme if the flag is set to true.

To QA
1. Run `npx chromatic@11.0.1--canary.937.8150625203.0 -t=PROJECT_TOKEN --junit-report=true`
2. Run the Unit tests.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>11.0.2--canary.937.8160328696.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@11.0.2--canary.937.8160328696.0
  # or 
  yarn add chromatic@11.0.2--canary.937.8160328696.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
