### PR TITLE
Ensure parent directory exists before writing log/diagnostics file

### DIFF
--- a/node-src/index.test.ts
+++ b/node-src/index.test.ts
@@ -284,6 +284,7 @@ vi.mock('fs', async (importOriginal) => {
   const originalModule = (await importOriginal()) as any;
   return {
     pathExists: async () => true,
+    mkdirSync: vi.fn(),
     readFileSync: originalModule.readFileSync,
     writeFileSync: vi.fn(),
     createReadStream: vi.fn(() => mockStatsFile),

--- a/node-src/lib/log.ts
+++ b/node-src/lib/log.ts
@@ -1,6 +1,7 @@
 import chalk from 'chalk';
 import debug from 'debug';
-import { createWriteStream, rm } from 'fs';
+import { createWriteStream, mkdirSync, rm } from 'fs';
+import path from 'path';
 import stripAnsi from 'strip-ansi';
 import { format } from 'util';
 
@@ -96,13 +97,16 @@ const fileLogger = {
     this.append = () => {};
     this.queue = [];
   },
-  initialize(path: string, onError: LogFunction) {
-    rm(path, { force: true }, (err) => {
+  initialize(filepath: string, onError: LogFunction) {
+    rm(filepath, { force: true }, (err) => {
       if (err) {
         this.disable();
         onError(err);
       } else {
-        const stream = createWriteStream(path, { flags: 'a' });
+        // Ensure the parent directory exists before we create the stream
+        mkdirSync(path.dirname(filepath), { recursive: true });
+
+        const stream = createWriteStream(filepath, { flags: 'a' });
         this.append = (...messages: string[]) => {
           stream?.write(
             messages

--- a/node-src/lib/writeChromaticDiagnostics.test.ts
+++ b/node-src/lib/writeChromaticDiagnostics.test.ts
@@ -1,6 +1,13 @@
-import { describe, expect, it } from 'vitest';
+import { mkdirSync } from 'fs';
+import jsonfile from 'jsonfile';
+import path from 'path';
+import { describe, expect, it, vi } from 'vitest';
 
-import { getDiagnostics } from './writeChromaticDiagnostics';
+import { createLogger } from './log';
+import { getDiagnostics, writeChromaticDiagnostics } from './writeChromaticDiagnostics';
+
+vi.mock('jsonfile');
+vi.mock('fs');
 
 describe('getDiagnostics', () => {
   it('returns context object', () => {
@@ -24,5 +31,24 @@ describe('getDiagnostics', () => {
       flags: { projectToken: undefined },
       extraOptions: { userToken: undefined },
     });
+  });
+});
+
+describe('writeChromaticDiagnostics', () => {
+  it('should create the parent directory if it does not exist', async () => {
+    const ctx = {
+      log: createLogger({}),
+      options: { diagnosticsFile: '/tmp/doesnotexist/diagnostics.json' },
+    };
+    await writeChromaticDiagnostics(ctx as any);
+
+    expect(mkdirSync).toHaveBeenCalledWith(path.dirname(ctx.options.diagnosticsFile), {
+      recursive: true,
+    });
+    expect(jsonfile.writeFile).toHaveBeenCalledWith(
+      ctx.options.diagnosticsFile,
+      expect.any(Object),
+      expect.any(Object)
+    );
   });
 });

--- a/node-src/lib/writeChromaticDiagnostics.ts
+++ b/node-src/lib/writeChromaticDiagnostics.ts
@@ -1,4 +1,6 @@
+import { mkdirSync } from 'fs';
 import jsonfile from 'jsonfile';
+import path from 'path';
 
 import { Context } from '..';
 import wroteReport from '../ui/messages/info/wroteReport';
@@ -17,6 +19,9 @@ export async function writeChromaticDiagnostics(ctx: Context) {
   }
 
   try {
+    // Ensure the parent directory exists before writing file
+    mkdirSync(path.dirname(ctx.options.diagnosticsFile), { recursive: true });
+
     await writeFile(ctx.options.diagnosticsFile, getDiagnostics(ctx), { spaces: 2 });
     ctx.log.info(wroteReport(ctx.options.diagnosticsFile, 'Chromatic diagnostics'));
   } catch (error) {


### PR DESCRIPTION
It's possible to send `--log-file` and `--diagnostics-file` to a random location that doesn't exist yet. In those cases, we were throwing a `ENOENT` error when attempting to write to the stream. This ensures the parent directory exists before we attempt to write those files!
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>11.16.4--canary.1117.11636662323.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@11.16.4--canary.1117.11636662323.0
  # or 
  yarn add chromatic@11.16.4--canary.1117.11636662323.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
