### PR TITLE
Add fallback type for Storybook 6 builder syntax

### DIFF
--- a/bin-src/__mocks__/normalProjectJson/project.json
+++ b/bin-src/__mocks__/normalProjectJson/project.json
@@ -8,7 +8,7 @@
   "packageManager": { "type": "yarn", "version": "1.22.19" },
   "typescriptOptions": { "reactDocgen": "react-docgen-typescript" },
   "preview": { "usesGlobals": false },
-  "framework": { "name": "@storybook/react-webpack5", "options": {} },
+  "framework": { "name": "@storybook/react-webpack5", "options": {}, "version": "8.1.5" },
   "builder": "@storybook/builder-webpack5",
   "renderer": "@storybook/react",
   "storybookVersion": "8.1.5",

--- a/bin-src/__mocks__/sb6ProjectJson/project.json
+++ b/bin-src/__mocks__/sb6ProjectJson/project.json
@@ -1,0 +1,66 @@
+{
+  "generatedAt": 1717341501873,
+  "builder": {
+    "name": "webpack4"
+  },
+  "hasCustomBabel": false,
+  "hasCustomWebpack": true,
+  "hasStaticDirs": true,
+  "hasStorybookEslint": false,
+  "refCount": 0,
+  "monorepo": "Turborepo",
+  "packageManager": {
+    "type": "yarn",
+    "version": "1.22.19"
+  },
+  "features": {
+    "postcss": false,
+    "interactionsDebugger": true,
+    "warnOnLegacyHierarchySeparator": false
+  },
+  "storybookVersion": "6.5.16",
+  "language": "javascript",
+  "storybookPackages": {
+    "@storybook/addon-actions": {
+      "version": "6.5.16"
+    },
+    "@storybook/addons": {
+      "version": "6.5.16"
+    },
+    "@storybook/builder-webpack4": {
+      "version": "6.5.16"
+    },
+    "@storybook/manager-webpack4": {
+      "version": "6.5.16"
+    },
+    "@storybook/react": {
+      "version": "6.5.16"
+    },
+    "@storybook/testing-library": {
+      "version": "0.0.13"
+    },
+    "@storybook/theming": {
+      "version": "6.5.16"
+    },
+    "msw-storybook-addon": {
+      "version": "1.7.0"
+    },
+    "storybook-mock-date-decorator": {
+      "version": "1.0.0"
+    }
+  },
+  "framework": {
+    "name": "react"
+  },
+  "addons": {
+    "@storybook/addon-links": {
+      "version": "6.5.16"
+    },
+    "@storybook/addon-essentials": {
+      "version": "6.5.16"
+    },
+    "@storybook/addon-interactions": {
+      "version": "6.5.16"
+    }
+  }
+}

--- a/bin-src/__mocks__/sb6ProjectJsonMissingBuilder/project.json
+++ b/bin-src/__mocks__/sb6ProjectJsonMissingBuilder/project.json
@@ -1,0 +1,63 @@
+{
+  "generatedAt": 1717341501873,
+  "hasCustomBabel": false,
+  "hasCustomWebpack": true,
+  "hasStaticDirs": true,
+  "hasStorybookEslint": false,
+  "refCount": 0,
+  "monorepo": "Turborepo",
+  "packageManager": {
+    "type": "yarn",
+    "version": "1.22.19"
+  },
+  "features": {
+    "postcss": false,
+    "interactionsDebugger": true,
+    "warnOnLegacyHierarchySeparator": false
+  },
+  "storybookVersion": "6.5.16",
+  "language": "javascript",
+  "storybookPackages": {
+    "@storybook/addon-actions": {
+      "version": "6.5.16"
+    },
+    "@storybook/addons": {
+      "version": "6.5.16"
+    },
+    "@storybook/builder-webpack4": {
+      "version": "6.5.16"
+    },
+    "@storybook/manager-webpack4": {
+      "version": "6.5.16"
+    },
+    "@storybook/react": {
+      "version": "6.5.16"
+    },
+    "@storybook/testing-library": {
+      "version": "0.0.13"
+    },
+    "@storybook/theming": {
+      "version": "6.5.16"
+    },
+    "msw-storybook-addon": {
+      "version": "1.7.0"
+    },
+    "storybook-mock-date-decorator": {
+      "version": "1.0.0"
+    }
+  },
+  "framework": {
+    "name": "react"
+  },
+  "addons": {
+    "@storybook/addon-links": {
+      "version": "6.5.16"
+    },
+    "@storybook/addon-essentials": {
+      "version": "6.5.16"
+    },
+    "@storybook/addon-interactions": {
+      "version": "6.5.16"
+    }
+  }
+}

