### PR TITLE
Restrict permissions in GitHub Action workflows

### DIFF
--- a/.github/workflows/check-labels.yml
+++ b/.github/workflows/check-labels.yml
@@ -3,6 +3,8 @@ on:
   pull_request:
     types: [opened, labeled, unlabeled, synchronize]
 
+permissions: {}
+
 jobs:
   check-labels:
     runs-on: ubuntu-latest

--- a/.github/workflows/chromatic-main-and-prs.yml
+++ b/.github/workflows/chromatic-main-and-prs.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     types: [assigned, ready_for_review, review_requested]
 
+permissions:
+  contents: read
+
 jobs:
   chromatic:
     runs-on: ubuntu-latest

--- a/.github/workflows/chromatic-prod.yml
+++ b/.github/workflows/chromatic-prod.yml
@@ -1,6 +1,9 @@
 name: Chromatic
 on: push
 
+permissions:
+  contents: read
+
 jobs:
   chromatic:
     runs-on: ubuntu-latest

--- a/.github/workflows/chromatic-staging.yml
+++ b/.github/workflows/chromatic-staging.yml
@@ -1,6 +1,9 @@
 name: Chromatic (staging)
 on: push
 
+permissions:
+  contents: read
+
 jobs:
   chromatic:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,10 @@ on:
       - package.json
       - storybook-addon.*
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   release:
     runs-on: ubuntu-latest

--- a/.github/workflows/smoke-test-action.yml
+++ b/.github/workflows/smoke-test-action.yml
@@ -1,6 +1,9 @@
 name: Smoke test via action
 on: push
 
+permissions:
+  contents: read
+
 jobs:
   self-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/smoke-test-node-api.yml
+++ b/.github/workflows/smoke-test-node-api.yml
@@ -1,6 +1,9 @@
 name: Smoke test via node api
 on: push
 
+permissions:
+  contents: read
+
 jobs:
   self-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/smoke-test-node18.yml
+++ b/.github/workflows/smoke-test-node18.yml
@@ -1,6 +1,9 @@
 name: Smoke test via Node 18
 on: push
 
+permissions:
+  contents: read
+
 jobs:
   self-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/smoke-test-node20.yml
+++ b/.github/workflows/smoke-test-node20.yml
@@ -1,6 +1,9 @@
 name: Smoke test via Node 20
 on: push
 
+permissions:
+  contents: read
+
 jobs:
   self-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/smoke-test-npx.yml
+++ b/.github/workflows/smoke-test-npx.yml
@@ -1,6 +1,9 @@
 name: Smoke test via npx
 on: push
 
+permissions:
+  contents: read
+
 jobs:
   chromatic:
     runs-on: ubuntu-latest

--- a/.github/workflows/smoke-test-windows.yml
+++ b/.github/workflows/smoke-test-windows.yml
@@ -1,6 +1,9 @@
 name: Smoke test via yarn on Windows
 on: push
 
+permissions:
+  contents: read
+
 jobs:
   chromatic:
     runs-on: windows-latest

--- a/.github/workflows/smoke-test-yarn-berry.yml
+++ b/.github/workflows/smoke-test-yarn-berry.yml
@@ -1,6 +1,9 @@
 name: Smoke test via yarn berry
 on: push
 
+permissions:
+  contents: read
+
 jobs:
   chromatic:
     runs-on: ubuntu-latest

--- a/.github/workflows/smoke-test-yarn-canary.yml
+++ b/.github/workflows/smoke-test-yarn-canary.yml
@@ -1,6 +1,9 @@
 name: Smoke test via yarn canary
 on: push
 
+permissions:
+  contents: read
+
 jobs:
   chromatic:
     runs-on: ubuntu-latest

--- a/.github/workflows/smoke-test-yarn-classic.yml
+++ b/.github/workflows/smoke-test-yarn-classic.yml
@@ -1,6 +1,9 @@
 name: Smoke test via yarn classic
 on: push
 
+permissions:
+  contents: read
+
 jobs:
   chromatic:
     runs-on: ubuntu-latest

--- a/.github/workflows/smoke-test-yarn.yml
+++ b/.github/workflows/smoke-test-yarn.yml
@@ -1,6 +1,9 @@
 name: Smoke test via yarn
 on: push
 
+permissions:
+  contents: read
+
 jobs:
   self-test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This came recommended by [Checkov](https://github.com/bridgecrewio/checkov).
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>11.0.9--canary.946.8261369317.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@11.0.9--canary.946.8261369317.0
  # or 
  yarn add chromatic@11.0.9--canary.946.8261369317.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
