### PR TITLE
Skip publish-action on `--dry-run`

### DIFF
--- a/scripts/publish-action.mjs
+++ b/scripts/publish-action.mjs
@@ -77,6 +77,7 @@ const publishAction = async ({ major, version, repo }) => {
     console.info(`📌 Using package.json version: ${version}`);
   } else {
     const data = JSON.parse(process.env.ARG_0);
+    console.info('DEBUG', data);
     if (data.dryRun) {
       console.info('Running as --dry-run, skipping publish action');
       return;

--- a/scripts/publish-action.mjs
+++ b/scripts/publish-action.mjs
@@ -77,6 +77,10 @@ const publishAction = async ({ major, version, repo }) => {
     console.info(`📌 Using package.json version: ${version}`);
   } else {
     const data = JSON.parse(process.env.ARG_0);
+    if (data.dryRun) {
+      console.info('Running as --dry-run, skipping publish action');
+      return;
+    }
     context = data.context;
     version = data.newVersion.replace(/^v/, '');
     console.info(`📌 Using auto shipIt context: ${context}`);

--- a/scripts/versionAndBuildForRelease.mjs
+++ b/scripts/versionAndBuildForRelease.mjs
@@ -9,7 +9,9 @@ async function main() {
     return;
   }
 
-  const { stdout: nextVersion } = await $`auto shipit --dry-run --quiet`;
+  const c = `auto shipit --dry-run --quiet`;
+  console.info('Executing command: ', c);
+  const { stdout: nextVersion } = await $`${c}`;
 
   console.info(`📌 Temporarily bumping version to '${nextVersion}' for build step`);
   await $`npm --no-git-tag-version version ${nextVersion}`;


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>11.12.1--canary.1086.11241931104.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@11.12.1--canary.1086.11241931104.0
  # or 
  yarn add chromatic@11.12.1--canary.1086.11241931104.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
