### PR TITLE
Detect `context.projectMetadata.hasRouter` and send to the index

### DIFF
--- a/node-src/git/git.test.ts
+++ b/node-src/git/git.test.ts
@@ -8,6 +8,7 @@ import {
   getNumberOfComitters,
   getRepositoryCreationDate,
   getSlug,
+  getStorybookCreationDate,
   hasPreviousCommit,
   mergeQueueBranchMatch,
   NULL_BYTE,
@@ -153,6 +154,28 @@ describe('getRepositoryCreationDate', () => {
   it('parses the date successfully', async () => {
     command.mockImplementation(() => Promise.resolve({ all: `2017-05-17 10:00:35 -0700` }) as any);
     expect(await getRepositoryCreationDate()).toEqual(new Date('2017-05-17T17:00:35.000Z'));
+  });
+});
+
+describe('getStorybookCreationDate', () => {
+  it('passes the config dir to the git command', async () => {
+    await getStorybookCreationDate({ options: { storybookConfigDir: 'special-config-dir' } });
+    expect(command).toHaveBeenCalledWith(
+      expect.stringMatching(/special-config-dir/),
+      expect.anything()
+    );
+  });
+
+  it('defaults the config dir to the git command', async () => {
+    await getStorybookCreationDate({ options: {} });
+    expect(command).toHaveBeenCalledWith(expect.stringMatching(/.storybook/), expect.anything());
+  });
+
+  it('parses the date successfully', async () => {
+    command.mockImplementation(() => Promise.resolve({ all: `2017-05-17 10:00:35 -0700` }) as any);
+    expect(
+      await getStorybookCreationDate({ options: { storybookConfigDir: '.storybook' } })
+    ).toEqual(new Date('2017-05-17T17:00:35.000Z'));
   });
 });
 

--- a/node-src/git/git.test.ts
+++ b/node-src/git/git.test.ts
@@ -4,6 +4,9 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   findFilesFromRepositoryRoot,
   getCommit,
+  getCommittedFileCount,
+  getNumberOfComitters,
+  getRepositoryCreationDate,
   getSlug,
   hasPreviousCommit,
   mergeQueueBranchMatch,
@@ -143,5 +146,33 @@ describe('findFilesFromRepositoryRoot', () => {
       expect.any(Object)
     );
     expect(results).toEqual(filesFound);
+  });
+});
+
+describe('getRepositoryCreationDate', () => {
+  it('parses the date successfully', async () => {
+    command.mockImplementation(() => Promise.resolve({ all: `2017-05-17 10:00:35 -0700` }) as any);
+    expect(await getRepositoryCreationDate()).toEqual(new Date('2017-05-17T17:00:35.000Z'));
+  });
+});
+
+describe('getNumberOfComitters', () => {
+  it('parses the count successfully', async () => {
+    command.mockImplementation(() => Promise.resolve({ all: `      17` }) as any);
+    expect(await getNumberOfComitters()).toEqual(17);
+  });
+});
+
+describe('getCommittedFileCount', () => {
+  it('constructs the correct command', async () => {
+    await getCommittedFileCount(['page', 'screen'], ['js', 'ts']);
+    expect(command).toHaveBeenCalledWith(
+      'git ls-files -- "*page*.js" "*page*.ts" "*Page*.js" "*Page*.ts" "*screen*.js" "*screen*.ts" "*Screen*.js" "*Screen*.ts" | wc -l',
+      expect.anything()
+    );
+  });
+  it('parses the count successfully', async () => {
+    command.mockImplementation(() => Promise.resolve({ all: `      17` }) as any);
+    expect(await getCommittedFileCount(['page', 'screen'], ['js', 'ts'])).toEqual(17);
   });
 });

