### PR TITLE
Upgrade to latest version of `snyk-nodejs-lockfile-parser`

### DIFF
--- a/package.json
+++ b/package.json
@@ -189,7 +189,7 @@
     "read-package-up": "^11.0.0",
     "semver": "^7.3.5",
     "slash": "^3.0.0",
-    "snyk-nodejs-lockfile-parser": "^1.52.1",
+    "snyk-nodejs-lockfile-parser": "^1.58.18",
     "sort-package-json": "1.50.0",
     "storybook": "^8.1.5",
     "string-argv": "^0.3.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7613,7 +7613,7 @@ __metadata:
     read-package-up: "npm:^11.0.0"
     semver: "npm:^7.3.5"
     slash: "npm:^3.0.0"
-    snyk-nodejs-lockfile-parser: "npm:^1.52.1"
+    snyk-nodejs-lockfile-parser: "npm:^1.58.18"
     sort-package-json: "npm:1.50.0"
     storybook: "npm:^8.1.5"
     string-argv: "npm:^0.3.1"
@@ -14032,13 +14032,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"micromatch@npm:^4.0.0, micromatch@npm:^4.0.2, micromatch@npm:^4.0.4, micromatch@npm:^4.0.5":
+"micromatch@npm:^4.0.0, micromatch@npm:^4.0.2, micromatch@npm:^4.0.4":
   version: 4.0.7
   resolution: "micromatch@npm:4.0.7"
   dependencies:
     braces: "npm:^3.0.3"
     picomatch: "npm:^2.3.1"
   checksum: 10c0/58fa99bc5265edec206e9163a1d2cec5fabc46a5b473c45f4a700adce88c2520456ae35f2b301e4410fb3afb27e9521fb2813f6fc96be0a48a89430e0916a772
+  languageName: node
+  linkType: hard
+
+"micromatch@npm:^4.0.8":
+  version: 4.0.8
+  resolution: "micromatch@npm:4.0.8"
+  dependencies:
+    braces: "npm:^3.0.3"
+    picomatch: "npm:^2.3.1"
+  checksum: 10c0/166fa6eb926b9553f32ef81f5f531d27b4ce7da60e5baf8c021d043b27a388fb95e46a8038d5045877881e673f8134122b59624d5cecbd16eb50a42e7a6b5ca8
   languageName: node
   linkType: hard
 
@@ -17651,7 +17661,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"snyk-config@npm:^5.0.0":
+"snyk-config@npm:^5.2.0":
   version: 5.3.0
   resolution: "snyk-config@npm:5.3.0"
   dependencies:
@@ -17663,9 +17673,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"snyk-nodejs-lockfile-parser@npm:^1.52.1":
-  version: 1.56.1
-  resolution: "snyk-nodejs-lockfile-parser@npm:1.56.1"
+"snyk-nodejs-lockfile-parser@npm:^1.58.18":
+  version: 1.58.18
+  resolution: "snyk-nodejs-lockfile-parser@npm:1.58.18"
   dependencies:
     "@snyk/dep-graph": "npm:^2.3.0"
     "@snyk/error-catalog-nodejs-public": "npm:^5.16.0"
@@ -17679,15 +17689,15 @@ __metadata:
     lodash.flatmap: "npm:^4.5.0"
     lodash.isempty: "npm:^4.4.0"
     lodash.topairs: "npm:^4.3.0"
-    micromatch: "npm:^4.0.5"
+    micromatch: "npm:^4.0.8"
     p-map: "npm:^4.0.0"
     semver: "npm:^7.6.0"
-    snyk-config: "npm:^5.0.0"
+    snyk-config: "npm:^5.2.0"
     tslib: "npm:^1.9.3"
     uuid: "npm:^8.3.0"
   bin:
     parse-nodejs-lockfile: bin/index.js
-  checksum: 10c0/3f1c8fa8af06569d4590f4f735deb9e7506bb46719a737f7f5701fc3f2f3073a0484ca8535bffdbfe09a5dce62e4796b2722ff3538ad0443a48ba8beac5d4ef5
+  checksum: 10c0/998b5f987480ccc5aecbe44a1d99e583adf21ddf27663bebb0ddecd0202850bce1c14a432bf5618676e1ce9b7e1bceae09ea463d35584e6e85d6f8ca00383ba9
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
We're looking to migrate to the dependency graph generation in `snyk-nodejs-lockfile-parser`. The first step is to upgrade so here it is!
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>11.26.0--canary.1158.13527878481.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@11.26.0--canary.1158.13527878481.0
  # or 
  yarn add chromatic@11.26.0--canary.1158.13527878481.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
