### PR TITLE
Manually update `package.json` and `CHANGELOG.md` v4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+# v11.12.4 (Wed Oct 09 2024)
+
+#### 🐛 Bug Fix
+
+- Manually update `package.json` and `CHANGELOG.md` v3 [#1091](https://github.com/chromaui/chromatic-cli/pull/1091) ([@codykaup](https://github.com/codykaup))
+
+#### Authors: 1
+
+- Cody Kaup ([@codykaup](https://github.com/codykaup))
+
+---
+
 # v11.12.3 (Wed Oct 09 2024)
 
 #### 🐛 Bug Fix

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chromatic",
-  "version": "11.12.3",
+  "version": "11.12.4",
   "description": "Automate visual testing across browsers. Gather UI feedback. Versioned documentation.",
   "keywords": [
     "storybook-addon",


### PR DESCRIPTION
Either there's something up with the docs or there's something more strange happening. Let's try this again with even more permissions on the bot. 😞 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>11.12.5--canary.1092.11261040200.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@11.12.5--canary.1092.11261040200.0
  # or 
  yarn add chromatic@11.12.5--canary.1092.11261040200.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