--- a/node-src/git/git.ts
+++ b/node-src/git/git.ts
@@ -434,6 +434,27 @@ export async function getRepositoryCreationDate() {
 }
 
 /**
+ * Determine the date the storybook was added to the repository
+ *
+ * @param ctx Context The context set when executing the CLI.
+ * @param ctx.options Object standard context options
+ * @param ctx.options.storybookConfigDir Configured Storybook config dir, if set
+ *
+ * @returns Date The date the storybook was added
+ */
+export async function getStorybookCreationDate(ctx: {
+  options: {
+    storybookConfigDir?: Context['options']['storybookConfigDir'];
+  };
+}) {
+  const configDirectory = ctx.options.storybookConfigDir ?? '.storybook';
+  const dateString = await execGitCommand(
+    `git log --follow --reverse --format=%cd --date=iso -- ${configDirectory} | head -1`
+  );
+  return dateString ? new Date(dateString) : undefined;
+}
+
+/**
  * Determine the number of committers in the last 6 months
  *
  * @returns number The number of committers

--- a/node-src/index.test.ts
+++ b/node-src/index.test.ts
@@ -310,6 +310,9 @@ vi.mock('./git/git', () => ({
   getUncommittedHash: () => Promise.resolve('abc123'),
   getUserEmail: () => Promise.resolve('test@test.com'),
   mergeQueueBranchMatch: () => Promise.resolve(undefined),
+  getRepositoryCreationDate: () => Promise.resolve(new Date('2024-11-01')),
+  getNumberOfComitters: () => Promise.resolve(17),
+  getCommittedFileCount: () => Promise.resolve(100),
 }));
 
 vi.mock('./git/getParentCommits', () => ({
@@ -320,6 +323,8 @@ const getCommit = vi.mocked(git.getCommit);
 const getSlug = vi.mocked(git.getSlug);
 
 vi.mock('./lib/emailHash');
+
+vi.mock('./lib/getHasRouter');
 
 vi.mock('./lib/getFileHashes', () => ({
   getFileHashes: (files: string[]) =>

--- a/node-src/index.test.ts
+++ b/node-src/index.test.ts
@@ -311,6 +311,7 @@ vi.mock('./git/git', () => ({
   getUserEmail: () => Promise.resolve('test@test.com'),
   mergeQueueBranchMatch: () => Promise.resolve(undefined),
   getRepositoryCreationDate: () => Promise.resolve(new Date('2024-11-01')),
+  getStorybookCreationDate: () => Promise.resolve(new Date('2025-11-01')),
   getNumberOfComitters: () => Promise.resolve(17),
   getCommittedFileCount: () => Promise.resolve(100),
 }));

--- a/node-src/lib/getHasRouter.test.ts
+++ b/node-src/lib/getHasRouter.test.ts
@@ -1,0 +1,29 @@
+import { expect, it } from 'vitest';
+
+import { getHasRouter } from './getHasRouter';
+
+it('returns true if there is a routing package in package.json', async () => {
+  expect(
+    getHasRouter({
+      dependencies: {
+        react: '^18',
+        'react-dom': '^18',
+        'react-router': '^6',
+      },
+    })
+  ).toBe(true);
+});
+
+it('sreturns false if there is a routing package in package.json dependenices', async () => {
+  expect(
+    getHasRouter({
+      dependencies: {
+        react: '^18',
+        'react-dom': '^18',
+      },
+      devDependencies: {
+        'react-router': '^6',
+      },
+    })
+  ).toBe(false);
+});

--- a/node-src/lib/getHasRouter.ts
+++ b/node-src/lib/getHasRouter.ts
@@ -1,4 +1,4 @@
-import { Context } from '../../dist/node';
+import type { Context } from '../types';
 
 const routerPackages = [
   'react-router',

--- a/node-src/lib/getHasRouter.ts
+++ b/node-src/lib/getHasRouter.ts
@@ -1,0 +1,33 @@
+import { Context } from '../../dist/node';
+
+const routerPackages = [
+  'react-router',
+  'react-router-dom',
+  'remix',
+  '@tanstack/react-router',
+  'expo-router',
+  '@reach/router',
+  'react-easy-router',
+  '@remix-run/router',
+  'wouter',
+  'wouter-preact',
+  'preact-router',
+  'vue-router',
+  'unplugin-vue-router',
+  '@angular/router',
+  '@solidjs/router',
+
+  // metaframeworks that imply routing
+  'next',
+  'react-scripts',
+  'gatsby',
+  'nuxt',
+  '@sveltejs/kit',
+];
+
+export function getHasRouter(packageJson: Context['packageJson']) {
+  // NOTE: we just check real dependencies; if it is in dev dependencies, it may just be an example
+  return !!Object.keys(packageJson?.dependencies ?? {}).find((depName) =>
+    routerPackages.includes(depName)
+  );
+}

--- a/node-src/lib/getHasRouter.ts
+++ b/node-src/lib/getHasRouter.ts
@@ -1,6 +1,6 @@
 import type { Context } from '../types';
 
-const routerPackages = [
+const routerPackages = new Set([
   'react-router',
   'react-router-dom',
   'remix',
@@ -23,11 +23,15 @@ const routerPackages = [
   'gatsby',
   'nuxt',
   '@sveltejs/kit',
-];
+]);
 
+/**
+ * @param packageJson The package JSON of the project (from context)
+ * @returns boolean Does this project use a routing package?
+ */
 export function getHasRouter(packageJson: Context['packageJson']) {
   // NOTE: we just check real dependencies; if it is in dev dependencies, it may just be an example
   return !!Object.keys(packageJson?.dependencies ?? {}).find((depName) =>
-    routerPackages.includes(depName)
+    routerPackages.has(depName)
   );
 }