--- a/bin-src/init.test.ts
+++ b/bin-src/init.test.ts
@@ -1,102 +1,134 @@
-import { execaCommand } from "execa"
-import { writeFile } from "jsonfile";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { execaCommand } from 'execa';
+import { writeFile } from 'jsonfile';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { addChromaticScriptToPackageJson, createChromaticConfigFile, installArchiveDependencies } from "./init";
-import { beforeEach } from "node:test";
+import {
+  addChromaticScriptToPackageJson,
+  createChromaticConfigFile,
+  installArchiveDependencies,
+} from './init';
 
 vi.mock('jsonfile', async (importOriginal) => {
-    return {
-        // @ts-expect-error TS does not think actual is an object, but it's fine.
-        ...await importOriginal(),
-        writeFile: vi.fn(() => Promise.resolve()),
-    };
+  return {
+    // @ts-expect-error TS does not think actual is an object, but it's fine.
+    ...(await importOriginal()),
+    writeFile: vi.fn(() => Promise.resolve()),
+  };
 });
 
 vi.mock('execa');
 
 describe('addChromaticScriptToPackageJson', () => {
-    afterEach(() => {
-        vi.restoreAllMocks()
-    })
-    it('outputs updated package.json with only chromatic script if Framework is Storybook', async () => {
-        await addChromaticScriptToPackageJson({
-            packageJson: {},
-            packagePath: './package.json'
-        })
-        expect(writeFile).toHaveBeenCalledOnce()
-        expect(writeFile).toHaveBeenCalledWith('./package.json', {
-            scripts: {
-                chromatic: `chromatic`
-            }
-        }, { spaces: 2 })
-    })
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+  it('outputs updated package.json with only chromatic script if Framework is Storybook', async () => {
+    await addChromaticScriptToPackageJson({
+      packageJson: {},
+      packagePath: './package.json',
+    });
+    expect(writeFile).toHaveBeenCalledOnce();
+    expect(writeFile).toHaveBeenCalledWith(
+      './package.json',
+      {
+        scripts: {
+          chromatic: `chromatic`,
+        },
+      },
+      { spaces: 2 }
+    );
+  });
 
-    it('outputs updated package.json with e2e script if Framework is not Storybook', async () => {
-        await addChromaticScriptToPackageJson({
-            packageJson: {},
-            packagePath: './package.json'
-        })
-        expect(writeFile).toHaveBeenCalledOnce()
-        expect(writeFile).toHaveBeenCalledWith('./package.json', {
-            scripts: {
-                chromatic: `chromatic`
-            }
-        }, { spaces: 2 })
-    })
-})
+  it('outputs updated package.json with e2e script if Framework is not Storybook', async () => {
+    await addChromaticScriptToPackageJson({
+      packageJson: {},
+      packagePath: './package.json',
+    });
+    expect(writeFile).toHaveBeenCalledOnce();
+    expect(writeFile).toHaveBeenCalledWith(
+      './package.json',
+      {
+        scripts: {
+          chromatic: `chromatic`,
+        },
+      },
+      { spaces: 2 }
+    );
+  });
+});
 
 describe('createChromaticConfigFile', () => {
-    it('outputs file without buildScriptName when not passed one', async () => {
-        await createChromaticConfigFile({configFile: 'chromatic.config.json'})
-        expect(writeFile).toHaveBeenCalledOnce()
-        expect(writeFile).toHaveBeenCalledWith('chromatic.config.json', {})
-    })
-})
+  it('outputs file without buildScriptName when not passed one', async () => {
+    await createChromaticConfigFile({ configFile: 'chromatic.config.json' });
+    expect(writeFile).toHaveBeenCalledOnce();
+    expect(writeFile).toHaveBeenCalledWith('chromatic.config.json', {});
+  });
+});
 
 describe('installArchiveDependencies', () => {
-    beforeEach(() => {
-        vi.doMock('find-up', async () => {
-            return {
-                findUp: vi.fn(() => Promise.resolve(undefined)),
-            };
-        });
-    })
-    afterEach(() => {
-        vi.clearAllMocks()
-        vi.resetModules()
-    })
-    it('successfully installs list of dependencies for Playwright if SB package is not found and Essentials is not found', async () => {
-        await installArchiveDependencies({}, 'playwright')
-        expect(execaCommand).toHaveBeenCalledOnce()
-        expect(execaCommand).toHaveBeenCalledWith('yarn add -D chromatic @chromatic-com/playwright storybook@latest @storybook/addon-essentials@latest @storybook/server-webpack5@latest')
-    })
-    it('successfully installs list of dependencies for Cypress if SB package is not found and Essentials is not found', async () => {
-        await installArchiveDependencies({}, 'cypress')
-        expect(execaCommand).toHaveBeenCalledOnce()
-        expect(execaCommand).toHaveBeenCalledWith('yarn add -D chromatic @chromatic-com/cypress storybook@latest @storybook/addon-essentials@latest @storybook/server-webpack5@latest')
-    })
-    it('successfully installs list of dependencies if SB package is found and Essentials is not found', async () => {
-        await installArchiveDependencies({devDependencies: {'storybook': '7.6.5'}}, 'playwright')
-        expect(execaCommand).toHaveBeenCalledOnce()
-        expect(execaCommand).toHaveBeenCalledWith('yarn add -D chromatic @chromatic-com/playwright @storybook/addon-essentials@7.6.5 @storybook/server-webpack5@7.6.5')
-    })
-    it('successfully installs list of dependencies if SB package is found and Essentials is found in devDependencies', async () => {
-        await installArchiveDependencies({devDependencies: {storybook: '7.6.5', '@storybook/addon-essentials': '7.6.5'}}, 'playwright')
-        expect(execaCommand).toHaveBeenCalledOnce()
-        expect(execaCommand).toHaveBeenCalledWith('yarn add -D chromatic @chromatic-com/playwright @storybook/server-webpack5@7.6.5')
-        vi.clearAllMocks()
-    })
-    it('successfully installs list of dependencies if SB package is found and Essentials is found in dependencies', async () => {
-        await installArchiveDependencies({dependencies: {storybook: '7.6.5', '@storybook/addon-essentials': '7.6.5'}}, 'playwright')
-        expect(execaCommand).toHaveBeenCalledOnce()
-        expect(execaCommand).toHaveBeenCalledWith('yarn add -D chromatic @chromatic-com/playwright @storybook/server-webpack5@7.6.5')
-        vi.clearAllMocks()
-    })
-    it('successfully installs list of dependencies if SB package is not found and Essentials is found in dependencies', async () => {
-        await installArchiveDependencies({dependencies: {'@storybook/addon-essentials': '7.6.5'}}, 'playwright')
-        expect(execaCommand).toHaveBeenCalledOnce()
-        expect(execaCommand).toHaveBeenCalledWith('yarn add -D chromatic @chromatic-com/playwright storybook@7.6.5 @storybook/server-webpack5@7.6.5')
-        vi.clearAllMocks()
-    })
-})
+  beforeEach(() => {
+    vi.doMock('find-up', async () => {
+      return {
+        findUp: vi.fn(() => Promise.resolve(undefined)),
+      };
+    });
+  });
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+  });
+  it('successfully installs list of dependencies for Playwright if SB package is not found and Essentials is not found', async () => {
+    await installArchiveDependencies({}, 'playwright');
+    expect(execaCommand).toHaveBeenCalledOnce();
+    expect(execaCommand).toHaveBeenCalledWith(
+      'yarn add -D chromatic @chromatic-com/playwright storybook@latest @storybook/addon-essentials@latest @storybook/server-webpack5@latest'
+    );
+  });
+  it('successfully installs list of dependencies for Cypress if SB package is not found and Essentials is not found', async () => {
+    await installArchiveDependencies({}, 'cypress');
+    expect(execaCommand).toHaveBeenCalledOnce();
+    expect(execaCommand).toHaveBeenCalledWith(
+      'yarn add -D chromatic @chromatic-com/cypress storybook@latest @storybook/addon-essentials@latest @storybook/server-webpack5@latest'
+    );
+  });
+  it('successfully installs list of dependencies if SB package is found and Essentials is not found', async () => {
+    await installArchiveDependencies({ devDependencies: { storybook: '7.6.5' } }, 'playwright');
+    expect(execaCommand).toHaveBeenCalledOnce();
+    expect(execaCommand).toHaveBeenCalledWith(
+      'yarn add -D chromatic @chromatic-com/playwright @storybook/addon-essentials@7.6.5 @storybook/server-webpack5@7.6.5'
+    );
+  });
+  it('successfully installs list of dependencies if SB package is found and Essentials is found in devDependencies', async () => {
+    await installArchiveDependencies(
+      { devDependencies: { storybook: '7.6.5', '@storybook/addon-essentials': '7.6.5' } },
+      'playwright'
+    );
+    expect(execaCommand).toHaveBeenCalledOnce();
+    expect(execaCommand).toHaveBeenCalledWith(
+      'yarn add -D chromatic @chromatic-com/playwright @storybook/server-webpack5@7.6.5'
+    );
+    vi.clearAllMocks();
+  });
+  it('successfully installs list of dependencies if SB package is found and Essentials is found in dependencies', async () => {
+    await installArchiveDependencies(
+      { dependencies: { storybook: '7.6.5', '@storybook/addon-essentials': '7.6.5' } },
+      'playwright'
+    );
+    expect(execaCommand).toHaveBeenCalledOnce();
+    expect(execaCommand).toHaveBeenCalledWith(
+      'yarn add -D chromatic @chromatic-com/playwright @storybook/server-webpack5@7.6.5'
+    );
+    vi.clearAllMocks();
+  });
+  it('successfully installs list of dependencies if SB package is not found and Essentials is found in dependencies', async () => {
+    await installArchiveDependencies(
+      { dependencies: { '@storybook/addon-essentials': '7.6.5' } },
+      'playwright'
+    );
+    expect(execaCommand).toHaveBeenCalledOnce();
+    expect(execaCommand).toHaveBeenCalledWith(
+      'yarn add -D chromatic @chromatic-com/playwright storybook@7.6.5 @storybook/server-webpack5@7.6.5'
+    );
+    vi.clearAllMocks();
+  });
+});

