### PR TITLE
Manually update `package.json` and `CHANGELOG.md` v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+# v11.12.2 (Wed Oct 09 2024)
+
+#### 🐛 Bug Fix
+
+- Manually update `package.json` and `CHANGELOG.md` [#1089](https://github.com/chromaui/chromatic-cli/pull/1089) ([@codykaup](https://github.com/codykaup))
+
+#### Authors: 1
+
+- Cody Kaup ([@codykaup](https://github.com/codykaup))
+
+---
+
 # v11.12.1 (Wed Oct 09 2024)
 
 #### 🐛 Bug Fix

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chromatic",
-  "version": "11.12.1",
+  "version": "11.12.2",
   "description": "Automate visual testing across browsers. Gather UI feedback. Versioned documentation.",
   "keywords": [
     "storybook-addon",


### PR DESCRIPTION
We had another bump in the road with our deployment pipeline so this updates `package.json` and `CHANGELOG.md` again so we can ensure the entire pipeline works.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>11.12.3--canary.1090.11258262264.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@11.12.3--canary.1090.11258262264.0
  # or 
  yarn add chromatic@11.12.3--canary.1090.11258262264.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
