### PR TITLE
Account for `rsbuild` stats JSON output and multiple locations

### DIFF
--- a/node-src/lib/getDependentStoryFiles.test.ts
+++ b/node-src/lib/getDependentStoryFiles.test.ts
@@ -179,7 +179,10 @@ describe('getDependentStoryFiles', () => {
         id: String.raw`./src lazy recursive ^\.\/.*$`,
         reasons: [
           {
-            moduleName: './node_modules/.cache/storybook/default/dev-server/storybook-stories.js',
+            resolvedModule:
+              './node_modules/.cache/storybook/default/dev-server/storybook-stories.js',
+            moduleName:
+              './node_modules/.cache/storybook/default/dev-server/storybook-stories.js + 2 modules',
           },
         ],
       },

--- a/node-src/lib/getDependentStoryFiles.ts
+++ b/node-src/lib/getDependentStoryFiles.ts
@@ -56,6 +56,7 @@ const getPackageName = (modulePath: string) => {
  */
 export function normalizePath(posixPath: string, rootPath: string, baseDirectory = '') {
   if (!posixPath || posixPath.startsWith('/virtual:')) return posixPath;
+
   return path.posix.isAbsolute(posixPath)
     ? path.posix.relative(rootPath, posixPath)
     : path.posix.join(baseDirectory, posixPath);
@@ -140,6 +141,7 @@ export async function getDependentStoryFiles(
       `/virtual:/@storybook/builder-vite/vite-app.js`,
       // rspack builder
       `./node_modules/.cache/storybook/default/dev-server/storybook-stories.js`,
+      `./node_modules/.cache/storybook/storybook-rsbuild-builder/storybook-config-entry.js`,
     ].map((file) => normalize(file))
   );
 
@@ -172,7 +174,12 @@ export async function getDependentStoryFiles(
       }
 
       const normalizedReasons = module_.reasons
-        ?.map((reason) => normalize(reason.moduleName))
+        ?.map((reason) =>
+          normalize(
+            reason.resolvedModule || // rspack sets a resolvedModule that holds the module name
+              reason.moduleName // vite, webpack, and default
+          )
+        )
         .filter((reasonName) => reasonName && reasonName !== normalizedName);
       if (normalizedReasons) {
         reasonsById.set(module_.id, normalizedReasons);

--- a/node-src/types.ts
+++ b/node-src/types.ts
@@ -352,6 +352,7 @@ export interface Task {
 }
 
 export interface Reason {
+  resolvedModule?: string; // rspack sets a resolvedModule field that holds the module name
   moduleName: string;
 }
 export interface Module {


### PR DESCRIPTION
At some point the `rsbuild` cache location changed which broke Turbosnap. Simply adding the new location to our list fixes that issue.

I also noticed the stats output is slightly different than Webpack/Vite so we lean on `resolvedModule` (which only exists in `rsbuild`) but fallback to `moduleName` when it doesn't exist.

Both of these changes allow `rsbuild` to work on the newer versions!

_Note: We've been doing some external testing with the canary and things are working great!_

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>11.16.2--canary.1110.11566394830.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@11.16.2--canary.1110.11566394830.0
  # or 
  yarn add chromatic@11.16.2--canary.1110.11566394830.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
