### PR TITLE
Add `outputDir` to GitHub Action options

### DIFF
--- a/action-src/main.ts
+++ b/action-src/main.ts
@@ -123,6 +123,7 @@ async function run() {
     const onlyChanged = getInput('onlyChanged');
     const onlyStoryFiles = getMultilineInput('onlyStoryFiles');
     const onlyStoryNames = getMultilineInput('onlyStoryNames');
+    const outputDir = getInput('outputDir');
     const playwright = getInput('playwright');
     const preserveMissing = getInput('preserveMissing');
     const projectToken = getInput('projectToken') || getInput('appCode'); // backwards compatibility
@@ -179,6 +180,7 @@ async function run() {
         onlyChanged: maybe(onlyChanged),
         onlyStoryFiles: maybe(onlyStoryFiles),
         onlyStoryNames: maybe(onlyStoryNames),
+        outputDir: maybe(outputDir),
         playwright: maybe(playwright),
         preserveMissing: maybe(preserveMissing),
         projectToken,


### PR DESCRIPTION
Closes #1135

Simply adds the `outputDir` option to our GitHub Action so `buildCommand` can work properly. 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>11.22.1--canary.1136.12677624564.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@11.22.1--canary.1136.12677624564.0
  # or 
  yarn add chromatic@11.22.1--canary.1136.12677624564.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
