### PR TITLE
Ignore duplication in test files and ignore all __mocks__

### DIFF
--- a/.codacy.yaml
+++ b/.codacy.yaml
@@ -2,6 +2,7 @@
 exclude_paths:
   - 'CHANGELOG.md'
   - 'vitest.no-threads.config.ts'
+  - '**/__mocks__/**'
 engines:
   duplication:
     exclude_paths:

--- a/.codacy.yaml
+++ b/.codacy.yaml
@@ -2,3 +2,8 @@
 exclude_paths:
   - 'CHANGELOG.md'
   - 'vitest.no-threads.config.ts'
+engines:
+  duplication:
+    exclude_paths:
+      - '**/*.test.js'
+      - '**/*.test.ts'


### PR DESCRIPTION
We're getting duplication errors from Codacy for our test files. We want to ignore those since we're okay with duplication there!
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>11.11.1--canary.1073.11164367227.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@11.11.1--canary.1073.11164367227.0
  # or 
  yarn add chromatic@11.11.1--canary.1073.11164367227.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
