### PR TITLE
Add `Empathy` and `CLI` labels to issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,7 +1,7 @@
 ---
 name: Bug report 🐞
 about: Found a bug in our CLI? Please open an issue. Is there a problem with the Chromatic platform? Please contact support.
-labels: needs triage, bug
+labels: needs triage, bug, Empathy, CLI
 ---
 
 **Bug report**

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,7 +1,7 @@
 ---
 name: Feature request 💡
 about: Suggest an idea for Chromatic.
-labels: needs triage, feature request
+labels: needs triage, feature request, CLI
 ---
 
 **Feature request**


### PR DESCRIPTION
We have some internal tracking that leans on labels. Therefore, this adds the `CLI` label to all bug reports and feature requests. It also adds `Empathy` for all bug reports.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>11.11.1--canary.1071.11151105868.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@11.11.1--canary.1071.11151105868.0
  # or 
  yarn add chromatic@11.11.1--canary.1071.11151105868.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
