### PR TITLE
Annotate Sentry events

### DIFF
--- a/node-src/errorMonitoring.ts
+++ b/node-src/errorMonitoring.ts
@@ -55,6 +55,7 @@ Sentry.init({
     tags: {
       entrypoint: process.env.CI && process.env.GITHUB_RUN_ID ? 'action' : 'cli',
       version: process.env.npm_package_version,
+      index_url: process.env.CHROMATIC_INDEX_URL,
     },
   },
   beforeSend: filterErrorEvent,

--- a/node-src/tasks/initialize.test.ts
+++ b/node-src/tasks/initialize.test.ts
@@ -110,7 +110,12 @@ describe('announceBuild', () => {
   };
 
   it('creates a build on the index and puts it on context', async () => {
-    const build = { number: 1, status: 'ANNOUNCED' };
+    const build = {
+      number: 1,
+      status: 'ANNOUNCED',
+      id: 'announced-build-id',
+      app: { id: 'announced-build-app-id' },
+    };
     const client = { runQuery: vi.fn() };
     client.runQuery.mockReturnValue({ announceBuild: build });
 

--- a/node-src/tasks/storybookInfo.ts
+++ b/node-src/tasks/storybookInfo.ts
@@ -1,3 +1,5 @@
+import * as Sentry from '@sentry/node';
+
 import getStorybookInfo from '../lib/getStorybookInfo';
 import { createTask, transitionTo } from '../lib/tasks';
 import { Context } from '../types';
@@ -5,6 +7,16 @@ import { initial, pending, success } from '../ui/tasks/storybookInfo';
 
 export const setStorybookInfo = async (ctx: Context) => {
   ctx.storybook = (await getStorybookInfo(ctx)) as Context['storybook'];
+
+  if (ctx.storybook) {
+    if (ctx.storybook.version) {
+      Sentry.setTag('storybookVersion', ctx.storybook.version);
+    }
+    if (ctx.storybook.viewLayer) {
+      Sentry.setTag('storybookViewLayer', ctx.storybook.viewLayer);
+    }
+    Sentry.setContext('storybook', ctx.storybook);
+  }
 };
 
 export default createTask({


### PR DESCRIPTION
Collecting some additional context and tags for Sentry

- Index URL (if overridden)
- Storybook metadata
- App ID (after announce)
- Build ID (after announce)
- Package manager in use
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>11.11.1--canary.1069.11148526667.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@11.11.1--canary.1069.11148526667.0
  # or 
  yarn add chromatic@11.11.1--canary.1069.11148526667.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
