### PR TITLE
escape special characters in onlyStoryFiles filenames

### DIFF
--- a/node-src/tasks/upload.test.ts
+++ b/node-src/tasks/upload.test.ts
@@ -164,6 +164,27 @@ describe('traceChangedFiles', () => {
     expect(ctx.onlyStoryFiles).toStrictEqual(Object.keys(deps));
   });
 
+  it('escapes special characters on context', async () => {
+    const deps = { './example-(new).stories.js': ['./example-(new).stories.js'] };
+    findChangedDependencies.mockResolvedValue([]);
+    findChangedPackageFiles.mockResolvedValue([]);
+    getDependentStoryFiles.mockResolvedValue(deps);
+
+    const ctx = {
+      env,
+      log,
+      http,
+      options: {},
+      sourceDir: '/static/',
+      fileInfo: { statsPath: '/static/preview-stats.json' },
+      git: { changedFiles: ['./example.js'] },
+      turboSnap: {},
+    } as any;
+    await traceChangedFiles(ctx, {} as any);
+
+    expect(ctx.onlyStoryFiles).toStrictEqual(["./example-\\(\\new\\)\\.stories.js"]);
+  });
+
   it('does not run package dependency analysis if there are no metadata changes', async () => {
     const deps = { 123: ['./example.stories.js'] };
     getDependentStoryFiles.mockResolvedValue(deps);

--- a/node-src/tasks/upload.ts
+++ b/node-src/tasks/upload.ts
@@ -37,6 +37,9 @@ interface PathSpec {
   contentLength: number;
 }
 
+const escapedSpecialChars = '`$^*+?()[]';
+const specialCharsRegex = new RegExp(`([${escapedSpecialChars.split('').join('\\')}])`);
+
 // Get all paths in rootDir, starting at dirname.
 // We don't want the paths to include rootDir -- so if rootDir = storybook-static,
 // paths will be like iframe.html rather than storybook-static/iframe.html
@@ -154,7 +157,9 @@ export const traceChangedFiles = async (ctx: Context, task: Task) => {
       changedDependencyNames || []
     );
     if (onlyStoryFiles) {
-      ctx.onlyStoryFiles = Object.keys(onlyStoryFiles);
+      // Escape special characters in the filename so it does not conflict with picomatch
+      ctx.onlyStoryFiles = Object.keys(onlyStoryFiles).map((key) => key.split(specialCharsRegex).join('\\'));
+
       if (!ctx.options.interactive) {
         if (!ctx.options.traceChanged) {
           ctx.log.info(


### PR DESCRIPTION
onlyStoryFiles filenames that contain special characters are potentially treated as globs during the picomatch evaluation step of TurboSnap

e.g. `./example-(new).stories.js` => `./example-\\(new\\).stories.js`


This PR escapes those special characters so they are treated as the true filepath and not a glob.


<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>11.0.5--canary.942.8193831248.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@11.0.5--canary.942.8193831248.0
  # or 
  yarn add chromatic@11.0.5--canary.942.8193831248.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
