### PR TITLE
Revert "Use --stats-json flag for SB 8.0.0+"

### DIFF
--- a/node-src/tasks/build.test.ts
+++ b/node-src/tasks/build.test.ts
@@ -113,43 +113,6 @@ describe('setBuildCommand', () => {
       'Storybook version 6.2.0 or later is required to use the --only-changed flag'
     );
   });
-
-  it('uses the correct flag for webpack stats for >= 8.0.0', async () => {
-    getCliCommand.mockReturnValue(Promise.resolve('npm run build:storybook'));
-
-    const ctx = {
-      sourceDir: './source-dir/',
-      options: { buildScriptName: 'build:storybook' },
-      storybook: { version: '8.0.0' },
-      git: { changedFiles: ['./index.js'] },
-    } as any;
-    await setBuildCommand(ctx);
-
-    expect(getCliCommand).toHaveBeenCalledWith(
-      expect.anything(),
-      ['build:storybook', '--output-dir=./source-dir/', '--stats-json=./source-dir/'],
-      { programmatic: true }
-    );
-    expect(ctx.buildCommand).toEqual('npm run build:storybook');
-  });
-
-  it('uses the old flag when it storybook version is undetected', async () => {
-    getCliCommand.mockReturnValue(Promise.resolve('npm run build:storybook'));
-
-    const ctx = {
-      sourceDir: './source-dir/',
-      options: { buildScriptName: 'build:storybook' },
-      git: { changedFiles: ['./index.js'] },
-    } as any;
-    await setBuildCommand(ctx);
-
-    expect(getCliCommand).toHaveBeenCalledWith(
-      expect.anything(),
-      ['build:storybook', '--output-dir=./source-dir/', '--webpack-stats-json=./source-dir/'],
-      { programmatic: true }
-    );
-    expect(ctx.buildCommand).toEqual('npm run build:storybook');
-  });
 });
 
 describe('buildStorybook', () => {

--- a/node-src/tasks/build.ts
+++ b/node-src/tasks/build.ts
@@ -27,29 +27,19 @@ export const setSourceDir = async (ctx: Context) => {
   }
 };
 
-// Storybook 8.0.0 deprecated --webpack-stats-json in favor of --stats-json.
-const getStatsFlag = (ctx: Context) => {
-  return ctx?.storybook?.version && semver.gte(semver.coerce(ctx.storybook.version), '8.0.0')
-    ? '--stats-json'
-    : '--webpack-stats-json';
-};
-
-const isStatsFlagSupported = (ctx: Context) => {
-  return ctx.storybook && ctx.storybook.version
-    ? semver.gte(semver.coerce(ctx.storybook.version), '6.2.0')
-    : true;
-};
-
 export const setBuildCommand = async (ctx: Context) => {
-  const statsFlagSupported = isStatsFlagSupported(ctx);
+  const webpackStatsSupported =
+    ctx.storybook && ctx.storybook.version
+      ? semver.gte(semver.coerce(ctx.storybook.version), '6.2.0')
+      : true;
 
-  if (ctx.git.changedFiles && !statsFlagSupported) {
+  if (ctx.git.changedFiles && !webpackStatsSupported) {
     ctx.log.warn('Storybook version 6.2.0 or later is required to use the --only-changed flag');
   }
 
   const buildCommandOptions = [
     `--output-dir=${ctx.sourceDir}`,
-    ctx.git.changedFiles && statsFlagSupported && `${getStatsFlag(ctx)}=${ctx.sourceDir}`,
+    ctx.git.changedFiles && webpackStatsSupported && `--webpack-stats-json=${ctx.sourceDir}`,
   ].filter(Boolean);
 
   ctx.buildCommand = await (isE2EBuild(ctx.options)

--- a/node-src/types.ts
+++ b/node-src/types.ts
@@ -225,8 +225,8 @@ export interface Context {
     matchesBranch?: (glob: boolean | string) => boolean;
     packageMetadataChanges?: { changedFiles: string[]; commit: string }[];
   };
-  storybook?: {
-    version?: string;
+  storybook: {
+    version: string;
     configDir: string;
     staticDir: string[];
     viewLayer: string;


### PR DESCRIPTION
Reverts chromaui/chromatic-cli#1049
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>11.10.4--canary.1058.11018369398.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@11.10.4--canary.1058.11018369398.0
  # or 
  yarn add chromatic@11.10.4--canary.1058.11018369398.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
