### PR TITLE
Fix flaky missing dependency test

### DIFF
--- a/node-src/lib/getStorybookInfo.test.ts
+++ b/node-src/lib/getStorybookInfo.test.ts
@@ -81,7 +81,9 @@ describe('getStorybookInfo', () => {
     await expect(getStorybookInfo(context)).resolves.toEqual(
       // We're getting the result of tracing chromatic-cli's node_modules here.
       expect.objectContaining({
-        viewLayer: 'react',
+        // We're currently using `react` and `@storybook/react-webpack5` so the we can end up with
+        // either one based on when those promises resolve.
+        viewLayer: expect.stringMatching(/(react|@storybook\/react-webpack5)/),
         version: expect.any(String),
         addons: [
           {


### PR DESCRIPTION
It appears we send a series of promises to search for various [view layers](https://github.com/chromaui/chromatic-cli/blob/b5e1dd39218f5ab477130ad1dd951149edc494b2/node-src/lib/viewLayers.ts) and use the first one to resolve. The problem with this test is we're using our own `node_modules` directory and we import two view layers from that list. Since the resolution of those promises is non-deterministic, this test can fail randomly.

To fix that problem, we can simply look for either option!
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>11.10.2--canary.1043.10838513797.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@11.10.2--canary.1043.10838513797.0
  # or 
  yarn add chromatic@11.10.2--canary.1043.10838513797.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
