### PR TITLE
Throw user-friendly error when config file fails to parse as JSON

### DIFF
--- a/node-src/lib/getConfiguration.test.ts
+++ b/node-src/lib/getConfiguration.test.ts
@@ -151,3 +151,24 @@ it('errors if config file contains unknown keys', async () => {
 
   await expect(getConfiguration('test.file')).rejects.toThrow(/random/);
 });
+
+it('errors if config file is unparseable', async () => {
+  {
+    mockedReadFile.mockReturnValue('invalid json');
+    await expect(getConfiguration('test.file')).rejects.toThrow(
+      /Configuration file .+ could not be parsed(.|\n)*Unexpected token i in JSON/
+    );
+  }
+  {
+    mockedReadFile.mockReturnValue('{ "foo": 1 "unexpectedString": 2 }');
+    await expect(getConfiguration('test.file')).rejects.toThrow(
+      /Configuration file .+ could not be parsed(.|\n)*Unexpected string in JSON/m
+    );
+  }
+  {
+    mockedReadFile.mockReturnValue('{ "unexpectedEnd": ');
+    await expect(getConfiguration('test.file')).rejects.toThrow(
+      /Configuration file .+ could not be parsed(.|\n)*Unexpected end of JSON input/m
+    );
+  }
+});

--- a/node-src/lib/getConfiguration.test.ts
+++ b/node-src/lib/getConfiguration.test.ts
@@ -156,19 +156,19 @@ it('errors if config file is unparseable', async () => {
   {
     mockedReadFile.mockReturnValue('invalid json');
     await expect(getConfiguration('test.file')).rejects.toThrow(
-      /Configuration file .+ could not be parsed(.|\n)*Unexpected token i in JSON/
+      /Configuration file .+ could not be parsed(.|\n)*Unexpected token/
     );
   }
   {
     mockedReadFile.mockReturnValue('{ "foo": 1 "unexpectedString": 2 }');
     await expect(getConfiguration('test.file')).rejects.toThrow(
-      /Configuration file .+ could not be parsed(.|\n)*Unexpected string in JSON/m
+      /Configuration file .+ could not be parsed(.|\n)*Unexpected string/m
     );
   }
   {
     mockedReadFile.mockReturnValue('{ "unexpectedEnd": ');
     await expect(getConfiguration('test.file')).rejects.toThrow(
-      /Configuration file .+ could not be parsed(.|\n)*Unexpected end of JSON input/m
+      /Configuration file .+ could not be parsed(.|\n)*Unexpected end/m
     );
   }
 });

--- a/node-src/lib/getConfiguration.test.ts
+++ b/node-src/lib/getConfiguration.test.ts
@@ -156,19 +156,19 @@ it('errors if config file is unparseable', async () => {
   {
     mockedReadFile.mockReturnValue('invalid json');
     await expect(getConfiguration('test.file')).rejects.toThrow(
-      /Configuration file .+ could not be parsed(.|\n)*Unexpected token/
+      /Configuration file .+ could not be parsed/
     );
   }
   {
     mockedReadFile.mockReturnValue('{ "foo": 1 "unexpectedString": 2 }');
     await expect(getConfiguration('test.file')).rejects.toThrow(
-      /Configuration file .+ could not be parsed(.|\n)*Unexpected string/m
+      /Configuration file .+ could not be parsed/
     );
   }
   {
     mockedReadFile.mockReturnValue('{ "unexpectedEnd": ');
     await expect(getConfiguration('test.file')).rejects.toThrow(
-      /Configuration file .+ could not be parsed(.|\n)*Unexpected end/m
+      /Configuration file .+ could not be parsed/
     );
   }
 });

--- a/node-src/lib/getConfiguration.ts
+++ b/node-src/lib/getConfiguration.ts
@@ -62,10 +62,7 @@ export async function getConfiguration(
         throw new Error(missingConfigurationFile(configFile));
       }
     }
-    if (
-      err.message.match('Unexpected string') ||
-      err.message.match('Unexpected end of JSON input')
-    ) {
+    if (err instanceof SyntaxError) {
       throw new Error(unparseableConfigurationFile(usedConfigFile, err));
     }
     if (err instanceof ZodError) {

--- a/node-src/lib/getConfiguration.ts
+++ b/node-src/lib/getConfiguration.ts
@@ -62,7 +62,10 @@ export async function getConfiguration(
         throw new Error(missingConfigurationFile(configFile));
       }
     }
-    if (err.message.match('Unexpected string')) {
+    if (
+      err.message.match('Unexpected string') ||
+      err.message.match('Unexpected end of JSON input')
+    ) {
       throw new Error(unparseableConfigurationFile(usedConfigFile, err));
     }
     if (err instanceof ZodError) {


### PR DESCRIPTION
Fixes https://github.com/chromaui/addon-visual-tests/issues/247

If the Chromatic config file contains invalid JSON, a parse error is thrown in the CLI and printed by the Storybook process. The CLI did already have some handling of this scenario but it wasn't covering every type of JSON syntax error. This update will make it print a nicer error message that includes the config file path so people will know where to look.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>11.3.0--canary.961.8469857131.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@11.3.0--canary.961.8469857131.0
  # or 
  yarn add chromatic@11.3.0--canary.961.8469857131.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
