### PR TITLE
Enable `unicorn/no-array-callback-reference` ESLint rule

### DIFF
--- a/bin-src/trim-stats-file.ts
+++ b/bin-src/trim-stats-file.ts
@@ -23,9 +23,11 @@ export async function main([statsFile = './storybook-static/preview-stats.json']
   try {
     const stats = await readStatsFile(statsFile);
     const trimmedModules = stats.modules
-      .filter(isUserCode)
+      .filter((module) => isUserCode(module))
       .map(({ id, name, modules, reasons }) => {
-        const trimmedReasons = dedupe(reasons.filter(isUserCode).map((r) => r.moduleName))
+        const trimmedReasons = dedupe(
+          reasons.filter((reason) => isUserCode(reason)).map((r) => r.moduleName)
+        )
           .filter((n) => n !== name)
           .map((moduleName) => ({ moduleName }));
         return {

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -139,7 +139,6 @@ export default [
       'unicorn/no-null': 'off',
       'unicorn/better-regex': 'off',
       'unicorn/no-array-reduce': 'off',
-      'unicorn/no-array-callback-reference': 'off',
       'unicorn/prefer-string-raw': 'off',
       'unicorn/prefer-module': 'off',
       'unicorn/prefer-spread': 'off',

--- a/node-src/lib/e2e.ts
+++ b/node-src/lib/e2e.ts
@@ -24,7 +24,7 @@ const parseNexec = ((agent, args) => {
   };
 
   const command = map[agent];
-  return command.replace('{0}', args.map(quote).join(' ')).trim();
+  return command.replace('{0}', args.map((c) => quote(c)).join(' ')).trim();
 }) as Runner;
 
 export async function getE2EBuildCommand(

--- a/node-src/lib/findChangedPackageFiles.ts
+++ b/node-src/lib/findChangedPackageFiles.ts
@@ -83,7 +83,7 @@ export const findChangedPackageFiles = async (
 ) => {
   const changedManifestFiles = await Promise.all(
     packageMetadataChanges.map(({ changedFiles, commit }) => {
-      const changedManifestFiles = changedFiles.filter(isPackageMetadataFile);
+      const changedManifestFiles = changedFiles.filter((f) => isPackageMetadataFile(f));
       if (!changedManifestFiles) return [];
       return getManifestFilesWithChangedDependencies(changedManifestFiles, commit);
     })

--- a/node-src/lib/getStorybookMetadata.ts
+++ b/node-src/lib/getStorybookMetadata.ts
@@ -24,15 +24,15 @@ export const resolvePackageJson = (pkg: string) => {
 
 const findDependency = (
   { dependencies, devDependencies, peerDependencies },
-  predicate: Parameters<typeof Array.prototype.find>[0]
+  predicate: (key: string) => string
 ) => [
-  Object.entries(dependencies || {}).find(predicate),
-  Object.entries(devDependencies || {}).find(predicate),
-  Object.entries(peerDependencies || {}).find(predicate),
+  Object.keys(dependencies || {}).find((dependency) => predicate(dependency)),
+  Object.keys(devDependencies || {}).find((dependency) => predicate(dependency)),
+  Object.keys(peerDependencies || {}).find((dependency) => predicate(dependency)),
 ];
 
 const getDependencyInfo = ({ packageJson, log }, dependencyMap: Record<string, string>) => {
-  const [dep, devDep, peerDep] = findDependency(packageJson, ([key]) => dependencyMap[key]);
+  const [dep, devDep, peerDep] = findDependency(packageJson, (key) => dependencyMap[key]);
   const [pkg, version] = dep || devDep || peerDep || [];
   const dependency = viewLayers[pkg];
 

--- a/node-src/lib/promises.ts
+++ b/node-src/lib/promises.ts
@@ -5,7 +5,7 @@ const invert = (promise: Promise<any>) =>
   new Promise<any>((resolve, reject) => promise.then(reject, resolve));
 
 export const raceFulfilled = <T>(promises: Promise<T>[]): Promise<T> =>
-  invert(Promise.all(promises.map(invert)).then((arr) => arr[0]));
+  invert(Promise.all(promises.map((promise) => invert(promise))).then((arr) => arr[0]));
 
 export const timeout = (ms: number) =>
   new Promise((_, rej) => {

--- a/node-src/tasks/gitInfo.ts
+++ b/node-src/tasks/gitInfo.ts
@@ -199,7 +199,7 @@ export const setGitInfo = async (ctx: Context, task: Task) => {
         ({ build, changedFiles, replacementBuild }) => {
           const metadataFiles = changedFiles
             .filter((f) => !untraced.some((glob) => matchesFile(glob, f)))
-            .filter(isPackageMetadataFile);
+            .filter((f) => isPackageMetadataFile(f));
 
           return metadataFiles.length > 0
             ? [{ changedFiles: metadataFiles, commit: replacementBuild?.commit ?? build.commit }]

--- a/node-src/ui/messages/errors/uploadFailed.ts
+++ b/node-src/ui/messages/errors/uploadFailed.ts
@@ -4,7 +4,11 @@ import { dedent } from 'ts-dedent';
 import { FileDesc, TargetInfo } from '../../../types';
 import { error as icon } from '../../components/icons';
 
-const encode = (path: string) => path.split('/').map(encodeURIComponent).join('/');
+const encode = (path: string) =>
+  path
+    .split('/')
+    .map((component) => encodeURIComponent(component))
+    .join('/');
 
 export function uploadFailed({ target }: { target: FileDesc & TargetInfo }, debug = false) {
   const diagnosis =

--- a/node-src/ui/messages/info/listingStories.ts
+++ b/node-src/ui/messages/info/listingStories.ts
@@ -14,7 +14,7 @@ const snapshotRow = ({ spec }: { spec: Spec }) =>
 export default (snapshots: { spec: Spec }[]) =>
   dedent(chalk`
     {bold Listing available stories:}
-    ${snapshots.map(snapshotRow).join('\n')}
+    ${snapshots.map((snapshot) => snapshotRow(snapshot)).join('\n')}
 
     ${info} Use {bold --only-story-names} to run a build for a specific component or story.
     Globs are supported, for example: {bold --only-story-names "${


### PR DESCRIPTION
Simply enables our `unicorn/no-array-callback-reference ` ESLint rule and fixes any errors that appear.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>11.10.3--canary.1051.10856015657.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@11.10.3--canary.1051.10856015657.0
  # or 
  yarn add chromatic@11.10.3--canary.1051.10856015657.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