--- a/node-src/lib/getPrebuiltStorybookMetadata.test.ts
+++ b/node-src/lib/getPrebuiltStorybookMetadata.test.ts
@@ -1,61 +1,93 @@
 import { getStorybookMetadataFromProjectJson } from './getPrebuiltStorybookMetadata';
 
-import { readFile } from 'jsonfile';
-import { afterEach, describe, expect, it, vi } from 'vitest';
-
-afterEach(() => {
-  vi.restoreAllMocks();
-});
-
-vi.mock('jsonfile', async (importOriginal) => {
-  return {
-    // @ts-expect-error TS does not think actual is an object, but it's fine.
-    ...(await importOriginal()),
-    readFile: vi.fn(() =>
-      Promise.resolve({
-        addons: {
-          '@storybook/addon-essentials': { version: '8.1.0' },
-          '@storybook/addon-links': { version: '8.1.0' },
-        },
-        builder: 'webpack5',
-        framework: { name: 'react' },
-        storybookVersion: '8.1.0',
-        storybookPackages: {
-          '@storybook/react': { version: '8.1.0' },
-          '@storybook/builder-webpack5': { version: '8.1.0' },
-          '@storybook/addon-essentials': { version: '8.1.0' },
-          '@storybook/addon-links': { version: '8.1.0' },
-        },
-      })
-    ),
-  };
-});
+import { describe, expect, it } from 'vitest';
 
 describe('getStorybookMetadataFromProjectJson', () => {
   it('should return the metadata from the project.json file', async () => {
-    const projectJsonPath = 'path/to/project.json';
+    const projectJsonPath = 'bin-src/__mocks__/normalProjectJson/project.json';
     const metadata = await getStorybookMetadataFromProjectJson(projectJsonPath);
 
     expect(metadata).toEqual({
-      viewLayer: 'react',
-      version: '8.1.0',
+      viewLayer: '@storybook/react-webpack5',
+      version: '8.1.5',
       builder: {
-        name: 'webpack5',
-        packageVersion: '8.1.0',
+        name: '@storybook/builder-webpack5',
+        packageVersion: '8.1.5',
       },
       addons: [
         {
           name: 'essentials',
           packageName: '@storybook/addon-essentials',
-          packageVersion: '8.1.0',
+          packageVersion: '8.1.5',
         },
         {
-          name: 'links',
-          packageName: '@storybook/addon-links',
-          packageVersion: '8.1.0',
+          name: 'compiler-swc',
+          packageName: '@storybook/addon-webpack5-compiler-swc',
+          packageVersion: '1.0.2',
         },
       ],
     });
-    expect(readFile).toHaveBeenCalledWith(projectJsonPath);
+  });
+
+  it('should return the metadata from a Storybook 6 project.json file', async () => {
+    const projectJsonPath = 'bin-src/__mocks__/sb6ProjectJson/project.json';
+    const metadata = await getStorybookMetadataFromProjectJson(projectJsonPath);
+
+    expect(metadata).toEqual({
+      viewLayer: 'react',
+      version: '6.5.16',
+      builder: {
+        name: 'webpack4',
+        packageVersion: '6.5.16',
+      },
+      addons: [
+        {
+          name: 'links',
+          packageName: '@storybook/addon-links',
+          packageVersion: '6.5.16',
+        },
+        {
+          name: 'essentials',
+          packageName: '@storybook/addon-essentials',
+          packageVersion: '6.5.16',
+        },
+        {
+          name: 'interactions',
+          packageName: '@storybook/addon-interactions',
+          packageVersion: '6.5.16',
+        },
+      ],
+    });
+  });
+
+  it('should return the metadata from the project.json file when the builder is missing', async () => {
+    const projectJsonPath = 'bin-src/__mocks__/sb6ProjectJsonMissingBuilder/project.json';
+    const metadata = await getStorybookMetadataFromProjectJson(projectJsonPath);
+
+    expect(metadata).toEqual({
+      viewLayer: 'react',
+      version: '6.5.16',
+      builder: {
+        name: 'webpack4',
+        packageVersion: '6.5.16',
+      },
+      addons: [
+        {
+          name: 'links',
+          packageName: '@storybook/addon-links',
+          packageVersion: '6.5.16',
+        },
+        {
+          name: 'essentials',
+          packageName: '@storybook/addon-essentials',
+          packageVersion: '6.5.16',
+        },
+        {
+          name: 'interactions',
+          packageName: '@storybook/addon-interactions',
+          packageVersion: '6.5.16',
+        },
+      ],
+    });
   });
 });

