### PR TITLE
Upload coverage reports to codecov

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -1,6 +1,9 @@
 name: Lint and Test
 
 on:
+  push:
+    branches:
+      - main
   workflow_call:
     secrets:
       CODECOV_TOKEN:

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -5,6 +5,8 @@ on:
     secrets:
       CODACY_PROJECT_TOKEN:
         required: true
+      CODECOV_TOKEN:
+        required: true
 
 permissions:
   contents: read
@@ -37,3 +39,8 @@ jobs:
       - run: bash <(curl -Ls https://coverage.codacy.com/get.sh)
         env:
           CODACY_PROJECT_TOKEN: ${{ secrets.CODACY_PROJECT_TOKEN }}
+
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -3,8 +3,6 @@ name: Lint and Test
 on:
   workflow_call:
     secrets:
-      CODACY_PROJECT_TOKEN:
-        required: true
       CODECOV_TOKEN:
         required: true
 
@@ -34,11 +32,6 @@ jobs:
 
       # unit test
       - run: yarn test
-
-      # publish code coverage results
-      - run: bash <(curl -Ls https://coverage.codacy.com/get.sh)
-        env:
-          CODACY_PROJECT_TOKEN: ${{ secrets.CODACY_PROJECT_TOKEN }}
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v5

--- a/.github/workflows/pull-request-workflow.yml
+++ b/.github/workflows/pull-request-workflow.yml
@@ -29,6 +29,7 @@ jobs:
     uses: ./.github/workflows/lint-and-test.yml
     secrets:
       CODACY_PROJECT_TOKEN: ${{ secrets.CODACY_PROJECT_TOKEN }}
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   chromatic:
     uses: ./.github/workflows/chromatic-prod.yml

--- a/.github/workflows/pull-request-workflow.yml
+++ b/.github/workflows/pull-request-workflow.yml
@@ -28,7 +28,6 @@ jobs:
   lint-and-test:
     uses: ./.github/workflows/lint-and-test.yml
     secrets:
-      CODACY_PROJECT_TOKEN: ${{ secrets.CODACY_PROJECT_TOKEN }}
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   chromatic:


### PR DESCRIPTION
This PR replaces Codacy with Codecov. You can test by going to the branch for this one in Codecov and seeing the coverage. Looks like vitest emits coverage for all files, not just executed ones, so we have a complete report by default.

Closes CAP-2546
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>11.20.3--canary.1132.12396133002.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@11.20.3--canary.1132.12396133002.0
  # or 
  yarn add chromatic@11.20.3--canary.1132.12396133002.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
