### PR TITLE
Use double quotes around command arguments

### DIFF
--- a/node-src/git/git.test.ts
+++ b/node-src/git/git.test.ts
@@ -136,7 +136,7 @@ describe('findFilesFromRepositoryRoot', () => {
     const results = await findFilesFromRepositoryRoot('package.json', '**/package.json');
 
     expect(command).toBeCalledTimes(2);
-    expect(command).toHaveBeenNthCalledWith(2, "git ls-files --full-name -z '/root/package.json' '/root/**/package.json'", expect.any(Object));
+    expect(command).toHaveBeenNthCalledWith(2, 'git ls-files --full-name -z "/root/package.json" "/root/**/package.json"', expect.any(Object));
     expect(results).toEqual(filesFound);
   });
 });

--- a/node-src/git/git.ts
+++ b/node-src/git/git.ts
@@ -295,7 +295,7 @@ export async function findFilesFromRepositoryRoot(...patterns: string[]) {
   
   // Uses `--full-name` to ensure that all files found are relative to the repository root,
   // not the directory in which this is executed from
-  const gitCommand = `git ls-files --full-name -z ${patternsFromRoot.map((p) => `'${p}'`).join(' ')}`;
+  const gitCommand = `git ls-files --full-name -z ${patternsFromRoot.map((p) => `"${p}"`).join(' ')}`;
   const files = await execGitCommand(gitCommand);
   return files.split(NULL_BYTE).filter(Boolean);
 }


### PR DESCRIPTION
When passing file paths to the `git ls-files` command to search for package manifest files, the paths are currently wrapped in single quotes.

This seems to be problematic on windows:
```
const results = await execGitCommand(`git ls-files --full-name -z 'C:/my/project/package.json'`);
console.log('execGitCommand results:', results);
...
execGitCommand results:
Done in 0.58s.
```

Switching to double quotes does the trick:
```
const results = await execGitCommand(`git ls-files --full-name -z "C:/my/project/package.json"`);
console.log('execGitCommand results:', results);
...
execGitCommand results: package.json
Done in 0.64s.
```

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>11.3.5--canary.985.9099077866.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@11.3.5--canary.985.9099077866.0
  # or 
  yarn add chromatic@11.3.5--canary.985.9099077866.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
