### PR TITLE
Fix moduleName resolution for Storybook files with import cycles.

### DIFF
--- a/node-src/lib/getDependentStoryFiles.test.ts
+++ b/node-src/lib/getDependentStoryFiles.test.ts
@@ -186,7 +186,6 @@ describe('getDependentStoryFiles', () => {
         id: String.raw`./src lazy recursive ^\.\/.*$`,
         reasons: [
           {
-            resolvedModule,
             moduleName: `${resolvedModule} + 2 modules`,
           },
         ],

--- a/node-src/types.ts
+++ b/node-src/types.ts
@@ -363,7 +363,6 @@ export interface Task {
 }
 
 export interface Reason {
-  resolvedModule?: string; // rspack sets a resolvedModule field that holds the module name
   moduleName: string;
 }
 export interface Module {


### PR DESCRIPTION
Newer versions of our webpack builder is now emitting `resolvedModule`, or perhaps always did in an undocumented manner.

This is generally not a problem, as we used `resolvedModule` for rspack and it is generally `null` from webpack, but when you have import cycles you can get a value which is not what we desire from it.

Removing it works with current rspack builders as well.