### PR TITLE
Include `storybookUrl` and `webUrl` on skipped rebuild

### DIFF
--- a/node-src/tasks/gitInfo.test.ts
+++ b/node-src/tasks/gitInfo.test.ts
@@ -137,4 +137,21 @@ describe('setGitInfo', () => {
     await setGitInfo(ctx, {} as any);
     expect(ctx.options.forceRebuild).toBe(true);
   });
+
+  it('sets storybookUrl and rebuildForBuild on skipped rebuild', async () => {
+    const lastBuild = {
+      id: 'parent',
+      status: 'ACCEPTED',
+      webUrl: 'some-web-url',
+      storybookUrl: 'some-storybook-url',
+    };
+
+    getParentCommits.mockResolvedValue([commitInfo.commit]);
+    client.runQuery.mockReturnValue({ app: { lastBuild } });
+
+    const ctx = { log, options: {}, client } as any;
+    await setGitInfo(ctx, {} as any);
+    expect(ctx.rebuildForBuild).toEqual(lastBuild);
+    expect(ctx.storybookUrl).toEqual(lastBuild.storybookUrl);
+  });
 });

--- a/node-src/tasks/gitInfo.ts
+++ b/node-src/tasks/gitInfo.ts
@@ -38,6 +38,8 @@ const LastBuildQuery = `
       lastBuild(ref: $commit, branch: $branch) {
         id
         status(legacy: false)
+        storybookUrl
+        webUrl
       }
     }
   }
@@ -48,6 +50,8 @@ interface LastBuildQueryResult {
     lastBuild: {
       id: string;
       status: string;
+      storybookUrl: string;
+      webUrl: string;
     };
   };
 }
@@ -141,6 +145,8 @@ export const setGitInfo = async (ctx: Context, task: Task) => {
         !ctx.git.matchesBranch(ctx.options.forceRebuild)
       ) {
         ctx.skip = true;
+        ctx.rebuildForBuild = result.app.lastBuild;
+        ctx.storybookUrl = result.app.lastBuild.storybookUrl;
         transitionTo(skippedRebuild, true)(ctx, task);
         ctx.log.info(forceRebuildHint());
         ctx.exitCode = 0;

--- a/node-src/types.ts
+++ b/node-src/types.ts
@@ -307,6 +307,12 @@ export interface Context {
       };
     }[];
   };
+  rebuildForBuild: {
+    id: string;
+    status: string;
+    webUrl: string;
+    storybookUrl: string;
+  };
   sourceDir: string;
   buildCommand?: string;
   buildLogFile?: string;


### PR DESCRIPTION
Closes #1053 

In our FAQ section, we point out that customers can pull `storybookUrl` and `webUrl` from the `chromatic-diagnostics.json` file. Source: https://www.chromatic.com/docs/faq/get-published-storybook-url-via-ci/

However, this field isn't being set when a rebuild is found. To keep things easy on our customers, this adds those fields back in.

_Note: Turns out, we don't have documented output for our diagnostics because it's more of an internal debugging file. However, I opted to add a new field for `rebuildForBuild` with the details in case any customers were relying on `build` for something._
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>11.11.0--canary.1060.11077751294.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@11.11.0--canary.1060.11077751294.0
  # or 
  yarn add chromatic@11.11.0--canary.1060.11077751294.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
