### PR TITLE
Use the `--flag=value` format for Storybook build options

### DIFF
--- a/node-src/tasks/build.test.ts
+++ b/node-src/tasks/build.test.ts
@@ -55,7 +55,7 @@ describe('setBuildCommand', () => {
 
     expect(getCliCommand).toHaveBeenCalledWith(
       expect.anything(),
-      ['build:storybook', '--output-dir', './source-dir/', '--webpack-stats-json', './source-dir/'],
+      ['build:storybook', '--output-dir=./source-dir/', '--webpack-stats-json=./source-dir/'],
       { programmatic: true }
     );
     expect(ctx.buildCommand).toEqual('npm run build:storybook');
@@ -74,7 +74,7 @@ describe('setBuildCommand', () => {
 
     expect(getCliCommand).toHaveBeenCalledWith(
       expect.anything(),
-      ['build:storybook', '--output-dir', './source-dir/', '--webpack-stats-json', './source-dir/'],
+      ['build:storybook', '--output-dir=./source-dir/', '--webpack-stats-json=./source-dir/'],
       { programmatic: true }
     );
     expect(ctx.buildCommand).toEqual('yarn run build:storybook');
@@ -93,7 +93,7 @@ describe('setBuildCommand', () => {
 
     expect(getCliCommand).toHaveBeenCalledWith(
       expect.anything(),
-      ['build:storybook', '--output-dir', './source-dir/', '--webpack-stats-json', './source-dir/'],
+      ['build:storybook', '--output-dir=./source-dir/', '--webpack-stats-json=./source-dir/'],
       { programmatic: true }
     );
     expect(ctx.buildCommand).toEqual('pnpm run build:storybook');

--- a/node-src/tasks/build.ts
+++ b/node-src/tasks/build.ts
@@ -38,10 +38,8 @@ export const setBuildCommand = async (ctx: Context) => {
   }
 
   const buildCommandOptions = [
-    '--output-dir',
-    ctx.sourceDir,
-    ctx.git.changedFiles && webpackStatsSupported && '--webpack-stats-json',
-    ctx.git.changedFiles && webpackStatsSupported && ctx.sourceDir,
+    `--output-dir=${ctx.sourceDir}`,
+    ctx.git.changedFiles && webpackStatsSupported && `--webpack-stats-json=${ctx.sourceDir}`,
   ].filter(Boolean);
 
   if (isE2EBuild(ctx.options)) {


### PR DESCRIPTION
This format is better supported by CLI wrappers (e.g. Angular) and prevents build errors.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>11.8.1--canary.1034.10797828139.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@11.8.1--canary.1034.10797828139.0
  # or 
  yarn add chromatic@11.8.1--canary.1034.10797828139.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
