### PR TITLE
Send project metadata to the index

### DIFF
--- a/bin-src/trace.ts
+++ b/bin-src/trace.ts
@@ -1,5 +1,6 @@
 import meow from 'meow';
 
+import { getRepositoryRoot } from '../node-src/git/git';
 import { getDependentStoryFiles } from '../node-src/lib/getDependentStoryFiles';
 import { isPackageManifestFile } from '../node-src/lib/utils';
 import { readStatsFile } from '../node-src/tasks/readStatsFile';
@@ -90,6 +91,9 @@ export async function main(argv: string[]) {
       storybookConfigDir: flags.storybookConfigDir,
       untraced: flags.untraced,
       traceChanged: flags.mode || true,
+    },
+    git: {
+      rootPath: await getRepositoryRoot(),
     },
   } as any;
   const stats = await readStatsFile(flags.statsFile);

--- a/node-src/git/execGit.test.ts
+++ b/node-src/git/execGit.test.ts
@@ -1,0 +1,167 @@
+import { PassThrough, Transform } from 'node:stream';
+import { beforeEach } from 'node:test';
+
+import { execaCommand as rawExecaCommand } from 'execa';
+import { describe, expect, it, vitest } from 'vitest';
+
+import gitNoCommits from '../ui/messages/errors/gitNoCommits';
+import gitNotInitialized from '../ui/messages/errors/gitNotInitialized';
+import gitNotInstalled from '../ui/messages/errors/gitNotInstalled';
+import { execGitCommand, execGitCommandCountLines, execGitCommandOneLine } from './execGit';
+
+vitest.mock('execa');
+
+const execaCommand = vitest.mocked(rawExecaCommand);
+beforeEach(() => {
+  execaCommand.mockReset();
+});
+
+describe('execGitCommand', () => {
+  it('returns execa output if it works', async () => {
+    execaCommand.mockResolvedValue({
+      all: Buffer.from('some output'),
+    } as any);
+
+    expect(await execGitCommand('some command')).toEqual('some output');
+  });
+
+  it('errors if there is no output', async () => {
+    execaCommand.mockResolvedValue({
+      all: undefined,
+    } as any);
+
+    await expect(execGitCommand('some command')).rejects.toThrow(/Unexpected missing git/);
+  });
+
+  it('handles missing git error', async () => {
+    execaCommand.mockRejectedValue(new Error('not a git repository'));
+
+    await expect(execGitCommand('some command')).rejects.toThrow(
+      gitNotInitialized({ command: 'some command' })
+    );
+  });
+
+  it('handles git not found error', async () => {
+    execaCommand.mockRejectedValue(new Error('git not found'));
+
+    await expect(execGitCommand('some command')).rejects.toThrow(
+      gitNotInstalled({ command: 'some command' })
+    );
+  });
+
+  it('handles no commits yet', async () => {
+    execaCommand.mockRejectedValue(new Error('does not have any commits yet'));
+
+    await expect(execGitCommand('some command')).rejects.toThrow(
+      gitNoCommits({ command: 'some command' })
+    );
+  });
+
+  it('rethrows arbitrary errors', async () => {
+    execaCommand.mockRejectedValue(new Error('something random'));
+    await expect(execGitCommand('some command')).rejects.toThrow('something random');
+  });
+});
+
+function createExecaStreamer() {
+  let resolver;
+  let rejecter;
+  const promiseLike = new Promise((aResolver, aRejecter) => {
+    resolver = aResolver;
+    rejecter = aRejecter;
+  }) as Promise<unknown> & {
+    stdout: Transform;
+    kill: () => void;
+    _rejecter: (err: Error) => void;
+  };
+  promiseLike.stdout = new PassThrough();
+  promiseLike.kill = resolver;
+  promiseLike._rejecter = rejecter;
+  return promiseLike;
+}
+
+describe('execGitCommandOneLine', () => {
+  it('returns the first line if the command works', async () => {
+    const streamer = createExecaStreamer();
+    execaCommand.mockReturnValue(streamer as any);
+
+    const promise = execGitCommandOneLine('some command');
+
+    streamer.stdout.write('First line\n');
+    streamer.stdout.write('Second line\n');
+
+    expect(await promise).toEqual('First line');
+  });
+
+  it('returns the output if the command only has one line', async () => {
+    const streamer = createExecaStreamer();
+    execaCommand.mockReturnValue(streamer as any);
+
+    const promise = execGitCommandOneLine('some command');
+
+    streamer.stdout.write('First line\n');
+    streamer.stdout.end();
+
+    expect(await promise).toEqual('First line');
+  });
+
+  it('Return an error if the command has no ouput', async () => {
+    const streamer = createExecaStreamer();
+    execaCommand.mockReturnValue(streamer as any);
+
+    const promise = execGitCommandOneLine('some command');
+
+    streamer.kill();
+
+    await expect(promise).rejects.toThrow(/missing git command output/);
+  });
+
+  it('rethrows arbitrary errors', async () => {
+    const streamer = createExecaStreamer();
+    execaCommand.mockReturnValue(streamer as any);
+
+    const promise = execGitCommandOneLine('some command');
+
+    streamer._rejecter(new Error('some error'));
+
+    await expect(promise).rejects.toThrow(/some error/);
+  });
+});
+
+describe('execGitCommandCountLines', () => {
+  it('counts lines, many', async () => {
+    const streamer = createExecaStreamer();
+    execaCommand.mockReturnValue(streamer as any);
+
+    const promise = execGitCommandCountLines('some command');
+
+    streamer.stdout.write('First line\n');
+    streamer.stdout.write('Second line\n');
+    streamer.kill();
+
+    expect(await promise).toEqual(2);
+  });
+
+  it('counts lines, one', async () => {
+    const streamer = createExecaStreamer();
+    execaCommand.mockReturnValue(streamer as any);
+
+    const promise = execGitCommandCountLines('some command');
+
+    streamer.stdout.write('First line\n');
+    streamer.kill();
+
+    expect(await promise).toEqual(1);
+  });
+
+  it('counts lines, none', async () => {
+    const streamer = createExecaStreamer();
+    execaCommand.mockReturnValue(streamer as any);
+
+    const promise = execGitCommandCountLines('some command');
+
+    streamer.kill();
+
+    expect(await promise).toEqual(0);
+  });
+});

