### PR TITLE
Trim `v` prefix from shipIt's version to avoid double prefixing tags

### DIFF
--- a/scripts/publish-action.mjs
+++ b/scripts/publish-action.mjs
@@ -76,14 +76,14 @@ const publishAction = async ({ major, version, repo }) => {
   } else {
     const data = JSON.parse(process.env.ARG_0);
     context = data.context;
-    version = data.newVersion;
+    version = data.newVersion.replace(/^v/, '');
     console.info(`📌 Using auto shipIt context: ${context}`);
     console.info(`📌 Using auto shipIt version: ${version}`);
     console.info(`Commits in release:`);
     data.commitsInRelease.forEach((c) => console.info(`- ${c.hash.slice(0, 8)} ${c.subject}`));
   }
 
-  const [, major, minor, patch] = version.match(/(\d+)\.(\d+)\.(\d+)-*(\w+)?/) || [];
+  const [, major, minor, patch] = version.match(/^(\d+)\.(\d+)\.(\d+)-*(\w+)?/) || [];
   if (!major || !minor || !patch) {
     console.error(`❗️ Invalid version: ${version}`);
     return;


### PR DESCRIPTION
Auto shipIt's `newVersion` field is prefixed with `v` (e.g. `v11.2.0`), whilst the `version` field in package.json is not. This was causing the tags on the GitHub Action repo to be double-prefixed, e.g. `vv11.2.0`. Trimming the prefix from `newVersion` avoids that.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>11.2.1--canary.960.8357991504.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@11.2.1--canary.960.8357991504.0
  # or 
  yarn add chromatic@11.2.1--canary.960.8357991504.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
