### PR TITLE
Pass `CI=1` environment variable to Storybook build command to disable prompts

### DIFF
--- a/node-src/tasks/build.ts
+++ b/node-src/tasks/build.ts
@@ -122,8 +122,9 @@ export const buildStorybook = async (ctx: Context) => {
 
     const subprocess = execaCommand(ctx.buildCommand, {
       stdio: [null, logFile, null],
+      preferLocal: true,
       signal,
-      env: { NODE_ENV: ctx.env.STORYBOOK_NODE_ENV || 'production' },
+      env: { CI: '1', NODE_ENV: ctx.env.STORYBOOK_NODE_ENV || 'production' },
     });
     await Promise.race([subprocess, timeoutAfter(ctx.env.STORYBOOK_BUILD_TIMEOUT)]);
   } catch (e) {


### PR DESCRIPTION
This should prevent the Storybook build script from prompting (e.g. to send a crash report), which would cause the CLI to hang. 

As an added bonus, [`preferLocal`](https://github.com/sindresorhus/execa/blob/main/docs/api.md#optionspreferlocal) might help ensure we use a locally installed package over a global one.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>11.4.1--canary.991.9225753804.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@11.4.1--canary.991.9225753804.0
  # or 
  yarn add chromatic@11.4.1--canary.991.9225753804.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
