### PR TITLE
Enable `unicorn/no-array-reduce` ESLint rule

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -137,7 +137,6 @@ export default [
       'unicorn/prefer-node-protocol': 'off', // This will error our Webpack build
       // TODO: remove the following lines when we are ready to enforce these rules
       'unicorn/no-null': 'off',
-      'unicorn/no-array-reduce': 'off',
       'unicorn/prefer-module': 'off',
     },
   },

--- a/node-src/lib/compareBaseline.ts
+++ b/node-src/lib/compareBaseline.ts
@@ -1,14 +1,6 @@
 import { Context } from '../types';
 import { getDependencies } from './getDependencies';
 
-// Retrieve a set of values which is in either set, but not both.
-const xor = <T>(left: Set<T>, right: Set<T>) =>
-  [...right.values()].reduce((acc, value) => {
-    if (acc.has(value)) acc.delete(value);
-    else acc.add(value);
-    return acc;
-  }, new Set(left));
-
 interface BaselineConfig {
   ref: string;
   rootPath: string;
@@ -31,3 +23,14 @@ export const compareBaseline = async (
   }
   return changedDependencyNames;
 };
+
+// Retrieve a set of values which is in either set, but not both.
+function xor<T>(left: Set<T>, right: Set<T>) {
+  const result = new Set(left);
+
+  for (const value of right.values()) {
+    result.has(value) ? result.delete(value) : result.add(value);
+  }
+
+  return result;
+}

--- a/node-src/lib/getDependencies.ts
+++ b/node-src/lib/getDependencies.ts
@@ -2,15 +2,6 @@ import { buildDepTreeFromFiles, PkgTree } from 'snyk-nodejs-lockfile-parser';
 
 import { Context } from '../types';
 
-const flattenDependencyTree = (
-  tree: PkgTree['dependencies'],
-  results = new Set<string>()
-): Set<string> =>
-  Object.values(tree).reduce((acc, dep) => {
-    acc.add(`${dep.name}@@${dep.version}`);
-    return flattenDependencyTree(dep.dependencies || {}, acc);
-  }, results);
-
 export const getDependencies = async (
   ctx: Context,
   {
@@ -41,3 +32,12 @@ export const getDependencies = async (
     throw err;
   }
 };
+
+function flattenDependencyTree(tree: PkgTree['dependencies'], results = new Set<string>()) {
+  for (const dep of Object.values(tree)) {
+    results.add(`${dep.name}@@${dep.version}`);
+    flattenDependencyTree(dep.dependencies || {}, results);
+  }
+
+  return results;
+}

--- a/node-src/lib/upload.ts
+++ b/node-src/lib/upload.ts
@@ -94,12 +94,14 @@ export async function uploadBuild(
   const targets: (TargetInfo & FileDesc)[] = [];
   let zipTarget: TargetInfo | undefined;
 
-  const batches = files.reduce<(typeof files)[]>((acc, file, fileIndex) => {
+  const batches: FileDesc[][] = [];
+  for (const [fileIndex, file] of files.entries()) {
     const batchIndex = Math.floor(fileIndex / MAX_FILES_PER_REQUEST);
-    if (!acc[batchIndex]) acc[batchIndex] = [];
-    acc[batchIndex].push(file);
-    return acc;
-  }, []);
+    if (!batches[batchIndex]) {
+      batches[batchIndex] = [];
+    }
+    batches[batchIndex].push(file);
+  }
 
   // The uploadBuild mutation has to run in batches to avoid hitting request/response payload limits
   // or running out of memory. These run sequentially to avoid too many concurrent requests.

--- a/node-src/tasks/initialize.ts
+++ b/node-src/tasks/initialize.ts
@@ -27,15 +27,18 @@ interface AnnounceBuildMutationResult {
 }
 
 export const setEnvironment = async (ctx: Context) => {
+  if (!ctx.environment) {
+    ctx.environment = {};
+  }
+
   // We send up all environment variables provided by these complicated systems.
   // We don't want to send up *all* environment vars as they could include sensitive information
   // about the user's build environment
-  ctx.environment = Object.entries(process.env).reduce((acc, [key, value]) => {
+  for (const [key, value] of Object.entries(process.env)) {
     if (ctx.env.ENVIRONMENT_WHITELIST.some((regex) => key.match(regex))) {
-      acc[key] = value;
+      ctx.environment[key] = value;
     }
-    return acc;
-  }, {});
+  }
 
   ctx.log.debug(`Got environment:\n${JSON.stringify(ctx.environment, null, 2)}`);
 };


### PR DESCRIPTION
Simply enables our `unicorn/no-array-reduce` ESLint rule and fixes any errors that appear.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>11.10.4--canary.1056.10999023014.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@11.10.4--canary.1056.10999023014.0
  # or 
  yarn add chromatic@11.10.4--canary.1056.10999023014.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
