### PR TITLE
Set `storybookUrl` action output on rebuild early exit

### DIFF
--- a/node-src/index.ts
+++ b/node-src/index.ts
@@ -139,7 +139,7 @@ export async function run({
     code: ctx.exitCode,
     url: ctx.build?.webUrl,
     buildUrl: ctx.build?.webUrl,
-    storybookUrl: ctx.build?.storybookUrl,
+    storybookUrl: ctx.build?.storybookUrl || ctx.storybookUrl,
     specCount: ctx.build?.specCount,
     componentCount: ctx.build?.componentCount,
     testCount: ctx.build?.testCount,

--- a/node-src/tasks/gitInfo.ts
+++ b/node-src/tasks/gitInfo.ts
@@ -179,8 +179,8 @@ export const setGitInfo = async (ctx: Context, task: Task) => {
         ctx.rebuildForBuild = result.app.lastBuild;
         ctx.storybookUrl = result.app.lastBuild.storybookUrl;
         transitionTo(skippedRebuild, true)(ctx, task);
+        setExitCode(ctx, exitCodes.OK);
         ctx.log.info(forceRebuildHint());
-        ctx.exitCode = 0;
         return;
       }
     }


### PR DESCRIPTION
When the action exits early due to an existing passed/accepted build for the commit, set the `storybookUrl` output to the value of the last build.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>11.21.0--canary.1134.12589333919.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@11.21.0--canary.1134.12589333919.0
  # or 
  yarn add chromatic@11.21.0--canary.1134.12589333919.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
