### PR TITLE
Fix directory flags for trace command.

### DIFF
--- a/bin-src/trace.ts
+++ b/bin-src/trace.ts
@@ -95,6 +95,10 @@ export async function main(argv: string[]) {
     git: {
       rootPath: await getRepositoryRoot(),
     },
+    storybook: {
+      baseDir: flags.storybookBaseDir,
+      configDir: flags.storybookConfigDir,
+    },
   } as any;
   const stats = await readStatsFile(flags.statsFile);
   const changedFiles = input.map((f) => f.replace(/^\.\//, ''));


### PR DESCRIPTION
The `trace` command was not putting the flag values where they belong, leading to a lot of confusion when tracing projects in sub-directories.  The main Chromatic command works as intended.  H/T @codykaup for finding this.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>11.25.3--canary.1148.13066235606.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@11.25.3--canary.1148.13066235606.0
  # or 
  yarn add chromatic@11.25.3--canary.1148.13066235606.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
