### PR TITLE
Only publish `latest` action on push to main

### DIFF
--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -15,7 +15,7 @@ async function main() {
   await $({ stdout: 'inherit', stderr: 'inherit' })`auto shipit`;
 
   // https://github.blog/changelog/2023-09-13-github-actions-updates-to-github_ref-and-github-ref/
-  if (process.env.GITHUB_REF === 'refs/heads/main') {
+  if (process.env.GITHUB_EVENT_NAME === 'push' && process.env.GITHUB_REF === 'refs/heads/main') {
     await publishAction('latest');
   } else {
     console.info('Skipping automatic publish of action-canary.');


### PR DESCRIPTION
It appears we're accidentally pushing canary releases to the `latest` tag on the [action repo](https://github.com/chromaui/action) instead of matching what's in NPM. It appears there were 2 `release` actions that were ran around the same time:

1. Push to main: https://github.com/chromaui/chromatic-cli/actions/runs/12130149407
2. Update to PR tags (this pushed the canary version): https://github.com/chromaui/chromatic-cli/actions/runs/12130166324

We're currently filtering by branch which shows up as `main` on the action that pushed the incorrect version for some reason (perhaps because the original branch doesn't exist?). 

![Screenshot 2024-12-06 at 11 47 26 AM](https://github.com/user-attachments/assets/064d94e7-cb10-479a-b45b-90ebd5692fe1)

To fix that, we can add another check to only push `latest` when the action event is `push` and the branch is `main`.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>11.20.1--canary.1129.12203588738.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@11.20.1--canary.1129.12203588738.0
  # or 
  yarn add chromatic@11.20.1--canary.1129.12203588738.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
