### PR TITLE
Fix type declaration for `isChromatic` import

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "exports": {
     ".": {
-      "types": "./dist/node.d.ts",
+      "types": "./isChromatic.d.ts",
       "require": "./isChromatic.js",
       "import": "./isChromatic.mjs"
     },


### PR DESCRIPTION
(cherry picked from commit d75ed21efe58db1529a479183442b701f3863903)

I created a cherry-pick from the Fork since the CI process is failing on the Fork.

The original PR to fix the type import: https://github.com/chromaui/chromatic-cli/pull/984
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>11.3.3--canary.986.9087708039.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@11.3.3--canary.986.9087708039.0
  # or 
  yarn add chromatic@11.3.3--canary.986.9087708039.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
