### PR TITLE
Fix e2e peer dep versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -206,8 +206,8 @@
     "zod": "^3.22.2"
   },
   "peerDependencies": {
-    "@chromatic-com/cypress": "^0.5.2 || ^1.0.0",
-    "@chromatic-com/playwright": "^0.5.2 || ^1.0.0"
+    "@chromatic-com/cypress": "^0.*.* || ^1.0.0",
+    "@chromatic-com/playwright": "^0.*.* || ^1.0.0"
   },
   "peerDependenciesMeta": {
     "@chromatic-com/cypress": {


### PR DESCRIPTION
The `^0.5.2` version specifier will only match `0.5.x` versions, but we're at `0.6.x`.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>11.0.8--canary.943.8236202501.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@11.0.8--canary.943.8236202501.0
  # or 
  yarn add chromatic@11.0.8--canary.943.8236202501.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
