### PR TITLE
Update actions/upload-artifact to v4

### DIFF
--- a/.github/workflows/chromatic-main-and-prs.yml
+++ b/.github/workflows/chromatic-main-and-prs.yml
@@ -31,7 +31,7 @@ jobs:
           traceChanged: true
           diagnostics: true
           skip: ${{ github.event.pull_request.draft == true }}
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         if: always()
         with:
           name: chromatic-build-artifacts-${{ github.run_id }}

--- a/.github/workflows/chromatic-prod.yml
+++ b/.github/workflows/chromatic-prod.yml
@@ -26,7 +26,7 @@ jobs:
           debug: true
         env:
           CHROMATIC_PROJECT_TOKEN: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         if: always()
         with:
           name: chromatic-build-artifacts-${{ github.run_id }}


### PR DESCRIPTION
The v2 version is deprecated and now causing failures: https://github.com/chromaui/chromatic-cli/actions/runs/10832862998/job/30058245987

There are no breaking changes in v4 for how we use the action, so it should be a simple upgrade.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>11.10.1--canary.1042.10835327466.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@11.10.1--canary.1042.10835327466.0
  # or 
  yarn add chromatic@11.10.1--canary.1042.10835327466.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
