### PR TITLE
Add TypeScript checking to CI pipeline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,6 +22,8 @@ jobs:
             - node_modules
           key: v4-dependencies-{{ checksum "yarn.lock" }}
 
+      - run: yarn typescript:check
+
       - run: yarn lint
 
       # test if dist is correctly generated from src


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>11.11.1--canary.1078.11169365831.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@11.11.1--canary.1078.11169365831.0
  # or 
  yarn add chromatic@11.11.1--canary.1078.11169365831.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
