### PR TITLE
Add `pnpm-lock.yaml` to list of lockfiles

### DIFF
--- a/node-src/lib/turbosnap/getDependentStoryFiles.test.ts
+++ b/node-src/lib/turbosnap/getDependentStoryFiles.test.ts
@@ -409,7 +409,13 @@ describe('getDependentStoryFiles', () => {
   });
 
   it('does not bail on changed global file', async () => {
-    const changedFiles = ['src/foo.stories.js', 'package.json', 'package-lock.json', 'yarn.lock'];
+    const changedFiles = [
+      'src/foo.stories.js',
+      'package.json',
+      'package-lock.json',
+      'yarn.lock',
+      'pnpm-lock.yaml',
+    ];
     const modules = [
       {
         id: './src/foo.stories.js',
@@ -478,7 +484,9 @@ describe('getDependentStoryFiles', () => {
         reasons: [{ moduleName: './.storybook/generated-stories-entry.js' }],
       },
     ];
-    const rawContext = getContext({ untraced: ['**/(package.json|package-lock.json|yarn.lock)'] });
+    const rawContext = getContext({
+      untraced: ['**/(package.json|package-lock.json|yarn.lock|pnpm-lock.yaml)'],
+    });
     const ctx = {
       ...rawContext,
       // signifying the package.json file had dependency changes
@@ -736,6 +744,7 @@ describe('getDependentStoryFiles', () => {
       'src/package.json',
       'src/package-lock.json',
       'src/yarn.lock',
+      'src/pnpm-lock.yaml',
     ];
     const modules = [
       {
@@ -760,7 +769,7 @@ describe('getDependentStoryFiles', () => {
       },
     ];
     const ctx = getContext({
-      untraced: ['**/(package**.json|yarn.lock)'],
+      untraced: ['**/(package**.json|yarn.lock|pnpm-lock.yaml)'],
     });
     const result = await getDependentStoryFiles(ctx, { modules }, statsPath, changedFiles);
     expect(ctx.turboSnap.bailReason).toBeUndefined();

--- a/node-src/lib/turbosnap/getDependentStoryFiles.ts
+++ b/node-src/lib/turbosnap/getDependentStoryFiles.ts
@@ -6,23 +6,17 @@ import tracedAffectedFiles from '../../ui/messages/info/tracedAffectedFiles';
 import bailFile from '../../ui/messages/warnings/bailFile';
 import { posix } from '../posix';
 import { isPackageManifestFile, matchesFile } from '../utils';
+import { SUPPORTED_LOCK_FILES } from './findChangedDependencies';
 
 type FilePath = string;
 type NormalizedName = string;
 type TraceToCheck = (string | number | string[])[];
 
-// Bail whenever one of these was changed
-const LOCKFILES = [
-  /^package-lock\.json$/,
-  /^yarn\.lock$/,
-  /\/package-lock\.json$/,
-  /\/yarn\.lock$/,
-];
-
 // Ignore these while tracing dependencies
 const INTERNALS = [/\/webpack\/runtime\//, /^\(webpack\)/];
 
-const isPackageLockFile = (name: string) => LOCKFILES.some((re) => re.test(name));
+const isPackageLockFile = (name: string) =>
+  SUPPORTED_LOCK_FILES.some((lockfile) => name.endsWith(lockfile));
 const isUserModule = (module_: Module | Reason) =>
   (module_ as Module).id !== undefined &&
   (module_ as Module).id !== null &&


### PR DESCRIPTION
Looks like we have a list of lockfiles and forgot to add pnpm-lock.yaml to it. This does just that!

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>11.27.1--canary.1164.13679750904.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@11.27.1--canary.1164.13679750904.0
  # or 
  yarn add chromatic@11.27.1--canary.1164.13679750904.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
