### PR TITLE
Fix flaky verify timeout test

### DIFF
--- a/node-src/tasks/verify.test.ts
+++ b/node-src/tasks/verify.test.ts
@@ -102,20 +102,15 @@ describe('verifyBuild', () => {
   });
 
   it('times out if build takes too long to start', async () => {
-    const build = {
-      status: 'IN_PROGRESS',
+    const publishedBuild = {
+      status: 'PUBLISHED',
       features: { uiTests: true, uiReview: false },
       app: {},
-      startedAt: Date.now(),
+      startedAt: null,
+      upgradeBuilds: [],
     };
-    const publishedBuild = { ...build, status: 'PUBLISHED', startedAt: null, upgradeBuilds: [] };
     const client = { runQuery: vi.fn() };
-    client.runQuery
-      // Polling four times is going to hit the timeout
-      .mockReturnValueOnce({ app: { build: publishedBuild } })
-      .mockReturnValueOnce({ app: { build: publishedBuild } })
-      .mockReturnValueOnce({ app: { build: publishedBuild } })
-      .mockReturnValue({ app: { build } });
+    client.runQuery.mockReturnValue({ app: { build: publishedBuild } });
 
     const ctx = { client, ...defaultContext } as any;
     await expect(verifyBuild(ctx, {} as any)).rejects.toThrow('Build verification timed out');


### PR DESCRIPTION
We had a flaky test which tests verify timeouts. We were returning the status `PUBLISHED` 3 times then `IN_PROGRESS` (which successfully resolves the `verifyBuild()` call). Instead, we can _always_ return a `PUBLISHED` build to avoid the timing issue.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>11.10.2--canary.1044.10838834040.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@11.10.2--canary.1044.10838834040.0
  # or 
  yarn add chromatic@11.10.2--canary.1044.10838834040.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
