### PR TITLE
Add new Vite builder entry for future SB versions

### DIFF
--- a/node-src/lib/getDependentStoryFiles.test.ts
+++ b/node-src/lib/getDependentStoryFiles.test.ts
@@ -6,7 +6,6 @@ import { Context } from '../types';
 import { getDependentStoryFiles, normalizePath } from './getDependentStoryFiles';
 
 const CSF_GLOB = String.raw`./src sync ^\.\/(?:(?!\.)(?=.)[^/]*?\.stories\.js)$`;
-const VITE_ENTRY = '/virtual:/@storybook/builder-vite/storybook-stories.js';
 const statsPath = 'preview-stats.json';
 
 const log = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() };
@@ -141,17 +140,20 @@ describe('getDependentStoryFiles', () => {
     });
   });
 
-  it('detects direct changes to CSF files, vite', async () => {
+  it.each([
+    '/virtual:/@storybook/builder-vite/storybook-stories.js',
+    'virtual:@storybook/builder-vite/storybook-stories.js',
+  ])('detects direct changes to CSF files, vite', async (viteEntry) => {
     const changedFiles = ['src/foo.stories.js'];
     const modules = [
       {
         id: './src/foo.stories.js',
         name: './src/foo.stories.js',
-        reasons: [{ moduleName: VITE_ENTRY }],
+        reasons: [{ moduleName: viteEntry }],
       },
       {
-        id: VITE_ENTRY,
-        name: VITE_ENTRY,
+        id: viteEntry,
+        name: viteEntry,
         reasons: [{ moduleName: '/virtual:/@storybook/builder-vite/vite-app.js' }],
       },
     ];

--- a/node-src/lib/getDependentStoryFiles.ts
+++ b/node-src/lib/getDependentStoryFiles.ts
@@ -130,6 +130,7 @@ export async function getDependentStoryFiles(
       `./storybook-stories.js`,
       // vite builder
       `/virtual:/@storybook/builder-vite/vite-app.js`,
+      `virtual:@storybook/builder-vite/vite-app.js`,
       // rspack builder
       `./node_modules/.cache/storybook/default/dev-server/storybook-stories.js`,
       './node_modules/.cache/storybook-rsbuild-builder/storybook-stories.js',


### PR DESCRIPTION
As discussed in https://github.com/storybookjs/storybook/pull/30522#issuecomment-2654298340, we're going to be removing the slashes from the `virtual:` path of our Vite builder at some point. This prepares for that change so TurboSnap will continue to work when that happens.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>11.25.3--canary.1155.13313018152.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@11.25.3--canary.1155.13313018152.0
  # or 
  yarn add chromatic@11.25.3--canary.1155.13313018152.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
