### PR TITLE
Enable`unicorn/no-array-for-each` ESLint rule

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -143,7 +143,6 @@ export default [
       'unicorn/no-array-callback-reference': 'off',
       'unicorn/prefer-string-raw': 'off',
       'unicorn/prefer-module': 'off',
-      'unicorn/no-array-for-each': 'off',
       'unicorn/prefer-spread': 'off',
     },
   },

--- a/node-src/io/GraphQLClient.ts
+++ b/node-src/io/GraphQLClient.ts
@@ -55,7 +55,7 @@ export default class GraphQLClient {
 
         // GraphQL typically returns a list of errors
         this.client.log.debug({ errors }, 'GraphQL errors');
-        errors.forEach((err) => {
+        for (const err of errors) {
           // Throw an error to retry the query if it's safe to do so, otherwise bail
           if (err.extensions && err.extensions.code === RETRYABLE_ERROR_CODE) throw err;
 
@@ -63,7 +63,7 @@ export default class GraphQLClient {
           err.at = `${err.path.join('.')} ${err.locations
             .map((l) => `${l.line}:${l.column}`)
             .join(', ')}`;
-        });
+        }
         return bail(errors.length === 1 ? errors[0] : errors);
       },
       { retries }

--- a/node-src/lib/compress.ts
+++ b/node-src/lib/compress.ts
@@ -23,10 +23,10 @@ export default async function makeZipFile(ctx: Context, files: FileDesc[]) {
     });
     archive.pipe(sink);
 
-    files.forEach(({ localPath, targetPath: name }) => {
+    for (const { localPath, targetPath: name } of files) {
       ctx.log.debug(`Adding to zip archive: ${name}`);
       archive.append(createReadStream(localPath), { name });
-    });
+    }
 
     ctx.log.debug('Finalizing zip archive');
     archive.finalize().catch((err) => reject(err));

--- a/node-src/lib/findChangedDependencies.ts
+++ b/node-src/lib/findChangedDependencies.ts
@@ -110,7 +110,9 @@ export const findChangedDependencies = async (ctx: Context) => {
             manifestPath: await checkoutFile(ctx, ref, manifestPath),
             lockfilePath: await checkoutFile(ctx, ref, lockfilePath),
           });
-          baselineChanges.forEach((change) => changedDependencyNames.add(change));
+          for (const change of baselineChanges) {
+            changedDependencyNames.add(change);
+          }
         })
       );
     })

