### PR TITLE
Send `storybookBaseDir` as part of project metadata

### DIFF
--- a/node-src/lib/getDependentStoryFiles.ts
+++ b/node-src/lib/getDependentStoryFiles.ts
@@ -1,6 +1,5 @@
 import path from 'path';
 
-import { getRepositoryRoot } from '../git/git';
 import { Context, Module, Reason, Stats } from '../types';
 import noCSFGlobs from '../ui/messages/errors/noCSFGlobs';
 import tracedAffectedFiles from '../ui/messages/info/tracedAffectedFiles';
@@ -85,27 +84,25 @@ export async function getDependentStoryFiles(
   changedFiles: string[],
   changedDependencies: string[] = []
 ) {
+  const { rootPath } = ctx.git || {};
+  if (!rootPath) {
+    throw new Error('Failed to determine repository root');
+  }
+
   const {
+    baseDir: storybookBaseDirectory = '',
     configDir: configDirectory = '.storybook',
     staticDir: staticDirectory = [],
     viewLayer,
   } = ctx.storybook || {};
   const {
     storybookBuildDir,
-    storybookBaseDir,
     // eslint-disable-next-line unicorn/prevent-abbreviations
     storybookConfigDir = configDirectory,
     untraced = [],
   } = ctx.options;
 
-  const rootPath = await getRepositoryRoot(); // e.g. `/path/to/project` (always absolute posix)
-  if (!rootPath) {
-    throw new Error('Failed to determine repository root');
-  }
-
-  const baseDirectory = storybookBaseDir
-    ? posix(storybookBaseDir)
-    : path.posix.relative(rootPath, '');
+  const baseDirectory = posix(storybookBaseDirectory);
 
   // Convert a "webpack path" (relative to storybookBaseDir) to a "git path" (relative to repository root)
   // e.g. `./src/file.js` => `path/to/storybook/src/file.js`

--- a/node-src/lib/getStorybookBaseDirectory.test.ts
+++ b/node-src/lib/getStorybookBaseDirectory.test.ts
@@ -1,0 +1,45 @@
+import process from 'node:process';
+
+import { expect, it, vi } from 'vitest';
+
+import { Context } from '../types';
+import { getStorybookBaseDirectory } from './getStorybookBaseDirectory';
+
+const mockedCwd = vi.spyOn(process, 'cwd');
+
+it('defaults to the configured value', () => {
+  expect(getStorybookBaseDirectory({ options: { storybookBaseDir: 'foobar' } } as Context)).toBe(
+    'foobar'
+  );
+});
+
+it('strips off leading dots from the configured value', () => {
+  expect(getStorybookBaseDirectory({ options: { storybookBaseDir: '.' } } as Context)).toBe('');
+});
+
+it('strips off leading dots from the configured value', () => {
+  expect(
+    getStorybookBaseDirectory({ options: { storybookBaseDir: './storybook' } } as Context)
+  ).toBe('storybook');
+});
+
+it('calculates the relative path of the cwd to the git root when they are equal', () => {
+  const rootPath = '/path/to/project';
+  mockedCwd.mockReturnValue(rootPath);
+
+  expect(getStorybookBaseDirectory({ git: { rootPath } } as Context)).toBe('');
+});
+
+it('calculates the relative path of the cwd to the git root when they are equal', () => {
+  const rootPath = '/path/to/project';
+  mockedCwd.mockReturnValue(`${rootPath}/storybook`);
+
+  expect(getStorybookBaseDirectory({ git: { rootPath } } as Context)).toBe('storybook');
+});
+
+it('falls back the empty string if there is no git root', () => {
+  const rootPath = '/path/to/project';
+  mockedCwd.mockReturnValue(`${rootPath}/storybook`);
+
+  expect(getStorybookBaseDirectory({} as Context)).toBe('');
+});

--- a/node-src/lib/getStorybookBaseDirectory.ts
+++ b/node-src/lib/getStorybookBaseDirectory.ts
@@ -1,0 +1,25 @@
+import path from 'path';
+
+import { Context } from '../types';
+
+/**
+ * Get the storybook base directory, relative to the git root.
+ * This is where you run SB from, NOT the config dir.
+ *
+ * @param ctx Context Regular context
+ *
+ * @returns string The base directory
+ */
+export function getStorybookBaseDirectory(ctx: Context) {
+  const { storybookBaseDir } = ctx.options || {};
+  if (storybookBaseDir) {
+    return storybookBaseDir.replace(/^\.[/\\]?/, '');
+  }
+
+  const { rootPath } = ctx.git || {};
+  if (!rootPath) {
+    return '';
+  }
+
+  return path.relative(rootPath, '');
+}

--- a/node-src/tasks/gitInfo.test.ts
+++ b/node-src/tasks/gitInfo.test.ts
@@ -21,6 +21,7 @@ const getSlug = vi.mocked(git.getSlug);
 const getVersion = vi.mocked(git.getVersion);
 const getUserEmail = vi.mocked(git.getUserEmail);
 const getRepositoryCreationDate = vi.mocked(git.getRepositoryCreationDate);
+const getRepositoryRoot = vi.mocked(git.getRepositoryRoot);
 const getStorybookCreationDate = vi.mocked(git.getStorybookCreationDate);
 const getNumberOfComitters = vi.mocked(git.getNumberOfComitters);
 const getCommittedFileCount = vi.mocked(git.getCommittedFileCount);
@@ -55,6 +56,7 @@ beforeEach(() => {
   getUserEmail.mockResolvedValue('user@email.com');
   getSlug.mockResolvedValue('user/repo');
   getRepositoryCreationDate.mockResolvedValue(new Date('2024-11-01'));
+  getRepositoryRoot.mockResolvedValue('/path/to/project');
   getStorybookCreationDate.mockResolvedValue(new Date('2025-11-01'));
   getNumberOfComitters.mockResolvedValue(17);
   getCommittedFileCount.mockResolvedValue(100);
@@ -68,6 +70,7 @@ describe('setGitInfo', () => {
     const ctx = { log, options: {}, client } as any;
     await setGitInfo(ctx, {} as any);
     expect(ctx.git).toMatchObject({
+      rootPath: '/path/to/project',
       commit: '123asdf',
       branch: 'something',
       parentCommits: ['asd2344'],

--- a/node-src/tasks/gitInfo.ts
+++ b/node-src/tasks/gitInfo.ts
@@ -8,6 +8,7 @@ import {
   getCommittedFileCount,
   getNumberOfComitters,
   getRepositoryCreationDate,
+  getRepositoryRoot,
   getSlug,
   getStorybookCreationDate,
   getUncommittedHash,
@@ -94,6 +95,7 @@ export const setGitInfo = async (ctx: Context, task: Task) => {
       ctx.log.warn('Failed to retrieve uncommitted files hash', err);
       return undefined;
     }),
+    rootPath: await getRepositoryRoot(),
     ...commitAndBranchInfo,
   };
 

--- a/node-src/tasks/initialize.test.ts
+++ b/node-src/tasks/initialize.test.ts
@@ -100,7 +100,7 @@ describe('announceBuild', () => {
     environment: ':environment',
     git: { version: 'whatever', matchesBranch: () => false, committedAt: 0 },
     pkg: { version: '1.0.0' },
-    storybook: { version: '2.0.0', viewLayer: 'react', addons: [] },
+    storybook: { baseDir: '', version: '2.0.0', viewLayer: 'react', addons: [] },
     runtimeMetadata: {
       nodePlatform: 'darwin',
       nodeVersion: '18.12.1',
@@ -138,6 +138,9 @@ describe('announceBuild', () => {
           storybookAddons: ctx.storybook.addons,
           storybookVersion: ctx.storybook.version,
           storybookViewLayer: ctx.storybook.viewLayer,
+          projectMetadata: {
+            storybookBaseDir: '',
+          },
           ...defaultContext.runtimeMetadata,
         },
       },

--- a/node-src/tasks/initialize.ts
+++ b/node-src/tasks/initialize.ts
@@ -70,7 +70,7 @@ export const setRuntimeMetadata = async (ctx: Context) => {
   }
 };
 
-export const announceBuild = async (ctx: Context) => {
+const announceBuildInput = (ctx: Context) => {
   const { patchBaseRef, patchHeadRef, preserveMissingSpecs, isLocalBuild } = ctx.options;
   const {
     version,
@@ -87,29 +87,35 @@ export const announceBuild = async (ctx: Context) => {
   const { rebuildForBuildId, turboSnap } = ctx;
   const autoAcceptChanges = matchesBranch?.(ctx.options.autoAcceptChanges);
 
+  return {
+    autoAcceptChanges,
+    patchBaseRef,
+    patchHeadRef,
+    preserveMissingSpecs,
+    ...(gitUserEmail && { gitUserEmailHash: emailHash(gitUserEmail) }),
+    ...commitInfo,
+    committedAt: new Date(committedAt),
+    ciVariables: ctx.environment,
+    isLocalBuild,
+    needsBaselines: !!turboSnap && !turboSnap.bailReason,
+    packageVersion: ctx.pkg.version,
+    ...ctx.runtimeMetadata,
+    rebuildForBuildId,
+    storybookAddons: ctx.storybook.addons,
+    storybookVersion: ctx.storybook.version,
+    storybookViewLayer: ctx.storybook.viewLayer,
+    projectMetadata: {
+      ...ctx.projectMetadata,
+      storybookBaseDir: ctx.storybook?.baseDir,
+    },
+  };
+};
+
+export const announceBuild = async (ctx: Context) => {
+  const input = announceBuildInput(ctx);
   const { announceBuild: announcedBuild } = await ctx.client.runQuery<AnnounceBuildMutationResult>(
     AnnounceBuildMutation,
-    {
-      input: {
-        autoAcceptChanges,
-        patchBaseRef,
-        patchHeadRef,
-        preserveMissingSpecs,
-        ...(gitUserEmail && { gitUserEmailHash: emailHash(gitUserEmail) }),
-        ...commitInfo,
-        committedAt: new Date(committedAt),
-        ciVariables: ctx.environment,
-        isLocalBuild,
-        needsBaselines: !!turboSnap && !turboSnap.bailReason,
-        packageVersion: ctx.pkg.version,
-        ...ctx.runtimeMetadata,
-        rebuildForBuildId,
-        storybookAddons: ctx.storybook.addons,
-        storybookVersion: ctx.storybook.version,
-        storybookViewLayer: ctx.storybook.viewLayer,
-        projectMetadata: ctx.projectMetadata,
-      },
-    },
+    { input },
     { retries: 3 }
   );
 
@@ -118,7 +124,7 @@ export const announceBuild = async (ctx: Context) => {
 
   ctx.announcedBuild = announcedBuild;
   ctx.isOnboarding =
-    announcedBuild.number === 1 || (announcedBuild.autoAcceptChanges && !autoAcceptChanges);
+    announcedBuild.number === 1 || (announcedBuild.autoAcceptChanges && !input.autoAcceptChanges);
 
   if (ctx.turboSnap && announcedBuild.app.turboSnapAvailability === 'UNAVAILABLE') {
     ctx.turboSnap.unavailable = true;

--- a/node-src/tasks/initialize.ts
+++ b/node-src/tasks/initialize.ts
@@ -82,6 +82,7 @@ const announceBuildInput = (ctx: Context) => {
     baselineCommits,
     packageMetadataChanges,
     gitUserEmail,
+    rootPath,
     ...commitInfo
   } = ctx.git; // omit some fields;
   const { rebuildForBuildId, turboSnap } = ctx;

--- a/node-src/tasks/storybookInfo.test.ts
+++ b/node-src/tasks/storybookInfo.test.ts
@@ -1,19 +1,26 @@
 import { describe, expect, it, vi } from 'vitest';
 
+import { getStorybookBaseDirectory } from '../lib/getStorybookBaseDirectory';
 import storybookInfo from '../lib/getStorybookInfo';
 import { setStorybookInfo } from './storybookInfo';
 
 vi.mock('../lib/getStorybookInfo');
+vi.mock('../lib/getStorybookBaseDirectory');
 
 const getStorybookInfo = vi.mocked(storybookInfo);
+const mockedGetStorybookBaseDirectory = vi.mocked(getStorybookBaseDirectory);
 
 describe('storybookInfo', () => {
   it('retrieves Storybook metadata and sets it on context', async () => {
     const storybook = { version: '1.0.0', viewLayer: 'react', addons: [] };
     getStorybookInfo.mockResolvedValue(storybook);
+    mockedGetStorybookBaseDirectory.mockReturnValue('');
 
-    const ctx = { packageJson: {} } as any;
+    const ctx = { packageJson: {}, git: { rootDir: process.cwd() } } as any;
     await setStorybookInfo(ctx);
-    expect(ctx.storybook).toEqual(storybook);
+    expect(ctx.storybook).toEqual({
+      ...storybook,
+      baseDir: '',
+    });
   });
 });

--- a/node-src/tasks/storybookInfo.ts
+++ b/node-src/tasks/storybookInfo.ts
@@ -1,12 +1,16 @@
 import * as Sentry from '@sentry/node';
 
+import { getStorybookBaseDirectory } from '../lib/getStorybookBaseDirectory';
 import getStorybookInfo from '../lib/getStorybookInfo';
 import { createTask, transitionTo } from '../lib/tasks';
 import { Context } from '../types';
 import { initial, pending, success } from '../ui/tasks/storybookInfo';
 
 export const setStorybookInfo = async (ctx: Context) => {
-  ctx.storybook = (await getStorybookInfo(ctx)) as Context['storybook'];
+  ctx.storybook = {
+    ...((await getStorybookInfo(ctx)) as Context['storybook']),
+    baseDir: getStorybookBaseDirectory(ctx),
+  };
 
   if (ctx.storybook) {
     if (ctx.storybook.version) {

--- a/node-src/types.ts
+++ b/node-src/types.ts
@@ -214,6 +214,8 @@ export interface Context {
 
   git: {
     version?: string;
+    /** The absolute location on disk of the git project */
+    rootPath?: string;
     /** The current user's email as pre git config */
     gitUserEmail?: string;
     branch: string;
@@ -235,6 +237,7 @@ export interface Context {
   };
   storybook: {
     version: string;
+    baseDir?: string;
     configDir: string;
     staticDir: string[];
     viewLayer: string;


### PR DESCRIPTION
And refactor things a little so we calculate it upfront rather than as part of TS.

This means we will need to re-test some TS stuff as part of this PR, to make sure I haven't messed it up. @ghengeveld let us know if you have any good playbooks there.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>11.19.0--canary.1120.11790916078.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@11.19.0--canary.1120.11790916078.0
  # or 
  yarn add chromatic@11.19.0--canary.1120.11790916078.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
