### PR TITLE
test setting outOfSync to false

### DIFF
--- a/node-src/lib/findChangedDependencies.test.ts
+++ b/node-src/lib/findChangedDependencies.test.ts
@@ -17,7 +17,9 @@ const buildDepTree = vi.mocked(buildDepTreeFromFiles);
 
 beforeEach(() => {
   getRepositoryRoot.mockResolvedValue('/root');
-  findFilesFromRepositoryRoot.mockImplementation((file) => Promise.resolve(file.startsWith('**') ? [] : [file]));
+  findFilesFromRepositoryRoot.mockImplementation((file) =>
+    Promise.resolve(file.startsWith('**') ? [] : [file])
+  );
 });
 afterEach(() => {
   getRepositoryRoot.mockReset();
@@ -247,21 +249,29 @@ describe('findChangedDependencies', () => {
     await expect(findChangedDependencies(context)).resolves.toEqual(['react', 'lodash']);
 
     // Root manifest and lock files are checked
-    expect(buildDepTree).toHaveBeenCalledWith('/root', 'package.json', 'yarn.lock', true);
-    expect(buildDepTree).toHaveBeenCalledWith('/root', 'A.package.json', 'A.yarn.lock', true);
+    expect(buildDepTree).toHaveBeenCalledWith('/root', 'package.json', 'yarn.lock', true, false);
+    expect(buildDepTree).toHaveBeenCalledWith(
+      '/root',
+      'A.package.json',
+      'A.yarn.lock',
+      true,
+      false
+    );
 
     // Subpackage manifest and lock files are checked
     expect(buildDepTree).toHaveBeenCalledWith(
       '/root',
       'subdir/package.json',
       'subdir/yarn.lock',
-      true
+      true,
+      false
     );
     expect(buildDepTree).toHaveBeenCalledWith(
       '/root',
       'A.subdir/package.json',
       'A.subdir/yarn.lock',
-      true
+      true,
+      false
     );
   });
 
@@ -286,7 +296,8 @@ describe('findChangedDependencies', () => {
       '/root',
       'A.subdir/package.json',
       'A.yarn.lock', // root lockfile
-      true
+      true,
+      false
     );
   });
 
@@ -334,7 +345,8 @@ describe('findChangedDependencies', () => {
       '/root',
       'A.subdir/package.json',
       'A.subdir/package-lock.json',
-      true
+      true,
+      false
     );
   });
 });

--- a/node-src/lib/getDependencies.ts
+++ b/node-src/lib/getDependencies.ts
@@ -17,15 +17,23 @@ export const getDependencies = async (
     manifestPath,
     lockfilePath,
     includeDev = true,
+    strictOutOfSync = false,
   }: {
     rootPath: string;
     manifestPath: string;
     lockfilePath: string;
     includeDev?: boolean;
+    strictOutOfSync?: boolean;
   }
 ) => {
   try {
-    const headTree = await buildDepTreeFromFiles(rootPath, manifestPath, lockfilePath, includeDev);
+    const headTree = await buildDepTreeFromFiles(
+      rootPath,
+      manifestPath,
+      lockfilePath,
+      includeDev,
+      strictOutOfSync
+    );
     return flattenDependencyTree(headTree.dependencies);
   } catch (e) {
     ctx.log.debug({ rootPath, manifestPath, lockfilePath }, 'Failed to get dependencies');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chromatic",
-  "version": "11.5.5",
+  "version": "11.5.6",
   "description": "Automate visual testing across browsers. Gather UI feedback. Versioned documentation.",
   "keywords": [
     "storybook-addon",


### PR DESCRIPTION
There is an issue where the manifest tracing of package version dependencies doesn't work correctly if `strictOutOfSync` is set to true and always errors.

I'm flipping the flag to test it out and see if the manifest trace can get to a passing point.

Documentation for [Snyk Parser](https://github.com/snyk/nodejs-lockfile-parser)
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>11.7.0--canary.1018.10185153847.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@11.7.0--canary.1018.10185153847.0
  # or 
  yarn add chromatic@11.7.0--canary.1018.10185153847.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
