### PR TITLE
Use pagination to get all tests in the build

### DIFF
--- a/node-src/tasks/report.test.ts
+++ b/node-src/tasks/report.test.ts
@@ -48,7 +48,7 @@ const mockTests = [
 
 vi.spyOn(reportBuilder, 'writeTo').mockImplementation(vi.fn());
 
-describe('generateRport', () => {
+describe('generateReport', () => {
   const client = { runQuery: vi.fn(), setAuthorization: vi.fn() };
   const build = {
     app: { repository: { provider: 'github' } },


### PR DESCRIPTION
Builds can have more tests than our max limit so details can go missing in CI pipelines and generated reports. This uses paginated queries to gather all the tests in the build in those cases.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>11.28.1--canary.1175.14502061051.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@11.28.1--canary.1175.14502061051.0
  # or 
  yarn add chromatic@11.28.1--canary.1175.14502061051.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
