### PR TITLE
Pass `SLACK_WEBHOOK_URL` to release script

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,3 +45,4 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
Unfortunately the last release failed due a [missing Slack URL](https://github.com/chromaui/chromatic-cli/actions/runs/9254329865/job/25455887520). This URL is configures as an environment variable on the repo, but it needs to be explicitly passed to the release step in the GitHub Action.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>11.4.2--canary.992.9254693214.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@11.4.2--canary.992.9254693214.0
  # or 
  yarn add chromatic@11.4.2--canary.992.9254693214.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
