### PR TITLE
Fix GitHub Action release script using data from Auto shipIt hook rather than from Git

### DIFF
--- a/node-src/types.ts
+++ b/node-src/types.ts
@@ -212,6 +212,8 @@ export interface Context {
     committerEmail?: string;
     committedAt: number;
     slug?: string;
+    fromCI: boolean;
+    ciService?: string;
     mergeCommit?: string;
     uncommittedHash?: string;
     parentCommits?: string[];

--- a/node-src/ui/messages/errors/fatalError.ts
+++ b/node-src/ui/messages/errors/fatalError.ts
@@ -40,7 +40,11 @@ export default function fatalError(
     {
       timestamp,
       sessionId,
-      gitVersion: git && git.version,
+      gitVersion: git?.version,
+      gitBranch: git?.branch,
+      gitSlug: git?.slug,
+      fromCI: git?.fromCI,
+      ciService: git?.ciService,
       nodePlatform: process.platform,
       nodeVersion: process.versions.node,
       ...runtimeMetadata,
@@ -50,6 +54,9 @@ export default function fatalError(
       flags,
       ...(extraOptions && { extraOptions }),
       ...(configuration && { configuration }),
+      ...('options' in ctx && ctx.options?.isLocalBuild
+        ? { isLocalBuild: ctx.options.isLocalBuild }
+        : {}),
       ...('options' in ctx && ctx.options?.buildScriptName
         ? { buildScript: scripts[ctx.options.buildScriptName] }
         : {}),

--- a/package.json
+++ b/package.json
@@ -228,7 +228,13 @@
     },
     "plugins": [
       "npm",
-      "released"
+      "released",
+      [
+        "exec",
+        {
+          "afterShipIt": "yarn run publish-action"
+        }
+      ]
     ]
   },
   "docs": "https://www.chromatic.com/docs/cli",

--- a/scripts/publish-action.mjs
+++ b/scripts/publish-action.mjs
@@ -79,6 +79,8 @@ const publishAction = async ({ major, version, repo }) => {
     version = data.newVersion;
     console.info(`📌 Using auto shipIt context: ${context}`);
     console.info(`📌 Using auto shipIt version: ${version}`);
+    console.info(`Commits in release:`);
+    data.commitsInRelease.forEach((c) => console.info(`- ${c.hash.slice(0, 8)} ${c.subject}`));
   }
 
   const [, major, minor, patch] = version.match(/(\d+)\.(\d+)\.(\d+)-*(\w+)?/) || [];

--- a/scripts/publish-action.mjs
+++ b/scripts/publish-action.mjs
@@ -2,6 +2,7 @@
 
 import cpy from 'cpy';
 import { $ } from 'execa';
+import { readFileSync } from 'fs';
 import tmp from 'tmp-promise';
 
 const copy = (globs, ...args) => {
@@ -65,7 +66,7 @@ const publishAction = async ({ major, version, repo }) => {
     return;
   }
 
-  const { default: pkg } = await import('../package.json', { assert: { type: 'json' } });
+  const pkg = JSON.parse(readFileSync('package.json', 'utf8'));
 
   const [, major, minor, patch, tag] = pkg.version.match(/(\d+)\.(\d+)\.(\d+)-*(\w+)?/) || [];
   if (!major || !minor || !patch) {


### PR DESCRIPTION
This restores the `afterShipIt` hook to automatically release the GitHub Action after releasing to npm. To prevent the wrong contents from being published, the publish-action script was updated to pull context (canary|next|latest) and package version number from the `ARG_0` environment variable provided by Auto, rather than trying to retrieve this info based on the Git branch and repository contents.

Furthermore, some log data was added for easier debugging.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>11.1.1--canary.956.8351561816.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@11.1.1--canary.956.8351561816.0
  # or 
  yarn add chromatic@11.1.1--canary.956.8351561816.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
