### PR TITLE
Account for configs when checking `exitOnceUploaded` in action

### DIFF
--- a/action-src/main.ts
+++ b/action-src/main.ts
@@ -165,7 +165,7 @@ async function run() {
         debug: maybe(debug),
         diagnosticsFile: maybe(diagnosticsFile),
         dryRun: maybe(dryRun),
-        exitOnceUploaded: maybe(exitOnceUploaded, false),
+        exitOnceUploaded: maybe(exitOnceUploaded),
         exitZeroOnChanges: maybe(exitZeroOnChanges, true),
         externals: maybe(externals),
         fileHashing: maybe(fileHashing, true),


### PR DESCRIPTION
Fixes #1128 

In our Action, we default `exitOnceUploaded` to `false` which means any options set in a configuration are ignored. Instead, we can default it to `undefined` so things parse out later on (and account for config options).

Test runs with this branch:
- No config (waits for build): https://github.com/chromaui/chromatic-cli/actions/runs/12241546124/job/34146875208
- With config (doesn't wait for build): https://github.com/chromaui/chromatic-cli/actions/runs/12241558833/job/34146917373
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>11.20.1--canary.1130.12241664568.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@11.20.1--canary.1130.12241664568.0
  # or 
  yarn add chromatic@11.20.1--canary.1130.12241664568.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
