### PR TITLE
Added logic to account for parentheses at the beginning

### DIFF
--- a/node-src/index.test.ts
+++ b/node-src/index.test.ts
@@ -595,8 +595,8 @@ describe('with TurboSnap', () => {
     await runAll(ctx);
 
     expect(ctx.exitCode).toBe(1);
-    expect(ctx.onlyStoryFiles).toEqual(['src/foo.stories.js']);
-    expect(publishedBuild.onlyStoryFiles).toEqual(['src/foo.stories.js']);
+    expect(ctx.onlyStoryFiles).toEqual(['./src/foo.stories.js']);
+    expect(publishedBuild.onlyStoryFiles).toEqual(['./src/foo.stories.js']);
   });
 });
 

--- a/node-src/index.test.ts
+++ b/node-src/index.test.ts
@@ -595,8 +595,8 @@ describe('with TurboSnap', () => {
     await runAll(ctx);
 
     expect(ctx.exitCode).toBe(1);
-    expect(ctx.onlyStoryFiles).toEqual(['./src/foo.stories.js']);
-    expect(publishedBuild.onlyStoryFiles).toEqual(['./src/foo.stories.js']);
+    expect(ctx.onlyStoryFiles).toEqual(['src/foo.stories.js']);
+    expect(publishedBuild.onlyStoryFiles).toEqual(['src/foo.stories.js']);
   });
 });
 

--- a/node-src/tasks/upload.test.ts
+++ b/node-src/tasks/upload.test.ts
@@ -189,9 +189,9 @@ describe('traceChangedFiles', () => {
     await traceChangedFiles(ctx, {} as any);
 
     expect(ctx.onlyStoryFiles).toStrictEqual([
-      './example-(new).stories.js',
-      './example[[lang=language]].stories.js',
-      '[./example/[account]/[id]/[unit]/language/example.stories.tsx]',
+      'example-(new).stories.js',
+      'example[[lang=language]].stories.js',
+      '[example/[account]/[id]/[unit]/language/example.stories.tsx]',
     ]);
   });
 

--- a/node-src/tasks/upload.test.ts
+++ b/node-src/tasks/upload.test.ts
@@ -195,6 +195,7 @@ describe('traceChangedFiles', () => {
       './\\+example-new.stories.js',
       './example-\\(new\\).stories.js',
       './example\\[\\[lang=language\\]\\].stories.js',
+      '\\[./example/\\[account\\]/\\[id\\]/\\[unit\\]/language/example.stories.tsx\\]',
     ]);
   });
 

--- a/node-src/tasks/upload.test.ts
+++ b/node-src/tasks/upload.test.ts
@@ -189,9 +189,9 @@ describe('traceChangedFiles', () => {
     await traceChangedFiles(ctx, {} as any);
 
     expect(ctx.onlyStoryFiles).toStrictEqual([
-      'example-(new).stories.js',
-      'example[[lang=language]].stories.js',
-      '[example/[account]/[id]/[unit]/language/example.stories.tsx]',
+      './example-(new).stories.js',
+      './example[[lang=language]].stories.js',
+      '[./example/[account]/[id]/[unit]/language/example.stories.tsx]',
     ]);
   });
 

