### PR TITLE
Fix GITHUB_REF check on release

### DIFF
--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -14,7 +14,8 @@ async function main() {
   await build();
   await $({ stdout: 'inherit', stderr: 'inherit' })`auto shipit`;
 
-  if (process.env.GITHUB_REF === 'main') {
+  // https://github.blog/changelog/2023-09-13-github-actions-updates-to-github_ref-and-github-ref/
+  if (process.env.GITHUB_REF === 'refs/heads/main') {
     await publishAction('latest');
   } else {
     console.info('Skipping automatic publish of action-canary.');


### PR DESCRIPTION
According to https://github.blog/changelog/2023-09-13-github-actions-updates-to-github_ref-and-github-ref/ we now need to check for `refs/heads/main`, not `main`.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>11.12.6--canary.1093.11262656284.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@11.12.6--canary.1093.11262656284.0
  # or 
  yarn add chromatic@11.12.6--canary.1093.11262656284.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
