### PR TITLE
Chore: Update the Snyk parser package and add support for pnpm.

### DIFF
--- a/node-src/lib/findChangedDependencies.test.ts
+++ b/node-src/lib/findChangedDependencies.test.ts
@@ -17,7 +17,9 @@ const buildDepTree = vi.mocked(buildDepTreeFromFiles);
 
 beforeEach(() => {
   getRepositoryRoot.mockResolvedValue('/root');
-  findFilesFromRepositoryRoot.mockImplementation((file) => Promise.resolve(file.startsWith('**') ? [] : [file]));
+  findFilesFromRepositoryRoot.mockImplementation((file) =>
+    Promise.resolve(file.startsWith('**') ? [] : [file])
+  );
 });
 afterEach(() => {
   getRepositoryRoot.mockReset();
@@ -247,21 +249,29 @@ describe('findChangedDependencies', () => {
     await expect(findChangedDependencies(context)).resolves.toEqual(['react', 'lodash']);
 
     // Root manifest and lock files are checked
-    expect(buildDepTree).toHaveBeenCalledWith('/root', 'package.json', 'yarn.lock', true);
-    expect(buildDepTree).toHaveBeenCalledWith('/root', 'A.package.json', 'A.yarn.lock', true);
+    expect(buildDepTree).toHaveBeenCalledWith('/root', 'package.json', 'yarn.lock', true, false);
+    expect(buildDepTree).toHaveBeenCalledWith(
+      '/root',
+      'A.package.json',
+      'A.yarn.lock',
+      true,
+      false
+    );
 
     // Subpackage manifest and lock files are checked
     expect(buildDepTree).toHaveBeenCalledWith(
       '/root',
       'subdir/package.json',
       'subdir/yarn.lock',
-      true
+      true,
+      false
     );
     expect(buildDepTree).toHaveBeenCalledWith(
       '/root',
       'A.subdir/package.json',
       'A.subdir/yarn.lock',
-      true
+      true,
+      false
     );
   });
 
@@ -286,7 +296,8 @@ describe('findChangedDependencies', () => {
       '/root',
       'A.subdir/package.json',
       'A.yarn.lock', // root lockfile
-      true
+      true,
+      false
     );
   });
 
@@ -334,7 +345,8 @@ describe('findChangedDependencies', () => {
       '/root',
       'A.subdir/package.json',
       'A.subdir/package-lock.json',
-      true
+      true,
+      false
     );
   });
 });

--- a/node-src/lib/findChangedDependencies.ts
+++ b/node-src/lib/findChangedDependencies.ts
@@ -9,6 +9,7 @@ import { matchesFile } from './utils';
 const PACKAGE_JSON = 'package.json';
 const PACKAGE_LOCK = 'package-lock.json';
 const YARN_LOCK = 'yarn.lock';
+const PNPM_LOCK = 'pnpm-lock.yaml';
 
 // Yields a list of dependency names which have changed since the baseline.
 // E.g. ['react', 'react-dom', '@storybook/react']
