### PR TITLE
Log Turbosnap metrics to New Relic

### DIFF
--- a/node-src/lib/newRelic.ts
+++ b/node-src/lib/newRelic.ts
@@ -1,0 +1,31 @@
+import fetch from 'node-fetch';
+
+// This is a temp (and limited) API key. This should be removed when we no longer need our TurboSnap
+// metrics.
+const NEW_RELIC_KEY = 'f887ede1f80741a1cd368cac8c8aa11fFFFFNRAL';
+const NEW_RELIC_ENDPOINT = 'https://log-api.newrelic.com/log/v1';
+
+/**
+ * Writes a log line to New Relic
+ *
+ * @param data The object to write
+ */
+export async function writeLog(data: object) {
+  const body = JSON.stringify({
+    name: 'cli',
+    service: 'cli',
+    ...data,
+  });
+
+  try {
+    await fetch(NEW_RELIC_ENDPOINT, {
+      method: 'POST',
+      headers: {
+        'Api-Key': NEW_RELIC_KEY,
+      },
+      body,
+    });
+  } catch {
+    // Purposefully left blank
+  }
+}


### PR DESCRIPTION
We want to monitor if our lock file parsing is still helping with TurboSnap. This adds some quick metrics to help us figure that out.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>11.24.0--canary.1141.12774591779.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@11.24.0--canary.1141.12774591779.0
  # or 
  yarn add chromatic@11.24.0--canary.1141.12774591779.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