--- a/node-src/lib/getHasRouter.ts
+++ b/node-src/lib/getHasRouter.ts
@@ -27,11 +27,12 @@ const routerPackages = new Set([
 
 /**
  * @param packageJson The package JSON of the project (from context)
+ *
  * @returns boolean Does this project use a routing package?
  */
 export function getHasRouter(packageJson: Context['packageJson']) {
   // NOTE: we just check real dependencies; if it is in dev dependencies, it may just be an example
-  return !!Object.keys(packageJson?.dependencies ?? {}).find((depName) =>
+  return Object.keys(packageJson?.dependencies ?? {}).some((depName) =>
     routerPackages.has(depName)
   );
 }

--- a/node-src/tasks/gitInfo.test.ts
+++ b/node-src/tasks/gitInfo.test.ts
@@ -5,6 +5,7 @@ import { getChangedFilesWithReplacement as getChangedFilesWithReplacementUnmocke
 import * as getCommitInfo from '../git/getCommitAndBranch';
 import { getParentCommits as getParentCommitsUnmocked } from '../git/getParentCommits';
 import * as git from '../git/git';
+import { getHasRouter as getHasRouterUnmocked } from '../lib/getHasRouter';
 import { setGitInfo } from './gitInfo';
 
 vi.mock('../git/getCommitAndBranch');
@@ -12,15 +13,20 @@ vi.mock('../git/git');
 vi.mock('../git/getParentCommits');
 vi.mock('../git/getBaselineBuilds');
 vi.mock('../git/getChangedFilesWithReplacement');
+vi.mock('../lib/getHasRouter');
 
 const getCommitAndBranch = vi.mocked(getCommitInfo.default);
 const getChangedFilesWithReplacement = vi.mocked(getChangedFilesWithReplacementUnmocked);
 const getSlug = vi.mocked(git.getSlug);
 const getVersion = vi.mocked(git.getVersion);
 const getUserEmail = vi.mocked(git.getUserEmail);
+const getRepositoryCreationDate = vi.mocked(git.getRepositoryCreationDate);
+const getNumberOfComitters = vi.mocked(git.getNumberOfComitters);
+const getCommittedFileCount = vi.mocked(git.getCommittedFileCount);
 const getUncommittedHash = vi.mocked(git.getUncommittedHash);
 const getBaselineBuilds = vi.mocked(getBaselineBuildsUnmocked);
 const getParentCommits = vi.mocked(getParentCommitsUnmocked);
+const getHasRouter = vi.mocked(getHasRouterUnmocked);
 
 const log = { info: vi.fn(), warn: vi.fn(), debug: vi.fn() };
 
@@ -47,6 +53,11 @@ beforeEach(() => {
   getVersion.mockResolvedValue('Git v1.0.0');
   getUserEmail.mockResolvedValue('user@email.com');
   getSlug.mockResolvedValue('user/repo');
+  getRepositoryCreationDate.mockResolvedValue(new Date('2024-11-01'));
+  getNumberOfComitters.mockResolvedValue(17);
+  getCommittedFileCount.mockResolvedValue(100);
+  getHasRouter.mockReturnValue(true);
+
   client.runQuery.mockReturnValue({ app: { isOnboarding: false } });
 });
 
@@ -163,5 +174,16 @@ describe('setGitInfo', () => {
     });
     await setGitInfo(ctx, {} as any);
     expect(ctx.git.branch).toBe('repo');
+  });
+
+  it('sets projectMetadata on context', async () => {
+    const ctx = { log, options: { isLocalBuild: true }, client } as any;
+    await setGitInfo(ctx, {} as any);
+    expect(ctx.projectMetadata).toMatchObject({
+      hasRouter: true,
+      creationDate: new Date('2024-11-01'),
+      numberOfCommitters: 17,
+      numberOfAppFiles: 100,
+    });
   });
 });