@@ -28,7 +29,7 @@ export const findChangedDependencies = async (ctx: Context) => {
 
   const rootPath = await getRepositoryRoot();
   const [rootManifestPath] = await findFilesFromRepositoryRoot(PACKAGE_JSON);
-  const [rootLockfilePath] = await findFilesFromRepositoryRoot(YARN_LOCK, PACKAGE_LOCK);
+  const [rootLockfilePath] = await findFilesFromRepositoryRoot(YARN_LOCK, PACKAGE_LOCK, PNPM_LOCK);
   if (!rootManifestPath || !rootLockfilePath) {
     ctx.log.debug(
       { rootPath, rootManifestPath, rootLockfilePath },
@@ -47,7 +48,8 @@ export const findChangedDependencies = async (ctx: Context) => {
       const dirname = path.dirname(manifestPath);
       const [lockfilePath] = await findFilesFromRepositoryRoot(
         `${dirname}/${YARN_LOCK}`,
-        `${dirname}/${PACKAGE_LOCK}`
+        `${dirname}/${PACKAGE_LOCK}`,
+        `${dirname}/${PNPM_LOCK}`
       );
       // Fall back to the root lockfile if we can't find one in the same directory.
       return [manifestPath, lockfilePath || rootLockfilePath];
@@ -57,7 +59,9 @@ export const findChangedDependencies = async (ctx: Context) => {
   if (rootManifestPath && rootLockfilePath) {
     metadataPathPairs.unshift([rootManifestPath, rootLockfilePath]);
   } else if (!metadataPathPairs.length) {
-    throw new Error(`Could not find any pairs of ${PACKAGE_JSON} + ${PACKAGE_LOCK} / ${YARN_LOCK}`);
+    throw new Error(
+      `Could not find any pairs of ${PACKAGE_JSON} + ${PACKAGE_LOCK} / ${YARN_LOCK} / ${PNPM_LOCK}`
+    );
   }
 
   ctx.log.debug(

--- a/node-src/lib/getDependencies.ts
+++ b/node-src/lib/getDependencies.ts
@@ -17,15 +17,23 @@ export const getDependencies = async (
     manifestPath,
     lockfilePath,
     includeDev = true,
+    strictOutOfSync = false,
   }: {
     rootPath: string;
     manifestPath: string;
     lockfilePath: string;
     includeDev?: boolean;
+    strictOutOfSync?: boolean;
   }
 ) => {
   try {
-    const headTree = await buildDepTreeFromFiles(rootPath, manifestPath, lockfilePath, includeDev);
+    const headTree = await buildDepTreeFromFiles(
+      rootPath,
+      manifestPath,
+      lockfilePath,
+      includeDev,
+      strictOutOfSync
+    );
     return flattenDependencyTree(headTree.dependencies);
   } catch (e) {
     ctx.log.debug({ rootPath, manifestPath, lockfilePath }, 'Failed to get dependencies');

--- a/package.json
+++ b/package.json
@@ -192,7 +192,7 @@
     "read-pkg-up": "^7.0.1",
     "semver": "^7.3.5",
     "slash": "^3.0.0",
-    "snyk-nodejs-lockfile-parser": "^1.52.1",
+    "snyk-nodejs-lockfile-parser": "^1.58.7",
     "sort-package-json": "1.50.0",
     "storybook": "^8.1.5",
     "string-argv": "^0.3.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6592,7 +6592,7 @@ __metadata:
     read-pkg-up: "npm:^7.0.1"
     semver: "npm:^7.3.5"
     slash: "npm:^3.0.0"
-    snyk-nodejs-lockfile-parser: "npm:^1.52.1"
+    snyk-nodejs-lockfile-parser: "npm:^1.58.7"
     sort-package-json: "npm:1.50.0"
     storybook: "npm:^8.1.5"
     string-argv: "npm:^0.3.1"
@@ -12774,7 +12774,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"micromatch@npm:^4.0.0, micromatch@npm:^4.0.2, micromatch@npm:^4.0.4, micromatch@npm:^4.0.5":
+"micromatch@npm:^4.0.0, micromatch@npm:^4.0.2, micromatch@npm:^4.0.4, micromatch@npm:^4.0.7":
   version: 4.0.7
   resolution: "micromatch@npm:4.0.7"
   dependencies:
@@ -16230,9 +16230,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"snyk-nodejs-lockfile-parser@npm:^1.52.1":
-  version: 1.56.1
-  resolution: "snyk-nodejs-lockfile-parser@npm:1.56.1"
+"snyk-nodejs-lockfile-parser@npm:^1.58.7":
+  version: 1.58.7
+  resolution: "snyk-nodejs-lockfile-parser@npm:1.58.7"
   dependencies:
     "@snyk/dep-graph": "npm:^2.3.0"
     "@snyk/error-catalog-nodejs-public": "npm:^5.16.0"
@@ -16246,7 +16246,7 @@ __metadata:
     lodash.flatmap: "npm:^4.5.0"
     lodash.isempty: "npm:^4.4.0"
     lodash.topairs: "npm:^4.3.0"
-    micromatch: "npm:^4.0.5"
+    micromatch: "npm:^4.0.7"
     p-map: "npm:^4.0.0"
     semver: "npm:^7.6.0"
     snyk-config: "npm:^5.0.0"
@@ -16254,7 +16254,7 @@ __metadata:
     uuid: "npm:^8.3.0"
   bin:
     parse-nodejs-lockfile: bin/index.js
-  checksum: 10c0/3f1c8fa8af06569d4590f4f735deb9e7506bb46719a737f7f5701fc3f2f3073a0484ca8535bffdbfe09a5dce62e4796b2722ff3538ad0443a48ba8beac5d4ef5
+  checksum: 10c0/e205e0184a3b945653b5afec292afadcb877d8ad9e776abf13989404c6f6e75c5224d62f5a5297228010be2a0f5a2f9950ac4f6a247bdb101ec69a257e13fdef
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
…ap-4370-the-turbosnap-manifest-tracing-logic-doesnt-work

Currently, the snyk parsing for the manifest package version tracing doesn't work for pnpm.

Snyk added support for pnpm and I'm updating Chromatic to process pnpm lock files now.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>11.7.0--canary.1019.10184330128.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@11.7.0--canary.1019.10184330128.0
  # or 
  yarn add chromatic@11.7.0--canary.1019.10184330128.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
