### PR TITLE
Fixes for various issues reported by Codacy

### DIFF
--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,3 +1,3 @@
 # Support
 
-👉 https://www.chromatic.com/docs/support
+👉 <https://www.chromatic.com/docs/support>

--- a/node-src/tasks/build.ts
+++ b/node-src/tasks/build.ts
@@ -64,17 +64,26 @@ const timeoutAfter = (ms) =>
 function isE2EBuildCommandNotFoundError(errorMessage: string) {
   // It's hard to know if this is the case as each package manager has a different type of
   // error for this, but we'll try to figure it out.
-  const errorRegexes = [
-    'command not found', // `Command not found: build-archive-storybook`
-    `[\\W]?${e2eBuildBinName}[\\W]? not found`, // `Command "build-archive-storybook" not found`
-    'code E404', // npm not found error can include this code
-    'exit code 127', // Exit code 127 is a generic not found exit code
-    `command failed.*${e2eBuildBinName}.*$`]; // A single line error from execa like `Command failed: yarn build-archive-storybook ...`
-
-  return errorRegexes.some((regex) => (new RegExp(regex, 'gi')).test(errorMessage));
+  const ERROR_PATTERNS = [
+    // `Command not found: build-archive-storybook`
+    'command not found',
+    // `Command "build-archive-storybook" not found`
+    `[\\W]?${e2eBuildBinName}[\\W]? not found`,
+    // npm not found error can include this code
+    'code E404',
+    // Exit code 127 is a generic not found exit code
+    'exit code 127',
+    // A single line error from execa like `Command failed: yarn build-archive-storybook ...`
+    `command failed.*${e2eBuildBinName}.*$`,
+  ];
+  return ERROR_PATTERNS.some((PATTERN) => new RegExp(PATTERN, 'gi').test(errorMessage));
 }
 
-function e2eBuildErrorMessage(err, workingDir: string, ctx: Context): { exitCode: number, message: string } {
+function e2eBuildErrorMessage(
+  err,
+  workingDir: string,
+  ctx: Context
+): { exitCode: number; message: string } {
   const flag = ctx.options.playwright ? 'playwright' : 'cypress';
   const errorMessage = err.message;
 

--- a/node-src/tasks/upload.ts
+++ b/node-src/tasks/upload.ts
@@ -37,8 +37,7 @@ interface PathSpec {
   contentLength: number;
 }
 
-const escapedSpecialChars = '`$^*+?()[]';
-const specialCharsRegex = new RegExp(`([${escapedSpecialChars.split('').join('\\')}])`);
+const SPECIAL_CHARS_REGEXP = new RegExp(`([${'`$^*+?()[]'.split('').join('\\')}])`);
 
 // Get all paths in rootDir, starting at dirname.
 // We don't want the paths to include rootDir -- so if rootDir = storybook-static,
@@ -158,7 +157,9 @@ export const traceChangedFiles = async (ctx: Context, task: Task) => {
     );
     if (onlyStoryFiles) {
       // Escape special characters in the filename so it does not conflict with picomatch
-      ctx.onlyStoryFiles = Object.keys(onlyStoryFiles).map((key) => key.split(specialCharsRegex).join('\\'));
+      ctx.onlyStoryFiles = Object.keys(onlyStoryFiles).map((key) =>
+        key.split(SPECIAL_CHARS_REGEXP).join('\\')
+      );
 
       if (!ctx.options.interactive) {
         if (!ctx.options.traceChanged) {


### PR DESCRIPTION
Codacy was complaining about some non-literal regexes. These use hardcoded values so they're safe, but that wasn't super obvious. I clarified that by using CONSTANT_CASE for these hardcoded values.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>11.0.9--canary.947.8261414908.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@11.0.9--canary.947.8261414908.0
  # or 
  yarn add chromatic@11.0.9--canary.947.8261414908.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
