### PR TITLE
Show steps for initializing a new Git repo

### DIFF
--- a/node-src/ui/messages/errors/gitNotInitialized.stories.ts
+++ b/node-src/ui/messages/errors/gitNotInitialized.stories.ts
@@ -4,4 +4,5 @@ export default {
   title: 'CLI/Messages/Errors',
 };
 
-export const GitNotInitialized = () => gitNotInitialized({ command: 'git --version' });
+export const GitNotInitialized = () =>
+  gitNotInitialized({ command: 'git --version' }).replaceAll('<', '&lt').replaceAll('>', '&gt');

--- a/node-src/ui/messages/errors/gitNotInitialized.ts
+++ b/node-src/ui/messages/errors/gitNotInitialized.ts
@@ -2,6 +2,7 @@ import chalk from 'chalk';
 import { dedent } from 'ts-dedent';
 
 import { error } from '../../components/icons';
+import link from '../../components/link';
 
 export default ({ command }: { command: string }) =>
   dedent(chalk`
@@ -16,4 +17,6 @@ export default ({ command }: { command: string }) =>
     - Commit the file(s) with \`git commit --message="<MESSAGE>"\`
 
     Once you've done so, please run this build again.
+
+    For more information on Git, feel free to check out the Pro Git book: ${link('https://git-scm.com/book/en/v2')}
   `);

--- a/node-src/ui/messages/errors/gitNotInitialized.ts
+++ b/node-src/ui/messages/errors/gitNotInitialized.ts
@@ -7,4 +7,13 @@ export default ({ command }: { command: string }) =>
   dedent(chalk`
     ${error} {bold Unable to execute command}: ${command}
     Chromatic only works from inside a Git repository.
+
+    You can initialize a new Git repository with \`git init\`.
+
+    You will also need a single commit in order to run a build. To do that:
+
+    - Add a file (or multiple files) with \`git add <FILE_PATH(S)>\`
+    - Commit the file(s) with \`git commit --message="<MESSAGE>"\`
+
+    Once you've done so, please run this build again.
   `);


### PR DESCRIPTION
It can be a little confusing when you try to run Chromatic in a directory that isn't a Git repo. You end up going through a couple of error steps before you finally get to a workable state. This adds a suggestion how to initialize an empty Git repo and add a single commit. Therefore, you only go through 1 error before you can run a build.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>11.12.0--canary.1081.11220007939.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@11.12.0--canary.1081.11220007939.0
  # or 
  yarn add chromatic@11.12.0--canary.1081.11220007939.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
