### PR TITLE
Add context to sentinel upload failures.

### DIFF
--- a/.github/workflows/smoke-test-node-api.yml
+++ b/.github/workflows/smoke-test-node-api.yml
@@ -13,7 +13,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-node@v3
         with:
-          node-version: latest
+          node-version: 'lts/*'
       - run: corepack enable
       - run: yarn
       - run: yarn build

--- a/node-src/tasks/upload.ts
+++ b/node-src/tasks/upload.ts
@@ -14,6 +14,7 @@ import { rewriteErrorMessage, throttle } from '../lib/utils';
 import { waitForSentinel } from '../lib/waitForSentinel';
 import { Context, FileDesc, Task } from '../types';
 import missingStatsFile from '../ui/messages/errors/missingStatsFile';
+import sentinelFileErrors from '../ui/messages/errors/sentinelFileErrors';
 import bailFile from '../ui/messages/warnings/bailFile';
 import deviatingOutputDirectory from '../ui/messages/warnings/deviatingOutputDirectory';
 import {
@@ -277,11 +278,8 @@ export const waitForSentinels = async (ctx: Context, task: Task) => {
   try {
     await Promise.all(Object.values(sentinels).map((sentinel) => waitForSentinel(ctx, sentinel)));
   } catch (err) {
-    throw new Error(
-      `Failed to finalize upload. Please check https://status.chromatic.com/ or contact support.
-
-${err.message}`
-    );
+    ctx.log.error(sentinelFileErrors());
+    throw err;
   }
 };
 

--- a/node-src/tasks/upload.ts
+++ b/node-src/tasks/upload.ts
@@ -274,7 +274,15 @@ export const waitForSentinels = async (ctx: Context, task: Task) => {
     })
   );
 
-  await Promise.all(Object.values(sentinels).map((sentinel) => waitForSentinel(ctx, sentinel)));
+  try {
+    await Promise.all(Object.values(sentinels).map((sentinel) => waitForSentinel(ctx, sentinel)));
+  } catch (err) {
+    throw new Error(
+      `Failed to finalize upload. Please check https://status.chromatic.com/ or contact support.
+
+${err.message}`
+    );
+  }
 };
 
 export default createTask({

--- a/node-src/ui/messages/errors/sentinelFileErrors.stories.ts
+++ b/node-src/ui/messages/errors/sentinelFileErrors.stories.ts
@@ -1,0 +1,7 @@
+import sentinelFileErrors from './sentinelFileErrors';
+
+export default {
+  title: 'CLI/Messages/Errors',
+};
+
+export const SentinelFileErrors = () => sentinelFileErrors();

--- a/node-src/ui/messages/errors/sentinelFileErrors.ts
+++ b/node-src/ui/messages/errors/sentinelFileErrors.ts
@@ -2,8 +2,9 @@ import chalk from 'chalk';
 import { dedent } from 'ts-dedent';
 
 import { error } from '../../components/icons';
+import link from '../../components/link';
 
 export default () =>
   dedent(chalk`
-    ${error} Failed to finalize upload. Please check https://status.chromatic.com/ or contact support.
+    ${error} Failed to finalize upload. Please check ${link('https://status.chromatic.com/')} or contact support.
   `);

--- a/node-src/ui/messages/errors/sentinelFileErrors.ts
+++ b/node-src/ui/messages/errors/sentinelFileErrors.ts
@@ -1,0 +1,9 @@
+import chalk from 'chalk';
+import { dedent } from 'ts-dedent';
+
+import { error } from '../../components/icons';
+
+export default () =>
+  dedent(chalk`
+    ${error} Failed to finalize upload. Please check https://status.chromatic.com/ or contact support.
+  `);


### PR DESCRIPTION
Adds useful information when a sentinel file check fails, which generally means there is a system outage.

![Screenshot 2024-10-10 at 3 51 56 PM](https://github.com/user-attachments/assets/69c062c1-e1f4-4718-96b0-7dc30c281c9f)

Closes #1063
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>11.12.7--canary.1094.11388633361.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@11.12.7--canary.1094.11388633361.0
  # or 
  yarn add chromatic@11.12.7--canary.1094.11388633361.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
