### PR TITLE
Fix remaining TypeScript errors and unable `strict: true`

### DIFF
--- a/action-src/main.ts
+++ b/action-src/main.ts
@@ -30,7 +30,7 @@ const getBuildInfo = (event: typeof context) => {
     case 'pull_request':
     case 'pull_request_review':
     case 'pull_request_target': {
-      const { head } = event.payload.pull_request;
+      const { head } = (event.payload.pull_request as any) || {};
       return {
         sha: head.sha,
         branch: head.ref,
@@ -43,7 +43,7 @@ const getBuildInfo = (event: typeof context) => {
       return {
         sha: after,
         branch: ref.replace('refs/heads/', ''),
-        slug: repository.full_name,
+        slug: repository?.full_name,
       };
     }
     case 'workflow_run': {
@@ -53,7 +53,7 @@ const getBuildInfo = (event: typeof context) => {
       return {
         sha: head_sha,
         branch: head_branch.replace('refs/heads/', ''),
-        slug: repository.full_name,
+        slug: repository?.full_name,
       };
     }
     case 'workflow_dispatch':
@@ -61,20 +61,20 @@ const getBuildInfo = (event: typeof context) => {
       return {
         sha: event.sha,
         branch: event.ref.replace('refs/heads/', ''),
-        slug: event.payload.repository.full_name,
+        slug: event.payload.repository?.full_name,
       };
     }
     case 'schedule':
       return {
         sha: event.sha,
         branch: event.ref.replace('refs/heads/', ''),
-        slug: event.payload.repository.full_name,
+        slug: event.payload.repository?.full_name,
       };
     case 'release': {
       return {
         sha: event.sha,
         branch: event.payload.release.target_commitish,
-        slug: event.payload.repository.full_name,
+        slug: event.payload.repository?.full_name,
       };
     }
     case 'merge_group': {
@@ -82,12 +82,12 @@ const getBuildInfo = (event: typeof context) => {
       return {
         sha: head_sha,
         branch: head_ref,
-        slug: event.payload.repository.full_name,
+        slug: event.payload.repository?.full_name,
       };
     }
     default: {
       setFailed(`${event.eventName} event is not supported in this action`);
-      return null;
+      return;
     }
   }
 };

--- a/bin-src/init.ts
+++ b/bin-src/init.ts
@@ -1,7 +1,7 @@
 import { getCliCommand, parseNi } from '@antfu/ni';
 import boxen from 'boxen';
 import { execaCommand } from 'execa';
-import { writeFile } from 'jsonfile';
+import { Path, writeFile } from 'jsonfile';
 import meow from 'meow';
 import prompts from 'prompts';
 import type { PackageJson } from 'read-pkg-up';
@@ -35,7 +35,13 @@ export const addChromaticScriptToPackageJson = async ({ packageJson, packagePath
   }
 };
 
-export const createChromaticConfigFile = async ({ configFile, buildScriptName = undefined }) => {
+export const createChromaticConfigFile = async ({
+  configFile,
+  buildScriptName = undefined,
+}: {
+  configFile: Path;
+  buildScriptName?: string;
+}) => {
   await writeFile(configFile, {
     ...(buildScriptName && {
       buildScriptName,
@@ -77,6 +83,10 @@ export const installArchiveDependencies = async (
   const sbPackages = getStorybookPackages(packageJson);
   const installArguments = [...defaultInstallArguments, ...sbPackages];
   const installCommand = await getPackageManagerInstallCommand(installArguments);
+  if (!installCommand) {
+    throw new Error('Could not determine package manager.');
+  }
+
   await execaCommand(installCommand);
 };
 

--- a/bin-src/trimStatsFile.ts
+++ b/bin-src/trimStatsFile.ts
@@ -30,7 +30,7 @@ export async function main([statsFile = './storybook-static/preview-stats.json']
       .filter((module) => isUserCode(module))
       .map(({ id, name, modules, reasons }) => {
         const trimmedReasons = dedupe(
-          reasons.filter((reason) => isUserCode(reason)).map((r) => r.moduleName)
+          reasons?.filter((reason) => isUserCode(reason)).map((r) => r.moduleName) || []
         )
           .filter((n) => n !== name)
           .map((moduleName) => ({ moduleName }));

--- a/node-src/errorMonitoring.test.ts
+++ b/node-src/errorMonitoring.test.ts
@@ -17,8 +17,8 @@ describe('filterErrorEvent', () => {
     const actual = filterErrorEvent({
       exception: { values: [{ value: redError }, { value: redError }] },
     } as Sentry.ErrorEvent);
-    expect(actual.exception.values[0].value).toBe('error');
-    expect(actual.exception.values[1].value).toBe('error');
+    expect(actual.exception?.values?.[0].value).toBe('error');
+    expect(actual.exception?.values?.[1].value).toBe('error');
   });
 });
 
@@ -34,7 +34,7 @@ describe('filterBreadcrumb', () => {
       category: 'console',
       message: blueMessage,
     } as Sentry.Breadcrumb);
-    expect(actual.message).toBe('message');
+    expect(actual?.message).toBe('message');
   });
 
   it('returns null for empty console breadcrumbs', () => {

--- a/node-src/errorMonitoring.ts
+++ b/node-src/errorMonitoring.ts
@@ -16,7 +16,9 @@ export function filterErrorEvent(event: Sentry.ErrorEvent) {
   // And from exception messages
   if (event.exception?.values) {
     for (const [index, exception] of event.exception.values.entries()) {
-      event.exception.values[index].value = stripAnsi(exception.value);
+      if (exception.value) {
+        event.exception.values[index].value = stripAnsi(exception.value);
+      }
     }
   }
   return event;

--- a/node-src/git/findAncestorBuildWithCommit.ts
+++ b/node-src/git/findAncestorBuildWithCommit.ts
@@ -56,7 +56,7 @@ export async function findAncestorBuildWithCommit(
   { client }: Pick<Context, 'client'>,
   buildNumber: number,
   { page = 10, limit = 80 } = {}
-): Promise<AncestorBuildsQueryResult['app']['build']['ancestorBuilds'][0] | null> {
+): Promise<AncestorBuildsQueryResult['app']['build']['ancestorBuilds'][0] | undefined> {
   let skip = 0;
   while (skip < limit) {
     const { app } = await client.runQuery<AncestorBuildsQueryResult>(AncestorBuildsQuery, {

--- a/node-src/git/getChangedFilesWithReplacement.ts
+++ b/node-src/git/getChangedFilesWithReplacement.ts
@@ -32,7 +32,7 @@ export async function getChangedFilesWithReplacement(
       throw new Error('Local build had uncommitted changes');
     }
 
-    const changedFiles = await getChangedFiles(build.commit);
+    const changedFiles = (await getChangedFiles(build.commit)) || [];
     return { changedFiles };
   } catch (err) {
     ctx.log.debug(
@@ -46,7 +46,7 @@ export async function getChangedFilesWithReplacement(
         ctx.log.debug(
           `Found replacement build for #${build.number}(${build.commit}): #${replacementBuild.number}(${replacementBuild.commit})`
         );
-        const changedFiles = await getChangedFiles(replacementBuild.commit);
+        const changedFiles = (await getChangedFiles(replacementBuild.commit)) || [];
         return { changedFiles, replacementBuild };
       }
       ctx.log.debug(`Couldn't find replacement for #${build.number}(${build.commit})`);

--- a/node-src/git/getCommitAndBranch.test.ts
+++ b/node-src/git/getCommitAndBranch.test.ts
@@ -70,7 +70,9 @@ describe('getCommitAndBranch', () => {
       slug: 'chromaui/env-ci',
     });
     getBranch.mockResolvedValue('HEAD');
-    getCommit.mockImplementation((commit) => Promise.resolve({ commit, ...commitInfo }));
+    getCommit.mockImplementation((commit) =>
+      Promise.resolve({ commit: commit as string, ...commitInfo })
+    );
     const info = await getCommitAndBranch(ctx);
     expect(info).toMatchObject({
       branch: 'ci-branch',
@@ -139,7 +141,9 @@ describe('getCommitAndBranch', () => {
       process.env.CHROMATIC_SHA = 'f78db92d';
       process.env.CHROMATIC_BRANCH = 'feature';
       process.env.CHROMATIC_SLUG = 'chromaui/chromatic';
-      getCommit.mockImplementation((commit) => Promise.resolve({ commit, ...commitInfo }));
+      getCommit.mockImplementation((commit) =>
+        Promise.resolve({ commit: commit as string, ...commitInfo })
+      );
       const info = await getCommitAndBranch(ctx);
       expect(info).toMatchObject({
         branch: 'feature',
@@ -214,7 +218,9 @@ describe('getCommitAndBranch', () => {
       process.env.TRAVIS_PULL_REQUEST_SHA = 'ef765ac7';
       process.env.TRAVIS_PULL_REQUEST_BRANCH = 'travis';
       process.env.TRAVIS_PULL_REQUEST_SLUG = 'chromaui/travis';
-      getCommit.mockImplementation((commit) => Promise.resolve({ commit, ...commitInfo }));
+      getCommit.mockImplementation((commit) =>
+        Promise.resolve({ commit: commit as string, ...commitInfo })
+      );
       const info = await getCommitAndBranch(ctx);
       expect(info).toMatchObject({
         branch: 'travis',

--- a/node-src/git/mocks/longLine.ts
+++ b/node-src/git/mocks/longLine.ts
@@ -8,7 +8,7 @@
 // |
 // Z
 
-const ACode = 'A'.codePointAt(0);
+const ACode = 'A'.codePointAt(0) as number;
 
 // [commit, parent(s)]
 export default [

--- a/node-src/index.ts
+++ b/node-src/index.ts
@@ -104,7 +104,7 @@ export async function run({
   argv?: string[];
   flags?: Flags;
   options?: Partial<Options>;
-}): Promise<Output> {
+}): Promise<Partial<Output>> {
   const {
     sessionId = uuid(),
     env: environment = getEnvironment(),
@@ -316,16 +316,16 @@ export async function getGitInfo(): Promise<GitInfo> {
   } catch {
     slug = '';
   }
-  const branch = await getBranch();
+  const branch = (await getBranch()) || '';
   const commitInfo = await getCommit();
-  const userEmail = await getUserEmail();
+  const userEmail = (await getUserEmail()) || '';
   const userEmailHash = emailHash(userEmail);
-  const repositoryRootDirectory = await getRepositoryRoot();
+  const repositoryRootDirectory = (await getRepositoryRoot()) || '';
 
   const [ownerName, repoName, ...rest] = slug ? slug.split('/') : [];
   const isValidSlug = !!ownerName && !!repoName && rest.length === 0;
 
-  const uncommittedHash = await getUncommittedHash();
+  const uncommittedHash = (await getUncommittedHash()) || '';
   return {
     slug: isValidSlug ? slug : '',
     branch,

--- a/node-src/io/getProxyAgent.ts
+++ b/node-src/io/getProxyAgent.ts
@@ -9,7 +9,7 @@ const agents = {};
 const getProxyAgent = (
   { env, log }: Pick<Context, 'env' | 'log'>,
   url: string,
-  options: HttpsProxyAgentOptions<any>
+  options?: HttpsProxyAgentOptions<any>
 ) => {
   const proxy = env.HTTPS_PROXY || env.HTTP_PROXY;
   if (!proxy || noProxy(url)) return undefined;

--- a/node-src/io/graphqlClient.ts
+++ b/node-src/io/graphqlClient.ts
@@ -19,7 +19,7 @@ export interface GraphQLError {
  */
 export default class GraphQLClient {
   endpoint: string;
-  headers: HTTPClientOptions['headers'];
+  headers: Record<string, string>;
   client: HTTPClient;
 
   constructor(ctx: InitialContext, endpoint: string, httpClientOptions: HTTPClientOptions) {

--- a/node-src/lib/checkStorybookBaseDirectory.ts
+++ b/node-src/lib/checkStorybookBaseDirectory.ts
@@ -16,6 +16,10 @@ import { exitCodes, setExitCode } from './setExitCode';
 export async function checkStorybookBaseDirectory(ctx: Context, stats: Stats) {
   const repositoryRoot = await getRepositoryRoot();
 
+  if (!repositoryRoot) {
+    throw new Error('Failed to determine repository root');
+  }
+
   // Assume CWD if no storybookBaseDir is provided
   const { storybookBaseDir: storybookBaseDirectory = path.relative(repositoryRoot, '') } =
     ctx.options;

--- a/node-src/lib/compress.ts
+++ b/node-src/lib/compress.ts
@@ -15,7 +15,8 @@ import { Context, FileDesc } from '../types';
 export default async function makeZipFile(ctx: Context, files: FileDesc[]) {
   const archive = archiver('zip', { zlib: { level: 9 } });
   const temporary = await temporaryFile({ postfix: '.zip' });
-  const sink = createWriteStream(undefined, { fd: temporary.fd });
+  // Passing a fd will cause `createWriteStream` to ignore the path (first) argument
+  const sink = createWriteStream('', { fd: temporary.fd });
 
   return new Promise<{ path: string; size: number }>((resolve, reject) => {
     sink.on('close', () => {

--- a/node-src/lib/findChangedPackageFiles.ts
+++ b/node-src/lib/findChangedPackageFiles.ts
@@ -54,7 +54,7 @@ const readGitFile = async (fileName: string, commit = 'HEAD') => {
   const key = `${commit}:${fileName}`;
   if (fileCache.has(key)) return fileCache.get(key);
   const contents = await execGitCommand(`git show ${key}`);
-  fileCache.set(key, contents);
+  if (contents) fileCache.set(key, contents);
   return contents;
 };
 export const clearFileCache = () => fileCache.clear();
@@ -67,6 +67,11 @@ const getManifestFilesWithChangedDependencies = async (manifestFiles: string[], 
       try {
         const base = await readGitFile(fileName, commit);
         const head = await readGitFile(fileName);
+
+        if (!base || !head) {
+          throw new Error('Failed to read git file');
+        }
+
         return arePackageDependenciesEqual(JSON.parse(base), JSON.parse(head)) ? [] : [fileName];
       } catch {
         // Consider the dependencies changed if we failed to compare files.

--- a/node-src/lib/getDependentStoryFiles.ts
+++ b/node-src/lib/getDependentStoryFiles.ts
@@ -9,7 +9,6 @@ import { isPackageManifestFile, matchesFile } from './utils';
 
 type FilePath = string;
 type NormalizedName = string;
-// type TraceToCheck = (string | number)[];
 type TraceToCheck = (string | number | string[])[];
 
 // Bail whenever one of these was changed

--- a/node-src/lib/getDependentStoryFiles.ts
+++ b/node-src/lib/getDependentStoryFiles.ts
@@ -9,6 +9,8 @@ import { isPackageManifestFile, matchesFile } from './utils';
 
 type FilePath = string;
 type NormalizedName = string;
+// type TraceToCheck = (string | number)[];
+type TraceToCheck = (string | number | string[])[];
 
 // Bail whenever one of these was changed
 const LOCKFILES = [
@@ -97,6 +99,10 @@ export async function getDependentStoryFiles(
   } = ctx.options;
 
   const rootPath = await getRepositoryRoot(); // e.g. `/path/to/project` (always absolute posix)
+  if (!rootPath) {
+    throw new Error('Failed to determine repository root');
+  }
+
   const baseDirectory = storybookBaseDir
     ? posix(storybookBaseDir)
     : path.posix.relative(rootPath, '');
@@ -157,7 +163,7 @@ export async function getDependentStoryFiles(
         // all those files "changed" if a dependency (version) changes, while still being able to
         // "untrace" certain files (or globs) in those packages.
         if (!nodeModules.has(packageName)) nodeModules.set(packageName, []);
-        nodeModules.get(packageName).push(normalizedName);
+        nodeModules.get(packageName)?.push(normalizedName);
       }
 
       if (module_.modules) {
@@ -167,11 +173,13 @@ export async function getDependentStoryFiles(
       }
 
       const normalizedReasons = module_.reasons
-        .map((reason) => normalize(reason.moduleName))
+        ?.map((reason) => normalize(reason.moduleName))
         .filter((reasonName) => reasonName && reasonName !== normalizedName);
-      reasonsById.set(module_.id, normalizedReasons);
+      if (normalizedReasons) {
+        reasonsById.set(module_.id, normalizedReasons);
+      }
 
-      if (reasonsById.get(module_.id).some((reason) => storiesEntryFiles.has(reason))) {
+      if (reasonsById.get(module_.id)?.some((reason) => storiesEntryFiles.has(reason))) {
         csfGlobsByName.add(normalizedName);
       }
     });
@@ -206,7 +214,7 @@ export async function getDependentStoryFiles(
   ctx.untracedFiles = [];
   function untrace(filepath: string) {
     if (untraced.some((glob) => matchesFile(glob, filepath))) {
-      ctx.untracedFiles.push(filepath);
+      ctx.untracedFiles?.push(filepath);
       return false;
     }
     return true;
@@ -229,7 +237,7 @@ export async function getDependentStoryFiles(
   const tracedPaths = new Set<string>();
   const affectedModuleIds = new Set<string | number>();
   const checkedIds = {};
-  const toCheck = [];
+  const toCheck: TraceToCheck[] = [];
 
   ctx.turboSnap = {
     rootPath,
@@ -277,14 +285,16 @@ export async function getDependentStoryFiles(
     if (ctx.turboSnap?.bailReason || isCsfGlob(name)) return;
     if (shouldBail(name)) return;
     const { id } = modulesByName.get(name) || {};
-    const normalizedName = namesById.get(id);
+    // eslint-disable-next-line unicorn/no-null
+    const normalizedName = namesById.get(id || null);
+    if (!normalizedName) return;
     if (shouldBail(normalizedName)) return;
 
     if (!id || !reasonsById.get(id) || checkedIds[id]) return;
     // Queue this id for tracing
-    toCheck.push([id, [...tracePath, id]]);
+    toCheck.push([id, [...tracePath, id.toString()]]);
 
-    if (reasonsById.get(id).some((reason) => isCsfGlob(reason))) {
+    if (reasonsById.get(id)?.some((reason) => isCsfGlob(reason))) {
       affectedModuleIds.add(id);
       tracedPaths.add([...tracePath, id].map((pid) => namesById.get(pid)).join('\n'));
     }
@@ -299,16 +309,26 @@ export async function getDependentStoryFiles(
   tracedFiles.map((posixPath) => traceName(posixPath));
   // If more were found during that process, check them too.
   while (toCheck.length > 0) {
-    const [id, tracePath] = toCheck.pop();
+    const [id, tracePath] = toCheck.pop() as TraceToCheck;
+
+    if (Array.isArray(id)) {
+      ctx.log.debug('Trace ID is an unexpected value, skipping');
+      continue;
+    }
+    if (!Array.isArray(tracePath)) {
+      ctx.log.debug('Trace path is an unexpected value, skipping');
+      continue;
+    }
+
     checkedIds[id] = true;
     reasonsById
       .get(id)
-      .filter((file) => untrace(file))
+      ?.filter((file) => untrace(file))
       .map((reason) => traceName(reason, tracePath));
   }
   const affectedModules = Object.fromEntries(
     // The id will be compared against the result of the stories' `.parameters.filename` values (stories retrieved from getStoriesJsonData())
-    [...affectedModuleIds].map((id) => [String(id), files(namesById.get(id))])
+    [...affectedModuleIds].map((id) => [String(id), files(namesById.get(id) || '')])
   );
 
   if (ctx.options.traceChanged) {

--- a/node-src/lib/getDependentStoryFiles.ts
+++ b/node-src/lib/getDependentStoryFiles.ts
@@ -258,6 +258,8 @@ export async function getDependentStoryFiles(
   }
 
   function shouldBail(moduleName: string) {
+    if (!ctx.turboSnap) ctx.turboSnap = {};
+
     if (isStorybookFile(moduleName)) {
       ctx.turboSnap.bailReason = { changedStorybookFiles: files(moduleName) };
       return true;

--- a/node-src/lib/getFileHashes.ts
+++ b/node-src/lib/getFileHashes.ts
@@ -9,7 +9,7 @@ const hashFile = (buffer: Buffer, path: string, xxhash: XXHashAPI): Promise<stri
   // This uses callback-style fs functions because it runs faster than with their promise-based counterparts.
   return new Promise((resolve, reject) => {
     const done = (fd: number, getResult: () => bigint) => {
-      let result: bigint = undefined;
+      let result = BigInt(0);
       close(fd, (closeError) => {
         if (closeError) reject(closeError);
         else resolve(result.toString(16).padStart(16, '0'));

--- a/node-src/lib/getOptions.ts
+++ b/node-src/lib/getOptions.ts
@@ -36,6 +36,17 @@ const undefinedIfEmpty = <T>(array: T[]) => {
 const stripUndefined = (object: Partial<Options>): Partial<Options> =>
   Object.fromEntries(Object.entries(object).filter(([_, v]) => v !== undefined));
 
+const defaultUnlessSetOrFalse = (input: string | boolean | undefined, fallback: string) => {
+  switch (typeof input) {
+    case 'boolean':
+      return input ? fallback : undefined;
+    case 'string':
+      return input || fallback;
+    default:
+      return;
+  }
+};
+
 /**
  * Parse options set when executing the CLI.
  *
@@ -163,9 +174,20 @@ export default function getOptions(ctx: InitialContext): Options {
     uploadMetadata: flags.uploadMetadata,
   });
 
+  // We need to parse boolean values and set their defaults
+  const { logFile, diagnosticsFile, junitReport, storybookLogFile, ...restOfConfiguration } =
+    configuration || {};
+  const configurationOptions: Partial<Options> = stripUndefined({
+    ...restOfConfiguration,
+    logFile: defaultUnlessSetOrFalse(logFile, DEFAULT_LOG_FILE),
+    diagnosticsFile: defaultUnlessSetOrFalse(diagnosticsFile, DEFAULT_DIAGNOSTICS_FILE),
+    junitReport: defaultUnlessSetOrFalse(junitReport, DEFAULT_REPORT_FILE),
+    storybookLogFile: defaultUnlessSetOrFalse(storybookLogFile, DEFAULT_STORYBOOK_LOG_FILE),
+  });
+
   const potentialOptions: Partial<Options> = {
     ...defaultOptions,
-    ...configuration,
+    ...configurationOptions,
     ...optionsFromFlags,
     ...extraOptions,
 

--- a/node-src/lib/getOptions.ts
+++ b/node-src/lib/getOptions.ts
@@ -16,9 +16,13 @@ import missingProjectToken from '../ui/messages/errors/missingProjectToken';
 import deprecatedOption from '../ui/messages/warnings/deprecatedOption';
 import { isE2EBuild } from './e2e';
 
-const takeLast = (input: string | string[]) => (Array.isArray(input) ? input.at(-1) : input);
+const takeLast = (input?: string | string[]) => (Array.isArray(input) ? input.at(-1) : input);
 
-const ensureArray = (input: string | string[]) => (Array.isArray(input) ? input : [input]);
+const ensureArray = (input?: string | string[]) => {
+  if (!input) return [];
+
+  return Array.isArray(input) ? input : [input];
+};
 
 const trueIfSet = <T>(value: T) => ((value as unknown) === '' ? true : value);
 const defaultIfSet = <T>(value: T, fallback: T) => ((value as unknown) === '' ? fallback : value);
@@ -125,7 +129,10 @@ export default function getOptions(ctx: InitialContext): Options {
     debug: flags.debug,
     diagnosticsFile:
       defaultIfSet(flags.diagnosticsFile, DEFAULT_DIAGNOSTICS_FILE) ||
-      defaultIfSet(flags.diagnostics && '', DEFAULT_DIAGNOSTICS_FILE), // for backwards compatibility
+      // for backwards compatibility
+      flags.diagnostics
+        ? DEFAULT_DIAGNOSTICS_FILE
+        : undefined,
     junitReport: defaultIfSet(flags.junitReport, DEFAULT_REPORT_FILE),
     zip: flags.zip,
     skipUpdateCheck: flags.skipUpdateCheck,
@@ -156,7 +163,7 @@ export default function getOptions(ctx: InitialContext): Options {
     uploadMetadata: flags.uploadMetadata,
   });
 
-  const options: Options = {
+  const potentialOptions: Partial<Options> = {
     ...defaultOptions,
     ...configuration,
     ...optionsFromFlags,
@@ -172,18 +179,21 @@ export default function getOptions(ctx: InitialContext): Options {
       process.env.NODE_ENV !== 'test',
   };
 
-  if (options.debug) {
+  if (potentialOptions.debug) {
     log.setLevel('debug');
     log.setInteractive(false);
   }
 
-  if (options.debug || options.uploadMetadata) {
+  if (potentialOptions.debug || potentialOptions.uploadMetadata) {
     // Implicitly enable these options unless they're already enabled or explicitly disabled
-    options.logFile = options.logFile ?? DEFAULT_LOG_FILE;
-    options.diagnosticsFile = options.diagnosticsFile ?? DEFAULT_DIAGNOSTICS_FILE;
+    potentialOptions.logFile = potentialOptions.logFile ?? DEFAULT_LOG_FILE;
+    potentialOptions.diagnosticsFile = potentialOptions.diagnosticsFile ?? DEFAULT_DIAGNOSTICS_FILE;
   }
 
-  if (!options.projectToken && !(options.projectId && options.userToken)) {
+  if (
+    !potentialOptions.projectToken &&
+    !(potentialOptions.projectId && potentialOptions.userToken)
+  ) {
     throw new Error(missingProjectToken());
   }
 
@@ -196,20 +206,20 @@ export default function getOptions(ctx: InitialContext): Options {
   }
 
   if (flags.patchBuild) {
-    if (!options.patchHeadRef || !options.patchBaseRef) {
+    if (!potentialOptions.patchHeadRef || !potentialOptions.patchBaseRef) {
       throw new Error(invalidPatchBuild());
     }
-    if (options.patchHeadRef === options.patchBaseRef) {
+    if (potentialOptions.patchHeadRef === potentialOptions.patchBaseRef) {
       throw new Error(duplicatePatchBuild());
     }
   }
 
-  if (options.onlyStoryNames?.some((glob) => !/[\w*]\/[\w*]/.test(glob))) {
+  if (potentialOptions.onlyStoryNames?.some((glob) => !/[\w*]\/[\w*]/.test(glob))) {
     throw new Error(invalidOnlyStoryNames());
   }
 
-  const { storybookBuildDir } = options;
-  let { buildScriptName } = options;
+  const { storybookBuildDir } = potentialOptions;
+  let { buildScriptName } = potentialOptions;
 
   // We can only have one of these arguments
   const singularOptions = {
@@ -217,7 +227,9 @@ export default function getOptions(ctx: InitialContext): Options {
     playwright: '--playwright',
     cypress: '--cypress',
   };
-  const foundSingularOptions = Object.keys(singularOptions).filter((name) => !!options[name]);
+  const foundSingularOptions = Object.keys(singularOptions).filter(
+    (name) => !!potentialOptions[name]
+  );
 
   if (foundSingularOptions.length > 1) {
     throw new Error(
@@ -225,35 +237,41 @@ export default function getOptions(ctx: InitialContext): Options {
     );
   }
 
-  if (options.onlyChanged && options.onlyStoryFiles) {
+  if (potentialOptions.onlyChanged && potentialOptions.onlyStoryFiles) {
     throw new Error(invalidSingularOptions(['--only-changed', '--only-story-files']));
   }
-  if (options.onlyChanged && options.onlyStoryNames) {
+  if (potentialOptions.onlyChanged && potentialOptions.onlyStoryNames) {
     throw new Error(invalidSingularOptions(['--only-changed', '--only-story-names']));
   }
-  if (options.onlyStoryNames && options.onlyStoryFiles) {
+  if (potentialOptions.onlyStoryNames && potentialOptions.onlyStoryFiles) {
     throw new Error(invalidSingularOptions(['--only-story-files', '--only-story-names']));
   }
 
-  if (options.untraced && !options.onlyChanged) {
+  if (potentialOptions.untraced && !potentialOptions.onlyChanged) {
     throw new Error(dependentOption('--untraced', '--only-changed'));
   }
 
-  if (options.externals && !options.onlyChanged) {
+  if (potentialOptions.externals && !potentialOptions.onlyChanged) {
     throw new Error(dependentOption('--externals', '--only-changed'));
   }
 
-  if (options.traceChanged && !options.onlyChanged) {
+  if (potentialOptions.traceChanged && !potentialOptions.onlyChanged) {
     throw new Error(dependentOption('--trace-changed', '--only-changed'));
   }
 
-  if (options.junitReport && options.exitOnceUploaded) {
+  if (potentialOptions.junitReport && potentialOptions.exitOnceUploaded) {
     throw new Error(incompatibleOptions(['--junit-report', '--exit-once-uploaded']));
   }
 
-  if (typeof options.junitReport === 'string' && path.extname(options.junitReport) !== '.xml') {
+  if (
+    typeof potentialOptions.junitReport === 'string' &&
+    path.extname(potentialOptions.junitReport) !== '.xml'
+  ) {
     throw new Error(invalidReportPath());
   }
+
+  // All options are validated and can now be used
+  const options = potentialOptions as Options;
 
   if (flags.only) {
     log.info('');

--- a/node-src/lib/getPackageManager.ts
+++ b/node-src/lib/getPackageManager.ts
@@ -13,6 +13,10 @@ export const getPackageManagerRunCommand = async (args: string[]) => {
 
 // e.g. `8.19.2`
 export const getPackageManagerVersion = async (packageManager: string) => {
+  if (!packageManager) {
+    throw new Error('No package manager provided');
+  }
+
   const { stdout } = await execa(packageManager, ['--version']);
   const [output] = (stdout.toString() as string).trim().split('\n', 1);
   return output.trim().replace(/^v/, '');

--- a/node-src/lib/getPackageManager.ts
+++ b/node-src/lib/getPackageManager.ts
@@ -13,7 +13,7 @@ export const getPackageManagerRunCommand = async (args: string[]) => {
 
 // e.g. `8.19.2`
 export const getPackageManagerVersion = async (packageManager: string) => {
-  const { stdout } = await execa(packageManager || (await getPackageManagerName()), ['--version']);
+  const { stdout } = await execa(packageManager, ['--version']);
   const [output] = (stdout.toString() as string).trim().split('\n', 1);
   return output.trim().replace(/^v/, '');
 };

--- a/node-src/lib/getPrebuiltStorybookMetadata.ts
+++ b/node-src/lib/getPrebuiltStorybookMetadata.ts
@@ -21,11 +21,11 @@ export interface SBProjectJson {
   storybookPackages?: Record<string, { version: string }>;
 }
 
-const getBuilder = (sbProjectJson: SBProjectJson): { name: string; packageVersion: string } => {
+const getBuilder = (sbProjectJson: SBProjectJson): { name: string; packageVersion?: string } => {
   const { builder, storybookPackages, storybookVersion } = sbProjectJson;
   const name = typeof builder === 'string' ? builder : builder?.name;
   return name
-    ? { name, packageVersion: storybookPackages[builders[name]]?.version }
+    ? { name, packageVersion: storybookPackages?.[builders[name]]?.version }
     : { name: 'webpack4', packageVersion: storybookVersion }; // the default builder for Storybook v6
 };
 
@@ -37,10 +37,14 @@ export const getStorybookMetadataFromProjectJson = async (
     (viewLayer) => viewLayers[viewLayer] === sbProjectJson.framework.name
   );
   const builder = getBuilder(sbProjectJson);
+  const version =
+    sbProjectJson.storybookPackages && viewLayerPackage
+      ? sbProjectJson.storybookPackages[viewLayerPackage].version
+      : '';
 
   return {
     viewLayer: sbProjectJson.framework.name,
-    version: sbProjectJson.storybookPackages[viewLayerPackage].version,
+    version,
     builder,
     addons: Object.entries(sbProjectJson.addons)
       .filter(([packageName]) => supportedAddons[packageName])

--- a/node-src/lib/getStorybookMetadata.ts
+++ b/node-src/lib/getStorybookMetadata.ts
@@ -221,7 +221,12 @@ export const getStorybookMetadata = async (ctx: Context) => {
   } catch (err) {
     ctx.log.debug({ storybookV6error: err });
     try {
-      mainConfig = await readConfig(await findStorybookConfigFile(ctx, /^main\.[jt]sx?$/));
+      const storybookConfig = await findStorybookConfigFile(ctx, /^main\.[jt]sx?$/);
+      if (!storybookConfig) {
+        throw new Error('Failed to locate Storybook config file');
+      }
+
+      mainConfig = await readConfig(storybookConfig);
       ctx.log.debug({ configDirectory, mainConfig });
       v7 = true;
     } catch (err) {

--- a/node-src/lib/localBuildsSpecifier.ts
+++ b/node-src/lib/localBuildsSpecifier.ts
@@ -9,7 +9,8 @@ import { emailHash } from './emailHash';
  * @returns Local build information used in GraphQL queries for build information.
  */
 export function localBuildsSpecifier(ctx: Pick<Context, 'options' | 'git'>) {
-  if (ctx.options.isLocalBuild) return { localBuildEmailHash: emailHash(ctx.git.gitUserEmail) };
+  if (ctx.options.isLocalBuild)
+    return { localBuildEmailHash: emailHash(ctx.git.gitUserEmail || '') };
 
   // For global builds, we only want local builds from the committer (besides global builds)
   if (ctx.git.committerEmail) return { localBuildEmailHash: emailHash(ctx.git.committerEmail) };

--- a/node-src/lib/tasks.ts
+++ b/node-src/lib/tasks.ts
@@ -36,7 +36,7 @@ export const createTask = ({
 });
 
 export const setTitle =
-  (title: ValueFunction, subtitle: ValueFunction) => (ctx: Context, task: Task) => {
+  (title: ValueFunction, subtitle?: ValueFunction) => (ctx: Context, task: Task) => {
     const ttl = typeof title === 'function' ? title(ctx, task) : title;
     const sub = typeof subtitle === 'function' ? subtitle(ctx, task) : subtitle;
     task.title = sub ? `${ttl}\n${chalk.dim(`    → ${sub}`)}` : ttl;
@@ -56,7 +56,8 @@ export const transitionTo =
 
 export const getDuration = (ctx: Context) => {
   const now = (Number.isInteger(ctx.now) ? ctx.now : Date.now()) as number;
-  const duration = Math.round((now - ctx.startedAt) / 1000);
+  const startedAt = ctx.startedAt || 0;
+  const duration = Math.round((now - startedAt) / 1000);
   const seconds = pluralize('second', Math.floor(duration % 60), true);
   if (duration < 60) return seconds;
   const minutes = pluralize('minute', Math.floor(duration / 60), true);

--- a/node-src/lib/uploadMetadataFiles.ts
+++ b/node-src/lib/uploadMetadataFiles.ts
@@ -34,14 +34,14 @@ export async function uploadMetadataFiles(ctx: Context) {
     ctx.fileInfo?.statsPath && (await trimStatsFile([ctx.fileInfo.statsPath])),
   ].filter((m): m is string => !!m);
 
-  let files = await Promise.all(
+  const unfilteredFiles = await Promise.all(
     metadataFiles.map(async (localPath) => {
       const contentLength = await fileSize(localPath);
       const targetPath = `.chromatic/${path.basename(localPath)}`;
       return contentLength && { contentLength, localPath, targetPath };
     })
   );
-  files = files
+  const files = unfilteredFiles
     .filter((f): f is FileDesc => !!f)
     .sort((a, b) => a.targetPath.localeCompare(b.targetPath, 'en', { numeric: true }));
 

--- a/node-src/lib/utils.ts
+++ b/node-src/lib/utils.ts
@@ -66,7 +66,8 @@ export const redact = <T>(value: T, ...fields: string[]): T => {
   if (value === null || typeof value !== 'object') return value;
   if (Array.isArray(value)) return value.map((item) => redact(item, ...fields)) as T;
   const object = { ...value };
-  for (const key in object)
+  for (const key of Object.keys(object)) {
     object[key] = fields.includes(key) ? undefined : redact(object[key], ...fields);
+  }
   return object;
 };

--- a/node-src/tasks/initialize.ts
+++ b/node-src/tasks/initialize.ts
@@ -37,6 +37,8 @@ export const setEnvironment = async (ctx: Context) => {
   // We don't want to send up *all* environment vars as they could include sensitive information
   // about the user's build environment
   for (const [key, value] of Object.entries(process.env)) {
+    if (!value) continue;
+
     if (ctx.env.ENVIRONMENT_WHITELIST.some((regex) => key.match(regex))) {
       ctx.environment[key] = value;
     }
@@ -53,6 +55,10 @@ export const setRuntimeMetadata = async (ctx: Context) => {
 
   try {
     const packageManager = await getPackageManagerName();
+    if (!packageManager) {
+      throw new Error('Failed to determine package manager');
+    }
+
     ctx.runtimeMetadata.packageManager = packageManager as any;
     Sentry.setTag('packageManager', packageManager);
 

--- a/node-src/tasks/report.ts
+++ b/node-src/tasks/report.ts
@@ -80,6 +80,12 @@ export const generateReport = async (ctx: Context) => {
     typeof junitReport === 'boolean' && junitReport
       ? 'chromatic-build-{buildNumber}.xml'
       : junitReport;
+
+  if (!file) {
+    log.debug('junit report not configured, skipping');
+    return;
+  }
+
   ctx.reportPath = path.resolve(file.replaceAll('{buildNumber}', String(buildNumber)));
 
   const {

--- a/node-src/tasks/snapshot.ts
+++ b/node-src/tasks/snapshot.ts
@@ -90,7 +90,7 @@ export const takeSnapshots = async (ctx: Context, task: Task) => {
     }
 
     if (actualTestCount > 0) {
-      const { inProgressCount } = ctx.build;
+      const { inProgressCount = 0 } = ctx.build;
       const cursor = actualTestCount - inProgressCount + 1;
       const label = (testLabels && testLabels[cursor - 1]) || '';
       updateProgress({ cursor, label });

--- a/node-src/types.ts
+++ b/node-src/types.ts
@@ -5,6 +5,8 @@ import type { Configuration } from './lib/getConfiguration';
 import { Environment } from './lib/getEnvironment';
 import { Logger } from './lib/log';
 
+type FilePath = string;
+
 export interface Flags {
   // Required options
   projectToken?: string[] | string;
@@ -205,7 +207,7 @@ export interface Context {
   client: GraphQLClient;
 
   git: {
-    version: string;
+    version?: string;
     /** The current user's email as pre git config */
     gitUserEmail?: string;
     branch: string;
@@ -318,7 +320,7 @@ export interface Context {
   buildLogFile?: string;
   fileInfo?: {
     paths: string[];
-    hashes?: Record<Context['fileInfo']['paths'][number], string>;
+    hashes?: Record<FilePath, string>;
     statsPath: string;
     lengths: {
       knownAs: string;
@@ -370,7 +372,7 @@ export interface Reason {
   moduleName: string;
 }
 export interface Module {
-  id: string | number;
+  id: string | number | null;
   name: string;
   modules?: Pick<Module, 'name'>[];
   reasons?: Reason[];

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,7 @@
     // Override module/moduleResolution since we're using tsup/esbuild
     "module": "es2022",
     "moduleResolution": "Bundler",
-    "strict": false,
+    "strict": true,
     "forceConsistentCasingInFileNames": true,
     "noImplicitAny": false, // Let this be a warning from ESLint until it becomes required
     "useUnknownInCatchVariables": false, // Treat caught errors as 'any' for now


### PR DESCRIPTION
This is a continuation from #1070 by cleaning up the remaining errors and finally enabling strictness in our `tsconfig.json`! 🎉 

I tried to make these changes as small as possible to not change the flow but some of the errors made that difficult. In theory, a good chunk of these rely on values existing despite the `Context` type having them as optional so throwing new errors when they don't exist shouldn't do anything in practice. 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>11.11.1--canary.1072.11163487586.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@11.11.1--canary.1072.11163487586.0
  # or 
  yarn add chromatic@11.11.1--canary.1072.11163487586.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
