### PR TITLE
Properly check `storybookBaseDir` against repository root rather than CWD

### DIFF
--- a/node-src/lib/checkStorybookBaseDir.ts
+++ b/node-src/lib/checkStorybookBaseDir.ts
@@ -4,10 +4,12 @@ import { invalidStorybookBaseDir } from '../ui/messages/errors/invalidStorybookB
 import { Context, Stats } from '../types';
 import pLimit from 'p-limit';
 import { exitCodes, setExitCode } from './setExitCode';
+import { getRepositoryRoot } from '../git/git';
 
 export async function checkStorybookBaseDir(ctx: Context, stats: Stats) {
+  const repositoryRoot = await getRepositoryRoot();
   const { storybookBaseDir = '' } = ctx.options;
-  ctx.log.debug('Storybook base directory:', storybookBaseDir);
+  ctx.log.debug('Storybook base directory:', path.join(repositoryRoot, storybookBaseDir));
 
   // Find all js(x)/ts(x) files in stats that are not in node_modules
   const sourceModuleFiles = stats.modules.filter(
@@ -22,7 +24,7 @@ export async function checkStorybookBaseDir(ctx: Context, stats: Stats) {
     await Promise.any(
       sourceModuleFiles.map((file) => {
         return limitConcurrency(() => {
-          const absolutePath = path.join(storybookBaseDir, file.name);
+          const absolutePath = path.join(repositoryRoot, storybookBaseDir, file.name);
           return new Promise((resolve, reject) =>
             fs.access(absolutePath, (err) => {
               if (err) {


### PR DESCRIPTION
The `storybookBaseDir` option was being checked as a relative path, which caused `checkStorybookBaseDir` to fail when running Storybook from a subdirectory rather than the repository root. This PR ensures we use the repository root rather than the current working directory when checking the `storybookBaseDir` value.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>11.3.1--canary.974.8970353514.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@11.3.1--canary.974.8970353514.0
  # or 
  yarn add chromatic@11.3.1--canary.974.8970353514.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
