### PR TITLE
Clean package.json before compiling into source

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ action
 node
 storybook-out
 coverage
+package.json.backup

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "isChromatic.d.ts"
   ],
   "scripts": {
-    "build": "tsup",
+    "build": "clean-package && tsup && clean-package restore",
     "build-storybook": "storybook build --stats-json",
     "build-test-storybook": "cross-env SMOKE_TEST=true storybook build -o test-storybook --stats-json",
     "build-subdir": "cd subdir ; yarn build ; cd ..",


### PR DESCRIPTION
The contents of `package.json` is compiled into the GitHub Action source code, so we need to clean that up as well.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>11.5.2--canary.1003.9395543210.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@11.5.2--canary.1003.9395543210.0
  # or 
  yarn add chromatic@11.5.2--canary.1003.9395543210.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
