### PR TITLE
Better handling of undefined values in branches

### DIFF
--- a/node-src/tasks/gitInfo.test.ts
+++ b/node-src/tasks/gitInfo.test.ts
@@ -154,4 +154,14 @@ describe('setGitInfo', () => {
     expect(ctx.rebuildForBuild).toEqual(lastBuild);
     expect(ctx.storybookUrl).toEqual(lastBuild.storybookUrl);
   });
+
+  it('removes undefined owner prefix from branch', async () => {
+    const ctx = { log, options: {}, client } as any;
+    getCommitAndBranch.mockResolvedValue({
+      ...commitInfo,
+      branch: 'undefined:repo',
+    });
+    await setGitInfo(ctx, {} as any);
+    expect(ctx.git.branch).toBe('repo');
+  });
 });

--- a/node-src/ui/messages/warnings/undefinedBranchOwner.stories.ts
+++ b/node-src/ui/messages/warnings/undefinedBranchOwner.stories.ts
@@ -1,0 +1,5 @@
+export default {
+  title: 'CLI/Messages/Warnings',
+};
+
+export { default as UndefinedBranchOwner } from './undefinedBranchOwner';

--- a/node-src/ui/messages/warnings/undefinedBranchOwner.ts
+++ b/node-src/ui/messages/warnings/undefinedBranchOwner.ts
@@ -1,0 +1,16 @@
+import chalk from 'chalk';
+import { dedent } from 'ts-dedent';
+
+import { info, warning } from '../../components/icons';
+import link from '../../components/link';
+
+const docsUrl =
+  'https://www.chromatic.com/docs/custom-ci-provider/#overriding-chromatics-branch-detection';
+
+export default () => {
+  return dedent(chalk`
+    ${warning} Removing unknown owner prefix from branch name.
+    You may wish to set the branch directly to avoid incorrect values.
+    ${info} Read more at ${link(docsUrl)}
+  `);
+};

--- a/node-src/ui/messages/warnings/undefinedBranchOwner.ts
+++ b/node-src/ui/messages/warnings/undefinedBranchOwner.ts
@@ -4,8 +4,7 @@ import { dedent } from 'ts-dedent';
 import { info, warning } from '../../components/icons';
 import link from '../../components/link';
 
-const docsUrl =
-  'https://www.chromatic.com/docs/custom-ci-provider/#overriding-chromatics-branch-detection';
+const docsUrl = 'https://www.chromatic.com/docs/faq/override-branch-name/';
 
 export default () => {
   return dedent(chalk`

--- a/package.json
+++ b/package.json
@@ -141,7 +141,7 @@
     "cross-spawn": "^7.0.2",
     "debug": "^4.3.2",
     "dotenv": "^8.2.0",
-    "env-ci": "^5.0.2",
+    "env-ci": "^11.1.0",
     "eslint": "^9.10.0",
     "eslint-config-prettier": "^9.0.0",
     "eslint-plugin-import": "^2.28.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7565,7 +7565,7 @@ __metadata:
     cross-spawn: "npm:^7.0.2"
     debug: "npm:^4.3.2"
     dotenv: "npm:^8.2.0"
-    env-ci: "npm:^5.0.2"
+    env-ci: "npm:^11.1.0"
     eslint: "npm:^9.10.0"
     eslint-config-prettier: "npm:^9.0.0"
     eslint-plugin-import: "npm:^2.28.1"
@@ -8987,7 +8987,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"env-ci@npm:^5.0.1, env-ci@npm:^5.0.2":
+"env-ci@npm:^11.1.0":
+  version: 11.1.0
+  resolution: "env-ci@npm:11.1.0"
+  dependencies:
+    execa: "npm:^8.0.0"
+    java-properties: "npm:^1.0.2"
+  checksum: 10c0/14f0a597c1fe9ab5585532c01759db62f4c553277b33137d33cb71cdd621833184f182dc67408750973c9f884f5a0d5103fad4f873aabd9e6c4baf65f88bc22a
+  languageName: node
+  linkType: hard
+
+"env-ci@npm:^5.0.1":
   version: 5.5.0
   resolution: "env-ci@npm:5.5.0"
   dependencies:
@@ -10008,7 +10018,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"execa@npm:^8.0.1":
+"execa@npm:^8.0.0, execa@npm:^8.0.1":
   version: 8.0.1
   resolution: "execa@npm:8.0.1"
   dependencies:
@@ -12282,7 +12292,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"java-properties@npm:^1.0.0":
+"java-properties@npm:^1.0.0, java-properties@npm:^1.0.2":
   version: 1.0.2
   resolution: "java-properties@npm:1.0.2"
   checksum: 10c0/be0f58c83b5a852f313de2ea57f7b8b7d46dc062b2ffe487d58838e7034d4660f4d22f2a96aae4daa622af6d734726c0d08b01396e59666ededbcfdc25a694d6


### PR DESCRIPTION
Sometimes our automatic CI detection lands us with an `undefined:<branch>` value, which is not correct.

This strips that from branch values (unless explicitly set), and prints a warning message so users can possibly switch to `CHROMATIC_BRANCH` and `CHROMATIC_SLUG`

![Screenshot 2024-10-18 at 11 54 31 AM](https://github.com/user-attachments/assets/87bd8336-02c8-40f1-aea6-e7bf095cabd6)

Also upgrades `env-ci` to detect more CI builders and hopefully avoid this situation in the first place.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>11.12.7--canary.1101.11410238455.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@11.12.7--canary.1101.11410238455.0
  # or 
  yarn add chromatic@11.12.7--canary.1101.11410238455.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
