### PR TITLE
Enable `@typescript-eslint/no-floating-promises` ESLint rule

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -71,8 +71,7 @@ export default [
       // TODO: make this an error when we have time to deal with it
       '@typescript-eslint/no-explicit-any': 'off',
       //   '@typescript-eslint/no-explicit-any': 'warn',
-      // TODO: make this an error when we have time to deal with it
-      '@typescript-eslint/no-floating-promises': 'warn',
+      '@typescript-eslint/no-floating-promises': 'error',
     },
   },
   {


### PR DESCRIPTION
I thought we had some of these sitting around but I guess I was wrong... therefore, we can simply enable our `@typescript-eslint/no-floating-promises` rule with no changes!