### PR TITLE
Do not run Sentry in dev

### DIFF
--- a/node-src/errorMonitoring.ts
+++ b/node-src/errorMonitoring.ts
@@ -50,7 +50,9 @@ Sentry.init({
   dsn: 'https://4fa173db2ef3fb073b8ea153a5466d28@o4504181686599680.ingest.us.sentry.io/4507930289373184',
   sampleRate: 1,
   environment: process.env.SENTRY_ENVIRONMENT,
-  enabled: process.env.DISABLE_ERROR_MONITORING !== 'true',
+  enabled:
+    process.env.DISABLE_ERROR_MONITORING !== 'true' &&
+    process.env.SENTRY_ENVIRONMENT !== 'development',
   enableTracing: false,
   integrations: [],
   initialScope: {


### PR DESCRIPTION
No need for Sentry during development, so turn it off.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>11.11.1--canary.1082.11219638552.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@11.11.1--canary.1082.11219638552.0
  # or 
  yarn add chromatic@11.11.1--canary.1082.11219638552.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
