### PR TITLE
Errors in project metadata gathering causing build failures

### DIFF
--- a/node-src/git/git.test.ts
+++ b/node-src/git/git.test.ts
@@ -163,7 +163,8 @@ describe('getCommittedFileCount', () => {
   it('constructs the correct command', async () => {
     await getCommittedFileCount(['page', 'screen'], ['js', 'ts']);
     expect(execGitCommandCountLines).toHaveBeenCalledWith(
-      'git ls-files -- "*page*.js" "*page*.ts" "*Page*.js" "*Page*.ts" "*screen*.js" "*screen*.ts" "*Screen*.js" "*Screen*.ts"'
+      'git ls-files -- "*page*.js" "*page*.ts" "*Page*.js" "*Page*.ts" "*screen*.js" "*screen*.ts" "*Screen*.js" "*Screen*.ts"',
+      expect.anything()
     );
   });
   it('parses the count successfully', async () => {

--- a/node-src/git/git.ts
+++ b/node-src/git/git.ts
@@ -462,7 +462,9 @@ export async function getCommittedFileCount(nameMatches: string[], extensions: s
       extensions.map((extension) => `"*${match}*.${extension}"`)
     );
 
-    return execGitCommandCountLines(`git ls-files -- ${globs.join(' ')}`);
+    return execGitCommandCountLines(`git ls-files -- ${globs.join(' ')}`, {
+      timeout: 5000,
+    });
   } catch {
     return undefined;
   }

--- a/node-src/git/git.ts
+++ b/node-src/git/git.ts
@@ -435,7 +435,7 @@ export async function getStorybookCreationDate(ctx: {
  */
 export async function getNumberOfComitters() {
   try {
-    return execGitCommandCountLines(`git shortlog -sn --all --since="6 months ago"`, {
+    return await execGitCommandCountLines(`git shortlog -sn --all --since="6 months ago"`, {
       timeout: 5000,
     });
   } catch {
@@ -462,7 +462,7 @@ export async function getCommittedFileCount(nameMatches: string[], extensions: s
       extensions.map((extension) => `"*${match}*.${extension}"`)
     );
 
-    return execGitCommandCountLines(`git ls-files -- ${globs.join(' ')}`, {
+    return await execGitCommandCountLines(`git ls-files -- ${globs.join(' ')}`, {
       timeout: 5000,
     });
   } catch {

--- a/node-src/tasks/gitInfo.ts
+++ b/node-src/tasks/gitInfo.ts
@@ -99,13 +99,17 @@ export const setGitInfo = async (ctx: Context, task: Task) => {
     ...commitAndBranchInfo,
   };
 
-  ctx.projectMetadata = {
-    hasRouter: getHasRouter(ctx.packageJson),
-    creationDate: await getRepositoryCreationDate(),
-    storybookCreationDate: await getStorybookCreationDate(ctx),
-    numberOfCommitters: await getNumberOfComitters(),
-    numberOfAppFiles: await getCommittedFileCount(['page', 'screen'], ['js', 'jsx', 'ts', 'tsx']),
-  };
+  try {
+    ctx.projectMetadata = {
+      hasRouter: getHasRouter(ctx.packageJson),
+      creationDate: await getRepositoryCreationDate(),
+      storybookCreationDate: await getStorybookCreationDate(ctx),
+      numberOfCommitters: await getNumberOfComitters(),
+      numberOfAppFiles: await getCommittedFileCount(['page', 'screen'], ['js', 'jsx', 'ts', 'tsx']),
+    };
+  } catch (err) {
+    ctx.log.debug('Failed to gather project metadata', err);
+  }
 
   if (isLocalBuild && !ctx.git.gitUserEmail) {
     throw new Error(gitUserEmailNotFound());


### PR DESCRIPTION
Unintentionally, the steps to gather project metadata were causing builds to fail if there was an error. 
As this data is not required, we should not fail the whole process if one of these fail.

This appears to be the original intention (with existing try/catch) but async returns bypassed them.

Additionally, the timeout on `getCommittedFileCount` was reduced, as an up to 20s slowdown for non-critical information was too high.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>11.20.2--canary.1131.12281896012.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@11.20.2--canary.1131.12281896012.0
  # or 
  yarn add chromatic@11.20.2--canary.1131.12281896012.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
