### PR TITLE
Remove console log

### DIFF
--- a/node-src/lib/e2e.ts
+++ b/node-src/lib/e2e.ts
@@ -32,8 +32,6 @@ export async function getE2EBuildCommand(
   flag: 'playwright' | 'cypress',
   buildCommandOptions: string[]
 ) {
-  console.log('here', ctx.options.inAction);
-
   // The action cannot "peer depend" on or import anything. So instead, we must attempt to exec
   // the binary directly.
   if (ctx.options.inAction) {


### PR DESCRIPTION
Removes a stray debugging log.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>11.3.6--canary.979.9173982602.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@11.3.6--canary.979.9173982602.0
  # or 
  yarn add chromatic@11.3.6--canary.979.9173982602.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
