### PR TITLE
Properly handle GitHub Action inputs that can have multiple values

### DIFF
--- a/action-src/main.ts
+++ b/action-src/main.ts
@@ -4,9 +4,13 @@ import path from 'path';
 
 import { run as runNode } from '../node-src';
 
-const maybe = (a: string, b: any = undefined) => {
+const maybe = (a: string | string[], b: any = undefined) => {
   if (!a) {
     return b;
+  }
+
+  if (Array.isArray(a)) {
+    return a;
   }
 
   try {

--- a/action-src/main.ts
+++ b/action-src/main.ts
@@ -1,4 +1,4 @@
-import { error, getInput, setFailed, setOutput } from '@actions/core';
+import { error, getInput, getMultilineInput, setFailed, setOutput } from '@actions/core';
 import { context } from '@actions/github';
 import path from 'path';
 
@@ -100,15 +100,15 @@ async function run() {
     const dryRun = getInput('dryRun');
     const exitOnceUploaded = getInput('exitOnceUploaded');
     const exitZeroOnChanges = getInput('exitZeroOnChanges');
-    const externals = getInput('externals');
+    const externals = getMultilineInput('externals');
     const fileHashing = getInput('fileHashing');
     const forceRebuild = getInput('forceRebuild');
     const ignoreLastBuildOnBranch = getInput('ignoreLastBuildOnBranch');
     const logFile = getInput('logFile');
     const only = getInput('only');
     const onlyChanged = getInput('onlyChanged');
-    const onlyStoryFiles = getInput('onlyStoryFiles');
-    const onlyStoryNames = getInput('onlyStoryNames');
+    const onlyStoryFiles = getMultilineInput('onlyStoryFiles');
+    const onlyStoryNames = getMultilineInput('onlyStoryNames');
     const playwright = getInput('playwright');
     const preserveMissing = getInput('preserveMissing');
     const projectToken = getInput('projectToken') || getInput('appCode'); // backwards compatibility
@@ -119,7 +119,7 @@ async function run() {
     const storybookConfigDir = getInput('storybookConfigDir');
     const storybookLogFile = getInput('storybookLogFile');
     const traceChanged = getInput('traceChanged');
-    const untraced = getInput('untraced');
+    const untraced = getMultilineInput('untraced');
     const uploadMetadata = getInput('uploadMetadata');
     const workingDir = getInput('workingDir') || getInput('workingDirectory');
     const zip = getInput('zip');


### PR DESCRIPTION
The syntax we currently propose for passing multiple values to an input in the GitHub Action is as follows:
```
externals: |
  - '*.sass'
  - 'public/**'
```

But that will be parsed into a single string with multiple lines that looks like this:
```
"- '*.sass'\n
- 'public/**'"
```

That won't behave as expected when passed along to the CLI.

The correct syntax for this should be like so:
```
externals: |
  *.sass
  public/**
```

That, along with the changes in this PR to use `getMultilineInput` to get those values will give us an array like we need:
```
["*.sass", "public/**"]
```

That can be passed along to the CLI, which expects a `string[]` for these inputs.

**How to test**
This has been published as `chromaui/action-canary@v1` and the CLI canary is below.

Try this out with no values for the inputs, a single value for `externals`, and multiple values with the new syntax for `externals`.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>11.1.1--canary.951.8349839764.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@11.1.1--canary.951.8349839764.0
  # or 
  yarn add chromatic@11.1.1--canary.951.8349839764.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
