### PR TITLE
:pencil2: Update help text to reflect actual state of exitOnceUploaded.

### DIFF
--- a/node-src/ui/messages/info/speedUpCI.ts
+++ b/node-src/ui/messages/info/speedUpCI.ts
@@ -14,6 +14,6 @@ export default (provider: string) =>
   dedent(chalk`
     ${info} {bold Speed up Continuous Integration}
     Your project is linked to ${providers[provider]} so Chromatic will report results there.
-    This means you can pass the {bold --exit-once-uploaded} flag to skip waiting for build results.
-    Read more here: ${link('https://www.chromatic.com/docs/cli#chromatic-options')}
+    This means you can add the option \`with: exitOnceUploaded: true\` to your workflow to skip waiting for build results.
+    Read more here: ${link('https://www.chromatic.com/docs/github-actions#available-options')}
   `);


### PR DESCRIPTION
We previously suggested that users use the flag --exit-once-uploaded, but now that we have a workflow parameter for this, our github action can actually take advantage of reporting the correct way to pass this option.

Fixes CAP-2374.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>11.28.1--canary.1169.14247692752.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@11.28.1--canary.1169.14247692752.0
  # or 
  yarn add chromatic@11.28.1--canary.1169.14247692752.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
