### PR TITLE
Skip lock file parsing if it's larger than 10MB

### DIFF
--- a/node-src/lib/findChangedDependencies.test.ts
+++ b/node-src/lib/findChangedDependencies.test.ts
@@ -1,5 +1,6 @@
+import { statSync as unMockedStatSync } from 'fs';
 import { buildDepTreeFromFiles } from 'snyk-nodejs-lockfile-parser';
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, Mock, vi } from 'vitest';
 
 import { Context } from '..';
 import * as git from '../git/git';
@@ -9,6 +10,10 @@ import TestLogger from './testLogger';
 vi.mock('snyk-nodejs-lockfile-parser');
 vi.mock('yarn-or-npm');
 vi.mock('../git/git');
+vi.mock('fs');
+
+const statSync = unMockedStatSync as Mock;
+statSync.mockReturnValue({ size: 1 });
 
 const getRepositoryRoot = vi.mocked(git.getRepositoryRoot);
 const checkoutFile = vi.mocked(git.checkoutFile);


### PR DESCRIPTION
We've been seeing some OOM errors in TurboSnap that appears to come from our lock file parser. This attempts to alleviate that issue by completely skipping the lock file parsing if it's larger than 10 MB so we still get some of the benefits of TurboSnap without completely disabling it.

In case it wasn't obvious, the 10MB limit is a guess. We can adjust it as needed.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>11.23.0--canary.1140.12752995895.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@11.23.0--canary.1140.12752995895.0
  # or 
  yarn add chromatic@11.23.0--canary.1140.12752995895.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
