### PR TITLE
Move deployment to single script

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "lint": "yarn lint:js bin-src node-src test-stories ./isChromatic.js ./isChromatic.mjs",
     "lint:js": "cross-env NODE_ENV=production eslint --cache --cache-location=.cache/eslint --report-unused-disable-directives",
     "lint:package": "sort-package-json",
-    "release": "./scripts/versionAndBuildForRelease.mjs && auto shipit",
+    "release": "./scripts/release.mjs",
     "prepack": "clean-package",
     "postpack": "clean-package restore",
     "publish-action": "./scripts/publish-action.mjs",
@@ -100,7 +100,6 @@
     "@actions/core": "^1.10.0",
     "@actions/github": "^5.0.0",
     "@antfu/ni": "^0.21.5",
-    "@auto-it/exec": "^11.0.4",
     "@auto-it/slack": "^11.1.6",
     "@discoveryjs/json-ext": "^0.5.7",
     "@eslint-community/eslint-plugin-eslint-comments": "^4.3.0",
@@ -233,12 +232,6 @@
     "plugins": [
       "npm",
       "released",
-      [
-        "exec",
-        {
-          "afterShipIt": "yarn run publish-action"
-        }
-      ],
       [
         "slack",
         {

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "release": "./scripts/release.mjs",
     "prepack": "clean-package",
     "postpack": "clean-package restore",
-    "publish-action": "./scripts/publish-action.mjs",
+    "publish-action": "./scripts/publishAction.mjs",
     "trace": "./dist/bin.js trace",
     "trim-stats": "./dist/bin.js trim-stats-file",
     "storybook": "storybook dev -p 9009",

--- a/scripts/publish-action.mjs
+++ b/scripts/publish-action.mjs
@@ -75,14 +75,6 @@ const publishAction = async ({ major, version, repo }) => {
     version = pkg.version;
     console.info(`📌 Using context arg: ${context}`);
     console.info(`📌 Using package.json version: ${version}`);
-  } else {
-    const data = JSON.parse(process.env.ARG_0);
-    context = data.context;
-    version = data.newVersion.replace(/^v/, '');
-    console.info(`📌 Using auto shipIt context: ${context}`);
-    console.info(`📌 Using auto shipIt version: ${version}`);
-    console.info(`Commits in release:`);
-    data.commitsInRelease.forEach((c) => console.info(`- ${c.hash.slice(0, 8)} ${c.subject}`));
   }
 
   const [, major, minor, patch] = version.match(/^(\d+)\.(\d+)\.(\d+)-*(\w+)?/) || [];
@@ -93,11 +85,6 @@ const publishAction = async ({ major, version, repo }) => {
 
   switch (context) {
     case 'canary':
-      if (process.argv[2] !== 'canary') {
-        console.info('Skipping automatic publish of action-canary.');
-        console.info('Run `yarn publish-action canary` to publish a canary action.');
-        return;
-      }
       await publishAction({ major, version, repo: 'chromaui/action-canary' });
       break;
     case 'next':

--- a/scripts/publishAction.mjs
+++ b/scripts/publishAction.mjs
@@ -51,31 +51,11 @@ const publishAction = async ({ major, version, repo }) => {
   return cleanup();
 };
 
-/**
- * Generally, this script is invoked by auto's `afterShipIt` hook.
- *
- * For manual (local) use:
- *   yarn publish-action {context} [--dry-run]
- *   e.g. yarn publish-action canary
- *   or   yarn publish-action latest --dry-run
- *
- * Make sure to build the action before publishing manually.
- */
-(async () => {
-  const { stdout: status } = await $`git status --porcelain`;
-  if (status) {
-    console.error(`❗️ Working directory is not clean:\n${status}`);
-    return;
-  }
-
-  let context, version;
-  if (['canary', 'next', 'latest'].includes(process.argv[2])) {
-    const pkg = JSON.parse(readFileSync('package.json', 'utf8'));
-    context = process.argv[2];
-    version = pkg.version;
-    console.info(`📌 Using context arg: ${context}`);
-    console.info(`📌 Using package.json version: ${version}`);
-  }
+export async function main(context) {
+  const pkg = JSON.parse(readFileSync('package.json', 'utf8'));
+  const version = pkg.version;
+  console.info(`📌 Using context arg: ${context}`);
+  console.info(`📌 Using package.json version: ${version}`);
 
   const [, major, minor, patch] = version.match(/^(\d+)\.(\d+)\.(\d+)-*(\w+)?/) || [];
   if (!major || !minor || !patch) {
@@ -96,4 +76,23 @@ const publishAction = async ({ major, version, repo }) => {
     default:
       console.error(`❗️ Unknown context: ${context}`);
   }
-})();
+}
+
+/**
+ * For manual (local) use:
+ *   yarn publish-action {context} [--dry-run]
+ *   e.g. yarn publish-action canary
+ *   or   yarn publish-action latest --dry-run
+ *
+ * Make sure to build the action before publishing manually.
+ */
+// eslint-disable-next-line unicorn/prefer-module
+if (process.argv[1] === import.meta.filename) {
+  const { stdout: status } = await $`git status --porcelain`;
+  if (status) {
+    console.error(`❗️ Working directory is not clean:\n${status}`);
+    process.exit(1);
+  }
+
+  main(process.argv[2]);
+}

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -9,6 +9,19 @@ async function main() {
     return;
   }
 
+  await build();
+  await $({ stdout: 'inherit', stderr: 'inherit' })`auto shipit`;
+
+  if (process.env.GITHUB_REF === 'main') {
+    await $({ stdout: 'inherit', stderr: 'inherit' })`yarn publish-action latest`;
+  } else {
+    console.info('Skipping automatic publish of action-canary.');
+    console.info('Run `yarn publish-action canary` to publish a canary action.');
+    return;
+  }
+}
+
+async function build() {
   const { stdout: nextVersion } = await $`auto shipit --dry-run --quiet`;
 
   console.info(`📌 Temporarily bumping version to '${nextVersion}' for build step`);

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -2,6 +2,8 @@
 
 import { $ } from 'execa';
 
+import { main as publishAction } from './publishAction.mjs';
+
 async function main() {
   const { stdout: status } = await $`git status --porcelain`;
   if (status) {
@@ -13,7 +15,7 @@ async function main() {
   await $({ stdout: 'inherit', stderr: 'inherit' })`auto shipit`;
 
   if (process.env.GITHUB_REF === 'main') {
-    await $({ stdout: 'inherit', stderr: 'inherit' })`yarn publish-action latest`;
+    await publishAction('latest');
   } else {
     console.info('Skipping automatic publish of action-canary.');
     console.info('Run `yarn publish-action canary` to publish a canary action.');

--- a/yarn.lock
+++ b/yarn.lock
@@ -138,20 +138,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@auto-it/exec@npm:^11.0.4":
-  version: 11.1.6
-  resolution: "@auto-it/exec@npm:11.1.6"
-  dependencies:
-    "@auto-it/core": "npm:11.1.6"
-    endent: "npm:^2.1.0"
-    fp-ts: "npm:^2.5.3"
-    fromentries: "npm:^1.2.0"
-    io-ts: "npm:^2.1.2"
-    tslib: "npm:2.1.0"
-  checksum: 10c0/190cc3f7f8e676bf7fe04ed0dfb9c3b39591ffb472a412f1890e1329cdbc93610c0780a8fe3a38ec86cb9f089b2a585ad819e649c1df77ba12225b6159224503
-  languageName: node
-  linkType: hard
-
 "@auto-it/npm@npm:11.1.6":
   version: 11.1.6
   resolution: "@auto-it/npm@npm:11.1.6"
@@ -7539,7 +7525,6 @@ __metadata:
     "@actions/core": "npm:^1.10.0"
     "@actions/github": "npm:^5.0.0"
     "@antfu/ni": "npm:^0.21.5"
-    "@auto-it/exec": "npm:^11.0.4"
     "@auto-it/slack": "npm:^11.1.6"
     "@discoveryjs/json-ext": "npm:^0.5.7"
     "@eslint-community/eslint-plugin-eslint-comments": "npm:^4.3.0"


### PR DESCRIPTION
We have quite a bit of indirection happening in the release pipeline. This turns that into a single script to manage everything instead of hooks via auto plugins.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>11.12.1--canary.1088.11243600462.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@11.12.1--canary.1088.11243600462.0
  # or 
  yarn add chromatic@11.12.1--canary.1088.11243600462.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
