### PR TITLE
Ensure GitHub Action runs in specified version of node

### DIFF
--- a/.github/workflows/smoke-test-node18.yml
+++ b/.github/workflows/smoke-test-node18.yml
@@ -14,6 +14,10 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 18
+
+      - name: Add engines to package.json to enforce above version of node
+        run: echo "`jq '.engines.node="18.x"' package.json`" > package.json
+
       - run: corepack enable
       - run: yarn
       - run: yarn build
@@ -27,3 +31,6 @@ jobs:
           LOG_LEVEL: debug
           DEBUG: chromatic-cli
           CHROMATIC_PROJECT_TOKEN: ${{ secrets.SMOKE_TESTS_CHROMATIC_PROJECT_TOKEN }}
+
+      - name: Revert engines addition to package.json
+        run: echo "`jq 'del(.engines)' package.json`" > package.json

--- a/.github/workflows/smoke-test-node18.yml
+++ b/.github/workflows/smoke-test-node18.yml
@@ -14,10 +14,6 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 18
-
-      - name: Add engines to package.json to enforce above version of node
-        run: echo "`jq '.engines.node="18.x"' package.json`" > package.json
-
       - run: corepack enable
       - run: yarn
       - run: yarn build
@@ -31,6 +27,3 @@ jobs:
           LOG_LEVEL: debug
           DEBUG: chromatic-cli
           CHROMATIC_PROJECT_TOKEN: ${{ secrets.SMOKE_TESTS_CHROMATIC_PROJECT_TOKEN }}
-
-      - name: Revert engines addition to package.json
-        run: echo "`jq 'del(.engines)' package.json`" > package.json

--- a/node-src/tasks/build.ts
+++ b/node-src/tasks/build.ts
@@ -122,8 +122,9 @@ export const buildStorybook = async (ctx: Context) => {
 
     const subprocess = execaCommand(ctx.buildCommand, {
       stdio: [null, logFile, null],
-      preferLocal: false, // When true, this will run in the node version set
-                          // by the action (node20), not the version set in the workflow
+      // When `true`, this will run in the node version set by the
+      // action (node20), not the version set in the workflow
+      preferLocal: false,
       signal,
       env: { CI: '1', NODE_ENV: ctx.env.STORYBOOK_NODE_ENV || 'production' },
     });

--- a/node-src/tasks/build.ts
+++ b/node-src/tasks/build.ts
@@ -122,7 +122,8 @@ export const buildStorybook = async (ctx: Context) => {
 
     const subprocess = execaCommand(ctx.buildCommand, {
       stdio: [null, logFile, null],
-      preferLocal: true,
+      preferLocal: false, // When true, this will run in the node version set
+                          // by the action (node20), not the version set in the workflow
       signal,
       env: { CI: '1', NODE_ENV: ctx.env.STORYBOOK_NODE_ENV || 'production' },
     });


### PR DESCRIPTION
Revert this small bit that was added in #991.

It was not necessary for the change made in that PR, and it caused the Storybook build command to run with the node version [specified by the GitHub Action](https://github.com/chromaui/chromatic-cli/blob/a1fb89f970745a6e55288603c09bf2015bb47766/action.yml#L151) (node 20), instead of the version of node that is installed in the workflow using something like `actions/setup-node`.

Fixes #1000
Fixes #1002

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>11.5.4--canary.1006.9485918262.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@11.5.4--canary.1006.9485918262.0
  # or 
  yarn add chromatic@11.5.4--canary.1006.9485918262.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
