### PR TITLE
Revert "Use --stats-json flag for SB 8.0.0+"

### DIFF
--- a/node-src/tasks/build.test.ts
+++ b/node-src/tasks/build.test.ts
@@ -113,25 +113,6 @@ describe('setBuildCommand', () => {
       'Storybook version 6.2.0 or later is required to use the --only-changed flag'
     );
   });
-
-  it('uses the correct flag for webpack stats for >= 8.0.0', async () => {
-    getCliCommand.mockReturnValue(Promise.resolve('npm run build:storybook'));
-
-    const ctx = {
-      sourceDir: './source-dir/',
-      options: { buildScriptName: 'build:storybook' },
-      storybook: { version: '8.0.0' },
-      git: { changedFiles: ['./index.js'] },
-    } as any;
-    await setBuildCommand(ctx);
-
-    expect(getCliCommand).toHaveBeenCalledWith(
-      expect.anything(),
-      ['build:storybook', '--output-dir=./source-dir/', '--stats-json=./source-dir/'],
-      { programmatic: true }
-    );
-    expect(ctx.buildCommand).toEqual('npm run build:storybook');
-  });
 });
 
 describe('buildStorybook', () => {

--- a/node-src/tasks/build.ts
+++ b/node-src/tasks/build.ts
@@ -27,11 +27,6 @@ export const setSourceDir = async (ctx: Context) => {
   }
 };
 
-// Storybook 8.0.0 deprecated --webpack-stats-json in favor of --stats-json.
-const webpackStatsFlag = (version: string) => {
-  return semver.gte(semver.coerce(version), '8.0.0') ? '--stats-json' : '--webpack-stats-json';
-};
-
 export const setBuildCommand = async (ctx: Context) => {
   const webpackStatsSupported =
     ctx.storybook && ctx.storybook.version
@@ -44,9 +39,7 @@ export const setBuildCommand = async (ctx: Context) => {
 
   const buildCommandOptions = [
     `--output-dir=${ctx.sourceDir}`,
-    ctx.git.changedFiles &&
-      webpackStatsSupported &&
-      `${webpackStatsFlag(ctx.storybook.version)}=${ctx.sourceDir}`,
+    ctx.git.changedFiles && webpackStatsSupported && `--webpack-stats-json=${ctx.sourceDir}`,
   ].filter(Boolean);
 
   ctx.buildCommand = await (isE2EBuild(ctx.options)


### PR DESCRIPTION
Reverts chromaui/chromatic-cli#1035
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>11.10.2--canary.1046.10847969470.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@11.10.2--canary.1046.10847969470.0
  # or 
  yarn add chromatic@11.10.2--canary.1046.10847969470.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
