### PR TITLE
Add rsbuild v0.1.7 support

### DIFF
--- a/node-src/lib/getDependentStoryFiles.test.ts
+++ b/node-src/lib/getDependentStoryFiles.test.ts
@@ -162,7 +162,11 @@ describe('getDependentStoryFiles', () => {
     });
   });
 
-  it('detects direct changes to CSF files, rspack', async () => {
+  it.each([
+    [`./node_modules/.cache/storybook/default/dev-server/storybook-stories.js`],
+    [`./node_modules/.cache/storybook/storybook-rsbuild-builder/storybook-config-entry.js`],
+    [`./node_modules/.cache/storybook-rsbuild-builder/storybook-config-entry.js`],
+  ])('detects direct changes to CSF files, rspack (%s)', async (resolvedModule) => {
     const changedFiles = ['src/foo.stories.js'];
     const modules = [
       {
@@ -179,10 +183,8 @@ describe('getDependentStoryFiles', () => {
         id: String.raw`./src lazy recursive ^\.\/.*$`,
         reasons: [
           {
-            resolvedModule:
-              './node_modules/.cache/storybook/default/dev-server/storybook-stories.js',
-            moduleName:
-              './node_modules/.cache/storybook/default/dev-server/storybook-stories.js + 2 modules',
+            resolvedModule,
+            moduleName: `${resolvedModule} + 2 modules`,
           },
         ],
       },

--- a/node-src/lib/getDependentStoryFiles.ts
+++ b/node-src/lib/getDependentStoryFiles.ts
@@ -133,6 +133,7 @@ export async function getDependentStoryFiles(
       // rspack builder
       `./node_modules/.cache/storybook/default/dev-server/storybook-stories.js`,
       `./node_modules/.cache/storybook/storybook-rsbuild-builder/storybook-config-entry.js`,
+      `./node_modules/.cache/storybook-rsbuild-builder/storybook-config-entry.js`,
     ].map((file) => normalize(file))
   );
 

--- a/node-src/lib/getStorybookMetadata.ts
+++ b/node-src/lib/getStorybookMetadata.ts
@@ -1,4 +1,4 @@
-import { readConfig } from '@storybook/csf-tools';
+import { printConfig, readConfig } from '@storybook/csf-tools';
 import { readdir } from 'fs/promises';
 import { readJson } from 'fs-extra';
 import meow from 'meow';
@@ -227,7 +227,7 @@ export const getStorybookMetadata = async (ctx: Context) => {
       }
 
       mainConfig = await readConfig(storybookConfig);
-      ctx.log.debug({ configDirectory, mainConfig });
+      ctx.log.debug({ configDirectory, mainConfig: printConfig(mainConfig) });
       v7 = true;
     } catch (err) {
       ctx.log.debug({ storybookV7error: err });


### PR DESCRIPTION
Closes #1137
Closes CAP-2412

This PR does a couple things:

1. Adds rsbuild v0.1.7 support
    - The cache directory was flattened so TurboSnap would fail to find the CSF globs
2. Fixes our large debug log line
    - That log line made it real tough to see if the TurboSnap change worked or not so I went ahead and fixed it

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>11.22.2--canary.1138.12694282800.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@11.22.2--canary.1138.12694282800.0
  # or 
  yarn add chromatic@11.22.2--canary.1138.12694282800.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
