### PR TITLE
Enable `unicorn/prefer-spread` ESLint rule

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -140,7 +140,6 @@ export default [
       'unicorn/better-regex': 'off',
       'unicorn/no-array-reduce': 'off',
       'unicorn/prefer-module': 'off',
-      'unicorn/prefer-spread': 'off',
     },
   },
   // prefer TS to complain when we miss an arg vs. sending an intentional undefined

--- a/node-src/git/getParentCommits.ts
+++ b/node-src/git/getParentCommits.ts
@@ -296,6 +296,6 @@ export async function getParentCommits(
   // For any pair A,B of builds, there is no point in using B if it is an ancestor of A.
   const descendentCommits = await maximallyDescendentCommits({ log }, commitsWithBuilds);
 
-  const ancestorCommits = extraParentCommits.concat(descendentCommits);
+  const ancestorCommits = [...extraParentCommits, ...descendentCommits];
   return ancestorCommits;
 }

--- a/node-src/lib/getDependentStoryFiles.ts
+++ b/node-src/lib/getDependentStoryFiles.ts
@@ -217,9 +217,10 @@ export async function getDependentStoryFiles(
     // If we didn't find any node_modules in the stats file, it's probably incomplete and we can't
     // trace changed dependencies, so we bail just in case.
     ctx.turboSnap.bailReason = {
-      changedPackageFiles: ctx.git.changedFiles
-        .filter((file) => isPackageManifestFile(file))
-        .concat(changedPackageLockFiles),
+      changedPackageFiles: [
+        ...ctx.git.changedFiles.filter((file) => isPackageManifestFile(file)),
+        ...changedPackageLockFiles,
+      ],
     };
   }
 

--- a/node-src/tasks/index.ts
+++ b/node-src/tasks/index.ts
@@ -29,5 +29,5 @@ export const runPatchBuild = [prepareWorkspace, ...runUploadBuild, restoreWorksp
 export default function index(options: Context['options']): Listr.ListrTask<Context>[] {
   const tasks = options.patchHeadRef && options.patchBaseRef ? runUploadBuild : runUploadBuild;
 
-  return options.junitReport ? tasks.concat(report) : tasks;
+  return options.junitReport ? [...tasks, report] : tasks;
 }

--- a/node-src/ui/messages/info/tracedAffectedFiles.ts
+++ b/node-src/ui/messages/info/tracedAffectedFiles.ts
@@ -97,20 +97,20 @@ export default (
   const seen = new Set();
   const traces = [...ctx.turboSnap.tracedPaths].map((p) => {
     const parts = p.split('\n');
-    return parts
-      .reduce((acc, part, index) => {
-        if (index === 0) return chalk`— ${printPath(part)} {cyan [changed]}${printModules(part)}`;
-        const indent = '  '.repeat(index);
-        let note = '';
-        if (index === parts.length - 1) {
-          if (seen.has(part)) note = chalk` {yellow [duplicate]}`;
-          else seen.add(part);
-        }
-        return chalk`${
-          expanded ? `File Path: ${part}\n\nBase Directory: ${basedir}\n\n` : ''
-        }${acc}\n${indent}∟ ${printPath(part)}${note}${printModules(part, indent)}`;
-      }, '')
-      .concat(chalk`\n${'  '.repeat(parts.length)}∟ {cyan [story index]}`);
+    const traceParts = parts.reduce((acc, part, index) => {
+      if (index === 0) return chalk`— ${printPath(part)} {cyan [changed]}${printModules(part)}`;
+      const indent = '  '.repeat(index);
+      let note = '';
+      if (index === parts.length - 1) {
+        if (seen.has(part)) note = chalk` {yellow [duplicate]}`;
+        else seen.add(part);
+      }
+      return chalk`${
+        expanded ? `File Path: ${part}\n\nBase Directory: ${basedir}\n\n` : ''
+      }${acc}\n${indent}∟ ${printPath(part)}${note}${printModules(part, indent)}`;
+    }, '');
+
+    return traceParts + chalk`\n${'  '.repeat(parts.length)}∟ {cyan [story index]}`;
   });
 
   const note = chalk`\n\nSet {bold ${flag}} to {bold 'expanded'} to reveal underlying modules.`;


### PR DESCRIPTION
Simply enables our `unicorn/prefer-spread` ESLint rule and fixes any errors that appear.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>11.10.3--canary.1052.10911085616.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@11.10.3--canary.1052.10911085616.0
  # or 
  yarn add chromatic@11.10.3--canary.1052.10911085616.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
