### PR TITLE
Tell SB8 users to pass `--stats-json` rather than `--webpack-stats-json`

### DIFF
--- a/node-src/ui/messages/errors/missingStatsFile.stories.ts
+++ b/node-src/ui/messages/errors/missingStatsFile.stories.ts
@@ -4,4 +4,6 @@ export default {
   title: 'CLI/Messages/Errors',
 };
 
-export const MissingStatsFile = () => missingStatsFile();
+export const MissingStatsFile = () => missingStatsFile({ legacy: false });
+
+export const MissingStatsFileLegacy = () => missingStatsFile({ legacy: true });

--- a/node-src/ui/messages/errors/missingStatsFile.ts
+++ b/node-src/ui/messages/errors/missingStatsFile.ts
@@ -3,9 +3,11 @@ import { dedent } from 'ts-dedent';
 
 import { error } from '../../components/icons';
 
-export default () =>
+export default ({ legacy }: { legacy: boolean }) =>
   dedent(chalk`
     ${error} {bold TurboSnap disabled due to missing stats file}
     Did not find {bold preview-stats.json} in your built Storybook.
-    Make sure you pass {bold --webpack-stats-json} when building your Storybook.
+    Make sure you pass {bold ${
+      legacy ? `--webpack-stats-json` : `--stats-json`
+    }} when building your Storybook.
   `);


### PR DESCRIPTION
Storybook 8 now supports generating stats for Vite projects, and so has updated the flag in order to not confuse Vite users. We should do likewise.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>11.0.9--canary.948.8260838530.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@11.0.9--canary.948.8260838530.0
  # or 
  yarn add chromatic@11.0.9--canary.948.8260838530.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