--- a/node-src/tasks/gitInfo.test.ts
+++ b/node-src/tasks/gitInfo.test.ts
@@ -21,6 +21,7 @@ const getSlug = vi.mocked(git.getSlug);
 const getVersion = vi.mocked(git.getVersion);
 const getUserEmail = vi.mocked(git.getUserEmail);
 const getRepositoryCreationDate = vi.mocked(git.getRepositoryCreationDate);
+const getStorybookCreationDate = vi.mocked(git.getStorybookCreationDate);
 const getNumberOfComitters = vi.mocked(git.getNumberOfComitters);
 const getCommittedFileCount = vi.mocked(git.getCommittedFileCount);
 const getUncommittedHash = vi.mocked(git.getUncommittedHash);
@@ -54,6 +55,7 @@ beforeEach(() => {
   getUserEmail.mockResolvedValue('user@email.com');
   getSlug.mockResolvedValue('user/repo');
   getRepositoryCreationDate.mockResolvedValue(new Date('2024-11-01'));
+  getStorybookCreationDate.mockResolvedValue(new Date('2025-11-01'));
   getNumberOfComitters.mockResolvedValue(17);
   getCommittedFileCount.mockResolvedValue(100);
   getHasRouter.mockReturnValue(true);
@@ -182,6 +184,7 @@ describe('setGitInfo', () => {
     expect(ctx.projectMetadata).toMatchObject({
       hasRouter: true,
       creationDate: new Date('2024-11-01'),
+      storybookCreationDate: new Date('2025-11-01'),
       numberOfCommitters: 17,
       numberOfAppFiles: 100,
     });

--- a/node-src/tasks/gitInfo.ts
+++ b/node-src/tasks/gitInfo.ts
@@ -9,6 +9,7 @@ import {
   getNumberOfComitters,
   getRepositoryCreationDate,
   getSlug,
+  getStorybookCreationDate,
   getUncommittedHash,
   getUserEmail,
   getVersion,
@@ -94,6 +95,14 @@ export const setGitInfo = async (ctx: Context, task: Task) => {
       return undefined;
     }),
     ...commitAndBranchInfo,
+  };
+
+  ctx.projectMetadata = {
+    hasRouter: getHasRouter(ctx.packageJson),
+    creationDate: await getRepositoryCreationDate(),
+    storybookCreationDate: await getStorybookCreationDate(ctx),
+    numberOfCommitters: await getNumberOfComitters(),
+    numberOfAppFiles: await getCommittedFileCount(['page', 'screen'], ['js', 'jsx', 'ts', 'tsx']),
   };
 
   if (isLocalBuild && !ctx.git.gitUserEmail) {
@@ -268,13 +277,6 @@ export const setGitInfo = async (ctx: Context, task: Task) => {
       }
     }
   }
-
-  ctx.projectMetadata = {
-    hasRouter: getHasRouter(ctx.packageJson),
-    creationDate: await getRepositoryCreationDate(),
-    numberOfCommitters: await getNumberOfComitters(),
-    numberOfAppFiles: await getCommittedFileCount(['page', 'screen'], ['js', 'jsx', 'ts', 'tsx']),
-  };
 
   transitionTo(success, true)(ctx, task);
 };

--- a/node-src/tasks/gitInfo.ts
+++ b/node-src/tasks/gitInfo.ts
@@ -4,7 +4,16 @@ import { getBaselineBuilds } from '../git/getBaselineBuilds';
 import { getChangedFilesWithReplacement } from '../git/getChangedFilesWithReplacement';
 import getCommitAndBranch from '../git/getCommitAndBranch';
 import { getParentCommits } from '../git/getParentCommits';
-import { getSlug, getUncommittedHash, getUserEmail, getVersion } from '../git/git';
+import {
+  getCommittedFileCount,
+  getNumberOfComitters,
+  getRepositoryCreationDate,
+  getSlug,
+  getUncommittedHash,
+  getUserEmail,
+  getVersion,
+} from '../git/git';
+import { getHasRouter } from '../lib/getHasRouter';
 import { exitCodes, setExitCode } from '../lib/setExitCode';
 import { createTask, transitionTo } from '../lib/tasks';
 import { isPackageMetadataFile, matchesFile } from '../lib/utils';
@@ -259,6 +268,13 @@ export const setGitInfo = async (ctx: Context, task: Task) => {
       }
     }
   }
