### PR TITLE
Support non-local ancestor builds with `uncommittedHash`

### DIFF
--- a/node-src/git/findAncestorBuildWithCommit.ts
+++ b/node-src/git/findAncestorBuildWithCommit.ts
@@ -70,7 +70,9 @@ export async function findAncestorBuildWithCommit(
         return [build, exists] as const;
       })
     );
-    const result = results.find(([build, exists]) => !build.uncommittedHash && exists);
+    const result = results.find(
+      ([build, exists]) => !(build.isLocalBuild && build.uncommittedHash) && exists
+    );
 
     if (result) return result[0];
 


### PR DESCRIPTION
Currently, we're reading the `build.uncommittedHash` value when determining a replacement build for a squash merge. Sometimes `build.uncommittedHash` is stored in the DB as an error string.

Not sure on the context around the `uncommittedHash` (how it's intended to be used/not used), but based on @tmeasday's suggestion we presumably only want to read the hash here if the build was local.


## QA notes:

1. Install canary (see below) into test project
2. Run a build on `main` (`M.1`) with uncommitted changes (e.g. touch a readme or something). Check this build has `uncommittedHash !== ''`
3. Create branch
4. Create build on branch (build `B.1`)
5. Squash-merge branch
6. Do a fresh clone of repo, check out squash merge commit 
7. Run build for merge (build `M.2`) with `--debug` and `--only-changed`

Check logs for 5., check that `B.1` was successfully "replaced" with `M.1`

We'll also need to check that local build replacement still works:

1. Get a VTA project, setup with TS
2. Make changes, do not commit
3. Run build `B.1`
4. Run second build `B.2`
5. Check that `B.1` was replaced with prior commit.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>11.5.6--canary.1015.10001756160.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@11.5.6--canary.1015.10001756160.0
  # or 
  yarn add chromatic@11.5.6--canary.1015.10001756160.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