--- a/node-src/lib/getPrebuiltStorybookMetadata.test.ts
+++ b/node-src/lib/getPrebuiltStorybookMetadata.test.ts
@@ -1,0 +1,61 @@
+import { getStorybookMetadataFromProjectJson } from './getPrebuiltStorybookMetadata';
+
+import { readFile } from 'jsonfile';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+vi.mock('jsonfile', async (importOriginal) => {
+  return {
+    // @ts-expect-error TS does not think actual is an object, but it's fine.
+    ...(await importOriginal()),
+    readFile: vi.fn(() =>
+      Promise.resolve({
+        addons: {
+          '@storybook/addon-essentials': { version: '8.1.0' },
+          '@storybook/addon-links': { version: '8.1.0' },
+        },
+        builder: 'webpack5',
+        framework: { name: 'react' },
+        storybookVersion: '8.1.0',
+        storybookPackages: {
+          '@storybook/react': { version: '8.1.0' },
+          '@storybook/builder-webpack5': { version: '8.1.0' },
+          '@storybook/addon-essentials': { version: '8.1.0' },
+          '@storybook/addon-links': { version: '8.1.0' },
+        },
+      })
+    ),
+  };
+});
+
+describe('getStorybookMetadataFromProjectJson', () => {
+  it('should return the metadata from the project.json file', async () => {
+    const projectJsonPath = 'path/to/project.json';
+    const metadata = await getStorybookMetadataFromProjectJson(projectJsonPath);
+
+    expect(metadata).toEqual({
+      viewLayer: 'react',
+      version: '8.1.0',
+      builder: {
+        name: 'webpack5',
+        packageVersion: '8.1.0',
+      },
+      addons: [
+        {
+          name: 'essentials',
+          packageName: '@storybook/addon-essentials',
+          packageVersion: '8.1.0',
+        },
+        {
+          name: 'links',
+          packageName: '@storybook/addon-links',
+          packageVersion: '8.1.0',
+        },
+      ],
+    });
+    expect(readFile).toHaveBeenCalledWith(projectJsonPath);
+  });
+});

