### PR TITLE
Set Apollo GraphQL client identification headers

### DIFF
--- a/node-src/index.ts
+++ b/node-src/index.ts
@@ -182,6 +182,8 @@ export async function runAll(ctx: InitialContext) {
       headers: {
         'x-chromatic-session-id': ctx.sessionId,
         'x-chromatic-cli-version': ctx.pkg.version,
+        'apollographql-client-name': 'chromatic-cli',
+        'apollographql-client-version': ctx.pkg.version,
       },
       retries: 3,
     });


### PR DESCRIPTION
Noticed we didn't differentiate the CLI client in Apollo when debugging something, so I added required headers.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>11.25.3--canary.1151.13186700181.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@11.25.3--canary.1151.13186700181.0
  # or 
  yarn add chromatic@11.25.3--canary.1151.13186700181.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
