### PR TITLE
Added logic to terminate with timeout or flag

### DIFF
--- a/node-src/lib/findChangedDependencies.test.ts
+++ b/node-src/lib/findChangedDependencies.test.ts
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { Context } from '..';
 import * as git from '../git/git';
 import { findChangedDependencies } from './findChangedDependencies';
+import { deps } from './output.js';
 import TestLogger from './testLogger';
 
 vi.mock('snyk-nodejs-lockfile-parser');
@@ -103,9 +104,7 @@ describe('findChangedDependencies', () => {
 
   it('returns updated dependencies', async () => {
     // HEAD
-    buildDepTree.mockResolvedValueOnce({
-      dependencies: { react: { name: 'react', version: '18.2.0', dependencies: {} } },
-    });
+    buildDepTree.mockResolvedValueOnce(deps.dependencies);
 
     // Baseline A
     checkoutFile.mockResolvedValueOnce('A.package.json');

--- a/node-src/lib/findChangedDependencies.ts
+++ b/node-src/lib/findChangedDependencies.ts
@@ -97,19 +97,9 @@ export const findChangedDependencies = async (ctx: Context) => {
   // Use a Set so we only keep distinct package names.
   const changedDependencyNames = new Set<string>();
 
-  const timeout = 60_000;
-  const timeoutPromise = new Promise<never>((_, reject) => {
-    setTimeout(() => {
-      reject(new Error('Timeout while attempting to resolve dependencies dependencies'));
-    }, timeout);
-  });
-
   await Promise.all(
     filteredPathPairs.map(async ([manifestPath, lockfilePath, commits]) => {
-      const headDependencies = await Promise.race([
-        getDependencies(ctx, { rootPath, manifestPath, lockfilePath }),
-        timeoutPromise,
-      ]);
+      const headDependencies = await getDependencies(ctx, { rootPath, manifestPath, lockfilePath });
       ctx.log.debug({ manifestPath, lockfilePath, headDependencies }, `Found HEAD dependencies`);
 
       // Retrieve the union of dependencies which changed compared to each baseline.

--- a/node-src/lib/outputs.js
+++ b/node-src/lib/outputs.js
@@ -1,0 +1,1 @@
+export const deps = {};

--- a/node-src/tasks/upload.ts
+++ b/node-src/tasks/upload.ts
@@ -138,7 +138,10 @@ export const traceChangedFiles = async (ctx: Context, task: Task) => {
   try {
     // eslint-disable-next-line @typescript-eslint/no-invalid-void-type
     let changedDependencyNames: void | string[] = [];
-    if (packageMetadataChanges?.length) {
+    if (ctx.options.skipDependencyUpdateCheck) {
+      ctx.log.debug('Skipping dependency update check');
+    }
+    if (packageMetadataChanges?.length && !ctx.options.skipDependencyUpdateCheck) {
       changedDependencyNames = await findChangedDependencies(ctx).catch((err) => {
         const { name, message, stack, code } = err;
         ctx.log.debug({ name, message, stack, code });

--- a/node-src/types.ts
+++ b/node-src/types.ts
@@ -41,6 +41,7 @@ export interface Flags {
   untraced?: string[];
   zip?: boolean;
   skipUpdateCheck?: boolean;
+  skipDependencyUpdateCheck?: boolean;
 
   // Debug options
   debug?: boolean;
@@ -151,6 +152,8 @@ export interface Options extends Configuration {
   env?: Environment;
 
   skipUpdateCheck: Flags['skipUpdateCheck'];
+
+  skipDependencyUpdateCheck: Flags['skipDependencyUpdateCheck'];
 }
 
 export type TaskName =


### PR DESCRIPTION
This draft PR will discuss ideas around current manifest tracing memory issues with Monorepos.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>11.23.0--canary.1139.12715215777.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@11.23.0--canary.1139.12715215777.0
  # or 
  yarn add chromatic@11.23.0--canary.1139.12715215777.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