+
+  ctx.projectMetadata = {
+    hasRouter: getHasRouter(ctx.packageJson),
+    creationDate: await getRepositoryCreationDate(),
+    numberOfCommitters: await getNumberOfComitters(),
+    numberOfAppFiles: await getCommittedFileCount(['page', 'screen'], ['js', 'jsx', 'ts', 'tsx']),
+  };
 
   transitionTo(success, true)(ctx, task);
 };

--- a/node-src/tasks/initialize.ts
+++ b/node-src/tasks/initialize.ts
@@ -107,6 +107,7 @@ export const announceBuild = async (ctx: Context) => {
         storybookAddons: ctx.storybook.addons,
         storybookVersion: ctx.storybook.version,
         storybookViewLayer: ctx.storybook.viewLayer,
+        projectMetadata: ctx.projectMetadata,
       },
     },
     { retries: 3 }

--- a/node-src/tasks/storybookInfo.test.ts
+++ b/node-src/tasks/storybookInfo.test.ts
@@ -12,8 +12,38 @@ describe('storybookInfo', () => {
     const storybook = { version: '1.0.0', viewLayer: 'react', addons: [] };
     getStorybookInfo.mockResolvedValue(storybook);
 
-    const ctx = {} as any;
+    const ctx = { packageJson: {} } as any;
     await setStorybookInfo(ctx);
     expect(ctx.storybook).toEqual(storybook);
+  });
+
+  it('sets hasRouter=true if there is a routing package in package.json', async () => {
+    const ctx = {
+      packageJson: {
+        dependencies: {
+          react: '^18',
+          'react-dom': '^18',
+          'react-router': '^6',
+        },
+      },
+    } as any;
+    await setStorybookInfo(ctx);
+    expect(ctx.projectMetadata.hasRouter).toEqual(true);
+  });
+
+  it('sets hasRouter=false if there is a routing package in package.json dependenices', async () => {
+    const ctx = {
+      packageJson: {
+        dependencies: {
+          react: '^18',
+          'react-dom': '^18',
+        },
+        devDependencies: {
+          'react-router': '^6',
+        },
+      },
+    } as any;
+    await setStorybookInfo(ctx);
+    expect(ctx.projectMetadata.hasRouter).toEqual(false);
   });
 });

--- a/node-src/tasks/storybookInfo.test.ts
+++ b/node-src/tasks/storybookInfo.test.ts
@@ -16,34 +16,4 @@ describe('storybookInfo', () => {
     await setStorybookInfo(ctx);
     expect(ctx.storybook).toEqual(storybook);
   });
-
-  it('sets hasRouter=true if there is a routing package in package.json', async () => {
-    const ctx = {
-      packageJson: {
-        dependencies: {
-          react: '^18',
-          'react-dom': '^18',
-          'react-router': '^6',
-        },
-      },
-    } as any;
-    await setStorybookInfo(ctx);
-    expect(ctx.projectMetadata.hasRouter).toEqual(true);
-  });
-
-  it('sets hasRouter=false if there is a routing package in package.json dependenices', async () => {
-    const ctx = {
-      packageJson: {
-        dependencies: {
-          react: '^18',
-          'react-dom': '^18',
-        },
-        devDependencies: {
-          'react-router': '^6',
-        },
-      },
-    } as any;
-    await setStorybookInfo(ctx);
-    expect(ctx.projectMetadata.hasRouter).toEqual(false);
-  });
 });