--- a/node-src/git/execGit.ts
+++ b/node-src/git/execGit.ts
@@ -29,7 +29,7 @@ export async function execGitCommand(
     const { all } = await execaCommand(command, { ...defaultOptions, ...options });
 
     if (all === undefined) {
-      throw new Error(`Unexpected missing git command output for command: '${command}`);
+      throw new Error(`Unexpected missing git command output for command: '${command}'`);
     }
 
     return all.toString();
@@ -70,7 +70,8 @@ export async function execGitCommandOneLine(
     // This promise will resolve only if there is an error or it times out
     (async () => {
       await process;
-      throw new Error(`Unexpected missing git command output for command: '${command}`);
+
+      throw new Error(`Unexpected missing git command output for command: '${command}'`);
     })(),
     // We expect this promise to resolve first
     new Promise<string>((resolve, reject) => {

--- a/node-src/git/execGit.ts
+++ b/node-src/git/execGit.ts
@@ -1,0 +1,95 @@
+import { createInterface } from 'node:readline';
+
+import { execaCommand } from 'execa';
+
+import gitNoCommits from '../ui/messages/errors/gitNoCommits';
+import gitNotInitialized from '../ui/messages/errors/gitNotInitialized';
+import gitNotInstalled from '../ui/messages/errors/gitNotInstalled';
+
+/**
+ * Execute a Git command in the local terminal.
+ *
+ * @param command The command to execute.
+ * @param options Execa options
+ *
+ * @returns The result of the command from the terminal.
+ */
+export async function execGitCommand(
+  command: string,
+  options?: Parameters<typeof execaCommand>[1]
+) {
+  try {
+    const { all } = await execaCommand(command, {
+      env: { LANG: 'C', LC_ALL: 'C' }, // make sure we're speaking English
+      timeout: 20_000, // 20 seconds
+      all: true, // interleave stdout and stderr
+      shell: true, // we'll deal with escaping ourselves (for now)
+      ...options,
+    });
+
+    if (all === undefined) {
+      throw new Error(`Unexpected missing git command output for command: '${command}`);
+    }
+
+    return all.toString();
+  } catch (error) {
+    const { message } = error;
+
+    if (message.includes('not a git repository')) {
+      throw new Error(gitNotInitialized({ command }));
+    }
+
+    if (message.includes('git not found')) {
+      throw new Error(gitNotInstalled({ command }));
+    }
+
+    if (message.includes('does not have any commits yet')) {
+      throw new Error(gitNoCommits({ command }));
+    }
+
+    throw error;
+  }
+}
+
+/**
+ * Execute a Git command in the local terminal and just get the first line.
+ *
+ * @param command The command to execute.
+ * @param options Execa options
+ *
+ * @returns The first line of the command from the terminal.
+ */
+export async function execGitCommandOneLine(
+  command: string,
+  options?: Parameters<typeof execaCommand>[1]
+) {
+  const process = execaCommand(command, {
+    env: { LANG: 'C', LC_ALL: 'C' }, // make sure we're speaking English
+    timeout: 20_000, // 20 seconds
+    all: true, // interleave stdout and stderr
+    shell: true, // we'll deal with escaping ourselves (for now)
+    ...options,
+  });
+
+  return Promise.race([
+    // This promise will resolve only if there is an error or it times out
+    (async () => {
+      await process;
+      throw new Error(`Unexpected missing git command output for command: '${command}`);
+    })(),
+    // We expect this promise to resolve first
+    new Promise<string>((resolve, reject) => {
+      if (!process.stdout) {
+        return reject(new Error('Unexpected missing stdout'));
+      }
+
+      const rl = createInterface(process.stdout);
+      rl.once('line', (line) => {
+        rl.close();
+        process.kill();
+
+        resolve(line);
+      });
+    }),
+  ]);
+}

--- a/node-src/git/getParentCommits.ts
+++ b/node-src/git/getParentCommits.ts
@@ -2,7 +2,8 @@ import gql from 'fake-tag';
 
 import { localBuildsSpecifier } from '../lib/localBuildsSpecifier';
 import { Context } from '../types';
-import { commitExists, execGitCommand } from './git';
+import { execGitCommand } from './execGit';
+import { commitExists } from './git';
 
 export const FETCH_N_INITIAL_BUILD_COMMITS = 20;
 

--- a/node-src/git/git.test.ts
+++ b/node-src/git/git.test.ts
@@ -4,7 +4,11 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   findFilesFromRepositoryRoot,
   getCommit,
+  getCommittedFileCount,
+  getNumberOfComitters,
+  getRepositoryCreationDate,
   getSlug,
+  getStorybookCreationDate,
   hasPreviousCommit,
   mergeQueueBranchMatch,
   NULL_BYTE,
@@ -143,5 +147,55 @@ describe('findFilesFromRepositoryRoot', () => {
       expect.any(Object)
     );
     expect(results).toEqual(filesFound);
+  });
+});
+
+describe('getRepositoryCreationDate', () => {
+  it('parses the date successfully', async () => {
+    command.mockImplementation(() => Promise.resolve({ all: `2017-05-17 10:00:35 -0700` }) as any);
+    expect(await getRepositoryCreationDate()).toEqual(new Date('2017-05-17T17:00:35.000Z'));
+  });
+});
+
+describe('getStorybookCreationDate', () => {
+  it('passes the config dir to the git command', async () => {
+    await getStorybookCreationDate({ options: { storybookConfigDir: 'special-config-dir' } });
+    expect(command).toHaveBeenCalledWith(
+      expect.stringMatching(/special-config-dir/),
+      expect.anything()
+    );
+  });
+
+  it('defaults the config dir to the git command', async () => {
+    await getStorybookCreationDate({ options: {} });
+    expect(command).toHaveBeenCalledWith(expect.stringMatching(/.storybook/), expect.anything());
+  });
+
+  it('parses the date successfully', async () => {
+    command.mockImplementation(() => Promise.resolve({ all: `2017-05-17 10:00:35 -0700` }) as any);
+    expect(
+      await getStorybookCreationDate({ options: { storybookConfigDir: '.storybook' } })
+    ).toEqual(new Date('2017-05-17T17:00:35.000Z'));
+  });
+});
+
+describe('getNumberOfComitters', () => {
+  it('parses the count successfully', async () => {
+    command.mockImplementation(() => Promise.resolve({ all: `      17` }) as any);
+    expect(await getNumberOfComitters()).toEqual(17);
+  });
+});
+
+describe('getCommittedFileCount', () => {
+  it('constructs the correct command', async () => {
+    await getCommittedFileCount(['page', 'screen'], ['js', 'ts']);
+    expect(command).toHaveBeenCalledWith(
+      'git ls-files -- "*page*.js" "*page*.ts" "*Page*.js" "*Page*.ts" "*screen*.js" "*screen*.ts" "*Screen*.js" "*Screen*.ts" | wc -l',
+      expect.anything()
+    );
+  });
+  it('parses the count successfully', async () => {
+    command.mockImplementation(() => Promise.resolve({ all: `      17` }) as any);
+    expect(await getCommittedFileCount(['page', 'screen'], ['js', 'ts'])).toEqual(17);
   });
 });

--- a/node-src/git/git.test.ts
+++ b/node-src/git/git.test.ts
@@ -18,6 +18,7 @@ vi.mock('./execGit');
 
 const execGitCommand = vi.mocked(execGit.execGitCommand);
 const execGitCommandOneLine = vi.mocked(execGit.execGitCommandOneLine);
+const execGitCommandCountLines = vi.mocked(execGit.execGitCommandCountLines);
 
 afterEach(() => {
   vi.clearAllMocks();
@@ -153,20 +154,20 @@ describe('getStorybookCreationDate', () => {
 
 describe('getNumberOfComitters', () => {
   it('parses the count successfully', async () => {
-    execGitCommand.mockResolvedValue(`tom\nzol\ndom`);
-    expect(await getNumberOfComitters()).toEqual(3);
+    execGitCommandCountLines.mockResolvedValue(17);
+    expect(await getNumberOfComitters()).toEqual(17);
   });
 });
 
 describe('getCommittedFileCount', () => {
   it('constructs the correct command', async () => {
     await getCommittedFileCount(['page', 'screen'], ['js', 'ts']);
-    expect(execGitCommand).toHaveBeenCalledWith(
+    expect(execGitCommandCountLines).toHaveBeenCalledWith(
       'git ls-files -- "*page*.js" "*page*.ts" "*Page*.js" "*Page*.ts" "*screen*.js" "*screen*.ts" "*Screen*.js" "*Screen*.ts"'
     );
   });
   it('parses the count successfully', async () => {
-    execGitCommand.mockResolvedValue(`pages/Main.ts\npages/Pricing.ts\npagesLogin.ts`);
-    expect(await getCommittedFileCount(['page', 'screen'], ['js', 'ts'])).toEqual(3);
+    execGitCommandCountLines.mockResolvedValue(17);
+    expect(await getCommittedFileCount(['page', 'screen'], ['js', 'ts'])).toEqual(17);
   });
 });

--- a/node-src/git/git.ts
+++ b/node-src/git/git.ts
@@ -3,7 +3,7 @@ import pLimit from 'p-limit';
 import { file as temporaryFile } from 'tmp-promise';
 
 import { Context } from '../types';
-import { execGitCommand, execGitCommandOneLine } from './execGit';
+import { execGitCommand, execGitCommandCountLines, execGitCommandOneLine } from './execGit';
 
 const newline = /\r\n|\r|\n/; // Git may return \n even on Windows, so we can't use EOL
 export const NULL_BYTE = '\0'; // Separator used when running `git ls-files` with `-z`
@@ -435,10 +435,9 @@ export async function getStorybookCreationDate(ctx: {
  */
 export async function getNumberOfComitters() {
   try {
-    const committerLines = await execGitCommand(`git shortlog -sn --all --since="6 months ago"`, {
+    return execGitCommandCountLines(`git shortlog -sn --all --since="6 months ago"`, {
       timeout: 5000,
     });
-    return committerLines.split('\n').length;
   } catch {
     return undefined;
   }
@@ -463,8 +462,7 @@ export async function getCommittedFileCount(nameMatches: string[], extensions: s
       extensions.map((extension) => `"*${match}*.${extension}"`)
     );
 
-    const globLines = await execGitCommand(`git ls-files -- ${globs.join(' ')}`);
-    return globLines.split('\n').length;
+    return execGitCommandCountLines(`git ls-files -- ${globs.join(' ')}`);
   } catch {
     return undefined;
   }

--- a/node-src/git/git.ts
+++ b/node-src/git/git.ts
@@ -422,3 +422,68 @@ export async function mergeQueueBranchMatch(branch: string) {
 
   return match ? Number(match[1]) : undefined;
 }
+
+/**
+ * Determine the date the repository was created
+ *
+ * @returns Date The date the repository was created
+ */
+export async function getRepositoryCreationDate() {
+  const dateString = await execGitCommand(`git log --reverse --format=%cd --date=iso | head -1`);
+  return dateString ? new Date(dateString) : undefined;
+}
+
+/**
+ * Determine the date the storybook was added to the repository
+ *
+ * @param ctx Context The context set when executing the CLI.
+ * @param ctx.options Object standard context options
+ * @param ctx.options.storybookConfigDir Configured Storybook config dir, if set
+ *
+ * @returns Date The date the storybook was added
+ */
+export async function getStorybookCreationDate(ctx: {
+  options: {
+    storybookConfigDir?: Context['options']['storybookConfigDir'];
+  };
+}) {
+  const configDirectory = ctx.options.storybookConfigDir ?? '.storybook';
+  const dateString = await execGitCommand(
+    `git log --follow --reverse --format=%cd --date=iso -- ${configDirectory} | head -1`
+  );
+  return dateString ? new Date(dateString) : undefined;
+}
+
+/**
+ * Determine the number of committers in the last 6 months
+ *
+ * @returns number The number of committers
+ */
+export async function getNumberOfComitters() {
+  const numberString = await execGitCommand(
+    `git shortlog -sn --all --since="6 months ago" | wc -l`
+  );
+  return numberString ? Number.parseInt(numberString, 10) : undefined;
+}
+
+/**
+ * Find the number of files in the git index that include a name with the given prefixes.
+ *
+ * @param nameMatches The names to match - will be matched with upper and lowercase first letter
+ * @param extensions The filetypes to match
+ *
+ * @returns The number of files matching the above
+ */
+export async function getCommittedFileCount(nameMatches: string[], extensions: string[]) {
+  const bothCasesNameMatches = nameMatches.flatMap((match) => [
+    match,
+    [match[0].toUpperCase(), ...match.slice(1)].join(''),
+  ]);
+
+  const globs = bothCasesNameMatches.flatMap((match) =>
+    extensions.map((extension) => `"*${match}*.${extension}"`)
+  );
+
+  const numberString = await execGitCommand(`git ls-files -- ${globs.join(' ')} | wc -l`);
+  return numberString ? Number.parseInt(numberString, 10) : undefined;
+}

--- a/node-src/index.test.ts
+++ b/node-src/index.test.ts
@@ -314,6 +314,10 @@ vi.mock('./git/git', () => ({
   getUncommittedHash: () => Promise.resolve('abc123'),
   getUserEmail: () => Promise.resolve('test@test.com'),
   mergeQueueBranchMatch: () => Promise.resolve(undefined),
+  getRepositoryCreationDate: () => Promise.resolve(new Date('2024-11-01')),
+  getStorybookCreationDate: () => Promise.resolve(new Date('2025-11-01')),
+  getNumberOfComitters: () => Promise.resolve(17),
+  getCommittedFileCount: () => Promise.resolve(100),
 }));
 
 vi.mock('./git/getParentCommits', () => ({
@@ -324,6 +328,8 @@ const getCommit = vi.mocked(git.getCommit);
 const getSlug = vi.mocked(git.getSlug);
 
 vi.mock('./lib/emailHash');
+
+vi.mock('./lib/getHasRouter');
 
 vi.mock('./lib/getFileHashes', () => ({
   getFileHashes: (files: string[]) =>

--- a/node-src/lib/findChangedPackageFiles.test.ts
+++ b/node-src/lib/findChangedPackageFiles.test.ts
@@ -1,15 +1,15 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import * as git from '../git/git';
+import * as execGit from '../git/execGit';
 import {
   arePackageDependenciesEqual,
   clearFileCache,
   findChangedPackageFiles,
 } from './findChangedPackageFiles';
 
-vi.mock('../git/git');
+vi.mock('../git/execGit');
 
-const execGitCommand = vi.mocked(git.execGitCommand);
+const execGitCommand = vi.mocked(execGit.execGitCommand);
 
 const mockFileContents = (packagesCommitsByFile) => {
   execGitCommand.mockImplementation(async (input) => {

--- a/node-src/lib/findChangedPackageFiles.ts
+++ b/node-src/lib/findChangedPackageFiles.ts
@@ -1,4 +1,4 @@
-import { execGitCommand } from '../git/git';
+import { execGitCommand } from '../git/execGit';
 import { isPackageMetadataFile } from './utils';
 
 // TODO: refactor this function

--- a/node-src/lib/getDependentStoryFiles.test.ts
+++ b/node-src/lib/getDependentStoryFiles.test.ts
@@ -21,7 +21,7 @@ const getContext: any = (
   options,
   turboSnap: {},
   storybook: {
-    baseDir: options.storybookBaseDir ? options.storybookBaseDir.replace(/^\.[/\\]?/, '') : '',
+    baseDir: options.storybookBaseDir ?? '',
     configDir,
     staticDir,
   },

--- a/node-src/lib/getDependentStoryFiles.test.ts
+++ b/node-src/lib/getDependentStoryFiles.test.ts
@@ -2,8 +2,8 @@
 import chalk from 'chalk';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
+import { Context } from '../types';
 import { getDependentStoryFiles, normalizePath } from './getDependentStoryFiles';
-import { Context } from '../../dist/node';
 
 const CSF_GLOB = String.raw`./src sync ^\.\/(?:(?!\.)(?=.)[^/]*?\.stories\.js)$`;
 const VITE_ENTRY = '/virtual:/@storybook/builder-vite/storybook-stories.js';

--- a/node-src/lib/getDependentStoryFiles.ts
+++ b/node-src/lib/getDependentStoryFiles.ts
@@ -1,6 +1,5 @@
 import path from 'path';
 
-import { getRepositoryRoot } from '../git/git';
 import { Context, Module, Reason, Stats } from '../types';
 import noCSFGlobs from '../ui/messages/errors/noCSFGlobs';
 import tracedAffectedFiles from '../ui/messages/info/tracedAffectedFiles';
@@ -85,27 +84,25 @@ export async function getDependentStoryFiles(
   changedFiles: string[],
   changedDependencies: string[] = []
 ) {
+  const { rootPath } = ctx.git || {};
+  if (!rootPath) {
+    throw new Error('Failed to determine repository root');
+  }
+
   const {
+    baseDir: storybookBaseDirectory = '',
     configDir: configDirectory = '.storybook',
     staticDir: staticDirectory = [],
     viewLayer,
   } = ctx.storybook || {};
   const {
     storybookBuildDir,
-    storybookBaseDir,
     // eslint-disable-next-line unicorn/prevent-abbreviations
     storybookConfigDir = configDirectory,
     untraced = [],
   } = ctx.options;
 
-  const rootPath = await getRepositoryRoot(); // e.g. `/path/to/project` (always absolute posix)
-  if (!rootPath) {
-    throw new Error('Failed to determine repository root');
-  }
-
-  const baseDirectory = storybookBaseDir
-    ? posix(storybookBaseDir)
-    : path.posix.relative(rootPath, '');
+  const baseDirectory = posix(storybookBaseDirectory);
 
   // Convert a "webpack path" (relative to storybookBaseDir) to a "git path" (relative to repository root)
   // e.g. `./src/file.js` => `path/to/storybook/src/file.js`

--- a/node-src/lib/getDependentStoryFiles.ts
+++ b/node-src/lib/getDependentStoryFiles.ts
@@ -4,6 +4,7 @@ import { Context, Module, Reason, Stats } from '../types';
 import noCSFGlobs from '../ui/messages/errors/noCSFGlobs';
 import tracedAffectedFiles from '../ui/messages/info/tracedAffectedFiles';
 import bailFile from '../ui/messages/warnings/bailFile';
+import { posix } from './posix';
 import { isPackageManifestFile, matchesFile } from './utils';
 
 type FilePath = string;
@@ -26,11 +27,6 @@ const isUserModule = (module_: Module | Reason) =>
   (module_ as Module).id !== undefined &&
   (module_ as Module).id !== null &&
   !INTERNALS.some((re) => re.test((module_ as Module).name || (module_ as Reason).moduleName));
-
-// Replaces Windows-style backslash path separators with POSIX-style forward slashes, because the
-// Webpack stats use forward slashes in the `name` and `moduleName` fields. Note `changedFiles`
-// already contains forward slashes, because that's what git yields even on Windows.
-const posix = (localPath: string) => localPath.split(path.sep).filter(Boolean).join(path.posix.sep);
 
 // For any path in node_modules, return the package name, including scope prefix if any.
 const getPackageName = (modulePath: string) => {
@@ -90,7 +86,7 @@ export async function getDependentStoryFiles(
   }
 
   const {
-    baseDir: storybookBaseDirectory = '',
+    baseDir: baseDirectory = '',
     configDir: configDirectory = '.storybook',
     staticDir: staticDirectory = [],
     viewLayer,
@@ -101,8 +97,6 @@ export async function getDependentStoryFiles(
     storybookConfigDir = configDirectory,
     untraced = [],
   } = ctx.options;
-
-  const baseDirectory = posix(storybookBaseDirectory);
 
   // Convert a "webpack path" (relative to storybookBaseDir) to a "git path" (relative to repository root)
   // e.g. `./src/file.js` => `path/to/storybook/src/file.js`

--- a/node-src/lib/getHasRouter.test.ts
+++ b/node-src/lib/getHasRouter.test.ts
@@ -1,0 +1,29 @@
+import { expect, it } from 'vitest';
+
+import { getHasRouter } from './getHasRouter';
+
+it('returns true if there is a routing package in package.json', async () => {
+  expect(
+    getHasRouter({
+      dependencies: {
+        react: '^18',
+        'react-dom': '^18',
+        'react-router': '^6',
+      },
+    })
+  ).toBe(true);
+});
+
+it('sreturns false if there is a routing package in package.json dependenices', async () => {
+  expect(
+    getHasRouter({
+      dependencies: {
+        react: '^18',
+        'react-dom': '^18',
+      },
+      devDependencies: {
+        'react-router': '^6',
+      },
+    })
+  ).toBe(false);
+});

--- a/node-src/lib/getHasRouter.ts
+++ b/node-src/lib/getHasRouter.ts
@@ -1,0 +1,38 @@
+import type { Context } from '../types';
+
+const routerPackages = new Set([
+  'react-router',
+  'react-router-dom',
+  'remix',
+  '@tanstack/react-router',
+  'expo-router',
+  '@reach/router',
+  'react-easy-router',
+  '@remix-run/router',
+  'wouter',
+  'wouter-preact',
+  'preact-router',
+  'vue-router',
+  'unplugin-vue-router',
+  '@angular/router',
+  '@solidjs/router',
+
+  // metaframeworks that imply routing
+  'next',
+  'react-scripts',
+  'gatsby',
+  'nuxt',
+  '@sveltejs/kit',
+]);
+
+/**
+ * @param packageJson The package JSON of the project (from context)
+ *
+ * @returns boolean Does this project use a routing package?
+ */
+export function getHasRouter(packageJson: Context['packageJson']) {
+  // NOTE: we just check real dependencies; if it is in dev dependencies, it may just be an example
+  return Object.keys(packageJson?.dependencies ?? {}).some((depName) =>
+    routerPackages.has(depName)
+  );
+}

--- a/node-src/lib/getStorybookBaseDirectory.test.ts
+++ b/node-src/lib/getStorybookBaseDirectory.test.ts
@@ -13,33 +13,30 @@ it('defaults to the configured value', () => {
   );
 });
 
-it('strips off leading dots from the configured value', () => {
-  expect(getStorybookBaseDirectory({ options: { storybookBaseDir: '.' } } as Context)).toBe('');
-});
-
-it('strips off leading dots from the configured value', () => {
-  expect(
-    getStorybookBaseDirectory({ options: { storybookBaseDir: './storybook' } } as Context)
-  ).toBe('storybook');
-});
-
 it('calculates the relative path of the cwd to the git root when they are equal', () => {
   const rootPath = '/path/to/project';
   mockedCwd.mockReturnValue(rootPath);
 
-  expect(getStorybookBaseDirectory({ git: { rootPath } } as Context)).toBe('');
+  expect(getStorybookBaseDirectory({ git: { rootPath } } as Context)).toBe('.');
 });
 
-it('calculates the relative path of the cwd to the git root when they are equal', () => {
+it('calculates the relative path of the cwd to the git root we are in subdir', () => {
   const rootPath = '/path/to/project';
   mockedCwd.mockReturnValue(`${rootPath}/storybook`);
 
   expect(getStorybookBaseDirectory({ git: { rootPath } } as Context)).toBe('storybook');
 });
 
+it('calculates the relative path of the cwd to the git root when we are outside the git root', () => {
+  const rootPath = '/path/to/project';
+  mockedCwd.mockReturnValue(`/path/to/elsewhere`);
+
+  expect(getStorybookBaseDirectory({ git: { rootPath } } as Context)).toBe('../elsewhere');
+});
+
 it('falls back the empty string if there is no git root', () => {
   const rootPath = '/path/to/project';
   mockedCwd.mockReturnValue(`${rootPath}/storybook`);
 
-  expect(getStorybookBaseDirectory({} as Context)).toBe('');
+  expect(getStorybookBaseDirectory({} as Context)).toBe('.');
 });

--- a/node-src/lib/getStorybookBaseDirectory.test.ts
+++ b/node-src/lib/getStorybookBaseDirectory.test.ts
@@ -1,0 +1,45 @@
+import process from 'node:process';
+
+import { expect, it, vi } from 'vitest';
+
+import { Context } from '../types';
+import { getStorybookBaseDirectory } from './getStorybookBaseDirectory';
+
+const mockedCwd = vi.spyOn(process, 'cwd');
+
+it('defaults to the configured value', () => {
+  expect(getStorybookBaseDirectory({ options: { storybookBaseDir: 'foobar' } } as Context)).toBe(
+    'foobar'
+  );
+});
+
+it('strips off leading dots from the configured value', () => {
+  expect(getStorybookBaseDirectory({ options: { storybookBaseDir: '.' } } as Context)).toBe('');
+});
+
+it('strips off leading dots from the configured value', () => {
+  expect(
+    getStorybookBaseDirectory({ options: { storybookBaseDir: './storybook' } } as Context)
+  ).toBe('storybook');
+});
+
+it('calculates the relative path of the cwd to the git root when they are equal', () => {
+  const rootPath = '/path/to/project';
+  mockedCwd.mockReturnValue(rootPath);
+
+  expect(getStorybookBaseDirectory({ git: { rootPath } } as Context)).toBe('');
+});
+
+it('calculates the relative path of the cwd to the git root when they are equal', () => {
+  const rootPath = '/path/to/project';
+  mockedCwd.mockReturnValue(`${rootPath}/storybook`);
+
+  expect(getStorybookBaseDirectory({ git: { rootPath } } as Context)).toBe('storybook');
+});
+
+it('falls back the empty string if there is no git root', () => {
+  const rootPath = '/path/to/project';
+  mockedCwd.mockReturnValue(`${rootPath}/storybook`);
+
+  expect(getStorybookBaseDirectory({} as Context)).toBe('');
+});

--- a/node-src/lib/getStorybookBaseDirectory.test.ts
+++ b/node-src/lib/getStorybookBaseDirectory.test.ts
@@ -1,11 +1,20 @@
+import path from 'node:path';
 import process from 'node:process';
 
-import { expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { Context } from '../types';
 import { getStorybookBaseDirectory } from './getStorybookBaseDirectory';
 
 const mockedCwd = vi.spyOn(process, 'cwd');
+const mockedRelative = vi.spyOn(path, 'relative');
+const mockedJoin = vi.spyOn(path, 'join');
+
+// The definition of posix depends on `path.sep` being correct for the system
+// (ie.equal to `\\` for windows), however we can't really mock that as it's a constant
+vi.mock('./posix', () => ({
+  posix: (localPath: string) => localPath.split('\\').filter(Boolean).join('/'),
+}));
 
 it('defaults to the configured value', () => {
   expect(getStorybookBaseDirectory({ options: { storybookBaseDir: 'foobar' } } as Context)).toBe(
@@ -39,4 +48,23 @@ it('falls back the empty string if there is no git root', () => {
   mockedCwd.mockReturnValue(`${rootPath}/storybook`);
 
   expect(getStorybookBaseDirectory({} as Context)).toBe('.');
+});
+
+describe('with windows paths', () => {
+  beforeEach(() => {
+    mockedRelative.mockImplementation(path.win32.relative);
+    mockedJoin.mockImplementation(path.win32.join);
+  });
+
+  afterEach(() => {
+    mockedRelative.mockRestore();
+    mockedJoin.mockRestore();
+  });
+
+  it('uses posix paths even if we are windows', () => {
+    const rootPath = String.raw`C:\path\to\project`;
+    mockedCwd.mockReturnValue(String.raw`${rootPath}\storybook\subdir`);
+
+    expect(getStorybookBaseDirectory({ git: { rootPath } } as Context)).toBe('storybook/subdir');
+  });
 });

--- a/node-src/lib/getStorybookBaseDirectory.ts
+++ b/node-src/lib/getStorybookBaseDirectory.ts
@@ -1,6 +1,7 @@
 import path from 'path';
 
 import { Context } from '../types';
+import { posix } from './posix';
 
 /**
  * Get the storybook base directory, relative to the git root.
@@ -24,5 +25,5 @@ export function getStorybookBaseDirectory(ctx: Context) {
   // NOTE:
   //  - path.relative does not have a leading '.', unless it starts with '../'
   //  - path.join('.', '') === '.' and path.join('.', '../x') = '../x'
-  return path.join('.', path.relative(rootPath, ''));
+  return posix(path.join('.', path.relative(rootPath, '')));
 }

--- a/node-src/lib/getStorybookBaseDirectory.ts
+++ b/node-src/lib/getStorybookBaseDirectory.ts
@@ -1,0 +1,25 @@
+import path from 'path';
+
+import { Context } from '../types';
+
+/**
+ * Get the storybook base directory, relative to the git root.
+ * This is where you run SB from, NOT the config dir.
+ *
+ * @param ctx Context Regular context
+ *
+ * @returns string The base directory
+ */
+export function getStorybookBaseDirectory(ctx: Context) {
+  const { storybookBaseDir } = ctx.options || {};
+  if (storybookBaseDir) {
+    return storybookBaseDir.replace(/^\.[/\\]?/, '');
+  }
+
+  const { rootPath } = ctx.git || {};
+  if (!rootPath) {
+    return '';
+  }
+
+  return path.relative(rootPath, '');
+}

--- a/node-src/lib/getStorybookBaseDirectory.ts
+++ b/node-src/lib/getStorybookBaseDirectory.ts
@@ -13,13 +13,16 @@ import { Context } from '../types';
 export function getStorybookBaseDirectory(ctx: Context) {
   const { storybookBaseDir } = ctx.options || {};
   if (storybookBaseDir) {
-    return storybookBaseDir.replace(/^\.[/\\]?/, '');
+    return storybookBaseDir;
   }
 
   const { rootPath } = ctx.git || {};
   if (!rootPath) {
-    return '';
+    return '.';
   }
 
-  return path.relative(rootPath, '');
+  // NOTE:
+  //  - path.relative does not have a leading '.', unless it starts with '../'
+  //  - path.join('.', '') === '.' and path.join('.', '../x') = '../x'
+  return path.join('.', path.relative(rootPath, ''));
 }

--- a/node-src/lib/posix.ts
+++ b/node-src/lib/posix.ts
@@ -1,0 +1,7 @@
+import path from 'path';
+
+// Replaces Windows-style backslash path separators with POSIX-style forward slashes, because the
+// Webpack stats use forward slashes in the `name` and `moduleName` fields. Note `changedFiles`
+// already contains forward slashes, because that's what git yields even on Windows.
+export const posix = (localPath: string) =>
+  localPath.split(path.sep).filter(Boolean).join(path.posix.sep);

--- a/node-src/tasks/gitInfo.test.ts
+++ b/node-src/tasks/gitInfo.test.ts
@@ -21,6 +21,7 @@ const getSlug = vi.mocked(git.getSlug);
 const getVersion = vi.mocked(git.getVersion);
 const getUserEmail = vi.mocked(git.getUserEmail);
 const getRepositoryCreationDate = vi.mocked(git.getRepositoryCreationDate);
+const getRepositoryRoot = vi.mocked(git.getRepositoryRoot);
 const getStorybookCreationDate = vi.mocked(git.getStorybookCreationDate);
 const getNumberOfComitters = vi.mocked(git.getNumberOfComitters);
 const getCommittedFileCount = vi.mocked(git.getCommittedFileCount);
@@ -55,6 +56,7 @@ beforeEach(() => {
   getUserEmail.mockResolvedValue('user@email.com');
   getSlug.mockResolvedValue('user/repo');
   getRepositoryCreationDate.mockResolvedValue(new Date('2024-11-01'));
+  getRepositoryRoot.mockResolvedValue('/path/to/project');
   getStorybookCreationDate.mockResolvedValue(new Date('2025-11-01'));
   getNumberOfComitters.mockResolvedValue(17);
   getCommittedFileCount.mockResolvedValue(100);
@@ -68,6 +70,7 @@ describe('setGitInfo', () => {
     const ctx = { log, options: {}, client } as any;
     await setGitInfo(ctx, {} as any);
     expect(ctx.git).toMatchObject({
+      rootPath: '/path/to/project',
       commit: '123asdf',
       branch: 'something',
       parentCommits: ['asd2344'],

--- a/node-src/tasks/gitInfo.test.ts
+++ b/node-src/tasks/gitInfo.test.ts
@@ -5,6 +5,7 @@ import { getChangedFilesWithReplacement as getChangedFilesWithReplacementUnmocke
 import * as getCommitInfo from '../git/getCommitAndBranch';
 import { getParentCommits as getParentCommitsUnmocked } from '../git/getParentCommits';
 import * as git from '../git/git';
+import { getHasRouter as getHasRouterUnmocked } from '../lib/getHasRouter';
 import { setGitInfo } from './gitInfo';
 
 vi.mock('../git/getCommitAndBranch');
@@ -12,15 +13,21 @@ vi.mock('../git/git');
 vi.mock('../git/getParentCommits');
 vi.mock('../git/getBaselineBuilds');
 vi.mock('../git/getChangedFilesWithReplacement');
+vi.mock('../lib/getHasRouter');
 
 const getCommitAndBranch = vi.mocked(getCommitInfo.default);
 const getChangedFilesWithReplacement = vi.mocked(getChangedFilesWithReplacementUnmocked);
 const getSlug = vi.mocked(git.getSlug);
 const getVersion = vi.mocked(git.getVersion);
 const getUserEmail = vi.mocked(git.getUserEmail);
+const getRepositoryCreationDate = vi.mocked(git.getRepositoryCreationDate);
+const getStorybookCreationDate = vi.mocked(git.getStorybookCreationDate);
+const getNumberOfComitters = vi.mocked(git.getNumberOfComitters);
+const getCommittedFileCount = vi.mocked(git.getCommittedFileCount);
 const getUncommittedHash = vi.mocked(git.getUncommittedHash);
 const getBaselineBuilds = vi.mocked(getBaselineBuildsUnmocked);
 const getParentCommits = vi.mocked(getParentCommitsUnmocked);
+const getHasRouter = vi.mocked(getHasRouterUnmocked);
 
 const log = { info: vi.fn(), warn: vi.fn(), debug: vi.fn() };
 
@@ -47,6 +54,12 @@ beforeEach(() => {
   getVersion.mockResolvedValue('Git v1.0.0');
   getUserEmail.mockResolvedValue('user@email.com');
   getSlug.mockResolvedValue('user/repo');
+  getRepositoryCreationDate.mockResolvedValue(new Date('2024-11-01'));
+  getStorybookCreationDate.mockResolvedValue(new Date('2025-11-01'));
+  getNumberOfComitters.mockResolvedValue(17);
+  getCommittedFileCount.mockResolvedValue(100);
+  getHasRouter.mockReturnValue(true);
+
   client.runQuery.mockReturnValue({ app: { isOnboarding: false } });
 });
 
@@ -163,5 +176,17 @@ describe('setGitInfo', () => {
     });
     await setGitInfo(ctx, {} as any);
     expect(ctx.git.branch).toBe('repo');
+  });
+
+  it('sets projectMetadata on context', async () => {
+    const ctx = { log, options: { isLocalBuild: true }, client } as any;
+    await setGitInfo(ctx, {} as any);
+    expect(ctx.projectMetadata).toMatchObject({
+      hasRouter: true,
+      creationDate: new Date('2024-11-01'),
+      storybookCreationDate: new Date('2025-11-01'),
+      numberOfCommitters: 17,
+      numberOfAppFiles: 100,
+    });
   });
 });

--- a/node-src/tasks/gitInfo.ts
+++ b/node-src/tasks/gitInfo.ts
@@ -4,7 +4,17 @@ import { getBaselineBuilds } from '../git/getBaselineBuilds';
 import { getChangedFilesWithReplacement } from '../git/getChangedFilesWithReplacement';
 import getCommitAndBranch from '../git/getCommitAndBranch';
 import { getParentCommits } from '../git/getParentCommits';
-import { getSlug, getUncommittedHash, getUserEmail, getVersion } from '../git/git';
+import {
+  getCommittedFileCount,
+  getNumberOfComitters,
+  getRepositoryCreationDate,
+  getSlug,
+  getStorybookCreationDate,
+  getUncommittedHash,
+  getUserEmail,
+  getVersion,
+} from '../git/git';
+import { getHasRouter } from '../lib/getHasRouter';
 import { exitCodes, setExitCode } from '../lib/setExitCode';
 import { createTask, transitionTo } from '../lib/tasks';
 import { isPackageMetadataFile, matchesFile } from '../lib/utils';
@@ -85,6 +95,14 @@ export const setGitInfo = async (ctx: Context, task: Task) => {
       return undefined;
     }),
     ...commitAndBranchInfo,
+  };
+
+  ctx.projectMetadata = {
+    hasRouter: getHasRouter(ctx.packageJson),
+    creationDate: await getRepositoryCreationDate(),
+    storybookCreationDate: await getStorybookCreationDate(ctx),
+    numberOfCommitters: await getNumberOfComitters(),
+    numberOfAppFiles: await getCommittedFileCount(['page', 'screen'], ['js', 'jsx', 'ts', 'tsx']),
   };
 
   if (isLocalBuild && !ctx.git.gitUserEmail) {

--- a/node-src/tasks/gitInfo.ts
+++ b/node-src/tasks/gitInfo.ts
@@ -8,6 +8,7 @@ import {
   getCommittedFileCount,
   getNumberOfComitters,
   getRepositoryCreationDate,
+  getRepositoryRoot,
   getSlug,
   getStorybookCreationDate,
   getUncommittedHash,
@@ -94,6 +95,7 @@ export const setGitInfo = async (ctx: Context, task: Task) => {
       ctx.log.warn('Failed to retrieve uncommitted files hash', err);
       return undefined;
     }),
+    rootPath: await getRepositoryRoot(),
     ...commitAndBranchInfo,
   };
 

--- a/node-src/tasks/initialize.test.ts
+++ b/node-src/tasks/initialize.test.ts
@@ -100,7 +100,7 @@ describe('announceBuild', () => {
     environment: ':environment',
     git: { version: 'whatever', matchesBranch: () => false, committedAt: 0 },
     pkg: { version: '1.0.0' },
-    storybook: { version: '2.0.0', viewLayer: 'react', addons: [] },
+    storybook: { baseDir: '', version: '2.0.0', viewLayer: 'react', addons: [] },
     runtimeMetadata: {
       nodePlatform: 'darwin',
       nodeVersion: '18.12.1',
@@ -138,6 +138,9 @@ describe('announceBuild', () => {
           storybookAddons: ctx.storybook.addons,
           storybookVersion: ctx.storybook.version,
           storybookViewLayer: ctx.storybook.viewLayer,
+          projectMetadata: {
+            storybookBaseDir: '',
+          },
           ...defaultContext.runtimeMetadata,
         },
       },

--- a/node-src/tasks/initialize.ts
+++ b/node-src/tasks/initialize.ts
@@ -107,6 +107,7 @@ export const announceBuild = async (ctx: Context) => {
         storybookAddons: ctx.storybook.addons,
         storybookVersion: ctx.storybook.version,
         storybookViewLayer: ctx.storybook.viewLayer,
+        projectMetadata: ctx.projectMetadata,
       },
     },
     { retries: 3 }

--- a/node-src/tasks/initialize.ts
+++ b/node-src/tasks/initialize.ts
@@ -70,7 +70,7 @@ export const setRuntimeMetadata = async (ctx: Context) => {
   }
 };
 
-export const announceBuild = async (ctx: Context) => {
+const announceBuildInput = (ctx: Context) => {
   const { patchBaseRef, patchHeadRef, preserveMissingSpecs, isLocalBuild } = ctx.options;
   const {
     version,
@@ -82,34 +82,41 @@ export const announceBuild = async (ctx: Context) => {
     baselineCommits,
     packageMetadataChanges,
     gitUserEmail,
+    rootPath,
     ...commitInfo
   } = ctx.git; // omit some fields;
   const { rebuildForBuildId, turboSnap } = ctx;
   const autoAcceptChanges = matchesBranch?.(ctx.options.autoAcceptChanges);
 
+  return {
+    autoAcceptChanges,
+    patchBaseRef,
+    patchHeadRef,
+    preserveMissingSpecs,
+    ...(gitUserEmail && { gitUserEmailHash: emailHash(gitUserEmail) }),
+    ...commitInfo,
+    committedAt: new Date(committedAt),
+    ciVariables: ctx.environment,
+    isLocalBuild,
+    needsBaselines: !!turboSnap && !turboSnap.bailReason,
+    packageVersion: ctx.pkg.version,
+    ...ctx.runtimeMetadata,
+    rebuildForBuildId,
+    storybookAddons: ctx.storybook.addons,
+    storybookVersion: ctx.storybook.version,
+    storybookViewLayer: ctx.storybook.viewLayer,
+    projectMetadata: {
+      ...ctx.projectMetadata,
+      storybookBaseDir: ctx.storybook?.baseDir,
+    },
+  };
+};
+
+export const announceBuild = async (ctx: Context) => {
+  const input = announceBuildInput(ctx);
   const { announceBuild: announcedBuild } = await ctx.client.runQuery<AnnounceBuildMutationResult>(
     AnnounceBuildMutation,
-    {
-      input: {
-        autoAcceptChanges,
-        patchBaseRef,
-        patchHeadRef,
-        preserveMissingSpecs,
-        ...(gitUserEmail && { gitUserEmailHash: emailHash(gitUserEmail) }),
-        ...commitInfo,
-        committedAt: new Date(committedAt),
-        ciVariables: ctx.environment,
-        isLocalBuild,
-        needsBaselines: !!turboSnap && !turboSnap.bailReason,
-        packageVersion: ctx.pkg.version,
-        ...ctx.runtimeMetadata,
-        rebuildForBuildId,
-        storybookAddons: ctx.storybook.addons,
-        storybookVersion: ctx.storybook.version,
-        storybookViewLayer: ctx.storybook.viewLayer,
-        projectMetadata: ctx.projectMetadata,
-      },
-    },
+    { input },
     { retries: 3 }
   );
 
@@ -118,7 +125,7 @@ export const announceBuild = async (ctx: Context) => {
 
   ctx.announcedBuild = announcedBuild;
   ctx.isOnboarding =
-    announcedBuild.number === 1 || (announcedBuild.autoAcceptChanges && !autoAcceptChanges);
+    announcedBuild.number === 1 || (announcedBuild.autoAcceptChanges && !input.autoAcceptChanges);
 
   if (ctx.turboSnap && announcedBuild.app.turboSnapAvailability === 'UNAVAILABLE') {
     ctx.turboSnap.unavailable = true;

--- a/node-src/tasks/storybookInfo.test.ts
+++ b/node-src/tasks/storybookInfo.test.ts
@@ -1,19 +1,26 @@
 import { describe, expect, it, vi } from 'vitest';
 
+import { getStorybookBaseDirectory } from '../lib/getStorybookBaseDirectory';
 import storybookInfo from '../lib/getStorybookInfo';
 import { setStorybookInfo } from './storybookInfo';
 
 vi.mock('../lib/getStorybookInfo');
+vi.mock('../lib/getStorybookBaseDirectory');
 
 const getStorybookInfo = vi.mocked(storybookInfo);
+const mockedGetStorybookBaseDirectory = vi.mocked(getStorybookBaseDirectory);
 
 describe('storybookInfo', () => {
   it('retrieves Storybook metadata and sets it on context', async () => {
     const storybook = { version: '1.0.0', viewLayer: 'react', addons: [] };
     getStorybookInfo.mockResolvedValue(storybook);
+    mockedGetStorybookBaseDirectory.mockReturnValue('');
 
-    const ctx = { packageJson: {} } as any;
+    const ctx = { packageJson: {}, git: { rootDir: process.cwd() } } as any;
     await setStorybookInfo(ctx);
-    expect(ctx.storybook).toEqual(storybook);
+    expect(ctx.storybook).toEqual({
+      ...storybook,
+      baseDir: '',
+    });
   });
 });

--- a/node-src/tasks/storybookInfo.test.ts
+++ b/node-src/tasks/storybookInfo.test.ts
@@ -12,7 +12,7 @@ describe('storybookInfo', () => {
     const storybook = { version: '1.0.0', viewLayer: 'react', addons: [] };
     getStorybookInfo.mockResolvedValue(storybook);
 
-    const ctx = {} as any;
+    const ctx = { packageJson: {} } as any;
     await setStorybookInfo(ctx);
     expect(ctx.storybook).toEqual(storybook);
   });

--- a/node-src/tasks/storybookInfo.ts
+++ b/node-src/tasks/storybookInfo.ts
@@ -1,12 +1,16 @@
 import * as Sentry from '@sentry/node';
 
+import { getStorybookBaseDirectory } from '../lib/getStorybookBaseDirectory';
 import getStorybookInfo from '../lib/getStorybookInfo';
 import { createTask, transitionTo } from '../lib/tasks';
 import { Context } from '../types';
 import { initial, pending, success } from '../ui/tasks/storybookInfo';
 
 export const setStorybookInfo = async (ctx: Context) => {
-  ctx.storybook = (await getStorybookInfo(ctx)) as Context['storybook'];
+  ctx.storybook = {
+    ...((await getStorybookInfo(ctx)) as Context['storybook']),
+    baseDir: getStorybookBaseDirectory(ctx),
+  };
 
   if (ctx.storybook) {
     if (ctx.storybook.version) {

--- a/node-src/types.ts
+++ b/node-src/types.ts
@@ -250,6 +250,13 @@ export interface Context {
     };
     mainConfigFilePath?: string;
   };
+  projectMetadata: {
+    hasRouter?: boolean;
+    creationDate?: Date;
+    storybookCreationDate?: Date;
+    numberOfCommitters?: number;
+    numberOfAppFiles?: number;
+  };
   storybookUrl?: string;
   announcedBuild: {
     id: string;

--- a/node-src/types.ts
+++ b/node-src/types.ts
@@ -214,6 +214,8 @@ export interface Context {
 
   git: {
     version?: string;
+    /** The absolute location on disk of the git project */
+    rootPath?: string;
     /** The current user's email as pre git config */
     gitUserEmail?: string;
     branch: string;
@@ -235,6 +237,7 @@ export interface Context {
   };
   storybook: {
     version: string;
+    baseDir?: string;
     configDir: string;
     staticDir: string[];
     viewLayer: string;


### PR DESCRIPTION
Reverts chromaui/chromatic-cli#1121 (re-implements https://github.com/chromaui/chromatic-cli/pull/1112) and incorporates https://github.com/chromaui/chromatic-cli/pull/1120.

Also:

 - added some error/timeout handling so we don't get stuck if there is something wrong with git.
 - shorted timeouts to 5s as it's not critical this works (we could shorten further?)
 - don't use `wc` or `head` as they may not be there. Instead:
   - simulate `head -n 1` via streams
   - just count the number of lines for `wc`. 
      - This is inefficient as it requires loading all the lines into memory. 
      - I'm not sure if this will be a problem or not if a repo has a heap of contributors or "app files".  
      - I could implement another `execGitCommandCountLines` but I figured it was better to keep the complexity down.

Things to check in QA:

- environments without access to `head` or `wc`.
- environments where these commands timeout [not sure how to simulate]

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>11.20.0--canary.1122.12129895074.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@11.20.0--canary.1122.12129895074.0
  # or 
  yarn add chromatic@11.20.0--canary.1122.12129895074.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
