### PR TITLE
Return additional build info on action rerun

### DIFF
--- a/node-src/index.ts
+++ b/node-src/index.ts
@@ -139,18 +139,20 @@ export async function run({
   return {
     // Keep this in sync with the configured outputs in action.yml
     code: ctx.exitCode,
-    url: ctx.build?.webUrl,
-    buildUrl: ctx.build?.webUrl,
+    url: ctx.build?.webUrl ?? ctx.rebuildForBuild?.webUrl,
+    buildUrl: ctx.build?.webUrl ?? ctx.rebuildForBuild?.webUrl,
     storybookUrl: ctx.build?.storybookUrl || ctx.storybookUrl,
-    specCount: ctx.build?.specCount,
-    componentCount: ctx.build?.componentCount,
-    testCount: ctx.build?.testCount,
-    changeCount: ctx.build?.changeCount,
-    errorCount: ctx.build?.errorCount,
-    interactionTestFailuresCount: ctx.build?.interactionTestFailuresCount,
-    actualTestCount: ctx.build?.actualTestCount,
-    actualCaptureCount: ctx.build?.actualCaptureCount,
-    inheritedCaptureCount: ctx.build?.inheritedCaptureCount,
+    specCount: ctx.build?.specCount ?? ctx.rebuildForBuild?.specCount,
+    componentCount: ctx.build?.componentCount ?? ctx.rebuildForBuild?.componentCount,
+    testCount: ctx.build?.testCount ?? ctx.rebuildForBuild?.testCount,
+    changeCount: ctx.build?.changeCount ?? ctx.rebuildForBuild?.changeCount,
+    errorCount: ctx.build?.errorCount ?? ctx.rebuildForBuild?.errorCount,
+    interactionTestFailuresCount:
+      ctx.build?.interactionTestFailuresCount ?? ctx.rebuildForBuild?.interactionTestFailuresCount,
+    actualTestCount: ctx.build?.actualTestCount ?? ctx.rebuildForBuild?.actualTestCount,
+    actualCaptureCount: ctx.build?.actualCaptureCount ?? ctx.rebuildForBuild?.actualCaptureCount,
+    inheritedCaptureCount:
+      ctx.build?.inheritedCaptureCount ?? ctx.rebuildForBuild?.inheritedCaptureCount,
   };
 }
 

--- a/node-src/tasks/gitInfo.test.ts
+++ b/node-src/tasks/gitInfo.test.ts
@@ -160,6 +160,15 @@ describe('setGitInfo', () => {
       status: 'ACCEPTED',
       webUrl: 'some-web-url',
       storybookUrl: 'some-storybook-url',
+      specCount: 1,
+      testCount: 2,
+      changeCount: 3,
+      errorCount: 4,
+      interactionTestFailuresCount: 5,
+      componentCount: 6,
+      actualTestCount: 7,
+      actualCaptureCount: 8,
+      inheritedCaptureCount: 9,
     };
 
     getParentCommits.mockResolvedValue([commitInfo.commit]);

--- a/node-src/tasks/gitInfo.ts
+++ b/node-src/tasks/gitInfo.ts
@@ -54,6 +54,15 @@ const LastBuildQuery = `
         status(legacy: false)
         storybookUrl
         webUrl
+        specCount
+        componentCount
+        testCount
+        changeCount
+        errorCount: testCount(statuses: [BROKEN])
+        actualTestCount: testCount(statuses: [IN_PROGRESS])
+        actualCaptureCount
+        inheritedCaptureCount
+        interactionTestFailuresCount
       }
     }
   }
@@ -66,6 +75,15 @@ interface LastBuildQueryResult {
       status: string;
       storybookUrl: string;
       webUrl: string;
+      specCount: number;
+      componentCount: number;
+      testCount: number;
+      changeCount: number;
+      errorCount: number;
+      actualTestCount: number;
+      actualCaptureCount: number;
+      inheritedCaptureCount: number;
+      interactionTestFailuresCount: number;
     };
   };
 }

--- a/node-src/types.ts
+++ b/node-src/types.ts
@@ -331,6 +331,15 @@ export interface Context {
     status: string;
     webUrl: string;
     storybookUrl: string;
+    specCount: number;
+    componentCount: number;
+    testCount: number;
+    changeCount: number;
+    errorCount: number;
+    actualTestCount: number;
+    actualCaptureCount: number;
+    inheritedCaptureCount: number;
+    interactionTestFailuresCount: number;
   };
   sourceDir: string;
   buildCommand?: string;


### PR DESCRIPTION
# Description

This PR fixes an issue whereby reruns of the GitHub action, which a user might trigger after approving visual changes, would not provide updated values for things like `testCount`, `changeCount`, etc. This was happening because we were only pulling these values from the `ctx.build` field, if it was defined. This PR updates that logic to pull from `ctx.rebuildForBuild` if `ctx.build` is undefined. I've also added the relevant fields to the `LastBuildQuery` GQL query so we're pulling that information from the index.

# Manual testing

I've verified through the Apollo GQL dashboard that the fields I've added to `LastBuildQuery` work as expected. I also ran a build with the CLI locally and triggered the `Skipping rebuild of an already fully passed/accepted build`, and confirmed that the relevant count values are being populated as expected.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>11.28.1--canary.1174.14513835718.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@11.28.1--canary.1174.14513835718.0
  # or 
  yarn add chromatic@11.28.1--canary.1174.14513835718.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
