### PR TITLE
Expose E2E build errors

### DIFF
--- a/node-src/lib/setExitCode.ts
+++ b/node-src/lib/setExitCode.ts
@@ -25,6 +25,9 @@ export const exitCodes = {
   STORYBOOK_START_FAILED: 22,
   STORYBOOK_BROKEN: 23,
 
+  // E2E errors
+  E2E_BUILD_FAILED: 51,
+
   // Subprocess errors
   GIT_NOT_CLEAN: 101,
   GIT_OUT_OF_DATE: 102,

--- a/node-src/tasks/build.test.ts
+++ b/node-src/tasks/build.test.ts
@@ -200,7 +200,7 @@ describe('buildStorybook E2E', () => {
       log: { debug: vi.fn(), error: vi.fn() },
     } as any;
 
-    const errorMessage = 'Cannot find archive directory\n\nOther info';
+    const errorMessage = 'Command failed with exit code 1: npm exec build-archive-storybook --output-dir /tmp/chromatic--4210-0cyodqfYZabe\n\nMore error message lines\n\nAnd more';
     command.mockRejectedValueOnce(new Error(errorMessage));
     await expect(buildStorybook(ctx)).rejects.toThrow('Command failed');
     expect(ctx.log.error).not.toHaveBeenCalledWith(expect.stringContaining('Failed to import `@chromatic-com/playwright`'));

--- a/node-src/tasks/build.ts
+++ b/node-src/tasks/build.ts
@@ -71,7 +71,7 @@ function isE2EBuildCommandNotFoundError(errorMessage: string) {
     'exit code 127', // Exit code 127 is a generic not found exit code
     `command failed.*${e2eBuildBinName}.*$`]; // A single line error from execa like `Command failed: yarn build-archive-storybook ...`
 
-  return errorRegexes.some((regex) => errorMessage.match(new RegExp(regex, 'gi')));
+  return errorRegexes.some((regex) => (new RegExp(regex, 'gi')).test(errorMessage));
 }
 
 function e2eBuildErrorMessage(err, workingDir: string, ctx: Context): { exitCode: number, message: string } {

--- a/node-src/tasks/build.ts
+++ b/node-src/tasks/build.ts
@@ -11,7 +11,7 @@ import { endActivity, startActivity } from '../ui/components/activity';
 import buildFailed from '../ui/messages/errors/buildFailed';
 import { failed, initial, pending, skipped, success } from '../ui/tasks/build';
 import { getPackageManagerRunCommand } from '../lib/getPackageManager';
-import { buildBinName as e2EbuildBinName, getE2EBuildCommand, isE2EBuild } from '../lib/e2e';
+import { getE2EBuildCommand, isE2EBuild } from '../lib/e2e';
 import e2eBuildFailed from '../ui/messages/errors/e2eBuildFailed';
 
 export const setSourceDir = async (ctx: Context) => {
@@ -86,10 +86,7 @@ export const buildStorybook = async (ctx: Context) => {
     // If we tried to run the E2E package's bin directly (due to being in the action)
     // and it failed, that means we couldn't find it. This probably means they haven't
     // installed the right dependency or run from the right directory
-    if (
-      e.message.match(e2EbuildBinName) &&
-      isE2EBuild(ctx.options)
-    ) {
+    if (isE2EBuild(ctx.options)) {
       const flag = ctx.options.playwright ? 'playwright' : 'cypress';
       ctx.log.error(e2eBuildFailed({ flag, errorMessage: e.message }));
       setExitCode(ctx, exitCodes.E2E_BUILD_FAILED, true);

--- a/node-src/tasks/build.ts
+++ b/node-src/tasks/build.ts
@@ -64,7 +64,13 @@ const timeoutAfter = (ms) =>
 function isE2EBuildCommandNotFoundError(errorMessage: string) {
   // It's hard to know if this is the case as each package manager has a different type of
   // error for this, but we'll try to figure it out.
-  const errorRegexes = ['command not found', `[\\W]?${e2eBuildBinName}[\\W]? not found`, 'code E404', 'exit code 127', `command failed.*${e2eBuildBinName}.*$`];
+  const errorRegexes = [
+    'command not found', // `Command not found: build-archive-storybook`
+    `[\\W]?${e2eBuildBinName}[\\W]? not found`, // `Command "build-archive-storybook" not found`
+    'code E404', // npm not found error can include this code
+    'exit code 127', // Exit code 127 is a generic not found exit code
+    `command failed.*${e2eBuildBinName}.*$`]; // A single line error from execa like `Command failed: yarn build-archive-storybook ...`
+
   return errorRegexes.some((regex) => errorMessage.match(new RegExp(regex, 'gi')));
 }
 

--- a/node-src/tasks/build.ts
+++ b/node-src/tasks/build.ts
@@ -12,7 +12,7 @@ import buildFailed from '../ui/messages/errors/buildFailed';
 import { failed, initial, pending, skipped, success } from '../ui/tasks/build';
 import { getPackageManagerRunCommand } from '../lib/getPackageManager';
 import { buildBinName as e2EbuildBinName, getE2EBuildCommand, isE2EBuild } from '../lib/e2e';
-import missingDependency from '../ui/messages/errors/missingDependency';
+import e2eBuildFailed from '../ui/messages/errors/e2eBuildFailed';
 
 export const setSourceDir = async (ctx: Context) => {
   if (ctx.options.outputDir) {
@@ -87,15 +87,12 @@ export const buildStorybook = async (ctx: Context) => {
     // and it failed, that means we couldn't find it. This probably means they haven't
     // installed the right dependency or run from the right directory
     if (
-      ctx.options.inAction &&
-      (isE2EBuild(ctx.options)) &&
-      e.message.match(e2EbuildBinName)
+      e.message.match(e2EbuildBinName) &&
+      isE2EBuild(ctx.options)
     ) {
       const flag = ctx.options.playwright ? 'playwright' : 'cypress';
-      const dependencyName = `@chromatic-com/${flag}`;
-      ctx.log.error(missingDependency({ dependencyName, flag, workingDir: process.cwd() }));
-      ctx.log.debug(e);
-      setExitCode(ctx, exitCodes.MISSING_DEPENDENCY, true);
+      ctx.log.error(e2eBuildFailed({ flag, errorMessage: e.message }));
+      setExitCode(ctx, exitCodes.E2E_BUILD_FAILED, true);
       throw new Error(failed(ctx).output);
     }
 

--- a/node-src/tasks/build.ts
+++ b/node-src/tasks/build.ts
@@ -77,7 +77,7 @@ export const buildStorybook = async (ctx: Context) => {
     ctx.log.debug('Runtime metadata:', JSON.stringify(ctx.runtimeMetadata, null, 2));
 
     const subprocess = execaCommand(ctx.buildCommand, {
-      stdio: [null, logFile, logFile],
+      stdio: [null, logFile, null],
       signal,
       env: { NODE_ENV: ctx.env.STORYBOOK_NODE_ENV || 'production' },
     });

--- a/node-src/tasks/build.ts
+++ b/node-src/tasks/build.ts
@@ -61,21 +61,21 @@ export const setBuildCommand = async (ctx: Context) => {
 const timeoutAfter = (ms) =>
   new Promise((resolve, reject) => setTimeout(reject, ms, new Error(`Operation timed out`)));
 
-function isE2EBuildCommandNotFoundError(err) {
+function isE2EBuildCommandNotFoundError(errorMessage: string) {
   // It's hard to know if this is the case as each package manager has a different type of
   // error for this, but we'll try to figure it out.
-  const msg = err.message as string;
   const errorRegexes = ['command not found', `[\\W]?${e2eBuildBinName}[\\W]? not found`, 'code E404', 'exit code 127', `command failed.*${e2eBuildBinName}.*$`];
-  return errorRegexes.some((regex) => msg.match(new RegExp(regex, 'gi')));
+  return errorRegexes.some((regex) => errorMessage.match(new RegExp(regex, 'gi')));
 }
 
-function e2eBuildErrorMessage(err, workingDir, ctx: Context): { exitCode: number, message: string } {
+function e2eBuildErrorMessage(err, workingDir: string, ctx: Context): { exitCode: number, message: string } {
   const flag = ctx.options.playwright ? 'playwright' : 'cypress';
+  const errorMessage = err.message;
 
   // If we tried to run the E2E package's bin directly (due to being in the action)
   // and it failed, that means we couldn't find it. This probably means they haven't
   // installed the right dependency or run from the right directory.
-  if (isE2EBuildCommandNotFoundError(err)) {
+  if (isE2EBuildCommandNotFoundError(errorMessage)) {
     const dependencyName = `@chromatic-com/${flag}`;
     return {
       exitCode: exitCodes.MISSING_DEPENDENCY,
@@ -85,7 +85,7 @@ function e2eBuildErrorMessage(err, workingDir, ctx: Context): { exitCode: number
 
   return {
     exitCode: exitCodes.E2E_BUILD_FAILED,
-    message: e2eBuildFailed({ flag, errorMessage: err.message }),
+    message: e2eBuildFailed({ flag, errorMessage }),
   };
 }
 

--- a/node-src/ui/messages/errors/e2eBuildFailed.stories.ts
+++ b/node-src/ui/messages/errors/e2eBuildFailed.stories.ts
@@ -1,0 +1,8 @@
+import e2eBuildFailed from './e2eBuildFailed';
+
+export default {
+  title: 'CLI/Messages/Errors',
+};
+
+export const E2EBuildFailed = () =>
+  e2eBuildFailed({ flag: 'playwright', errorMessage: 'Error Message' });

--- a/node-src/ui/messages/errors/e2eBuildFailed.ts
+++ b/node-src/ui/messages/errors/e2eBuildFailed.ts
@@ -1,0 +1,17 @@
+import chalk from 'chalk';
+import { dedent } from 'ts-dedent';
+import { error } from '../../components/icons';
+
+export default ({
+  flag,
+  errorMessage,
+}: {
+  flag: string;
+  errorMessage: string;
+}) => {
+  return dedent(chalk`
+      ${error} Failed to run \`chromatic --${flag}\`:
+      
+      ${errorMessage}
+    `);
+};


### PR DESCRIPTION
Currently, any error thrown during the build step of an E2E build is treated as a missing dependency error, and the error message output is very specific to that. However, the build can fail for other reasons, such as archive directory not found. These other legit errors are swallowed and the resulting output is confusing.

This flips things around to try to determine if the error is due to a missing dependency, where the error usually has something to do about a command not being found. If the error message doesn't match, this will output a more generic error message that includes the original error message. 

**How to test**
* With a local project, install the canary CLI and try to run the chromatic command in both of the following scenarios and see that the errors are correct:
  * With the E2E dep installed, but with the archive directory removed
  * With the archive directory in place, but without the E2E dep installed
* Using the canary github action (`chromaui/action-canary@v1`), test a project with the above two scenarios and see that the errors are correct. 

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>11.0.5--canary.940.8192597877.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@11.0.5--canary.940.8192597877.0
  # or 
  yarn add chromatic@11.0.5--canary.940.8192597877.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
