### PR TITLE
Use --stats-json flag for SB 8.0.0+

### DIFF
--- a/node-src/tasks/build.test.ts
+++ b/node-src/tasks/build.test.ts
@@ -113,6 +113,25 @@ describe('setBuildCommand', () => {
       'Storybook version 6.2.0 or later is required to use the --only-changed flag'
     );
   });
+
+  it('uses the correct flag for webpack stats for >= 8.0.0', async () => {
+    getCliCommand.mockReturnValue(Promise.resolve('npm run build:storybook'));
+
+    const ctx = {
+      sourceDir: './source-dir/',
+      options: { buildScriptName: 'build:storybook' },
+      storybook: { version: '8.0.0' },
+      git: { changedFiles: ['./index.js'] },
+    } as any;
+    await setBuildCommand(ctx);
+
+    expect(getCliCommand).toHaveBeenCalledWith(
+      expect.anything(),
+      ['build:storybook', '--output-dir=./source-dir/', '--stats-json=./source-dir/'],
+      { programmatic: true }
+    );
+    expect(ctx.buildCommand).toEqual('npm run build:storybook');
+  });
 });
 
 describe('buildStorybook', () => {

--- a/node-src/tasks/build.ts
+++ b/node-src/tasks/build.ts
@@ -27,16 +27,16 @@ export const setSourceDir = async (ctx: Context) => {
   }
 };
 
+// Storybook 8.0.0 deprecated --webpack-stats-json in favor of --stats-json.
+const webpackStatsFlag = (version: string) => {
+  return semver.gte(semver.coerce(version), '8.0.0') ? '--stats-json' : '--webpack-stats-json';
+};
+
 export const setBuildCommand = async (ctx: Context) => {
   const webpackStatsSupported =
     ctx.storybook && ctx.storybook.version
       ? semver.gte(semver.coerce(ctx.storybook.version), '6.2.0')
       : true;
-
-  const webpackStatsFlag =
-    webpackStatsSupported && semver.gte(semver.coerce(ctx.storybook.version), '8.0.0')
-      ? '--stats-json'
-      : '--webpack-stats-json';
 
   if (ctx.git.changedFiles && !webpackStatsSupported) {
     ctx.log.warn('Storybook version 6.2.0 or later is required to use the --only-changed flag');
@@ -44,7 +44,9 @@ export const setBuildCommand = async (ctx: Context) => {
 
   const buildCommandOptions = [
     `--output-dir=${ctx.sourceDir}`,
-    ctx.git.changedFiles && webpackStatsSupported && `${webpackStatsFlag}=${ctx.sourceDir}`,
+    ctx.git.changedFiles &&
+      webpackStatsSupported &&
+      `${webpackStatsFlag(ctx.storybook.version)}=${ctx.sourceDir}`,
   ].filter(Boolean);
 
   if (isE2EBuild(ctx.options)) {

--- a/node-src/tasks/build.ts
+++ b/node-src/tasks/build.ts
@@ -33,13 +33,18 @@ export const setBuildCommand = async (ctx: Context) => {
       ? semver.gte(semver.coerce(ctx.storybook.version), '6.2.0')
       : true;
 
+  const webpackStatsFlag =
+    webpackStatsSupported && semver.gte(semver.coerce(ctx.storybook.version), '8.0.0')
+      ? '--stats-json'
+      : '--webpack-stats-json';
+
   if (ctx.git.changedFiles && !webpackStatsSupported) {
     ctx.log.warn('Storybook version 6.2.0 or later is required to use the --only-changed flag');
   }
 
   const buildCommandOptions = [
     `--output-dir=${ctx.sourceDir}`,
-    ctx.git.changedFiles && webpackStatsSupported && `--webpack-stats-json=${ctx.sourceDir}`,
+    ctx.git.changedFiles && webpackStatsSupported && `${webpackStatsFlag}=${ctx.sourceDir}`,
   ].filter(Boolean);
 
   if (isE2EBuild(ctx.options)) {


### PR DESCRIPTION
At 8.0.0, [`--webpack-stats-json` was renamed to `--stats-json`](https://github.com/storybookjs/storybook/blob/v8.0.0/MIGRATION.md#--webpack-stats-json-option-renamed---stats-json)

Prefer that option for projects using 8.0.0 or greater.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>11.10.1--canary.1035.10835841995.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@11.10.1--canary.1035.10835841995.0
  # or 
  yarn add chromatic@11.10.1--canary.1035.10835841995.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
