### PR TITLE
Enable `unicorn/prefer-module` ESLint rule

### DIFF
--- a/bin-src/register.js
+++ b/bin-src/register.js
@@ -1,13 +1,19 @@
 #!/usr/bin/env node
-/* eslint-disable @typescript-eslint/no-var-requires */
 
-require('dotenv').config();
+import { config } from 'dotenv';
+
+import { main as initMain } from './init';
+import { main } from './main';
+import { main as traceMain } from './trace';
+import { main as trimMain } from './trim-stats-file';
+
+config();
 
 const commands = {
-  init: () => require('./init').main(process.argv.slice(3)),
-  main: () => require('./main').main(process.argv.slice(2)),
-  trace: () => require('./trace').main(process.argv.slice(3)),
-  'trim-stats-file': () => require('./trim-stats-file').main(process.argv.slice(3)),
+  init: () => initMain(process.argv.slice(3)),
+  main: () => main(process.argv.slice(2)),
+  trace: () => traceMain(process.argv.slice(3)),
+  'trim-stats-file': () => trimMain(process.argv.slice(3)),
 };
 
 (commands[process.argv[2]] || commands.main)();

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -137,8 +137,6 @@ export default [
       'unicorn/switch-case-braces': 'off',
       'unicorn/no-process-exit': 'off',
       'unicorn/prefer-node-protocol': 'off', // This will error our Webpack build
-      // TODO: remove the following lines when we are ready to enforce these rules
-      'unicorn/prefer-module': 'off',
     },
   },
   // prefer TS to complain when we miss an arg vs. sending an intentional undefined

--- a/isChromatic.js
+++ b/isChromatic.js
@@ -1,3 +1,4 @@
+/* eslint-disable unicorn/prefer-module */
 /* eslint-env browser */
 
 module.exports = function isChromatic(windowArgument) {

--- a/node-src/lib/checkStorybookBaseDirectory.test.ts
+++ b/node-src/lib/checkStorybookBaseDirectory.test.ts
@@ -1,10 +1,13 @@
 import path from 'path';
+import { fileURLToPath } from 'url';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import * as git from '../git/git';
 import { checkStorybookBaseDirectory } from './checkStorybookBaseDirectory';
 import { exitCodes } from './setExitCode';
 import TestLogger from './testLogger';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 vi.mock('../git/git');
 

--- a/node-src/lib/compareBaseline.test.ts
+++ b/node-src/lib/compareBaseline.test.ts
@@ -1,9 +1,12 @@
 import path from 'path';
+import { fileURLToPath } from 'url';
 import { describe, expect, it } from 'vitest';
 
 import { compareBaseline } from './compareBaseline';
 import { getDependencies } from './getDependencies';
 import TestLogger from './testLogger';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 const getContext: any = (baselineCommits: string[]) => ({
   log: new TestLogger(),

--- a/node-src/lib/e2e.ts
+++ b/node-src/lib/e2e.ts
@@ -44,6 +44,7 @@ export async function getE2EBuildCommand(
   try {
     return [
       'node',
+      // eslint-disable-next-line unicorn/prefer-module
       require.resolve(`${dependencyName}/bin/${buildBinName}`),
       ...buildCommandOptions,
     ].join(' ');

--- a/node-src/lib/getDependencies.test.ts
+++ b/node-src/lib/getDependencies.test.ts
@@ -1,10 +1,13 @@
 import path from 'path';
+import { fileURLToPath } from 'url';
 import { describe, expect, it } from 'vitest';
 
 import packageJson from '../__mocks__/dependencyChanges/plain-package.json';
 import { checkoutFile } from '../git/git';
 import { getDependencies } from './getDependencies';
 import TestLogger from './testLogger';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 const ctx = { log: new TestLogger() } as any;
 

--- a/node-src/lib/getStorybookMetadata.ts
+++ b/node-src/lib/getStorybookMetadata.ts
@@ -210,6 +210,7 @@ export const findStorybookConfigFile = async (ctx: Context, pattern: RegExp) => 
 
 export const getStorybookMetadata = async (ctx: Context) => {
   const configDirectory = ctx.options.storybookConfigDir ?? '.storybook';
+  // eslint-disable-next-line unicorn/prefer-module
   const r = typeof __non_webpack_require__ === 'undefined' ? require : __non_webpack_require__;
 
   let mainConfig;

--- a/node-src/tasks/report.test.ts
+++ b/node-src/tasks/report.test.ts
@@ -1,8 +1,11 @@
 import reportBuilder from 'junit-report-builder';
 import path from 'path';
+import { fileURLToPath } from 'url';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { generateReport } from './report';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 const log = { error: vi.fn(), info: vi.fn() };
 const mockTests = [

--- a/test-stories/timing.stories-disabled.js
+++ b/test-stories/timing.stories-disabled.js
@@ -29,6 +29,7 @@ const WaitFor = ({ seconds }) => {
   );
 };
 
+// eslint-disable-next-line unicorn/prefer-module
 storiesOf('Timing', module)
   .add('5s', () => <WaitFor seconds={5} />)
   .add('40s', () => <WaitFor seconds={40} />)


### PR DESCRIPTION
Simply enables our `unicorn/prefer-module` ESLint rule and fixes any errors that appear.

Unfortunately, `import.meta.dirname` was unavailable so you have to grab it from `import.meta.url` 😞 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>11.11.1--canary.1061.11113701181.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@11.11.1--canary.1061.11113701181.0
  # or 
  yarn add chromatic@11.11.1--canary.1061.11113701181.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