--- a/node-src/lib/getPrebuiltStorybookMetadata.ts
+++ b/node-src/lib/getPrebuiltStorybookMetadata.ts
@@ -12,7 +12,7 @@ import { viewLayers } from './viewLayers';
 
 export interface SBProjectJson {
   addons: Record<string, { version: string; options: any }>;
-  builder?: string;
+  builder?: string | { name: string };
   framework: {
     name: string;
   };
@@ -22,15 +22,23 @@ export interface SBProjectJson {
 
 const getBuilder = (sbProjectJson: SBProjectJson): { name: string; packageVersion: string } => {
   const { builder, storybookPackages, storybookVersion } = sbProjectJson;
-  return builder
-    ? {
+  switch (typeof builder) {
+    case 'string':
+      return {
         name: builder,
         packageVersion: storybookPackages[builders[builder]].version,
-      }
-    : {
+      };
+    case 'object':
+      return {
+        name: builder.name,
+        packageVersion: storybookPackages[builders[builder.name]].version,
+      };
+    default:
+      return {
         name: 'webpack4', // the default builder for Storybook v6
         packageVersion: storybookVersion,
       };
+  }
 };
 
 export const getStorybookMetadataFromProjectJson = async (

--- a/node-src/lib/getPrebuiltStorybookMetadata.ts
+++ b/node-src/lib/getPrebuiltStorybookMetadata.ts
@@ -22,23 +22,10 @@ export interface SBProjectJson {
 
 const getBuilder = (sbProjectJson: SBProjectJson): { name: string; packageVersion: string } => {
   const { builder, storybookPackages, storybookVersion } = sbProjectJson;
-  switch (typeof builder) {
-    case 'string':
-      return {
-        name: builder,
-        packageVersion: storybookPackages[builders[builder]].version,
-      };
-    case 'object':
-      return {
-        name: builder.name,
-        packageVersion: storybookPackages[builders[builder.name]].version,
-      };
-    default:
-      return {
-        name: 'webpack4', // the default builder for Storybook v6
-        packageVersion: storybookVersion,
-      };
-  }
+  const name = typeof builder === 'string' ? builder : builder?.name;
+  return name
+    ? { name, packageVersion: storybookPackages[builders[name]]?.version }
+    : { name: 'webpack4', packageVersion: storybookVersion }; // the default builder for Storybook v6
 };
 
 export const getStorybookMetadataFromProjectJson = async (

--- a/node-src/lib/getStorybookInfo.test.ts
+++ b/node-src/lib/getStorybookInfo.test.ts
@@ -64,10 +64,12 @@ describe('getStorybookInfo', () => {
           {
             name: 'essentials',
             packageName: '@storybook/addon-essentials',
+            packageVersion: expect.any(String),
           },
           {
             name: 'compiler-swc',
             packageName: '@storybook/addon-webpack5-compiler-swc',
+            packageVersion: expect.any(String),
           },
         ],
         builder: { name: '@storybook/react-webpack5', packageVersion: '8.1.5' },
@@ -80,7 +82,19 @@ describe('getStorybookInfo', () => {
       // We're getting the result of tracing chromatic-cli's node_modules here.
       expect.objectContaining({
         viewLayer: 'react',
-        version: expect.any(String),
+        version: '8.1.5',
+        addons: expect.arrayContaining([
+          expect.objectContaining({
+            name: 'essentials',
+            packageName: '@storybook/addon-essentials',
+            packageVersion: expect.any(String),
+          }),
+          expect.objectContaining({
+            name: 'compiler-swc',
+            packageName: '@storybook/addon-webpack5-compiler-swc',
+            packageVersion: expect.any(String),
+          }),
+        ]),
         builder: { name: '@storybook/react-webpack5', packageVersion: '8.1.5' },
       })
     );
@@ -212,6 +226,35 @@ describe('getStorybookInfo', () => {
         builder: { name: '@storybook/builder-webpack5', packageVersion: '8.1.5' },
         version: '8.1.5',
         viewLayer: '@storybook/react-webpack5',
+      });
+    });
+
+    it('returns the correct metadata for Storybook 6', async () => {
+      const ctx = getContext({
+        options: { storybookBuildDir: 'bin-src/__mocks__/sb6ProjectJson' },
+        packageJson: { dependencies: REACT },
+      });
+      expect(await getStorybookInfo(ctx)).toEqual({
+        addons: [
+          {
+            name: 'links',
+            packageName: '@storybook/addon-links',
+            packageVersion: '6.5.16',
+          },
+          {
+            name: 'essentials',
+            packageName: '@storybook/addon-essentials',
+            packageVersion: '6.5.16',
+          },
+          {
+            name: 'interactions',
+            packageName: '@storybook/addon-interactions',
+            packageVersion: '6.5.16',
+          },
+        ],
+        builder: { name: 'webpack4', packageVersion: '6.5.16' },
+        version: '6.5.16',
+        viewLayer: 'react',
       });
     });
   });

--- a/node-src/lib/getStorybookMetadata.ts
+++ b/node-src/lib/getStorybookMetadata.ts
@@ -134,7 +134,7 @@ const findAddons = async (ctx, mainConfig, v7) => {
         return {
           name: supportedAddons[name],
           packageName: name,
-          packageVersion: allDependencies[name],
+          packageVersion: allDependencies[name] || addon.version,
         };
       }),
     };
@@ -204,15 +204,19 @@ export const findStorybookConfigFile = async (ctx: Context, pattern: RegExp) => 
 
 export const getStorybookMetadata = async (ctx: Context) => {
   const configDir = ctx.options.storybookConfigDir ?? '.storybook';
+  console.log(configDir);
   const r = typeof __non_webpack_require__ !== 'undefined' ? __non_webpack_require__ : require;
 
   let mainConfig;
   let v7 = false;
   try {
     mainConfig = await r(path.resolve(configDir, 'main'));
+    console.log(mainConfig);
   } catch (storybookV6error) {
+    console.log(storybookV6error);
     try {
       mainConfig = await readConfig(await findStorybookConfigFile(ctx, /^main\.[jt]sx?$/));
+      console.log(mainConfig);
       v7 = true;
     } catch (storybookV7error) {
       mainConfig = null;

--- a/node-src/lib/getStorybookMetadata.ts
+++ b/node-src/lib/getStorybookMetadata.ts
@@ -204,21 +204,21 @@ export const findStorybookConfigFile = async (ctx: Context, pattern: RegExp) => 
 
 export const getStorybookMetadata = async (ctx: Context) => {
   const configDir = ctx.options.storybookConfigDir ?? '.storybook';
-  console.log(configDir);
   const r = typeof __non_webpack_require__ !== 'undefined' ? __non_webpack_require__ : require;
 
   let mainConfig;
   let v7 = false;
   try {
     mainConfig = await r(path.resolve(configDir, 'main'));
-    console.log(mainConfig);
+    ctx.log.debug({ configDir, mainConfig });
   } catch (storybookV6error) {
-    console.log(storybookV6error);
+    ctx.log.debug({ storybookV6error });
     try {
       mainConfig = await readConfig(await findStorybookConfigFile(ctx, /^main\.[jt]sx?$/));
-      console.log(mainConfig);
+      ctx.log.debug({ configDir, mainConfig });
       v7 = true;
     } catch (storybookV7error) {
+      ctx.log.debug({ storybookV7error });
       mainConfig = null;
     }
   }


### PR DESCRIPTION
There is a builder check in the storybook metadata, and SB 6 uses an object for the builder rather than the new format of a string value.

We added logic to handle both.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>11.5.1--canary.1001.9355178223.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@11.5.1--canary.1001.9355178223.0
  # or 
  yarn add chromatic@11.5.1--canary.1001.9355178223.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
