### PR TITLE
Add nicer formatting to TS bail reasons.

### DIFF
--- a/.github/workflows/smoke-test-node-api.yml
+++ b/.github/workflows/smoke-test-node-api.yml
@@ -13,7 +13,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-node@v3
         with:
-          node-version: latest
+          node-version: 'lts/*'
       - run: corepack enable
       - run: yarn
       - run: yarn build

--- a/node-src/types.ts
+++ b/node-src/types.ts
@@ -332,30 +332,7 @@ export interface Context {
   sentinelUrls?: string[];
   uploadedBytes?: number;
   uploadedFiles?: number;
-  turboSnap?: Partial<{
-    unavailable?: boolean;
-    rootPath: string;
-    baseDir: string;
-    storybookDir: string;
-    staticDirs: string[];
-    globs: string[];
-    modules: string[];
-    tracedFiles: string[];
-    tracedPaths: Set<string>;
-    changedDependencyNames: Set<string>;
-    changedManifestFiles: Set<string>;
-    affectedModuleIds: Set<string | number>;
-    bailReason: {
-      changedPackageFiles?: string[];
-      changedStorybookFiles?: string[];
-      changedStaticFiles?: string[];
-      changedExternalFiles?: string[];
-      invalidChangedFiles?: true;
-      missingStatsFile?: true;
-      noAncestorBuild?: true;
-      rebuild?: true;
-    };
-  }>;
+  turboSnap?: TurboSnap;
   mergeBase?: string;
   onlyStoryFiles?: string[];
   untracedFiles?: string[];
@@ -394,6 +371,31 @@ export interface TargetInfo {
   filePath: string;
   formAction: string;
   formFields: Record<string, string>;
+}
+
+export interface TurboSnap {
+  unavailable?: boolean;
+  rootPath?: string;
+  baseDir?: string;
+  storybookDir?: string;
+  staticDirs?: string[];
+  globs?: string[];
+  modules?: string[];
+  tracedFiles?: string[];
+  tracedPaths?: Set<string>;
+  changedDependencyNames?: Set<string>;
+  changedManifestFiles?: Set<string>;
+  affectedModuleIds?: Set<string | number>;
+  bailReason?: {
+    changedPackageFiles?: string[];
+    changedStorybookFiles?: string[];
+    changedStaticFiles?: string[];
+    changedExternalFiles?: string[];
+    invalidChangedFiles?: true;
+    missingStatsFile?: true;
+    noAncestorBuild?: true;
+    rebuild?: true;
+  };
 }
 
 export { type Configuration } from './lib/getConfiguration';

--- a/node-src/ui/messages/info/tracedAffectedFiles.stories.ts
+++ b/node-src/ui/messages/info/tracedAffectedFiles.stories.ts
@@ -85,6 +85,26 @@ export const TracedAffectedFilesExpanded = () =>
     }
   );
 
+export const TracedAffectedFilesExpandedBailed = () =>
+  tracedAffectedFiles(
+    {
+      options: { traceChanged: 'expanded' },
+      turboSnap: {
+        rootPath,
+        tracedPaths: new Set(tracedPaths),
+        bailReason: {
+          changedStorybookFiles: ['.storybook/preview.tsx', '.storybook/preview.less'],
+        },
+      },
+    } as any,
+    {
+      changedFiles: ['src/app/dashboard/index.ts'],
+      affectedModules,
+      modulesByName,
+      normalize: (f) => f,
+    }
+  );
+
 export const TracedAffectedFilesCompact = () =>
   tracedAffectedFiles(
     {

--- a/node-src/ui/messages/info/tracedAffectedFiles.ts
+++ b/node-src/ui/messages/info/tracedAffectedFiles.ts
@@ -1,7 +1,7 @@
 import chalk from 'chalk';
 import pluralize from 'pluralize';
 
-import { Context, Module } from '../../../types';
+import { Context, Module, TurboSnap } from '../../../types';
 import { info } from '../../components/icons';
 
 const printFilePath = (filepath: string, basedir: string, expanded: boolean) => {
@@ -54,7 +54,9 @@ export default (
   let directoryDebug;
 
   if (expanded) {
-    const bailReason = ctx.turboSnap?.bailReason ? `${ctx.turboSnap.bailReason}\n\n` : '';
+    const bailReason = ctx.turboSnap?.bailReason
+      ? `${formatBailReason(ctx.turboSnap.bailReason)}\n\n`
+      : '';
     const rootPath = `${chalk.magenta(rootDirectoryNote)} ${ctx.turboSnap?.rootPath}\n\n`;
     const basePath = `${chalk.magenta(baseDirectoryNote)} ${basedir}\n\n`;
     const storybookPath = `${chalk.magenta(storybookDirectoryNote)} ${storybookConfigDirectory}\n\n`;
@@ -128,3 +130,37 @@ export default (
   const note = chalk`\n\nSet {bold ${flag}} to {bold 'expanded'} to reveal underlying modules.`;
   return `${summary}:\n\n${traces.join('\n\n')}${expanded ? '' : note}`;
 };
+
+const formatBailReasonSection = (name: string, files: string[]) => {
+  return chalk`{bold ${name}}\n` + files.map((f) => `  - ${f}`).join('\n');
+};
+
+function formatBailReason(bailReason: TurboSnap['bailReason']) {
+  if (!bailReason) {
+    return '';
+  }
+
+  const sections: string[] = [];
+
+  if (bailReason.changedPackageFiles) {
+    sections.push(formatBailReasonSection('Changed Package Files', bailReason.changedPackageFiles));
+  }
+
+  if (bailReason.changedStorybookFiles) {
+    sections.push(
+      formatBailReasonSection('Changed Storybook Files', bailReason.changedStorybookFiles)
+    );
+  }
+
+  if (bailReason.changedExternalFiles) {
+    sections.push(
+      formatBailReasonSection('Changed External Files', bailReason.changedExternalFiles)
+    );
+  }
+
+  if (bailReason.changedStaticFiles) {
+    sections.push(formatBailReasonSection('Changed Static Files', bailReason.changedStaticFiles));
+  }
+
+  return sections.join('\n');
+}


### PR DESCRIPTION
Previously we were printing `[object Object]` there, something must have shifted in the types.

This adds nice formatting for this object;

<img width="231" alt="Screenshot 2024-10-11 at 10 43 49 AM" src="https://github.com/user-attachments/assets/404eccf4-0997-4a17-8432-2e0fef0dd370">

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>11.12.6--canary.1095.11387612750.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@11.12.6--canary.1095.11387612750.0
  # or 
  yarn add chromatic@11.12.6--canary.1095.11387612750.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
