### PR TITLE
Added the deployment status event for waiting on GHA deployment

### DIFF
--- a/action-src/main.ts
+++ b/action-src/main.ts
@@ -56,6 +56,7 @@ const getBuildInfo = (event: typeof context) => {
         slug: repository?.full_name,
       };
     }
+    case 'deployment_status':
     case 'workflow_dispatch':
     case 'issue_comment': {
       return {


### PR DESCRIPTION
Support the [deployment_status](https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#deployment_status) event type for Github Actions.

This allows consumers to support running Playwright or Cypress tests _after_ a deployment is complete to a third party platform such as Vercel when using the action in the same workflow file.

Fixes #647 

### Example Configuration

The following configuration currently exits with an error for unsupported event type. This PR fixes the error.

```yml
name: Chromatic

on:
  deployment_status:
  
jobs:
  playwright:
    container:
      image: mcr.microsoft.com/playwright:v1.49.0-jammy
    steps:
      - uses: actions/checkout@v4
      
      - name: Run Playwright Tests
        run: npx playwright test
        env:
          PLAYWRIGHT_TEST_BASE_URL: ${{ github.event.deployment_status.target_url }}
          
      - uses: actions/upload-artifact@v4
        if: always()
        with:
          name: playwright-results
          path: ./playwright-report
          retention-days: 30

  chromatic:
    name: Run Chromatic
    needs: playwright
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@v4 
      
      - uses: actions/download-artifact@v4
        with:
          path: ${{ github.workspace }}
          
      - name: Chromatic
        uses: chromaui/action@latest
        with:
          playwright: true
          projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
```
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>11.28.0--canary.1165.13792095216.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@11.28.0--canary.1165.13792095216.0
  # or 
  yarn add chromatic@11.28.0--canary.1165.13792095216.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
