### PR TITLE
Fix `.env` parsing

### DIFF
--- a/bin-src/register.js
+++ b/bin-src/register.js
@@ -1,19 +1,13 @@
 #!/usr/bin/env node
 
-import { config } from 'dotenv';
-
-import { main as initMain } from './init';
-import { main } from './main';
-import { main as traceMain } from './trace';
-import { main as trimMain } from './trimStatsFile';
-
-config();
+import 'dotenv/config';
 
 const commands = {
-  init: () => initMain(process.argv.slice(3)),
-  main: () => main(process.argv.slice(2)),
-  trace: () => traceMain(process.argv.slice(3)),
-  'trim-stats-file': () => trimMain(process.argv.slice(3)),
+  init: () => import('./init').then(({ main: initMain }) => initMain(process.argv.slice(3))),
+  main: () => import('./main').then(({ main }) => main(process.argv.slice(2))),
+  trace: () => import('./trace').then(({ main: traceMain }) => traceMain(process.argv.slice(3))),
+  'trim-stats-file': () =>
+    import('./trimStatsFile').then(({ main: trimMain }) => trimMain(process.argv.slice(3))),
 };
 
 (commands[process.argv[2]] || commands.main)();

--- a/package.json
+++ b/package.json
@@ -140,7 +140,7 @@
     "cross-env": "^7.0.3",
     "cross-spawn": "^7.0.2",
     "debug": "^4.3.2",
-    "dotenv": "^8.2.0",
+    "dotenv": "^16.4.5",
     "env-ci": "^11.1.0",
     "eslint": "^9.10.0",
     "eslint-config-prettier": "^9.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7564,7 +7564,7 @@ __metadata:
     cross-env: "npm:^7.0.3"
     cross-spawn: "npm:^7.0.2"
     debug: "npm:^4.3.2"
-    dotenv: "npm:^8.2.0"
+    dotenv: "npm:^16.4.5"
     env-ci: "npm:^11.1.0"
     eslint: "npm:^9.10.0"
     eslint-config-prettier: "npm:^9.0.0"
@@ -8796,14 +8796,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dotenv@npm:^16.0.0":
+"dotenv@npm:^16.0.0, dotenv@npm:^16.4.5":
   version: 16.4.5
   resolution: "dotenv@npm:16.4.5"
   checksum: 10c0/48d92870076832af0418b13acd6e5a5a3e83bb00df690d9812e94b24aff62b88ade955ac99a05501305b8dc8f1b0ee7638b18493deb6fe93d680e5220936292f
   languageName: node
   linkType: hard
 
-"dotenv@npm:^8.0.0, dotenv@npm:^8.2.0":
+"dotenv@npm:^8.0.0":
   version: 8.6.0
   resolution: "dotenv@npm:8.6.0"
   checksum: 10c0/6750431dea8efbd54b9f2d9681b04e1ccc7989486461dcf058bb708d9e3d63b04115fcdf8840e38ad1e24a4a2e1e7c1560626c5e3ac7bc09371b127c49e2d45f


### PR DESCRIPTION
Closes #1103 

When fixing `unicorn/prefer-module` errors in #1061, I moved the import to the top of the file but since `dotenv` hasn't ran yet, the `.env` file is parsed _after_ those imports. Simply moving those to dynamic imports fixes that issue!

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>11.13.1--canary.1104.11444006930.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@11.13.1--canary.1104.11444006930.0
  # or 
  yarn add chromatic@11.13.1--canary.1104.11444006930.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
