### PR TITLE
:book: Add new issue template that references Chromatic support.

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,9 +1,14 @@
 ---
 name: Bug report 🐞
-about: Found a bug in our CLI? Please open an issue. Is there a problem with the Chromatic platform? Please contact support.
+about: If you're experiencing a problem with Chromatic, please contact Chromatic support. Found a bug in our CLI? Please open an issue.
 labels: needs triage, bug, Empathy, CLI
 ---
+**Chromatic Issues**
+If you're experiencing an issue with Chromatic itself, such as a build showing a component error that
+you don't see when running Storybook locally, you should [contact Chromatic support](https://www.chromatic.com/docs/support/).
+If you're seeing an issue with the Chromatic command-line interface (the CLI tool itself), then this
+is the appropriate forum to file a ticket.
 
 **Bug report**
 
-A clear and concise description of what the bug is. Include screenshots if you can, but be aware this is a public medium. If you need to share private information, please contact the Chromatic support team.
+A clear and concise description of what the bug is. Include screenshots if you can, but be aware this is a public medium. If you need to share private information, please contact the Chromatic support team [here](mailto:support@chromatic.com).


### PR DESCRIPTION
We want users that are having issues with Chromatic or the Chromatic platform to be more aggressively redirected to Chromatic support when they attempt to file an issue.

Refs CAP-2364.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>11.17.1--canary.1119.11732427490.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@11.17.1--canary.1119.11732427490.0
  # or 
  yarn add chromatic@11.17.1--canary.1119.11732427490.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
