### PR TITLE
Only run `package-size` on pull request

### DIFF
--- a/.github/workflows/pull-request-workflow.yml
+++ b/.github/workflows/pull-request-workflow.yml
@@ -15,6 +15,7 @@ permissions:
 
 jobs:
   package-size:
+    if: github.event_name == 'pull_request'
     uses: ./.github/workflows/package-size.yml
     permissions:
       contents: read


### PR DESCRIPTION
We don't need `package-size` to run on anything that isn't a PR so we can skip these in the merge queue!

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>11.13.1--canary.1105.11444002865.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@11.13.1--canary.1105.11444002865.0
  # or 
  yarn add chromatic@11.13.1--canary.1105.11444002865.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
