### PR TITLE
Add  key to configuration to fix #1022

### DIFF
--- a/node-src/lib/getConfiguration.test.ts
+++ b/node-src/lib/getConfiguration.test.ts
@@ -13,6 +13,7 @@ beforeEach(() => {
 it('reads configuration successfully', async () => {
   mockedReadFile.mockReturnValue(
     JSON.stringify({
+      $schema: 'https://www.chromatic.com/config-file.schema.json',
       projectId: 'project-id',
       projectToken: 'project-token',
 
@@ -47,6 +48,7 @@ it('reads configuration successfully', async () => {
   );
 
   expect(await getConfiguration()).toEqual({
+    $schema: 'https://www.chromatic.com/config-file.schema.json',
     configFile: 'chromatic.config.json',
     projectId: 'project-id',
     projectToken: 'project-token',

--- a/node-src/lib/getConfiguration.ts
+++ b/node-src/lib/getConfiguration.ts
@@ -6,6 +6,8 @@ import { invalidConfigurationFile } from '../ui/messages/errors/invalidConfigura
 
 const configurationSchema = z
   .object({
+    $schema: z.string(),
+
     projectId: z.string(),
     projectToken: z.string(), // deprecated
 


### PR DESCRIPTION
We now offer the option to [validate the config file using JSON schema](https://www.chromatic.com/docs/cli/#chromatic-config-file). This PR allows the user to specify the schema within the config file itself. 

Fixes #1022

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>11.7.1--canary.1023.10387892202.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@11.7.1--canary.1023.10387892202.0
  # or 
  yarn add chromatic@11.7.1--canary.1023.10387892202.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
