### PR TITLE
Enable `unicorn/prefer-string-raw` ESLint rule

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -141,7 +141,6 @@ export default [
       'unicorn/better-regex': 'off',
       'unicorn/no-array-reduce': 'off',
       'unicorn/no-array-callback-reference': 'off',
-      'unicorn/prefer-string-raw': 'off',
       'unicorn/prefer-module': 'off',
       'unicorn/prefer-spread': 'off',
     },

--- a/node-src/index.test.ts
+++ b/node-src/index.test.ts
@@ -264,11 +264,11 @@ const mockStats = {
     {
       id: './src/foo.stories.js',
       name: './src/foo.stories.js',
-      reasons: [{ moduleName: './src sync ^\\.\\/(?:(?!\\.)(?=.)[^/]*?\\.stories\\.js)$' }],
+      reasons: [{ moduleName: String.raw`./src sync ^\.\/(?:(?!\.)(?=.)[^/]*?\.stories\.js)$` }],
     },
     {
-      id: './src sync ^\\.\\/(?:(?!\\.)(?=.)[^/]*?\\.stories\\.js)$',
-      name: './src sync ^\\.\\/(?:(?!\\.)(?=.)[^/]*?\\.stories\\.js)$',
+      id: String.raw`./src sync ^\.\/(?:(?!\.)(?=.)[^/]*?\.stories\.js)$`,
+      name: String.raw`./src sync ^\.\/(?:(?!\.)(?=.)[^/]*?\.stories\.js)$`,
       reasons: [{ moduleName: './storybook-stories.js' }],
     },
   ],

--- a/node-src/lib/getDependentStoryFiles.test.ts
+++ b/node-src/lib/getDependentStoryFiles.test.ts
@@ -7,7 +7,7 @@ import { getDependentStoryFiles, normalizePath } from './getDependentStoryFiles'
 
 vi.mock('../git/git');
 
-const CSF_GLOB = './src sync ^\\.\\/(?:(?!\\.)(?=.)[^/]*?\\.stories\\.js)$';
+const CSF_GLOB = String.raw`./src sync ^\.\/(?:(?!\.)(?=.)[^/]*?\.stories\.js)$`;
 const VITE_ENTRY = '/virtual:/@storybook/builder-vite/storybook-stories.js';
 const statsPath = 'preview-stats.json';
 
@@ -170,14 +170,13 @@ describe('getDependentStoryFiles', () => {
         id: './src/foo.stories.js',
         reasons: [
           {
-            moduleName:
-              '/path/to/project|/^\\.\\/.*$/|include: /(?!.*node_modules)(?:\\/\\.\\.\\/(?!\\.)(?=.)[^/]*?\\.stories\\.js)$/|chunkName: [request]|groupOptions: {}|namespace object',
+            moduleName: String.raw`/path/to/project|/^\.\/.*$/|include: /(?!.*node_modules)(?:\/\.\.\/(?!\.)(?=.)[^/]*?\.stories\.js)$/|chunkName: [request]|groupOptions: {}|namespace object`,
           },
         ],
       },
       {
-        name: '/path/to/project|/^\\.\\/.*$/|include: /(?!.*node_modules)(?:\\/\\.\\.\\/(?!\\.)(?=.)[^/]*?\\.stories\\.js)$/|chunkName: [request]|groupOptions: {}|namespace object',
-        id: './src lazy recursive ^\\.\\/.*$',
+        name: String.raw`/path/to/project|/^\.\/.*$/|include: /(?!.*node_modules)(?:\/\.\.\/(?!\.)(?=.)[^/]*?\.stories\.js)$/|chunkName: [request]|groupOptions: {}|namespace object`,
+        id: String.raw`./src lazy recursive ^\.\/.*$`,
         reasons: [
           {
             moduleName: './node_modules/.cache/storybook/default/dev-server/storybook-stories.js',
@@ -791,8 +790,8 @@ describe('getDependentStoryFiles', () => {
     const changedFiles = ['src/utils.js', 'src/packages/design-system/components/button.jsx'];
     const modules = [
       {
-        id: './packages/website/containers/ weak ^\\.\\/.*\\/index$',
-        name: './packages/website/containers/ weak ^\\.\\/.*\\/index$',
+        id: String.raw`./packages/website/containers/ weak ^\.\/.*\/index$`,
+        name: String.raw`./packages/website/containers/ weak ^\.\/.*\/index$`,
         reasons: [{ moduleName: './src/packages/design-system/components/button.jsx' }],
       },
       {

--- a/node-src/tasks/upload.test.ts
+++ b/node-src/tasks/upload.test.ts
@@ -222,11 +222,11 @@ describe('traceChangedFiles', () => {
     await traceChangedFiles(ctx, {} as any);
 
     expect(ctx.onlyStoryFiles).toStrictEqual([
-      './\\$example-new.stories.js',
-      './\\+example-new.stories.js',
-      './example-\\(new\\).stories.js',
-      './example\\[\\[lang=language\\]\\].stories.js',
-      '\\[./example/\\[account\\]/\\[id\\]/\\[unit\\]/language/example.stories.tsx\\]',
+      String.raw`./\$example-new.stories.js`,
+      String.raw`./\+example-new.stories.js`,
+      String.raw`./example-\(new\).stories.js`,
+      String.raw`./example\[\[lang=language\]\].stories.js`,
+      String.raw`\[./example/\[account\]/\[id\]/\[unit\]/language/example.stories.tsx\]`,
     ]);
   });
 

--- a/node-src/tasks/upload.ts
+++ b/node-src/tasks/upload.ts
@@ -173,7 +173,7 @@ export const traceChangedFiles = async (ctx: Context, task: Task) => {
     if (onlyStoryFiles) {
       // Escape special characters in the filename so it does not conflict with picomatch
       ctx.onlyStoryFiles = Object.keys(onlyStoryFiles).map((key) =>
-        key.replaceAll(SPECIAL_CHARS_REGEXP, '\\$1')
+        key.replaceAll(SPECIAL_CHARS_REGEXP, String.raw`\$1`)
       );
 
       if (!ctx.options.interactive) {


### PR DESCRIPTION
Simply enables our `unicorn/prefer-string-raw` ESLint rule and fixes any errors that appear.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>11.10.3--canary.1050.10855415334.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@11.10.3--canary.1050.10855415334.0
  # or 
  yarn add chromatic@11.10.3--canary.1050.10855415334.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
