### PR TITLE
Enable `unicorn/better-regex` ESLint rule

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -137,7 +137,6 @@ export default [
       'unicorn/prefer-node-protocol': 'off', // This will error our Webpack build
       // TODO: remove the following lines when we are ready to enforce these rules
       'unicorn/no-null': 'off',
-      'unicorn/better-regex': 'off',
       'unicorn/no-array-reduce': 'off',
       'unicorn/prefer-module': 'off',
       'unicorn/prefer-spread': 'off',

--- a/node-src/git/getParentCommits.test.ts
+++ b/node-src/git/getParentCommits.test.ts
@@ -44,7 +44,7 @@ function createClient({
   const mockIndex = createMockIndex(repository, builds, prs);
   return {
     runQuery(query, variables) {
-      const queryName = query.match(/query ([a-zA-Z]+)/)[1];
+      const queryName = query.match(/query ([A-Za-z]+)/)[1];
       return mockIndex(queryName, variables);
     },
   };
@@ -403,7 +403,7 @@ describe('getParentCommits', () => {
     };
     const client = {
       runQuery(query, variables) {
-        const queryName = query.match(/query ([a-zA-Z]+)/)[1];
+        const queryName = query.match(/query ([A-Za-z]+)/)[1];
         return mockIndexWithNullFirstBuildCommittedAt(queryName, variables);
       },
     };

--- a/node-src/git/git.ts
+++ b/node-src/git/git.ts
@@ -241,7 +241,7 @@ export async function findMergeBase(headRef: string, baseRef: string) {
   const branchNames = await Promise.all(
     mergeBases.map(async (sha) => {
       const name = await execGitCommand(`git name-rev --name-only --exclude="tags/*" ${sha}`);
-      return name.replace(/~[0-9]+$/, ''); // Drop the potential suffix
+      return name.replace(/~\d+$/, ''); // Drop the potential suffix
     })
   );
   const baseRefIndex = branchNames.indexOf(baseRef);
@@ -299,7 +299,7 @@ export async function findFilesFromRepositoryRoot(...patterns: string[]) {
 }
 
 export async function mergeQueueBranchMatch(branch) {
-  const mergeQueuePattern = new RegExp(/gh-readonly-queue\/.*\/pr-(\d+)-[a-f0-9]{30}/);
+  const mergeQueuePattern = new RegExp(/gh-readonly-queue\/.*\/pr-(\d+)-[\da-f]{30}/);
   const match = branch.match(mergeQueuePattern);
 
   return match ? Number(match[1]) : null;

--- a/node-src/lib/getDependencies.test.ts
+++ b/node-src/lib/getDependencies.test.ts
@@ -17,7 +17,7 @@ describe('getDependencies', () => {
     });
 
     const [dep] = dependencies;
-    expect(dep).toMatch(/^[\w@/-]+@@[\d.]+$/);
+    expect(dep).toMatch(/^[\w/@-]+@@[\d.]+$/);
 
     const dependencyNames = [...dependencies].map((dependency) => dependency.split('@@')[0]);
     expect(dependencyNames).toEqual(

--- a/node-src/lib/getStorybookConfiguration.ts
+++ b/node-src/lib/getStorybookConfiguration.ts
@@ -7,7 +7,7 @@ export default function getStorybookConfiguration(
   longName?: string
 ) {
   if (!storybookScript) return null;
-  const parts = storybookScript.split(/[\s='"]+/);
+  const parts = storybookScript.split(/[\s"'=]+/);
   let index = parts.indexOf(longName);
   if (index === -1) {
     index = parts.indexOf(shortName);

--- a/node-src/tasks/report.ts
+++ b/node-src/tasks/report.ts
@@ -106,7 +106,7 @@ export const generateReport = async (ctx: Context) => {
     const suffix = parameters.viewportIsDefault ? '' : testSuffixName;
     const testCase = suite
       .testCase()
-      .className(spec.component.name.replaceAll(/[|/]/g, '.')) // transform story path to class path
+      .className(spec.component.name.replaceAll(/[/|]/g, '.')) // transform story path to class path
       .name(`${spec.name} ${suffix}`);
 
     switch (status) {

--- a/node-src/tasks/upload.ts
+++ b/node-src/tasks/upload.ts
@@ -39,7 +39,7 @@ interface PathSpec {
 }
 // These are the special characters that need to be escaped in the filename
 // because they are used as special characters in picomatch
-const SPECIAL_CHARS_REGEXP = /([$^*+?()[\]])/g;
+const SPECIAL_CHARS_REGEXP = /([$()*+?[\]^])/g;
 
 // Get all paths in rootDir, starting at dirname.
 // We don't want the paths to include rootDir -- so if rootDir = storybook-static,

--- a/node-src/ui/messages/warnings/deviatingOutputDir.ts
+++ b/node-src/ui/messages/warnings/deviatingOutputDir.ts
@@ -13,7 +13,7 @@ const getHint = (buildScriptName: string, buildScript: string) => {
       You can fix this by invoking {bold build-storybook} from your {bold "${buildScriptName}"} script directly.
     `);
 
-  const invokesBuild = /(^|[ ])build-storybook([ ]|;|&&)/.test(buildScript);
+  const invokesBuild = /(^| )build-storybook( |;|&&)/.test(buildScript);
   const isChained = /build-storybook.*(&&|;)/.test(buildScript);
   if (invokesBuild && isChained)
     return dedent(chalk`


### PR DESCRIPTION
Simply enables our `unicorn/better-regex` ESLint rule and fixes any errors that appear.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>11.10.3--canary.1055.10997453293.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@11.10.3--canary.1055.10997453293.0
  # or 
  yarn add chromatic@11.10.3--canary.1055.10997453293.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
