### PR TITLE
Allow commit hash to not be known when finding merge queue PR number [with github secrets]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,6 @@ chromatic-build-*.xml
 chromatic-diagnostics.json
 dist
 bin
-# action
+action
 node
 storybook-out

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,6 @@ chromatic-build-*.xml
 chromatic-diagnostics.json
 dist
 bin
-action
+# action
 node
 storybook-out

--- a/node-src/git/getCommitAndBranch.ts
+++ b/node-src/git/getCommitAndBranch.ts
@@ -166,7 +166,7 @@ export default async function getCommitAndBranch(
   // To do this, GitHub creates a new commit and does a CI run with the branch changed to e.g. gh-readonly-queue/main/pr-4-da07417adc889156224d03a7466ac712c647cd36
   // If you configure merge queues to rebase in this circumstance, 
   // we lose track of baselines as the branch name has changed so our usual rebase detection (based on branch name) doesn't work.
-  const mergeQueueBranchPrNumber = await mergeQueueBranchMatch(commit.commit, branch)
+  const mergeQueueBranchPrNumber = await mergeQueueBranchMatch(branch)
   if (mergeQueueBranchPrNumber) {
     // This is why we extract the PR number from the branch name and use it to find the branch name of the PR that was merged.
     const branchFromMergeQueuePullRequestNumber = await getBranchFromMergeQueuePullRequestNumber(ctx, { number: mergeQueueBranchPrNumber });

--- a/node-src/git/git.test.ts
+++ b/node-src/git/git.test.ts
@@ -96,14 +96,12 @@ gpg: Can't check signature: No public key
 describe('mergeQueueBranchMatch', () => {
   it('returns pr number if it is a merge queue branch', async () => {
     const branch = "gh-readonly-queue/main/pr-4-da07417adc889156224d03a7466ac712c647cd36"
-    const commit = "da07417adc889156224d03a7466ac712c647cd36"
-    expect(await mergeQueueBranchMatch(commit, branch)).toEqual(4);
+    expect(await mergeQueueBranchMatch(branch)).toEqual(4);
   });
 
   it('returns null if it is not a merge queue branch', async () => {
     const branch = "develop"
-    const commit = "da07417adc889156224d03a7466ac712c647cd36"
-    expect(await mergeQueueBranchMatch(commit, branch)).toEqual(
+    expect(await mergeQueueBranchMatch(branch)).toEqual(
       null
     );
   });

--- a/node-src/git/git.ts
+++ b/node-src/git/git.ts
@@ -282,8 +282,8 @@ export async function findFiles(...patterns: string[]) {
   return files.split('\0').filter(Boolean);
 }
 
-export async function mergeQueueBranchMatch(commit, branch) {
-  const mergeQueuePattern = new RegExp(`gh-readonly-queue/.*/pr-(\\d+)-${commit}$`);
+export async function mergeQueueBranchMatch(branch) {
+  const mergeQueuePattern = new RegExp(/gh-readonly-queue\/.*\/pr-(\d+)-[a-f0-9]{30}/);
   const match = branch.match(mergeQueuePattern);
 
   return match ? Number(match[1]) : null;


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>11.0.1--canary.938.8157036058.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@11.0.1--canary.938.8157036058.0
  # or 
  yarn add chromatic@11.0.1--canary.938.8157036058.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
