### PR TITLE
Fix dependency tracing when running from a subdirectory

### DIFF
--- a/node-src/git/git.ts
+++ b/node-src/git/git.ts
@@ -8,7 +8,6 @@ import { Context } from '../types';
 import gitNoCommits from '../ui/messages/errors/gitNoCommits';
 import gitNotInitialized from '../ui/messages/errors/gitNotInitialized';
 import gitNotInstalled from '../ui/messages/errors/gitNotInstalled';
-import path from 'node:path';
 
 const newline = /\r\n|\r|\n/; // Git may return \n even on Windows, so we can't use EOL
 export const NULL_BYTE = '\0'; // Separator used when running `git ls-files` with `-z`
@@ -289,8 +288,10 @@ export async function findFilesFromRepositoryRoot(...patterns: string[]) {
 
   // Ensure patterns are referenced from the repository root so that running
   // from within a subdirectory does not skip the directories above
-  // e.g. /root/package.json and /root/**/package.json
-  const patternsFromRoot = patterns.map((pattern) => path.join(repoRoot, pattern));
+  // e.g. /root/package.json, /root/**/package.json
+  // Note that this does not use `path.join` to concatenate the file paths because
+  // git uses forward slashes, even on windows
+  const patternsFromRoot = patterns.map((pattern) => `${repoRoot}/${pattern}`);
   
   // Uses `--full-name` to ensure that all files found are relative to the repository root,
   // not the directory in which this is executed from

--- a/node-src/git/git.ts
+++ b/node-src/git/git.ts
@@ -11,6 +11,7 @@ import gitNotInstalled from '../ui/messages/errors/gitNotInstalled';
 import path from 'node:path';
 
 const newline = /\r\n|\r|\n/; // Git may return \n even on Windows, so we can't use EOL
+export const NULL_BYTE = '\0'; // Separator used when running `git ls-files` with `-z`
 
 export async function execGitCommand(command: string) {
   try {
@@ -295,7 +296,7 @@ export async function findFilesFromRepositoryRoot(...patterns: string[]) {
   // not the directory in which this is executed from
   const gitCommand = `git ls-files --full-name -z ${patternsFromRoot.map((p) => `'${p}'`).join(' ')}`;
   const files = await execGitCommand(gitCommand);
-  return files.split('\0').filter(Boolean);
+  return files.split(NULL_BYTE).filter(Boolean);
 }
 
 export async function mergeQueueBranchMatch(branch) {

--- a/node-src/lib/findChangedDependencies.test.ts
+++ b/node-src/lib/findChangedDependencies.test.ts
@@ -12,17 +12,17 @@ vi.mock('../git/git');
 
 const getRepositoryRoot = vi.mocked(git.getRepositoryRoot);
 const checkoutFile = vi.mocked(git.checkoutFile);
-const findFiles = vi.mocked(git.findFiles);
+const findFilesFromRepositoryRoot = vi.mocked(git.findFilesFromRepositoryRoot);
 const buildDepTree = vi.mocked(buildDepTreeFromFiles);
 
 beforeEach(() => {
   getRepositoryRoot.mockResolvedValue('/root');
-  findFiles.mockImplementation((file) => Promise.resolve(file.startsWith('**') ? [] : [file]));
+  findFilesFromRepositoryRoot.mockImplementation((file) => Promise.resolve(file.startsWith('**') ? [] : [file]));
 });
 afterEach(() => {
   getRepositoryRoot.mockReset();
   checkoutFile.mockReset();
-  findFiles.mockReset();
+  findFilesFromRepositoryRoot.mockReset();
   buildDepTree.mockReset();
 });
 
@@ -214,7 +214,7 @@ describe('findChangedDependencies', () => {
   });
 
   it('looks for manifest and lock files in subpackages', async () => {
-    findFiles.mockImplementation((file) =>
+    findFilesFromRepositoryRoot.mockImplementation((file) =>
       Promise.resolve(file.startsWith('**') ? [file.replace('**', 'subdir')] : [file])
     );
 
@@ -266,7 +266,7 @@ describe('findChangedDependencies', () => {
   });
 
   it('uses root lockfile when subpackage lockfile is missing', async () => {
-    findFiles.mockImplementation((file) => {
+    findFilesFromRepositoryRoot.mockImplementation((file) => {
       if (file === 'subdir/yarn.lock') return Promise.resolve([]);
       return Promise.resolve(file.startsWith('**') ? [file.replace('**', 'subdir')] : [file]);
     });
@@ -291,7 +291,7 @@ describe('findChangedDependencies', () => {
   });
 
   it('ignores lockfile changes if metadata file is untraced', async () => {
-    findFiles.mockImplementation((file) => {
+    findFilesFromRepositoryRoot.mockImplementation((file) => {
       if (file === 'subdir/yarn.lock') return Promise.resolve([]);
       return Promise.resolve(file.startsWith('**') ? [file.replace('**', 'subdir')] : [file]);
     });
@@ -313,7 +313,7 @@ describe('findChangedDependencies', () => {
   });
 
   it('uses package-lock.json if yarn.lock is missing', async () => {
-    findFiles.mockImplementation((file) => {
+    findFilesFromRepositoryRoot.mockImplementation((file) => {
       if (file.endsWith('yarn.lock'))
         return Promise.resolve([file.replace('yarn.lock', 'package-lock.json')]);
       return Promise.resolve(file.startsWith('**') ? [file.replace('**', 'subdir')] : [file]);

--- a/node-src/lib/findChangedDependencies.ts
+++ b/node-src/lib/findChangedDependencies.ts
@@ -39,13 +39,15 @@ export const findChangedDependencies = async (ctx: Context) => {
   ctx.log.debug({ rootPath, rootManifestPath, rootLockfilePath }, `Found manifest and lockfile`);
 
   // Handle monorepos with (multiple) nested package.json files.
-  const nestedManifestPaths = await findFilesFromRepositoryRoot(path.join('**', PACKAGE_JSON));
+  // Note that this does not use `path.join` to concatenate the file paths because
+  // git uses forward slashes, even on windows
+  const nestedManifestPaths = await findFilesFromRepositoryRoot(`**/${PACKAGE_JSON}`);
   const metadataPathPairs = await Promise.all(
     nestedManifestPaths.map(async (manifestPath) => {
       const dirname = path.dirname(manifestPath);
       const [lockfilePath] = await findFilesFromRepositoryRoot(
-        path.join(dirname, YARN_LOCK),
-        path.join(dirname, PACKAGE_LOCK)
+        `${dirname}/${YARN_LOCK}`,
+        `${dirname}/${PACKAGE_LOCK}`
       );
       // Fall back to the root lockfile if we can't find one in the same directory.
       return [manifestPath, lockfilePath || rootLockfilePath];

--- a/node-src/lib/findChangedDependencies.ts
+++ b/node-src/lib/findChangedDependencies.ts
@@ -39,13 +39,13 @@ export const findChangedDependencies = async (ctx: Context) => {
   ctx.log.debug({ rootPath, rootManifestPath, rootLockfilePath }, `Found manifest and lockfile`);
 
   // Handle monorepos with (multiple) nested package.json files.
-  const nestedManifestPaths = await findFilesFromRepositoryRoot(`**/${PACKAGE_JSON}`);
+  const nestedManifestPaths = await findFilesFromRepositoryRoot(path.join('**', PACKAGE_JSON));
   const metadataPathPairs = await Promise.all(
     nestedManifestPaths.map(async (manifestPath) => {
       const dirname = path.dirname(manifestPath);
       const [lockfilePath] = await findFilesFromRepositoryRoot(
-        `${dirname}/${YARN_LOCK}`,
-        `${dirname}/${PACKAGE_LOCK}`
+        path.join(dirname, YARN_LOCK),
+        path.join(dirname, PACKAGE_LOCK)
       );
       // Fall back to the root lockfile if we can't find one in the same directory.
       return [manifestPath, lockfilePath || rootLockfilePath];

--- a/node-src/lib/findChangedDependencies.ts
+++ b/node-src/lib/findChangedDependencies.ts
@@ -1,6 +1,6 @@
 import path from 'path';
 
-import { checkoutFile, findFiles, getRepositoryRoot } from '../git/git';
+import { checkoutFile, findFilesFromRepositoryRoot, getRepositoryRoot } from '../git/git';
 import { Context } from '../types';
 import { compareBaseline } from './compareBaseline';
 import { getDependencies } from './getDependencies';
@@ -27,8 +27,8 @@ export const findChangedDependencies = async (ctx: Context) => {
   );
 
   const rootPath = await getRepositoryRoot();
-  const [rootManifestPath] = await findFiles(PACKAGE_JSON);
-  const [rootLockfilePath] = await findFiles(YARN_LOCK, PACKAGE_LOCK);
+  const [rootManifestPath] = await findFilesFromRepositoryRoot(PACKAGE_JSON);
+  const [rootLockfilePath] = await findFilesFromRepositoryRoot(YARN_LOCK, PACKAGE_LOCK);
   if (!rootManifestPath || !rootLockfilePath) {
     ctx.log.debug(
       { rootPath, rootManifestPath, rootLockfilePath },
@@ -39,11 +39,11 @@ export const findChangedDependencies = async (ctx: Context) => {
   ctx.log.debug({ rootPath, rootManifestPath, rootLockfilePath }, `Found manifest and lockfile`);
 
   // Handle monorepos with (multiple) nested package.json files.
-  const nestedManifestPaths = await findFiles(`**/${PACKAGE_JSON}`);
+  const nestedManifestPaths = await findFilesFromRepositoryRoot(PACKAGE_JSON, `**/${PACKAGE_JSON}`);
   const metadataPathPairs = await Promise.all(
     nestedManifestPaths.map(async (manifestPath) => {
       const dirname = path.dirname(manifestPath);
-      const [lockfilePath] = await findFiles(
+      const [lockfilePath] = await findFilesFromRepositoryRoot(
         `${dirname}/${YARN_LOCK}`,
         `${dirname}/${PACKAGE_LOCK}`
       );

--- a/node-src/lib/findChangedDependencies.ts
+++ b/node-src/lib/findChangedDependencies.ts
@@ -39,7 +39,7 @@ export const findChangedDependencies = async (ctx: Context) => {
   ctx.log.debug({ rootPath, rootManifestPath, rootLockfilePath }, `Found manifest and lockfile`);
 
   // Handle monorepos with (multiple) nested package.json files.
-  const nestedManifestPaths = await findFilesFromRepositoryRoot(PACKAGE_JSON, `**/${PACKAGE_JSON}`);
+  const nestedManifestPaths = await findFilesFromRepositoryRoot(`**/${PACKAGE_JSON}`);
   const metadataPathPairs = await Promise.all(
     nestedManifestPaths.map(async (manifestPath) => {
       const dirname = path.dirname(manifestPath);


### PR DESCRIPTION
Fixes [#927](https://github.com/chromaui/chromatic-cli/issues/927)

When running from within a subdirectory (either cd-ing or setting `workingDir` on the GitHub Action), there is currently a bug with finding changed package manifest and lock files.

Given a repository structure like the following:
`package.json`
`yarn.lock`
`some-project/package.json`
`some-project/yarn.lock`

Currently, the manifest and lock files found for tracing changed dependencies will be relative to the current working dir. However, the list of manifest or lock files that have changed in the current commit will be relative to the repository root.

So if we're running Chromatic from within `some-project`, we will miss any changes to `some-project/package.json` because we'll be comparing the relative path of that file from where we're running (`package.json`) to the full path of the file from our changed list (`some-project/package.json`). Those don't match up, so we'll think that there are no dependency changes.

This fixes the bug by ensuring that we're always finding manifest and lock files relative to the repository root. This will ensure that we match those against our list of changed files correctly since those are always relative to the repository root as well.

### How to test

* Using the canary version of the CLI, run a turbosnap build from within a subdirectory of a monorepo project like the one described above (with debug enabled). See that changes to the package manifest or lock file in the subdirectory are picked up.
* Do the same with the `chromaui/action-canary@v1` action with `workingDir` set to the subdirectory


<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>11.3.4--canary.982.9098816311.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@11.3.4--canary.982.9098816311.0
  # or 
  yarn add chromatic@11.3.4--canary.982.9098816311.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
