### PR TITLE
Add additional rspack builder entrypoint

### DIFF
--- a/node-src/lib/getDependentStoryFiles.test.ts
+++ b/node-src/lib/getDependentStoryFiles.test.ts
@@ -164,6 +164,7 @@ describe('getDependentStoryFiles', () => {
 
   it.each([
     [`./node_modules/.cache/storybook/default/dev-server/storybook-stories.js`],
+    ['./node_modules/.cache/storybook-rsbuild-builder/storybook-stories.js'],
     [`./node_modules/.cache/storybook/storybook-rsbuild-builder/storybook-config-entry.js`],
     [`./node_modules/.cache/storybook-rsbuild-builder/storybook-config-entry.js`],
   ])('detects direct changes to CSF files, rspack (%s)', async (resolvedModule) => {

--- a/node-src/lib/getDependentStoryFiles.ts
+++ b/node-src/lib/getDependentStoryFiles.ts
@@ -132,6 +132,7 @@ export async function getDependentStoryFiles(
       `/virtual:/@storybook/builder-vite/vite-app.js`,
       // rspack builder
       `./node_modules/.cache/storybook/default/dev-server/storybook-stories.js`,
+      './node_modules/.cache/storybook-rsbuild-builder/storybook-stories.js',
       `./node_modules/.cache/storybook/storybook-rsbuild-builder/storybook-config-entry.js`,
       `./node_modules/.cache/storybook-rsbuild-builder/storybook-config-entry.js`,
     ].map((file) => normalize(file))


### PR DESCRIPTION
Add an entrypoint we missed for rspack tracing.

Closes #1146
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>11.25.2--canary.1147.13036792280.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@11.25.2--canary.1147.13036792280.0
  # or 
  yarn add chromatic@11.25.2--canary.1147.13036792280.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
