### PR TITLE
Suppress issues caused by missing Git remote

### DIFF
--- a/node-src/git/git.ts
+++ b/node-src/git/git.ts
@@ -148,10 +148,15 @@ export async function getChangedFiles(baseCommit: string, headCommit = '') {
 
 /**
  * Returns a boolean indicating whether the workspace is up-to-date (neither ahead nor behind) with
- * the remote.
+ * the remote. Returns true on error, assuming the workspace is up-to-date.
  */
 export async function isUpToDate({ log }: Pick<Context, 'log'>) {
-  execGitCommand(`git remote update`);
+  try {
+    await execGitCommand(`git remote update`);
+  } catch (e) {
+    log.warn(e);
+    return true;
+  }
 
   let localCommit;
   try {

--- a/node-src/tasks/gitInfo.ts
+++ b/node-src/tasks/gitInfo.ts
@@ -83,12 +83,11 @@ export const setGitInfo = async (ctx: Context, task: Task) => {
   }
 
   if (!ctx.git.slug) {
-    await getSlug().then(
-      (slug) => {
-        ctx.git.slug = slug;
-      },
-      (e) => ctx.log.warn('Failed to retrieve slug', e)
-    );
+    try {
+      ctx.git.slug = await getSlug();
+    } catch (e) {
+      ctx.log.debug('Failed to retrieve Git repository slug', e);
+    }
   }
 
   if (ownerName) {


### PR DESCRIPTION
A missing slug (caused by missing Git remote URL) is not a serious problem, so there is no need to log a warning for it. A debug message is more appropriate.

The patch build mechanism attempts to check for remote updates, which when failed should not prevent the patch build from running. In this case a warning _is_ appropriate because it might lead to unexpected results.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>11.2.1--canary.962.8479861319.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@11.2.1--canary.962.8479861319.0
  # or 
  yarn add chromatic@11.2.1--canary.962.8479861319.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
