### PR TITLE
Rename new action job name for merge queue UI

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -1,5 +1,5 @@
 name: Lint and Test
-on: [push, merge_group]
+on: push
 
 permissions:
   contents: read

--- a/.github/workflows/smoke-test-action-next.yml
+++ b/.github/workflows/smoke-test-action-next.yml
@@ -5,7 +5,7 @@ permissions:
   contents: read
 
 jobs:
-  lint-and-test:
+  smoke-test-action-next:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
A continuation from #1098 from the findings of the latest merge queue tests:

1. Removes `on: merge_queue` from `lint-and-test` because that actually caused it to run _twice_ on merge
2. Updates the job name on `smoke-test-action-next` so the merge queue UI doesn't have `lint-and-test` multiple times
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>11.12.7--canary.1100.11406787748.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@11.12.7--canary.1100.11406787748.0
  # or 
  yarn add chromatic@11.12.7--canary.1100.11406787748.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
