### PR TITLE
GitHub action to add package size comment to PR

### DIFF
--- a/.github/workflows/package-size.yml
+++ b/.github/workflows/package-size.yml
@@ -1,0 +1,62 @@
+name: Chromatic Package Size
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  chromatic:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v3
+        with:
+          node-version: lts/*
+      - run: corepack enable
+      - name: install
+        run: yarn install --immutable
+      - name: build
+        run: yarn build
+      - name: Get Package Size
+        id: package_size
+        run: |
+          export DIST_SIZE="$(du -k ./dist | cut -f1)"
+          echo "Package Size: $DIST_SIZE KB"
+          echo "size=$DIST_SIZE" >> "$GITHUB_OUTPUT"
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            // 1. Retrieve existing bot comments for the PR
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            })
+            const botComment = comments.find(comment => {
+              return comment.user.type === 'Bot' && comment.body.includes('Package Size')
+            })
+
+            const output = "📦 Package Size: ${{ steps.package_size.outputs.size }} KB";
+
+            if (botComment) {
+              github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: botComment.id,
+                body: output
+              })
+            } else {
+              github.rest.issues.createComment({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: output
+              })
+            }


### PR DESCRIPTION
We can later adapt this to track +/- changes over previous release.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>11.10.3--canary.1040.10851820355.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@11.10.3--canary.1040.10851820355.0
  # or 
  yarn add chromatic@11.10.3--canary.1040.10851820355.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
