### PR TITLE
Use --stats-json flag for SB 8.0.0+

### DIFF
--- a/node-src/tasks/build.test.ts
+++ b/node-src/tasks/build.test.ts
@@ -132,6 +132,24 @@ describe('setBuildCommand', () => {
     );
     expect(ctx.buildCommand).toEqual('npm run build:storybook');
   });
+
+  it('uses the old flag when it storybook version is undetected', async () => {
+    getCliCommand.mockReturnValue(Promise.resolve('npm run build:storybook'));
+
+    const ctx = {
+      sourceDir: './source-dir/',
+      options: { buildScriptName: 'build:storybook' },
+      git: { changedFiles: ['./index.js'] },
+    } as any;
+    await setBuildCommand(ctx);
+
+    expect(getCliCommand).toHaveBeenCalledWith(
+      expect.anything(),
+      ['build:storybook', '--output-dir=./source-dir/', '--webpack-stats-json=./source-dir/'],
+      { programmatic: true }
+    );
+    expect(ctx.buildCommand).toEqual('npm run build:storybook');
+  });
 });
 
 describe('buildStorybook', () => {

--- a/node-src/tasks/build.test.ts
+++ b/node-src/tasks/build.test.ts
@@ -113,6 +113,25 @@ describe('setBuildCommand', () => {
       'Storybook version 6.2.0 or later is required to use the --only-changed flag'
     );
   });
+
+  it('uses the correct flag for webpack stats for >= 8.0.0', async () => {
+    getCliCommand.mockReturnValue(Promise.resolve('npm run build:storybook'));
+
+    const ctx = {
+      sourceDir: './source-dir/',
+      options: { buildScriptName: 'build:storybook' },
+      storybook: { version: '8.0.0' },
+      git: { changedFiles: ['./index.js'] },
+    } as any;
+    await setBuildCommand(ctx);
+
+    expect(getCliCommand).toHaveBeenCalledWith(
+      expect.anything(),
+      ['build:storybook', '--output-dir=./source-dir/', '--stats-json=./source-dir/'],
+      { programmatic: true }
+    );
+    expect(ctx.buildCommand).toEqual('npm run build:storybook');
+  });
 });
 
 describe('buildStorybook', () => {

--- a/node-src/types.ts
+++ b/node-src/types.ts
@@ -225,8 +225,8 @@ export interface Context {
     matchesBranch?: (glob: boolean | string) => boolean;
     packageMetadataChanges?: { changedFiles: string[]; commit: string }[];
   };
-  storybook: {
-    version: string;
+  storybook?: {
+    version?: string;
     configDir: string;
     staticDir: string[];
     viewLayer: string;


### PR DESCRIPTION
At 8.0.0, [--webpack-stats-json was renamed to --stats-json](https://github.com/storybookjs/storybook/blob/v8.0.0/MIGRATION.md#--webpack-stats-json-option-renamed---stats-json)

Prefer that option for projects using 8.0.0 or greater.

New version of #1035, which had a bug when `storybook.version` was missing on the `Context` object.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>11.10.3--canary.1049.10997678109.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@11.10.3--canary.1049.10997678109.0
  # or 
  yarn add chromatic@11.10.3--canary.1049.10997678109.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
