### PR TITLE
Add new check to test the CLI action in merge queue

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -1,5 +1,5 @@
 name: Lint and Test
-on: push
+on: [push, merge_group]
 
 permissions:
   contents: read

--- a/.github/workflows/smoke-test-action-next.yml
+++ b/.github/workflows/smoke-test-action-next.yml
@@ -1,0 +1,32 @@
+name: Smoke test via action next
+on: merge_group
+
+permissions:
+  contents: read
+
+jobs:
+  lint-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v3
+        with:
+          node-version: lts/*
+      - run: corepack enable
+      - run: yarn
+      - name: Push to action-next
+        run: yarn run release-next
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+      - name: Run build against action-next
+        uses: chromaui/action-next@latest
+        with:
+          buildScriptName: build-test-storybook
+          exitZeroOnChanges: true
+          forceRebuild: true
+        env:
+          LOG_LEVEL: debug
+          DEBUG: chromatic-cli
+          CHROMATIC_PROJECT_TOKEN: ${{ secrets.SMOKE_TESTS_CHROMATIC_PROJECT_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "lint:js": "cross-env NODE_ENV=production eslint --cache --cache-location=.cache/eslint --report-unused-disable-directives",
     "lint:package": "sort-package-json",
     "release": "./scripts/release.mjs",
+    "release-next": "./scripts/releaseNext.mjs",
     "prepack": "clean-package",
     "postpack": "clean-package restore",
     "publish-action": "./scripts/publishAction.mjs",

--- a/scripts/releaseNext.mjs
+++ b/scripts/releaseNext.mjs
@@ -30,10 +30,7 @@ async function build() {
     },
   })`yarn build`;
 
-  console.info('🧹 Resetting changes to let `auto` do its thing');
-  await $`git reset --hard`;
-
-  console.info('✅ Build with new version completed, ready for auto!');
+  console.info('✅ Build with new version completed, ready for push to action-next!');
 }
 
 main();

--- a/scripts/releaseNext.mjs
+++ b/scripts/releaseNext.mjs
@@ -1,0 +1,39 @@
+#!/usr/bin/env node
+
+import { $ } from 'execa';
+
+import { main as publishAction } from './publishAction.mjs';
+
+async function main() {
+  const { stdout: status } = await $`git status --porcelain`;
+  if (status) {
+    console.error(`❗️ Working directory is not clean:\n${status}`);
+    return;
+  }
+
+  await build();
+  await publishAction('next');
+}
+
+async function build() {
+  const { stdout: nextVersion } = await $`auto shipit --dry-run --quiet`;
+
+  console.info(`📌 Temporarily bumping version to '${nextVersion}' for build step`);
+  await $`npm --no-git-tag-version version ${nextVersion}`;
+
+  console.info('📦 Building with new version');
+  await $({
+    stdio: 'inherit',
+    env: {
+      ...process.env,
+      SENTRY_RELEASE: nextVersion,
+    },
+  })`yarn build`;
+
+  console.info('🧹 Resetting changes to let `auto` do its thing');
+  await $`git reset --hard`;
+
+  console.info('✅ Build with new version completed, ready for auto!');
+}
+
+main();


### PR DESCRIPTION
This adds a new status check for our merge queue that:

1. Pushes to the [action-next](https://github.com/chromaui/action-next) repo
2. Runs a test build against it

This should help catch any action-specific issues until we can put together a better system in the future.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>11.12.7--canary.1098.11406177933.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@11.12.7--canary.1098.11406177933.0
  # or 
  yarn add chromatic@11.12.7--canary.1098.11406177933.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
