### PR TITLE
Add steps for how to run builds against local CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Other platforms/versions may work, but are not officially supported. Certain fea
 
 ## Contributing
 
-Contributions of any kind are welcome! We're available to chat via the Intercom widget on the documentation site.
+Contributions of any kind are welcome! If you're a maintainer, refer to the following [instructions](./docs/DEVELOPMENT.md) to set up your development environment with Chromatic.
 
 ### Compatibility & versioning
 
@@ -44,58 +44,3 @@ To facilitate upgrading in the future, removing and adding features, this is the
 - Any new features will have to be on Chromatic production before they could be used in this package
 - We can add feature flags to be able to test new functionality
 - Chromatic production can not remove any features this package depends on until after the usage has been removed from this package in addition to a grace period to allow users to upgrade
-
-### Building and running locally
-
-This project uses `yarn 4`. If you have `yarn 1` installed globally, it is recommended that you run `corepack enable` so that the version of yarn set in `packageManager` in `package.json` is used for this project. You may have to install `corepack`, [see the installation instructions](https://yarnpkg.com/corepack#installation) for more information.
-
-1. Ensure `yarn -v` shows that you're using `yarn 4` for the project
-2. Install all dependencies with `yarn install`
-3. Build + watch the code locally: `yarn dev`
-4. Run a build of all the CLI's stories against a Chromatic project: `yarn chromatic -t <token>`.
-
-#### Running against staging
-
-```bash
-CHROMATIC_INDEX_URL=https://index.staging-chromatic.com yarn chromatic -t <token>
-```
-
-#### Running against development
-
-To test against a local development version of the Chromatic stack, use
-
-```bash
-CHROMATIC_INDEX_URL=https://index.dev-chromatic.com yarn chromatic -t <token>
-```
-
-To only test a small number of test stories as a smoke test, use:
-
-```bash
-SMOKE_TEST=1 CHROMATIC_INDEX_URL=https://index.dev-chromatic.com yarn chromatic -t <token>
-```
-
-### Publishing a new version
-
-We use `auto` to automate the release process. Versions are bumped, tags are created and the changelog is updated automatically. A new release goes out whenever a PR is merged to `main`. A PR **must** have **exactly one** of the following labels before merging:
-
-- `major` triggers a major version bump
-- `minor` triggers a minor version bump
-- `patch` triggers a patch version bump
-
-Additionally, a PR **may** have exactly one of these labels:
-
-- `release` creates a `latest` release on npm
-- `skip-release` does not create a release at all (changes roll into the next release)
-
-We have two types of releases:
-
-- `latest` releases are the general audience production releases, used by most people. Automatically created when merging a PR with the `release` label.
-- `canary` releases are intended for testing purposes and should not be used in production, as they may only work against a staging or dev environment. Automatically created on every PR, but does not auto-publish the GitHub Action.
-
-> For GitHub Actions, we may manually publish `chromaui/action-canary`.
-
-A script is provided to manually publish the GitHub Action, though it's typically only necessary for `action-canary` releases:
-
-```sh
-yarn publish-action <canary|latest>
-```

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -1,0 +1,56 @@
+# Development
+
+## Building and running locally
+
+This project uses `yarn 4`. If you have `yarn 1` installed globally, it is recommended that you run `corepack enable` so that the version of yarn set in `packageManager` in `package.json` is used for this project. You may have to install `corepack`, [see the installation instructions](https://yarnpkg.com/corepack#installation) for more information.
+
+1. Ensure `yarn -v` shows that you're using `yarn 4` for the project
+2. Install all dependencies with `yarn install`
+3. Build + watch the code locally: `yarn dev`
+4. Run a build of all the CLI's stories against a Chromatic project: `yarn chromatic -t <token>`.
+
+### Running against staging
+
+```bash
+CHROMATIC_INDEX_URL=https://index.staging-chromatic.com yarn chromatic -t <token>
+```
+
+### Running against development
+
+To test against a local development version of the Chromatic stack, use
+
+```bash
+CHROMATIC_INDEX_URL=https://index.dev-chromatic.com yarn chromatic -t <token>
+```
+
+To only test a small number of test stories as a smoke test, use:
+
+```bash
+SMOKE_TEST=1 CHROMATIC_INDEX_URL=https://index.dev-chromatic.com yarn chromatic -t <token>
+```
+
+## Publishing a new version
+
+We use `auto` to automate the release process. Versions are bumped, tags are created and the changelog is updated automatically. A new release goes out whenever a PR is merged to `main`. A PR **must** have **exactly one** of the following labels before merging:
+
+- `major` triggers a major version bump
+- `minor` triggers a minor version bump
+- `patch` triggers a patch version bump
+
+Additionally, a PR **may** have exactly one of these labels:
+
+- `release` creates a `latest` release on npm
+- `skip-release` does not create a release at all (changes roll into the next release)
+
+We have two types of releases:
+
+- `latest` releases are the general audience production releases, used by most people. Automatically created when merging a PR with the `release` label.
+- `canary` releases are intended for testing purposes and should not be used in production, as they may only work against a staging or dev environment. Automatically created on every PR, but does not auto-publish the GitHub Action.
+
+> For GitHub Actions, we may manually publish `chromaui/action-canary`.
+
+A script is provided to manually publish the GitHub Action, though it's typically only necessary for `action-canary` releases:
+
+```sh
+yarn publish-action <canary|latest>
+```

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -31,6 +31,16 @@ SMOKE_TEST=1 CHROMATIC_INDEX_URL=https://index.dev-chromatic.com yarn chromatic 
 
 ### Running another project against local CLI
 
+#### Call CLI directly
+
+```
+node /path/to/cli/repo/dist/bin.js -t <token>
+```
+
+_This should work in most cases. However, if you run into weird issues, try the symlink version below._
+
+#### Symlink CLI
+
 1. Navigate to the project you'd like to run builds against
 2. Add `chromatic` to your dependencies
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -29,6 +29,31 @@ To only test a small number of test stories as a smoke test, use:
 SMOKE_TEST=1 CHROMATIC_INDEX_URL=https://index.dev-chromatic.com yarn chromatic -t <token>
 ```
 
+### Running another project against local CLI
+
+1. Navigate to the project you'd like to run builds against
+2. Add `chromatic` to your dependencies
+
+   ```
+   yarn add chromatic
+   ```
+
+3. Use [yarn link](https://yarnpkg.com/cli/link) to symlink your local CLI repo
+
+   ```
+   yarn link /path/to/cli/repo
+   ```
+
+4. Run your build
+
+   ```
+   yarn chromatic -t <token>
+   ```
+
+You can also combine this with the `CHROMATIC_INDEX_URL` environment variable to run the build against different versions of Chromatic.
+
+Also note: Since your `chromatic` dependency is symlinked, you can build your local CLI and your project will automatically get the updated code.
+
 ## Publishing a new version
 
 We use `auto` to automate the release process. Versions are bumped, tags are created and the changelog is updated automatically. A new release goes out whenever a PR is merged to `main`. A PR **must** have **exactly one** of the following labels before merging:

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -60,7 +60,7 @@ async function build() {
   await $({
     stdout: 'inherit',
     stderr: 'inherit',
-  })`sentry-cli releases set-commits --auto ${nextVersion}`;
+  })`sentry-cli releases set-commits --auto ${nextVersion} --ignore-missing`;
 
   console.info('🧹 Removing sourcemaps from build');
   await $`yarn clean:sourcemaps`;


### PR DESCRIPTION
Just as the title says - this adds docs on how to run a separate project against your local copy of the CLI.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>11.16.4--canary.1113.11600333794.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@11.16.4--canary.1113.11600333794.0
  # or 
  yarn add chromatic@11.16.4--canary.1113.11600333794.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
