### PR TITLE
Account for `--exit-zero-on-changes=true`

### DIFF
--- a/node-src/tasks/snapshot.ts
+++ b/node-src/tasks/snapshot.ts
@@ -115,6 +115,8 @@ export const takeSnapshots = async (ctx: Context, task: Task) => {
     case 'DENIED': {
       if (
         build.autoAcceptChanges ||
+        // The boolean version of this check is handled by ctx.git.matchesBranch
+        ctx.options?.exitZeroOnChanges === 'true' ||
         ctx.git.matchesBranch?.(ctx.options?.exitZeroOnChanges || false)
       ) {
         setExitCode(ctx, exitCodes.OK);


### PR DESCRIPTION
Closes #973

If you pass something to `--exit-zero-on-changes`, the CLI assumes you're providing a branch name. However, if you pass `--exit-zero-on-changes=true`, it assumes `true` is the branch and essentially breaks the flag (unless your branch is literally `true`).

To account for this, we can simply check if the `--exit-zero-on-changes` contains the string `'true'` when we set the exit code on the snapshot step.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>11.11.1--canary.1083.11219791549.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@11.11.1--canary.1083.11219791549.0
  # or 
  yarn add chromatic@11.11.1--canary.1083.11219791549.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