--- a/node-src/lib/getDependentStoryFiles.ts
+++ b/node-src/lib/getDependentStoryFiles.ts
@@ -124,7 +124,7 @@ export async function getDependentStoryFiles(
 
   stats.modules
     .filter((mod) => isUserModule(mod))
-    .forEach((mod) => {
+    .map((mod) => {
       const normalizedName = normalize(mod.name);
       modulesByName.set(normalizedName, mod);
       namesById.set(mod.id, normalizedName);
@@ -139,7 +139,9 @@ export async function getDependentStoryFiles(
       }
 
       if (mod.modules) {
-        mod.modules.forEach((m) => modulesByName.set(normalize(m.name), mod));
+        for (const m of mod.modules) {
+          modulesByName.set(normalize(m.name), mod);
+        }
       }
 
       const normalizedReasons = mod.reasons
@@ -258,7 +260,7 @@ export async function getDependentStoryFiles(
   }
 
   // First, check the files that have changed according to git
-  tracedFiles.forEach((posixPath) => traceName(posixPath));
+  tracedFiles.map((posixPath) => traceName(posixPath));
   // If more were found during that process, check them too.
   while (toCheck.length > 0) {
     const [id, tracePath] = toCheck.pop();
@@ -266,7 +268,7 @@ export async function getDependentStoryFiles(
     reasonsById
       .get(id)
       .filter(untrace)
-      .forEach((reason) => traceName(reason, tracePath));
+      .map((reason) => traceName(reason, tracePath));
   }
   const affectedModules = Object.fromEntries(
     // The id will be compared against the result of the stories' `.parameters.filename` values (stories retrieved from getStoriesJsonData())

--- a/node-src/lib/getStorybookMetadata.ts
+++ b/node-src/lib/getStorybookMetadata.ts
@@ -237,13 +237,13 @@ export const getStorybookMetadata = async (ctx: Context) => {
 
   ctx.log.debug(info);
   let metadata = {};
-  info.forEach((sbItem) => {
+  for (const sbItem of info) {
     if (sbItem.status === 'fulfilled') {
       metadata = {
         ...metadata,
         ...(sbItem?.value as any),
       };
     }
-  });
+  }
   return metadata;
 };

--- a/node-src/lib/upload.ts
+++ b/node-src/lib/upload.ts
@@ -121,15 +121,15 @@ export async function uploadBuild(
     );
 
     if (uploadBuild.userErrors.length > 0) {
-      uploadBuild.userErrors.forEach((e) => {
-        if (e.__typename === 'MaxFileCountExceededError') {
-          ctx.log.error(maxFileCountExceeded(e));
-        } else if (e.__typename === 'MaxFileSizeExceededError') {
-          ctx.log.error(maxFileSizeExceeded(e));
+      for (const err of uploadBuild.userErrors) {
+        if (err.__typename === 'MaxFileCountExceededError') {
+          ctx.log.error(maxFileCountExceeded(err));
+        } else if (err.__typename === 'MaxFileSizeExceededError') {
+          ctx.log.error(maxFileSizeExceeded(err));
         } else {
-          ctx.log.error(e.message);
+          ctx.log.error(err.message);
         }
-      });
+      }
       return options.onError?.(new Error('Upload rejected due to user error'));
     }
 
@@ -237,6 +237,6 @@ export async function uploadMetadata(ctx: Context, files: FileDesc[]) {
   }
 
   if (uploadMetadata.userErrors.length > 0) {
-    uploadMetadata.userErrors.forEach((e) => ctx.log.warn(e.message));
+    uploadMetadata.userErrors.map((e) => ctx.log.warn(e.message));
   }
 }

--- a/node-src/lib/uploadFiles.ts
+++ b/node-src/lib/uploadFiles.ts
@@ -35,7 +35,9 @@ export async function uploadFiles(
             });
 
             const formData = new FormData();
-            Object.entries(formFields).forEach(([k, v]) => formData.append(k, v));
+            for (const [k, v] of Object.entries(formFields)) {
+              formData.append(k, v);
+            }
             formData.append('file', blob);
 
             try {

--- a/node-src/lib/uploadZip.ts
+++ b/node-src/lib/uploadZip.ts
@@ -28,7 +28,9 @@ export async function uploadZip(
       });
 
       const formData = new FormData();
-      Object.entries(formFields).forEach(([k, v]) => formData.append(k, v));
+      for (const [k, v] of Object.entries(formFields)) {
+        formData.append(k, v);
+      }
       formData.append('file', blob);
 
       const res = await ctx.http.fetch(

--- a/node-src/tasks/report.ts
+++ b/node-src/tasks/report.ts
@@ -69,6 +69,8 @@ interface ReportQueryResult {
   };
 }
 
+// TODO: refactor this function
+// eslint-disable-next-line complexity
 export const generateReport = async (ctx: Context) => {
   const { client, log } = ctx;
   const { junitReport } = ctx.options;
@@ -99,7 +101,7 @@ export const generateReport = async (ctx: Context) => {
     .property('buildUrl', build.webUrl)
     .property('storybookUrl', build.storybookUrl);
 
-  build.tests.forEach(({ status, result, spec, parameters, mode }) => {
+  for (const { status, result, spec, parameters, mode } of build.tests) {
     const testSuffixName = mode.name || `[${parameters.viewport}px]`;
     const suffix = parameters.viewportIsDefault ? '' : testSuffixName;
     const testCase = suite
@@ -126,7 +128,7 @@ export const generateReport = async (ctx: Context) => {
         }
       }
     }
-  });
+  }
 
   reportBuilder.writeTo(ctx.reportPath);
   log.info(wroteReport(ctx.reportPath, 'JUnit XML'));


### PR DESCRIPTION
Simply enables our `unicorn/no-array-for-each` ESLint rule and fixes any errors that appear.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>11.10.3--canary.1048.10853398088.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@11.10.3--canary.1048.10853398088.0
  # or 
  yarn add chromatic@11.10.3--canary.1048.10853398088.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
