### PR TITLE
Use current working directory as default value for `storybookBaseDir`

### DIFF
--- a/node-src/lib/checkStorybookBaseDir.test.ts
+++ b/node-src/lib/checkStorybookBaseDir.test.ts
@@ -99,4 +99,22 @@ describe('checkStorybookBaseDir', () => {
 
     await expect(() => checkStorybookBaseDir(ctx, stats)).rejects.toThrow();
   });
+
+  it('should assume current working directory if no storybookBaseDir is specified', async () => {
+    const ctx = getContext();
+    const stats = {
+      modules: [
+        {
+          id: './node-src/index.ts',
+          name: './node-src/index.ts',
+        },
+      ],
+    };
+
+    getRepositoryRoot.mockResolvedValueOnce(process.cwd());
+    await expect(checkStorybookBaseDir(ctx, stats)).resolves.toBeUndefined();
+
+    getRepositoryRoot.mockResolvedValueOnce(path.resolve(process.cwd(), '..'));
+    await expect(checkStorybookBaseDir(ctx, stats)).resolves.toBeUndefined();
+  });
 });

--- a/node-src/lib/checkStorybookBaseDir.ts
+++ b/node-src/lib/checkStorybookBaseDir.ts
@@ -8,8 +8,9 @@ import { getRepositoryRoot } from '../git/git';
 
 export async function checkStorybookBaseDir(ctx: Context, stats: Stats) {
   const repositoryRoot = await getRepositoryRoot();
-  const { storybookBaseDir = '' } = ctx.options;
-  ctx.log.debug('Storybook base directory:', path.join(repositoryRoot, storybookBaseDir));
+
+  // Assume CWD if no storybookBaseDir is provided
+  const { storybookBaseDir = path.relative(repositoryRoot, '') } = ctx.options;
 
   // Find all js(x)/ts(x) files in stats that are not in node_modules
   const sourceModuleFiles = stats.modules.filter(
@@ -39,7 +40,6 @@ export async function checkStorybookBaseDir(ctx: Context, stats: Stats) {
       })
     );
   } catch (err) {
-    ctx.log.error(invalidStorybookBaseDir());
     setExitCode(ctx, exitCodes.INVALID_OPTIONS, true);
     throw new Error(invalidStorybookBaseDir());
   }

--- a/node-src/lib/checkStorybookBaseDir.ts
+++ b/node-src/lib/checkStorybookBaseDir.ts
@@ -40,6 +40,7 @@ export async function checkStorybookBaseDir(ctx: Context, stats: Stats) {
       })
     );
   } catch (err) {
+    ctx.log.debug(`Invalid storybookBaseDir: ${storybookBaseDir}`);
     setExitCode(ctx, exitCodes.INVALID_OPTIONS, true);
     throw new Error(invalidStorybookBaseDir());
   }


### PR DESCRIPTION
`getDependentStoryFiles` has always used the current working directory as base directory when `storybookBaseDir` isn't set, making it zero-config in most cases. `checkStorybookBaseDir` wasn't behaving in the same way, causing it to throw an error when it shouldn't. This update fixes this inconsistency by using the current working directory relative to the repository root as the default value for `storybookBaseDir`.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>11.3.2--canary.976.9002833958.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@11.3.2--canary.976.9002833958.0
  # or 
  yarn add chromatic@11.3.2--canary.976.9002833958.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
