### PR TITLE
Bail on preview file changes

### DIFF
--- a/node-src/lib/getDependentStoryFiles.test.ts
+++ b/node-src/lib/getDependentStoryFiles.test.ts
@@ -514,6 +514,33 @@ describe('getDependentStoryFiles', () => {
     );
   });
 
+  it('bails on changed preview.js file', async () => {
+    const changedFiles = ['src/foo.stories.js', 'path/to/storybook-config/preview.js'];
+    const modules = [
+      {
+        id: './path/to/storybook-config/preview.js',
+        name: './path/to/storybook-config/preview.js',
+        reasons: [{ moduleName: './path/to/storybook-config/generated-stories-entry.js' }],
+      },
+      {
+        id: CSF_GLOB,
+        name: CSF_GLOB,
+        reasons: [{ moduleName: './path/to/storybook-config/generated-stories-entry.js' }],
+      },
+    ];
+    const ctx = getContext({ configDir: 'path/to/storybook-config' });
+    const result = await getDependentStoryFiles(ctx, { modules }, statsPath, changedFiles);
+    expect(result).toBeUndefined();
+    expect(ctx.turboSnap.bailReason).toEqual({
+      changedStorybookFiles: ['path/to/storybook-config/preview.js'],
+    });
+    expect(ctx.log.warn).toHaveBeenCalledWith(
+      expect.stringContaining(
+        chalk`Found a Storybook config change in {bold path/to/storybook-config/preview.js}`
+      )
+    );
+  });
+
   it('bails on changed dependency of config file', async () => {
     const changedFiles = ['src/styles.js'];
     const modules = [

--- a/node-src/lib/getDependentStoryFiles.ts
+++ b/node-src/lib/getDependentStoryFiles.ts
@@ -142,8 +142,13 @@ export async function getDependentStoryFiles(
   const reasonsById = new Map<Module['id'], NormalizedName[]>();
   const csfGlobsByName = new Set<NormalizedName>();
 
+  const isStorybookFile = (name: string) =>
+    name && name.startsWith(`${storybookDirectory}/`) && !storiesEntryFiles.has(name);
+
   stats.modules
     .filter((module_) => isUserModule(module_))
+    // TODO: refactor this function
+    // eslint-disable-next-line complexity
     .map((module_) => {
       const normalizedName = normalize(module_.name);
       modulesByName.set(normalizedName, module_);
@@ -176,7 +181,10 @@ export async function getDependentStoryFiles(
         reasonsById.set(module_.id, normalizedReasons);
       }
 
-      if (reasonsById.get(module_.id)?.some((reason) => storiesEntryFiles.has(reason))) {
+      if (
+        !isStorybookFile(normalizedName) &&
+        reasonsById.get(module_.id)?.some((reason) => storiesEntryFiles.has(reason))
+      ) {
         csfGlobsByName.add(normalizedName);
       }
     });
@@ -203,8 +211,6 @@ export async function getDependentStoryFiles(
   }
 
   const isCsfGlob = (name: NormalizedName) => csfGlobsByName.has(name);
-  const isStorybookFile = (name: string) =>
-    name && name.startsWith(`${storybookDirectory}/`) && !storiesEntryFiles.has(name);
   const isStaticFile = (name: string) =>
     staticDirectories.some((directory) => name && name.startsWith(`${directory}/`));
 


### PR DESCRIPTION
It's possible to make a change to `preview.js` and TurboSnap doesn't trigger a full rebuild (as seen with Vite projects). Instead, we want this to trigger a full rebuild to not miss anything.

1. Go to https://new-storybook.netlify.app/ and download the zip for the repo of a React Vite project.
2. Run `build` and then `build-storybook --stats-json`
3. Run npx `chromatic trace .storybook/main.ts` and notice the TurboSnap bail message outputs in the terminal (be sure to use the canary listed in this PR)
4. Run `npx chromatic trace .storybook/preview.tsx` and you should see the same bail message but pointing to `preview.tsx` (again, with the canary from this PR)

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>11.22.0--canary.1133.12600382394.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@11.22.0--canary.1133.12600382394.0
  # or 
  yarn add chromatic@11.22.0--canary.1133.12600382394.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
