### PR TITLE
Don't upload files from `.chromatic` directory

### DIFF
--- a/node-src/tasks/upload.ts
+++ b/node-src/tasks/upload.ts
@@ -46,7 +46,7 @@ const SPECIAL_CHARS_REGEXP = /([$^*+?()[\]])/g;
 // paths will be like iframe.html rather than storybook-static/iframe.html
 function getPathsInDir(ctx: Context, rootDir: string, dirname = '.'): PathSpec[] {
   // .chromatic is a special directory reserved for internal use and should not be uploaded
-  if(dirname === '.chromatic') {
+  if (dirname === '.chromatic') {
     return [];
   }
 

--- a/node-src/tasks/upload.ts
+++ b/node-src/tasks/upload.ts
@@ -45,6 +45,11 @@ const SPECIAL_CHARS_REGEXP = /([$^*+?()[\]])/g;
 // We don't want the paths to include rootDir -- so if rootDir = storybook-static,
 // paths will be like iframe.html rather than storybook-static/iframe.html
 function getPathsInDir(ctx: Context, rootDir: string, dirname = '.'): PathSpec[] {
+  // .chromatic is a special directory reserved for internal use and should not be uploaded
+  if(dirname === '.chromatic') {
+    return [];
+  }
+
   try {
     return readdirSync(join(rootDir, dirname)).flatMap((p: string) => {
       const pathname = join(dirname, p);


### PR DESCRIPTION
This is largely caused by using pre-built storybooks with the `-d` / `--storybook-build-dir` flag.  Filtering out this directory will prevent accidental upload of reserved files like trace metadata or processing sentinels.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>11.8.0--canary.1028.10715425881.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@11.8.0--canary.1028.10715425881.0
  # or 
  yarn add chromatic@11.8.0--canary.1028.10715425881.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
