### PR TITLE
Move TurboSnap to a local lib

### DIFF
--- a/bin-src/trace.ts
+++ b/bin-src/trace.ts
@@ -1,7 +1,7 @@
+import { getDependentStoryFiles } from '@cli/turbosnap';
 import meow from 'meow';
 
 import { getRepositoryRoot } from '../node-src/git/git';
-import { getDependentStoryFiles } from '../node-src/lib/getDependentStoryFiles';
 import { isPackageManifestFile } from '../node-src/lib/utils';
 import { readStatsFile } from '../node-src/tasks/readStatsFile';
 import { Context } from '../node-src/types';

--- a/node-src/lib/turbosnap/compareBaseline.test.ts
+++ b/node-src/lib/turbosnap/compareBaseline.test.ts
@@ -2,9 +2,9 @@ import path from 'path';
 import { fileURLToPath } from 'url';
 import { describe, expect, it } from 'vitest';
 
+import TestLogger from '../testLogger';
 import { compareBaseline } from './compareBaseline';
 import { getDependencies } from './getDependencies';
-import TestLogger from './testLogger';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -17,12 +17,12 @@ describe('compareBaseline', () => {
   it('finds changed dependency names', async () => {
     const ctx = getContext();
     const headDependencies = await getDependencies(ctx, {
-      rootPath: path.join(__dirname, '../__mocks__/dependencyChanges/react-async-10'),
+      rootPath: path.join(__dirname, '../../__mocks__/dependencyChanges/react-async-10'),
       manifestPath: 'package.json',
       lockfilePath: 'yarn.lock',
     });
     const baselineChanges = await compareBaseline(ctx, headDependencies, {
-      rootPath: path.join(__dirname, '../__mocks__/dependencyChanges/react-async-9'),
+      rootPath: path.join(__dirname, '../../__mocks__/dependencyChanges/react-async-9'),
       manifestPath: 'package.json',
       lockfilePath: 'yarn.lock',
     });
@@ -33,12 +33,12 @@ describe('compareBaseline', () => {
   it('finds added dependency names', async () => {
     const ctx = getContext();
     const headDependencies = await getDependencies(ctx, {
-      rootPath: path.join(__dirname, '../__mocks__/dependencyChanges/react-async-9'),
+      rootPath: path.join(__dirname, '../../__mocks__/dependencyChanges/react-async-9'),
       manifestPath: 'package.json',
       lockfilePath: 'yarn.lock',
     });
     const baselineChanges = await compareBaseline(ctx, headDependencies, {
-      rootPath: path.join(__dirname, '../__mocks__/dependencyChanges/plain'),
+      rootPath: path.join(__dirname, '../../__mocks__/dependencyChanges/plain'),
       manifestPath: 'package.json',
       lockfilePath: 'yarn.lock',
     });
@@ -49,12 +49,12 @@ describe('compareBaseline', () => {
   it('finds removed dependency names', async () => {
     const ctx = getContext();
     const headDependencies = await getDependencies(ctx, {
-      rootPath: path.join(__dirname, '../__mocks__/dependencyChanges/plain'),
+      rootPath: path.join(__dirname, '../../__mocks__/dependencyChanges/plain'),
       manifestPath: 'package.json',
       lockfilePath: 'yarn.lock',
     });
     const baselineChanges = await compareBaseline(ctx, headDependencies, {
-      rootPath: path.join(__dirname, '../__mocks__/dependencyChanges/react-async-9'),
+      rootPath: path.join(__dirname, '../../__mocks__/dependencyChanges/react-async-9'),
       manifestPath: 'package.json',
       lockfilePath: 'yarn.lock',
     });
@@ -65,12 +65,12 @@ describe('compareBaseline', () => {
   it('finds nothing given identical files', async () => {
     const ctx = getContext();
     const headDependencies = await getDependencies(ctx, {
-      rootPath: path.join(__dirname, '../__mocks__/dependencyChanges/plain'),
+      rootPath: path.join(__dirname, '../../__mocks__/dependencyChanges/plain'),
       manifestPath: 'package.json',
       lockfilePath: 'yarn.lock',
     });
     const baselineChanges = await compareBaseline(ctx, headDependencies, {
-      rootPath: path.join(__dirname, '../__mocks__/dependencyChanges/plain'),
+      rootPath: path.join(__dirname, '../../__mocks__/dependencyChanges/plain'),
       manifestPath: 'package.json',
       lockfilePath: 'yarn.lock',
     });
@@ -81,12 +81,12 @@ describe('compareBaseline', () => {
   it('runs the manifest check on yarn berry lock files successfully', async () => {
     const ctx = getContext();
     const headDependencies = await getDependencies(ctx, {
-      rootPath: path.join(__dirname, '../__mocks__/dependencyChanges/berry'),
+      rootPath: path.join(__dirname, '../../__mocks__/dependencyChanges/berry'),
       manifestPath: 'package.json',
       lockfilePath: 'yarn.lock',
     });
     const baselineChanges = await compareBaseline(ctx, headDependencies, {
-      rootPath: path.join(__dirname, '../__mocks__/dependencyChanges/berry'),
+      rootPath: path.join(__dirname, '../../__mocks__/dependencyChanges/berry'),
       manifestPath: 'package.json',
       lockfilePath: 'yarn.lock',
     });
@@ -97,12 +97,12 @@ describe('compareBaseline', () => {
   it('does not find yarn berry changed dependency name for set resolution', async () => {
     const ctx = getContext();
     const headDependencies = await getDependencies(ctx, {
-      rootPath: path.join(__dirname, '../__mocks__/dependencyChanges/berry'),
+      rootPath: path.join(__dirname, '../../__mocks__/dependencyChanges/berry'),
       manifestPath: 'package.json',
       lockfilePath: 'yarn.lock',
     });
     const baselineChanges = await compareBaseline(ctx, headDependencies, {
-      rootPath: path.join(__dirname, '../__mocks__/dependencyChanges/berry-chalk'),
+      rootPath: path.join(__dirname, '../../__mocks__/dependencyChanges/berry-chalk'),
       manifestPath: 'package.json',
       lockfilePath: 'yarn.lock',
     });
@@ -113,12 +113,12 @@ describe('compareBaseline', () => {
   it('finds yarn berry dependency change name', async () => {
     const ctx = getContext();
     const headDependencies = await getDependencies(ctx, {
-      rootPath: path.join(__dirname, '../__mocks__/dependencyChanges/berry'),
+      rootPath: path.join(__dirname, '../../__mocks__/dependencyChanges/berry'),
       manifestPath: 'package.json',
       lockfilePath: 'yarn.lock',
     });
     const baselineChanges = await compareBaseline(ctx, headDependencies, {
-      rootPath: path.join(__dirname, '../__mocks__/dependencyChanges/berry-chalk'),
+      rootPath: path.join(__dirname, '../../__mocks__/dependencyChanges/berry-chalk'),
       manifestPath: 'package.json',
       lockfilePath: 'yarn.lock',
     });

--- a/node-src/lib/turbosnap/compareBaseline.ts
+++ b/node-src/lib/turbosnap/compareBaseline.ts
@@ -1,7 +1,7 @@
 import { DepGraph } from '@snyk/dep-graph';
 import { createChangedPackagesGraph } from '@snyk/dep-graph';
 
-import { Context } from '../types';
+import { Context } from '../../types';
 import { BaselineConfig, getDependencies } from './getDependencies';
 
 export const compareBaseline = async (

--- a/node-src/lib/turbosnap/findChangedDependencies.test.ts
+++ b/node-src/lib/turbosnap/findChangedDependencies.test.ts
@@ -5,16 +5,16 @@ import { buildDepTreeFromFiles } from 'snyk-nodejs-lockfile-parser';
 import snyk from 'snyk-nodejs-plugin';
 import { afterEach, beforeEach, describe, expect, it, Mock, vi } from 'vitest';
 
-import { Context } from '..';
-import * as git from '../git/git';
+import { Context } from '../..';
+import * as git from '../../git/git';
+import TestLogger from '../testLogger';
 import { findChangedDependencies } from './findChangedDependencies';
-import TestLogger from './testLogger';
 
 vi.mock('snyk-nodejs-lockfile-parser');
 vi.mock('snyk-nodejs-plugin');
 vi.mock('@snyk/dep-graph');
 vi.mock('yarn-or-npm');
-vi.mock('../git/git');
+vi.mock('../../git/git');
 vi.mock('fs');
 
 const tmpdir = '/tmpdir';

--- a/node-src/lib/turbosnap/findChangedDependencies.ts
+++ b/node-src/lib/turbosnap/findChangedDependencies.ts
@@ -2,11 +2,11 @@ import fs from 'fs';
 import os from 'os';
 import path from 'path';
 
-import { checkoutFile, findFilesFromRepositoryRoot, getRepositoryRoot } from '../git/git';
-import { Context } from '../types';
+import { checkoutFile, findFilesFromRepositoryRoot, getRepositoryRoot } from '../../git/git';
+import { Context } from '../../types';
+import { matchesFile } from '../utils';
 import { compareBaseline } from './compareBaseline';
 import { getDependencies } from './getDependencies';
-import { matchesFile } from './utils';
 
 const PACKAGE_JSON = 'package.json';
 const SUPPORTED_LOCK_FILES = ['yarn.lock', 'pnpm-lock.yaml', 'package-lock.json'];

--- a/node-src/lib/turbosnap/findChangedPackageFiles.test.ts
+++ b/node-src/lib/turbosnap/findChangedPackageFiles.test.ts
@@ -1,13 +1,13 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import * as execGit from '../git/execGit';
+import * as execGit from '../../git/execGit';
 import {
   arePackageDependenciesEqual,
   clearFileCache,
   findChangedPackageFiles,
 } from './findChangedPackageFiles';
 
-vi.mock('../git/execGit');
+vi.mock('../../git/execGit');
 
 const execGitCommand = vi.mocked(execGit.execGitCommand);
 

--- a/node-src/lib/turbosnap/findChangedPackageFiles.ts
+++ b/node-src/lib/turbosnap/findChangedPackageFiles.ts
@@ -1,5 +1,5 @@
-import { execGitCommand } from '../git/execGit';
-import { isPackageMetadataFile } from './utils';
+import { execGitCommand } from '../../git/execGit';
+import { isPackageMetadataFile } from '../utils';
 
 // TODO: refactor this function
 // eslint-disable-next-line complexity

--- a/node-src/lib/turbosnap/getDependencies.test.ts
+++ b/node-src/lib/turbosnap/getDependencies.test.ts
@@ -5,10 +5,10 @@ import { inspect as unmockedInspect } from 'snyk-nodejs-plugin';
 import { fileURLToPath } from 'url';
 import { describe, expect, it, Mock, vi } from 'vitest';
 
-import packageJson from '../__mocks__/dependencyChanges/plain/package.json';
-import { checkoutFile } from '../git/git';
+import packageJson from '../../__mocks__/dependencyChanges/plain/package.json';
+import { checkoutFile } from '../../git/git';
+import TestLogger from '../testLogger';
 import { getDependencies, MAX_LOCK_FILE_SIZE } from './getDependencies';
-import TestLogger from './testLogger';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -40,7 +40,7 @@ vi.mock('snyk-nodejs-plugin', async (original) => {
 describe('getDependencies', () => {
   it('should return a set of dependencies', async () => {
     const dependencies = await getDependencies(ctx, {
-      rootPath: path.join(__dirname, '../__mocks__/dependencyChanges/plain'),
+      rootPath: path.join(__dirname, '../../__mocks__/dependencyChanges/plain'),
       manifestPath: 'package.json',
       lockfilePath: 'yarn.lock',
     });
@@ -132,7 +132,7 @@ describe('getDependencies', () => {
 
     await expect(() =>
       getDependencies(ctx, {
-        rootPath: path.join(__dirname, '../__mocks__/dependencyChanges/plain'),
+        rootPath: path.join(__dirname, '../../__mocks__/dependencyChanges/plain'),
         manifestPath: 'package.json',
         lockfilePath: 'yarn.lock',
       })
@@ -144,7 +144,7 @@ describe('getDependencies', () => {
     statSync.mockReturnValue({ size: MAX_LOCK_FILE_SIZE + 1000 });
 
     const dependencies = await getDependencies(ctx, {
-      rootPath: path.join(__dirname, '../__mocks__/dependencyChanges/plain'),
+      rootPath: path.join(__dirname, '../../__mocks__/dependencyChanges/plain'),
       manifestPath: 'package.json',
       lockfilePath: 'yarn.lock',
     });

--- a/node-src/lib/turbosnap/getDependencies.ts
+++ b/node-src/lib/turbosnap/getDependencies.ts
@@ -2,7 +2,7 @@ import { statSync } from 'fs';
 import path from 'path';
 import { inspect } from 'snyk-nodejs-plugin';
 
-import { Context } from '../types';
+import { Context } from '../../types';
 
 export const MAX_LOCK_FILE_SIZE = 10_485_760; // 10 MB
 

--- a/node-src/lib/turbosnap/getDependentStoryFiles.test.ts
+++ b/node-src/lib/turbosnap/getDependentStoryFiles.test.ts
@@ -2,7 +2,7 @@
 import chalk from 'chalk';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { Context } from '../types';
+import { Context } from '../../types';
 import { getDependentStoryFiles, normalizePath } from './getDependentStoryFiles';
 
 const CSF_GLOB = String.raw`./src sync ^\.\/(?:(?!\.)(?=.)[^/]*?\.stories\.js)$`;

--- a/node-src/lib/turbosnap/getDependentStoryFiles.ts
+++ b/node-src/lib/turbosnap/getDependentStoryFiles.ts
@@ -1,11 +1,11 @@
 import path from 'path';
 
-import { Context, Module, Reason, Stats } from '../types';
-import noCSFGlobs from '../ui/messages/errors/noCSFGlobs';
-import tracedAffectedFiles from '../ui/messages/info/tracedAffectedFiles';
-import bailFile from '../ui/messages/warnings/bailFile';
-import { posix } from './posix';
-import { isPackageManifestFile, matchesFile } from './utils';
+import { Context, Module, Reason, Stats } from '../../types';
+import noCSFGlobs from '../../ui/messages/errors/noCSFGlobs';
+import tracedAffectedFiles from '../../ui/messages/info/tracedAffectedFiles';
+import bailFile from '../../ui/messages/warnings/bailFile';
+import { posix } from '../posix';
+import { isPackageManifestFile, matchesFile } from '../utils';
 
 type FilePath = string;
 type NormalizedName = string;

--- a/node-src/lib/turbosnap/index.test.ts
+++ b/node-src/lib/turbosnap/index.test.ts
@@ -1,0 +1,133 @@
+import { access } from 'fs';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { exitCodes } from '../setExitCode';
+import { traceChangedFiles } from '.';
+import { findChangedDependencies as findChangedDependenciesDep } from './findChangedDependencies';
+import { findChangedPackageFiles as findChangedPackageFilesDep } from './findChangedPackageFiles';
+import { getDependentStoryFiles as getDependentStoryFilesDep } from './getDependentStoryFiles';
+
+vi.mock('fs');
+vi.mock('./findChangedDependencies');
+vi.mock('./findChangedPackageFiles');
+vi.mock('./getDependentStoryFiles');
+vi.mock('../../tasks/readStatsFile', () => ({
+  readStatsFile: () =>
+    Promise.resolve({
+      modules: [
+        {
+          id: '../__mocks__/storybookBaseDir/test.ts',
+          name: '../__mocks__/storybookBaseDir/test.ts',
+        },
+      ],
+    }),
+}));
+
+const getDependentStoryFiles = vi.mocked(getDependentStoryFilesDep);
+const findChangedPackageFiles = vi.mocked(findChangedPackageFilesDep);
+const findChangedDependencies = vi.mocked(findChangedDependenciesDep);
+const accessMock = vi.mocked(access);
+
+const environment = { CHROMATIC_RETRIES: 2, CHROMATIC_OUTPUT_INTERVAL: 0 };
+const log = { info: vi.fn(), warn: vi.fn(), debug: vi.fn(), error: vi.fn() };
+const http = { fetch: vi.fn() };
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+beforeEach(() => {
+  accessMock.mockImplementation((_path, callback) => Promise.resolve(callback(null)));
+});
+
+describe('traceChangedFiles', () => {
+  it('does not run package dependency analysis if there are no metadata changes', async () => {
+    const deps = { 123: ['./example.stories.js'] };
+    getDependentStoryFiles.mockResolvedValue(deps);
+
+    const ctx = {
+      env: environment,
+      log,
+      http,
+      options: {},
+      sourceDir: '/static/',
+      fileInfo: { statsPath: '/static/preview-stats.json' },
+      git: { changedFiles: ['./example.js'] },
+      turboSnap: {},
+    } as any;
+    const onlyStoryFiles = await traceChangedFiles(ctx);
+
+    expect(onlyStoryFiles).toStrictEqual(deps);
+    expect(findChangedDependencies).not.toHaveBeenCalled();
+    expect(findChangedPackageFiles).not.toHaveBeenCalled();
+  });
+
+  it('bails on package.json changes if it fails to retrieve lockfile changes (fallback scenario)', async () => {
+    findChangedDependencies.mockRejectedValue(new Error('no lockfile'));
+    findChangedPackageFiles.mockResolvedValue(['./package.json']);
+
+    const packageMetadataChanges = [{ changedFiles: ['./package.json'], commit: 'abcdef' }];
+    const ctx = {
+      env: environment,
+      log,
+      http,
+      options: {},
+      sourceDir: '/static/',
+      fileInfo: { statsPath: '/static/preview-stats.json' },
+      git: { changedFiles: ['./example.js', './package.json'], packageMetadataChanges },
+      turboSnap: {},
+    } as any;
+    await traceChangedFiles(ctx);
+
+    expect(ctx.turboSnap.bailReason).toEqual({ changedPackageFiles: ['./package.json'] });
+    expect(findChangedPackageFiles).toHaveBeenCalledWith(packageMetadataChanges);
+    expect(getDependentStoryFiles).not.toHaveBeenCalled();
+  });
+
+  it('throws an error if storybookBaseDir is incorrect', async () => {
+    const deps = { 123: ['./example.stories.js'] };
+    findChangedDependencies.mockResolvedValue([]);
+    findChangedPackageFiles.mockResolvedValue([]);
+    getDependentStoryFiles.mockResolvedValue(deps);
+    accessMock.mockImplementation((_path, callback) =>
+      Promise.resolve(callback(new Error('some error')))
+    );
+
+    const ctx = {
+      env: environment,
+      log,
+      http,
+      options: { storybookBaseDir: '/wrong' },
+      sourceDir: '/static/',
+      fileInfo: { statsPath: '/static/preview-stats.json' },
+      git: { changedFiles: ['./example.js'] },
+      turboSnap: {},
+    } as any;
+    await expect(traceChangedFiles(ctx)).rejects.toThrow();
+    expect(ctx.exitCode).toBe(exitCodes.INVALID_OPTIONS);
+  });
+
+  it('continues story file tracing if no dependencies are changed in package.json (fallback scenario)', async () => {
+    const deps = { 123: ['./example.stories.js'] };
+    findChangedDependencies.mockRejectedValue(new Error('no lockfile'));
+    findChangedPackageFiles.mockResolvedValue([]); // no dependency changes
+    getDependentStoryFiles.mockResolvedValue(deps);
+
+    const packageMetadataChanges = [{ changedFiles: ['./package.json'], commit: 'abcdef' }];
+    const ctx = {
+      env: environment,
+      log,
+      http,
+      options: {},
+      sourceDir: '/static/',
+      fileInfo: { statsPath: '/static/preview-stats.json' },
+      git: { changedFiles: ['./example.js', './package.json'], packageMetadataChanges },
+      turboSnap: {},
+    } as any;
+    const onlyStoryFiles = await traceChangedFiles(ctx);
+
+    expect(ctx.turboSnap.bailReason).toBeUndefined();
+    expect(onlyStoryFiles).toStrictEqual(deps);
+    expect(findChangedPackageFiles).toHaveBeenCalledWith(packageMetadataChanges);
+  });
+});

--- a/node-src/lib/turbosnap/index.ts
+++ b/node-src/lib/turbosnap/index.ts
@@ -1,0 +1,72 @@
+import semver from 'semver';
+
+import { readStatsFile } from '../../tasks/readStatsFile';
+import { Context } from '../../types';
+import missingStatsFile from '../../ui/messages/errors/missingStatsFile';
+import bailFile from '../../ui/messages/warnings/bailFile';
+import { checkStorybookBaseDirectory } from '../checkStorybookBaseDirectory';
+import { findChangedDependencies } from './findChangedDependencies';
+import { findChangedPackageFiles } from './findChangedPackageFiles';
+import { getDependentStoryFiles } from './getDependentStoryFiles';
+
+// eslint-disable-next-line complexity
+export const traceChangedFiles = async (ctx: Context) => {
+  if (!ctx.turboSnap || ctx.turboSnap.unavailable) return;
+  if (!ctx.git.changedFiles) return;
+  if (!ctx.fileInfo?.statsPath) {
+    // If we don't know the SB version, we should assume we don't support `--stats-json`
+    const nonLegacyStatsSupported =
+      ctx.storybook?.version &&
+      semver.gte(semver.coerce(ctx.storybook.version) || '0.0.0', '8.0.0');
+
+    ctx.turboSnap.bailReason = { missingStatsFile: true };
+    throw new Error(missingStatsFile({ legacy: !nonLegacyStatsSupported }));
+  }
+
+  const { statsPath } = ctx.fileInfo;
+  const { changedFiles, packageMetadataChanges } = ctx.git;
+
+  // eslint-disable-next-line @typescript-eslint/no-invalid-void-type
+  let changedDependencyNames: void | string[] = [];
+  if (packageMetadataChanges?.length) {
+    changedDependencyNames = await findChangedDependencies(ctx).catch((err) => {
+      const { name, message, stack, code } = err;
+      ctx.log.debug({ name, message, stack, code });
+    });
+    if (changedDependencyNames) {
+      ctx.git.changedDependencyNames = changedDependencyNames;
+      if (!ctx.options.interactive) {
+        const list =
+          changedDependencyNames.length > 0
+            ? `:\n${changedDependencyNames.map((f) => `  ${f}`).join('\n')}`
+            : '';
+        ctx.log.info(`Found ${changedDependencyNames.length} changed dependencies${list}`);
+      }
+    } else {
+      ctx.log.warn(`Could not retrieve dependency changes from lockfiles; checking package.json`);
+
+      const changedPackageFiles = await findChangedPackageFiles(packageMetadataChanges);
+      if (changedPackageFiles.length > 0) {
+        ctx.turboSnap.bailReason = { changedPackageFiles };
+        ctx.log.warn(bailFile({ turboSnap: ctx.turboSnap }));
+        return;
+      }
+    }
+  }
+
+  const stats = await readStatsFile(statsPath);
+
+  await checkStorybookBaseDirectory(ctx, stats);
+
+  return await getDependentStoryFiles(
+    ctx,
+    stats,
+    statsPath,
+    changedFiles,
+    changedDependencyNames || []
+  );
+};
+
+export { findChangedDependencies } from './findChangedDependencies';
+export { findChangedPackageFiles } from './findChangedPackageFiles';
+export { getDependentStoryFiles } from './getDependentStoryFiles';

--- a/package.json
+++ b/package.json
@@ -205,6 +205,7 @@
     "util-deprecate": "^1.0.2",
     "uuid": "^8.3.2",
     "vite": "^4.4.9",
+    "vite-tsconfig-paths": "^5.1.4",
     "vitest": "^2.0.5",
     "why-is-node-running": "^2.1.2",
     "xxhash-wasm": "^1.0.2",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,9 @@
     "module": "es2022",
     "moduleResolution": "Bundler",
     "strict": true,
+    "paths": {
+      "@cli/*": ["./node-src/lib/*"]
+    },
     "forceConsistentCasingInFileNames": true,
     "noImplicitAny": false, // Let this be a warning from ESLint until it becomes required
     "useUnknownInCatchVariables": false, // Treat caught errors as 'any' for now

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -1,4 +1,5 @@
-import { configDefaults, coverageConfigDefaults, defineConfig } from 'vitest/config';
+import tsconfigPaths from 'vite-tsconfig-paths';
+import { configDefaults, coverageConfigDefaults, defineConfig, Plugin } from 'vitest/config';
 
 export default defineConfig({
   test: {
@@ -14,4 +15,5 @@ export default defineConfig({
       ],
     },
   },
+  plugins: [tsconfigPaths() as Plugin],
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -7695,6 +7695,7 @@ __metadata:
     util-deprecate: "npm:^1.0.2"
     uuid: "npm:^8.3.2"
     vite: "npm:^4.4.9"
+    vite-tsconfig-paths: "npm:^5.1.4"
     vitest: "npm:^2.0.5"
     why-is-node-running: "npm:^2.1.2"
     xxhash-wasm: "npm:^1.0.2"
@@ -11056,6 +11057,13 @@ __metadata:
     pify: "npm:^4.0.1"
     slash: "npm:^2.0.0"
   checksum: 10c0/2bd47ec43797b81000f3619feff96803b22591961788c06d746f6c8ba2deb14676b591ee625eb74b197c0047b2236e4a7a2ad662417661231b317c1de67aee94
+  languageName: node
+  linkType: hard
+
+"globrex@npm:^0.1.2":
+  version: 0.1.2
+  resolution: "globrex@npm:0.1.2"
+  checksum: 10c0/a54c029520cf58bda1d8884f72bd49b4cd74e977883268d931fd83bcbd1a9eb96d57c7dbd4ad80148fb9247467ebfb9b215630b2ed7563b2a8de02e1ff7f89d1
   languageName: node
   linkType: hard
 
@@ -19021,6 +19029,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tsconfck@npm:^3.0.3":
+  version: 3.1.5
+  resolution: "tsconfck@npm:3.1.5"
+  peerDependencies:
+    typescript: ^5.0.0
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  bin:
+    tsconfck: bin/tsconfck.js
+  checksum: 10c0/9b62cd85d5702aa23ea50ea578d7124f3d59cc4518fcc7eacc04f4f9c9c481f720738ff8351bd4472247c0723a17dfd01af95a5b60ad623cdb8727fbe4881847
+  languageName: node
+  linkType: hard
+
 "tsconfig-paths@npm:^3.15.0":
   version: 3.15.0
   resolution: "tsconfig-paths@npm:3.15.0"
@@ -19998,6 +20020,22 @@ __metadata:
   bin:
     vite-node: vite-node.mjs
   checksum: 10c0/affcc58ae8d45bce3e8bc3b5767acd57c24441634e2cd967cf97f4e5ed2bcead1714b60150cdf7ee153ebad47659c5cd419883207e1a95b69790331e3243749f
+  languageName: node
+  linkType: hard
+
+"vite-tsconfig-paths@npm:^5.1.4":
+  version: 5.1.4
+  resolution: "vite-tsconfig-paths@npm:5.1.4"
+  dependencies:
+    debug: "npm:^4.1.1"
+    globrex: "npm:^0.1.2"
+    tsconfck: "npm:^3.0.3"
+  peerDependencies:
+    vite: "*"
+  peerDependenciesMeta:
+    vite:
+      optional: true
+  checksum: 10c0/6228f23155ea25d92b1e1702284cf8dc52ad3c683c5ca691edd5a4c82d2913e7326d00708cef1cbfde9bb226261df0e0a12e03ef1d43b6a92d8f02b483ef37e3
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Closes CAP-2835

We want to isolate the TurboSnap functions to a local lib so things are easier to test and reason about. This change

- Adds `paths` to `tsconfig.json` so we can import any local lib via `@cli/<package_name>`
- Moves all TurboSnap files to `lib/turbosnap`
- Adds a couple tests to increase coverage of `index.ts`

Note: Further refactoring and cleanup will happen in separate PRs!

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>11.27.1--canary.1162.13641777959.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@11.27.1--canary.1162.13641777959.0
  # or 
  yarn add chromatic@11.27.1--canary.1162.13641777959.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