--- a/node-src/tasks/storybookInfo.ts
+++ b/node-src/tasks/storybookInfo.ts
@@ -1,6 +1,5 @@
 import * as Sentry from '@sentry/node';
 
-import { getHasRouter } from '../lib/getHasRouter';
 import getStorybookInfo from '../lib/getStorybookInfo';
 import { createTask, transitionTo } from '../lib/tasks';
 import { Context } from '../types';
@@ -18,11 +17,6 @@ export const setStorybookInfo = async (ctx: Context) => {
     }
     Sentry.setContext('storybook', ctx.storybook);
   }
-
-  // Also get some project-level data for analytics
-  ctx.projectMetadata = {
-    hasRouter: getHasRouter(ctx.packageJson),
-  };
 };
 
 /**

--- a/node-src/tasks/storybookInfo.ts
+++ b/node-src/tasks/storybookInfo.ts
@@ -1,10 +1,10 @@
 import * as Sentry from '@sentry/node';
 
+import { getHasRouter } from '../lib/getHasRouter';
 import getStorybookInfo from '../lib/getStorybookInfo';
 import { createTask, transitionTo } from '../lib/tasks';
 import { Context } from '../types';
 import { initial, pending, success } from '../ui/tasks/storybookInfo';
-import { getHasRouter } from '../lib/getHasRouter';
 
 export const setStorybookInfo = async (ctx: Context) => {
   ctx.storybook = (await getStorybookInfo(ctx)) as Context['storybook'];

--- a/node-src/tasks/storybookInfo.ts
+++ b/node-src/tasks/storybookInfo.ts
@@ -4,6 +4,7 @@ import getStorybookInfo from '../lib/getStorybookInfo';
 import { createTask, transitionTo } from '../lib/tasks';
 import { Context } from '../types';
 import { initial, pending, success } from '../ui/tasks/storybookInfo';
+import { getHasRouter } from '../lib/getHasRouter';
 
 export const setStorybookInfo = async (ctx: Context) => {
   ctx.storybook = (await getStorybookInfo(ctx)) as Context['storybook'];
@@ -17,6 +18,11 @@ export const setStorybookInfo = async (ctx: Context) => {
     }
     Sentry.setContext('storybook', ctx.storybook);
   }
+
+  // Also get some project-level data for analytics
+  ctx.projectMetadata = {
+    hasRouter: getHasRouter(ctx.packageJson),
+  };
 };
 
 /**

--- a/node-src/types.ts
+++ b/node-src/types.ts
@@ -250,6 +250,9 @@ export interface Context {
     };
     mainConfigFilePath?: string;
   };
+  projectMetadata: {
+    hasRouter: boolean;
+  };
   storybookUrl?: string;
   announcedBuild: {
     id: string;

--- a/node-src/types.ts
+++ b/node-src/types.ts
@@ -251,7 +251,10 @@ export interface Context {
     mainConfigFilePath?: string;
   };
   projectMetadata: {
-    hasRouter: boolean;
+    hasRouter?: boolean;
+    creationDate?: Date;
+    numberOfCommitters?: number;
+    numberOfAppFiles?: number;
   };
   storybookUrl?: string;
   announcedBuild: {

--- a/node-src/types.ts
+++ b/node-src/types.ts
@@ -253,6 +253,7 @@ export interface Context {
   projectMetadata: {
     hasRouter?: boolean;
     creationDate?: Date;
+    storybookCreationDate?: Date;
     numberOfCommitters?: number;
     numberOfAppFiles?: number;
   };


### PR DESCRIPTION
This PR is blocked on an index change (to come).

To QA:

- Create a routing based project (e.g. SB Next Sandbox)
- Run a build, check it sets `hasRouter=true`
- Create a non-routed project (e.g. `react-vite` Sandbox)
- Run a build, check it sets `hasRouter=false`

Use this review app: https://github.com/chromaui/chromatic/pull/9061

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>11.17.0--canary.1112.11702183022.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@11.17.0--canary.1112.11702183022.0
  # or 
  yarn add chromatic@11.17.0--canary.1112.11702183022.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
