### PR TITLE
Throw on multiple scanned projects from snyk

### DIFF
--- a/node-src/lib/getDependencies.ts
+++ b/node-src/lib/getDependencies.ts
@@ -36,11 +36,10 @@ export const getDependencies = async (
       strictOutOfSync,
     });
 
-    if (!headGraph.scannedProjects[0].depGraph) {
+    if (headGraph.scannedProjects.length !== 1 || !headGraph.scannedProjects[0].depGraph) {
       throw new Error('Failed to parse dependency graph');
     }
 
-    // TODO: Handle multiple scanned projects
     return headGraph.scannedProjects[0].depGraph;
   } catch (err) {
     ctx.log.debug({ rootPath, manifestPath, lockfilePath }, 'Failed to get dependencies');


### PR DESCRIPTION
The code from `snyk-nodejs-plugin` does not currently support multiple scanned projects, but we want to make sure we cover that in case of a package upgrade we miss.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>11.26.2--canary.1161.13639680647.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@11.26.2--canary.1161.13639680647.0
  # or 
  yarn add chromatic@11.26.2--canary.1161.13639680647.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
