### PR TITLE
Track package size over time.

### DIFF
--- a/.github/workflows/package-size-main.yml
+++ b/.github/workflows/package-size-main.yml
@@ -1,0 +1,33 @@
+name: Chromatic Package Size Update
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  chromatic:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v3
+        with:
+          node-version: lts/*
+      - run: corepack enable
+      - name: install
+        run: yarn install --immutable
+      - name: build
+        run: yarn build
+      - name: Get Package Size
+        id: package_size
+        run: |
+          export DIST_SIZE="$(du -k ./dist | cut -f1)"
+          echo "Package Size: $DIST_SIZE KB"
+          echo "size=$DIST_SIZE" >> "$GITHUB_OUTPUT"
+      - name: Update Database
+        run: |
+          curl "${{ secrets.UPSTASH_REDIS_REST_URL }}/set/$GITHUB_SHA/${{ steps.package_size.outputs.size }}" -H "Authorization: Bearer ${{ secrets.UPSTASH_API_KEY }}"

--- a/.github/workflows/package-size.yml
+++ b/.github/workflows/package-size.yml
@@ -30,6 +30,20 @@ jobs:
           export DIST_SIZE="$(du -k ./dist | cut -f1)"
           echo "Package Size: $DIST_SIZE KB"
           echo "size=$DIST_SIZE" >> "$GITHUB_OUTPUT"
+      - name: Update Database
+        run: |
+          curl "${{ secrets.UPSTASH_REDIS_REST_URL }}/set/$GITHUB_SHA/${{ steps.package_size.outputs.size }}" -H "Authorization: Bearer ${{ secrets.UPSTASH_API_KEY }}"
+      - name: Get Previous Size
+        id: previous
+        run: |
+          export MAIN_HEAD_SHA="$(git rev-parse origin/main)"
+          echo "origin/main: $MAIN_HEAD_SHA"
+
+          export MAIN_HEAD_SIZE="$(curl -s "${{ secrets.UPSTASH_REDIS_REST_URL }}/get/$MAIN_HEAD_SHA" -H "Authorization: Bearer ${{ secrets.UPSTASH_API_KEY }}")"
+          echo "origin/main: $MAIN_HEAD_SIZE"
+
+          echo "main_head_sha=$MAIN_HEAD_SHA" >> "$GITHUB_OUTPUT"
+          echo "main_head_size=$MAIN_HEAD_SIZE" >> "$GITHUB_OUTPUT"
       - uses: actions/github-script@v7
         with:
           script: |
@@ -39,24 +53,33 @@ jobs:
               repo: context.repo.repo,
               issue_number: context.issue.number,
             })
+
             const botComment = comments.find(comment => {
               return comment.user.type === 'Bot' && comment.body.includes('Package Size')
-            })
+            });
 
-            const output = "📦 Package Size: ${{ steps.package_size.outputs.size }} KB";
+            const output = ["📦 Package Size: ${{ steps.package_size.outputs.size }} KB"];
+
+            const main_head_json = JSON.parse(`${{ steps.previous.outputs.main_head_size }}`);
+            if(main_head_json && main_head_json.result) {
+              const diff = parseInt("${{ steps.package_size.outputs.size }}") - parseInt(main_head_json.result);
+              const diffEmoji = diff > 0 ? '⚠️' : '✅';
+              const diffSymbol = diff > 0 ? '+' : '';
+              output.push(`${diffEmoji} Compared to main: ${main_head_json.result} KB (${diffSymbol}${diff}) ${{ steps.previous.outputs.main_head_sha }}`);
+            }
 
             if (botComment) {
               github.rest.issues.updateComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 comment_id: botComment.id,
-                body: output
+                body: output.join('\n'),
               })
             } else {
               github.rest.issues.createComment({
                 issue_number: context.issue.number,
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                body: output
+                body: output.join('\n'),
               })
             }

--- a/.github/workflows/package-size.yml
+++ b/.github/workflows/package-size.yml
@@ -65,7 +65,7 @@ jobs:
               const diff = parseInt("${{ steps.package_size.outputs.size }}") - parseInt(main_head_json.result);
               const diffEmoji = diff > 0 ? '⚠️' : '✅';
               const diffSymbol = diff > 0 ? '+' : '';
-              output.push(`${diffEmoji} Compared to main: ${main_head_json.result} KB (${diffSymbol}${diff}) ${{ steps.previous.outputs.main_head_sha }}`);
+              output.push(`${diffEmoji} Compared to main: ${diffSymbol}${diff} KB ${{ steps.previous.outputs.main_head_sha }} (${main_head_json.result} KB)`);
             }
 
             if (botComment) {


### PR DESCRIPTION
Adds package size tracking against `main` via Upstash.

### Workflow

- Build CLI
- Get size of dist
- Set key for the current SHA in Upstash
- Get the current SHA of `main`
- Get the value of the main SHA from Upstash
- Update/Set comment with size of this PR, and the +/- from `main`

The `main` workflow just does the update to Upstash.

-----

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>11.10.5--canary.1059.11021374226.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@11.10.5--canary.1059.11021374226.0
  # or 
  yarn add chromatic@11.10.5--canary.1059.11021374226.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