--- a/node-src/tasks/upload.test.ts
+++ b/node-src/tasks/upload.test.ts
@@ -166,6 +166,8 @@ describe('traceChangedFiles', () => {
 
   it('escapes special characters on context', async () => {
     const deps = {
+      './$example-new.stories.js': ['./$example-new.stories.js'],
+      './+example-new.stories.js': ['./+example-new.stories.js'],
       './example-(new).stories.js': ['./example-(new).stories.js'],
       './example[[lang=language]].stories.js': ['./example[[lang=language]].stories.js'],
       '[./example/[account]/[id]/[unit]/language/example.stories.tsx]': [
@@ -189,9 +191,10 @@ describe('traceChangedFiles', () => {
     await traceChangedFiles(ctx, {} as any);
 
     expect(ctx.onlyStoryFiles).toStrictEqual([
-      './example-(new).stories.js',
-      './example[[lang=language]].stories.js',
-      '[./example/[account]/[id]/[unit]/language/example.stories.tsx]',
+      './\\$example-new.stories.js',
+      './\\+example-new.stories.js',
+      './example-\\(new\\).stories.js',
+      './example\\[\\[lang=language\\]\\].stories.js',
     ]);
   });
 

--- a/node-src/tasks/upload.test.ts
+++ b/node-src/tasks/upload.test.ts
@@ -189,9 +189,9 @@ describe('traceChangedFiles', () => {
     await traceChangedFiles(ctx, {} as any);
 
     expect(ctx.onlyStoryFiles).toStrictEqual([
-      './example-\\(\\new\\)\\.stories.js',
-      './example\\[\\[\\lang=language\\]\\]\\.stories.js',
-      '\\[\\./example/\\[\\account\\]\\/\\[\\id\\]\\/\\[\\unit\\]\\/language/example.stories.tsx\\]\\',
+      './example-(new).stories.js',
+      './example[[lang=language]].stories.js',
+      '[./example/[account]/[id]/[unit]/language/example.stories.tsx]',
     ]);
   });
 

--- a/node-src/tasks/upload.test.ts
+++ b/node-src/tasks/upload.test.ts
@@ -168,6 +168,9 @@ describe('traceChangedFiles', () => {
     const deps = {
       './example-(new).stories.js': ['./example-(new).stories.js'],
       './example[[lang=language]].stories.js': ['./example[[lang=language]].stories.js'],
+      '[./example/[account]/[id]/[unit]/language/example.stories.tsx]': [
+        '[./example/[account]/[id]/[unit]/language/example.stories.tsx]',
+      ],
     };
     findChangedDependencies.mockResolvedValue([]);
     findChangedPackageFiles.mockResolvedValue([]);
@@ -188,6 +191,7 @@ describe('traceChangedFiles', () => {
     expect(ctx.onlyStoryFiles).toStrictEqual([
       './example-\\(\\new\\)\\.stories.js',
       './example\\[\\[\\lang=language\\]\\]\\.stories.js',
+      '\\[\\./example/\\[\\account\\]\\/\\[\\id\\]\\/\\[\\unit\\]\\/language/example.stories.tsx\\]\\',
     ]);
   });
 

--- a/node-src/tasks/upload.ts
+++ b/node-src/tasks/upload.ts
@@ -161,9 +161,14 @@ export const traceChangedFiles = async (ctx: Context, task: Task) => {
       changedDependencyNames || []
     );
     if (onlyStoryFiles) {
+      let filteredArray = [];
       // Escape special characters in the filename so it does not conflict with picomatch
       ctx.onlyStoryFiles = Object.keys(onlyStoryFiles).map((key) => {
-        const filteredArray = key.split(SPECIAL_CHARS_REGEXP).filter((item) => item !== '');
+        if (key.split(SPECIAL_CHARS_REGEXP)[0] === '') {
+          filteredArray = key.split(SPECIAL_CHARS_REGEXP);
+        } else {
+          filteredArray = key.split(SPECIAL_CHARS_REGEXP).filter((item) => item !== '');
+        }
         return filteredArray.join('\\');
       });
 

--- a/node-src/tasks/upload.ts
+++ b/node-src/tasks/upload.ts
@@ -37,6 +37,9 @@ interface PathSpec {
   pathname: string;
   contentLength: number;
 }
+// These are the special characters that need to be escaped in the filename
+// because they are used as special characters in picomatch
+const SPECIAL_CHARS_REGEXP = /([$^*+?()[\]])/g;
 
 // Get all paths in rootDir, starting at dirname.
 // We don't want the paths to include rootDir -- so if rootDir = storybook-static,
@@ -159,7 +162,10 @@ export const traceChangedFiles = async (ctx: Context, task: Task) => {
       changedDependencyNames || []
     );
     if (onlyStoryFiles) {
-      ctx.onlyStoryFiles = Object.keys(onlyStoryFiles);
+      // Escape special characters in the filename so it does not conflict with picomatch
+      ctx.onlyStoryFiles = Object.keys(onlyStoryFiles).map((key) =>
+        key.replace(SPECIAL_CHARS_REGEXP, '\\$1')
+      );
 
       if (!ctx.options.interactive) {
         if (!ctx.options.traceChanged) {

--- a/node-src/tasks/upload.ts
+++ b/node-src/tasks/upload.ts
@@ -159,10 +159,7 @@ export const traceChangedFiles = async (ctx: Context, task: Task) => {
       changedDependencyNames || []
     );
     if (onlyStoryFiles) {
-      console.log(onlyStoryFiles);
-      ctx.onlyStoryFiles = Object.keys(onlyStoryFiles).flatMap((value) =>
-        value.replace(/\.\//, '')
-      );
+      ctx.onlyStoryFiles = Object.keys(onlyStoryFiles);
 
       if (!ctx.options.interactive) {
         if (!ctx.options.traceChanged) {

--- a/node-src/tasks/upload.ts
+++ b/node-src/tasks/upload.ts
@@ -159,7 +159,10 @@ export const traceChangedFiles = async (ctx: Context, task: Task) => {
       changedDependencyNames || []
     );
     if (onlyStoryFiles) {
-      ctx.onlyStoryFiles = Object.keys(onlyStoryFiles);
+      console.log(onlyStoryFiles);
+      ctx.onlyStoryFiles = Object.keys(onlyStoryFiles).flatMap((value) =>
+        value.replace(/\.\//, '')
+      );
 
       if (!ctx.options.interactive) {
         if (!ctx.options.traceChanged) {

--- a/node-src/tasks/upload.ts
+++ b/node-src/tasks/upload.ts
@@ -38,8 +38,6 @@ interface PathSpec {
   contentLength: number;
 }
 
-const SPECIAL_CHARS_REGEXP = new RegExp(`([${'`$^*+?()[]'.split('').join('\\')}])`);
-
 // Get all paths in rootDir, starting at dirname.
 // We don't want the paths to include rootDir -- so if rootDir = storybook-static,
 // paths will be like iframe.html rather than storybook-static/iframe.html
@@ -161,16 +159,7 @@ export const traceChangedFiles = async (ctx: Context, task: Task) => {
       changedDependencyNames || []
     );
     if (onlyStoryFiles) {
-      let filteredArray = [];
-      // Escape special characters in the filename so it does not conflict with picomatch
-      ctx.onlyStoryFiles = Object.keys(onlyStoryFiles).map((key) => {
-        if (key.split(SPECIAL_CHARS_REGEXP)[0] === '') {
-          filteredArray = key.split(SPECIAL_CHARS_REGEXP);
-        } else {
-          filteredArray = key.split(SPECIAL_CHARS_REGEXP).filter((item) => item !== '');
-        }
-        return filteredArray.join('\\');
-      });
+      ctx.onlyStoryFiles = Object.keys(onlyStoryFiles);
 
       if (!ctx.options.interactive) {
         if (!ctx.options.traceChanged) {


### PR DESCRIPTION
The original pattern to address the split of the special characters didn't account for the empty string at the beginning and end of the pattern. We only want to ignore empty strings in the middle of the string.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>11.6.0--canary.1016.10173197749.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@11.6.0--canary.1016.10173197749.0
  # or 
  yarn add chromatic@11.6.0--canary.1016.10173197749.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
