### PR TITLE
Use replacement build when encountering baseline build with uncommitted changes

### DIFF
--- a/node-src/git/findAncestorBuildWithCommit.test.ts
+++ b/node-src/git/findAncestorBuildWithCommit.test.ts
@@ -14,6 +14,7 @@ const makeBuild = (build: Partial<Build> = {}): Build => ({
   id: 'id',
   number: 1,
   commit: 'missing',
+  uncommittedHash: '',
   ...build,
 });
 const makeResult = (ancestorBuilds: Build[]): AncestorBuildsQueryResult => ({
@@ -33,6 +34,14 @@ describe('findAncestorBuildWithCommit', () => {
     expect(await findAncestorBuildWithCommit({ client }, 1)).toEqual(toFind);
     expect(client.runQuery).toHaveBeenCalledTimes(1);
     expect(client.runQuery.mock.calls[0][1]).toMatchObject({ buildNumber: 1 });
+  });
+
+  it('does not return build with uncommitted changes', async () => {
+    client.runQuery.mockReturnValue(
+      makeResult([makeBuild({ commit: 'exists', uncommittedHash: 'abc123' })])
+    );
+
+    expect(await findAncestorBuildWithCommit({ client }, 1, { page: 1, limit: 1 })).toBeNull();
   });
 
   it('passes skip and limit and recurse', async () => {

--- a/node-src/git/getBaselineBuilds.ts
+++ b/node-src/git/getBaselineBuilds.ts
@@ -16,6 +16,7 @@ const BaselineCommitsQuery = gql`
         status(legacy: false)
         commit
         committedAt
+        uncommittedHash
         changeCount
       }
     }
@@ -29,6 +30,7 @@ interface BaselineCommitsQueryResult {
       status: string;
       commit: string;
       committedAt: number;
+      uncommittedHash: string;
       changeCount: number;
     }[];
   };

--- a/node-src/tasks/gitInfo.test.ts
+++ b/node-src/tasks/gitInfo.test.ts
@@ -111,6 +111,7 @@ describe('setGitInfo', () => {
         id: 'parent',
         number: 1,
         commit: '987bca',
+        uncommittedHash: '',
       },
     });
     const ctx = { log, options: { onlyChanged: true }, client } as any;

--- a/node-src/tasks/gitInfo.ts
+++ b/node-src/tasks/gitInfo.ts
@@ -178,7 +178,7 @@ export const setGitInfo = async (ctx: Context, task: Task) => {
 
     try {
       // Map the baseline builds to their changed files, falling back to an earlier "replacement"
-      // build if the baseline commit no longer exists (e.g. due to force-pushing).
+      // build if the baseline commit no longer exists or the baseline had uncommitted changes.
       const changedFilesWithInfo = await Promise.all(
         baselineBuilds.map(async (build) => {
           const changedFilesWithReplacement = await getChangedFilesWithReplacement(ctx, build);


### PR DESCRIPTION
Addresses https://github.com/chromaui/addon-visual-tests/issues/231

Similar to how we use a replacement build as baseline when an ancestor build's commit cannot be found, this will use a replacement build as baseline when the original baseline build had uncommitted changes.