### PR TITLE
Update the replacement build logic to search for multiple replacement builds

### DIFF
--- a/node-src/git/getChangedFilesWithReplacement.test.ts
+++ b/node-src/git/getChangedFilesWithReplacement.test.ts
@@ -4,7 +4,7 @@ import TestLogger from '../lib/testLogger';
 import { getChangedFilesWithReplacement } from './getChangedFilesWithReplacement';
 
 vi.mock('./git', () => ({
-  getChangedFiles: async (hash) => {
+  getChangedFiles: (hash) => {
     if (/exists/.test(hash)) return ['changed', 'files'];
     throw new Error(`fatal: bad object ${hash}`);
   },

--- a/node-src/git/getChangedFilesWithReplacement.test.ts
+++ b/node-src/git/getChangedFilesWithReplacement.test.ts
@@ -125,4 +125,106 @@ describe('getChangedFilesWithReplacements', () => {
       })
     ).rejects.toThrow(/fatal: bad object missing/);
   });
+
+  it('tries multiple replacement builds until finding a working one', async () => {
+    const failingBuild = {
+      id: 'failing',
+      number: 2,
+      commit: 'failing',
+      uncommittedHash: '',
+    };
+    const workingBuild = {
+      id: 'working',
+      number: 1,
+      commit: 'exists',
+      uncommittedHash: '',
+    };
+    client.runQuery
+      .mockReturnValueOnce({ app: { build: { ancestorBuilds: [failingBuild] } } })
+      .mockReturnValueOnce({ app: { build: { ancestorBuilds: [workingBuild] } } });
+
+    expect(
+      await getChangedFilesWithReplacement(context, {
+        id: 'id',
+        number: 3,
+        commit: 'missing',
+        uncommittedHash: '',
+        isLocalBuild: false,
+      })
+    ).toEqual({
+      changedFiles: ['changed', 'files'],
+      replacementBuild: workingBuild,
+    });
+
+    expect(client.runQuery).toHaveBeenCalledTimes(2);
+  });
+
+  it('tries multiple replacement builds in the same batch', async () => {
+    const failingBuild1 = {
+      id: 'failing1',
+      number: 2,
+      commit: 'failing1',
+      uncommittedHash: '',
+    };
+    const failingBuild2 = {
+      id: 'failing2',
+      number: 1,
+      commit: 'failing2',
+      uncommittedHash: '',
+    };
+    const workingBuild = {
+      id: 'working',
+      number: 0,
+      commit: 'exists',
+      uncommittedHash: '',
+    };
+    client.runQuery.mockReturnValue({
+      app: { build: { ancestorBuilds: [failingBuild1, failingBuild2, workingBuild] } },
+    });
+
+    expect(
+      await getChangedFilesWithReplacement(context, {
+        id: 'id',
+        number: 3,
+        commit: 'missing',
+        uncommittedHash: '',
+        isLocalBuild: false,
+      })
+    ).toEqual({
+      changedFiles: ['changed', 'files'],
+      replacementBuild: workingBuild,
+    });
+
+    expect(client.runQuery).toHaveBeenCalledTimes(1);
+  });
+
+  it('throws if all replacement builds fail', async () => {
+    const failingBuild1 = {
+      id: 'failing1',
+      number: 2,
+      commit: 'failing1',
+      uncommittedHash: '',
+    };
+    const failingBuild2 = {
+      id: 'failing2',
+      number: 1,
+      commit: 'failing2',
+      uncommittedHash: '',
+    };
+    client.runQuery.mockReturnValue({
+      app: { build: { ancestorBuilds: [failingBuild1, failingBuild2] } },
+    });
+
+    await expect(
+      getChangedFilesWithReplacement(context, {
+        id: 'id',
+        number: 3,
+        commit: 'missing',
+        uncommittedHash: '',
+        isLocalBuild: false,
+      })
+    ).rejects.toThrow(/fatal: bad object missing/);
+
+    expect(client.runQuery).toHaveBeenCalledTimes(1);
+  });
 });

--- a/node-src/git/getChangedFilesWithReplacement.test.ts
+++ b/node-src/git/getChangedFilesWithReplacement.test.ts
@@ -4,11 +4,8 @@ import TestLogger from '../lib/testLogger';
 import { getChangedFilesWithReplacement } from './getChangedFilesWithReplacement';
 
 vi.mock('./git', () => ({
-  getChangedFiles: (hash) => {
+  getChangedFiles: async (hash) => {
     if (/exists/.test(hash)) return ['changed', 'files'];
-    if (/exists/.test('timeout')) {
-      throw new Error('Command timed out after 20000ms');
-    }
     throw new Error(`fatal: bad object ${hash}`);
   },
   commitExists: (hash) => hash.match(/exists/),

--- a/node-src/git/getChangedFilesWithReplacement.ts
+++ b/node-src/git/getChangedFilesWithReplacement.ts
@@ -39,7 +39,7 @@ export async function getChangedFilesWithReplacement(
       `Got error fetching commit for #${build.number}(${build.commit}): ${err.message}`
     );
 
-    if (/(bad object|uncommitted changes|timeout)/.test(err.message)) {
+    if (/(bad object|uncommitted changes)/.test(err.message) || err.timedOut) {
       const replacementBuild = await findAncestorBuildWithCommit(ctx, build.number);
 
       if (replacementBuild) {

--- a/node-src/git/getChangedFilesWithReplacement.ts
+++ b/node-src/git/getChangedFilesWithReplacement.ts
@@ -39,7 +39,6 @@ export async function getChangedFilesWithReplacement(
       `Got error fetching commit for #${build.number}(${build.commit}): ${err.message}`
     );
 
-    console.error(err.message);
     if (/(bad object|uncommitted changes|timeout)/.test(err.message)) {
       const replacementBuild = await findAncestorBuildWithCommit(ctx, build.number);
 

--- a/node-src/git/getChangedFilesWithReplacement.ts
+++ b/node-src/git/getChangedFilesWithReplacement.ts
@@ -35,11 +35,11 @@ export async function getChangedFilesWithReplacement(
     const changedFiles = (await getChangedFiles(build.commit)) || [];
     return { changedFiles };
   } catch (err) {
+    console.log(err);
     ctx.log.debug(
       `Got error fetching commit for #${build.number}(${build.commit}): ${err.message}`
     );
 
-    console.log(err.message);
     if (!/(bad object|uncommitted changes)/.test(err.message)) {
       throw err;
     }

--- a/node-src/git/getChangedFilesWithReplacement.ts
+++ b/node-src/git/getChangedFilesWithReplacement.ts
@@ -35,7 +35,6 @@ export async function getChangedFilesWithReplacement(
     const changedFiles = (await getChangedFiles(build.commit)) || [];
     return { changedFiles };
   } catch (err) {
-    console.log(err);
     ctx.log.debug(
       `Got error fetching commit for #${build.number}(${build.commit}): ${err.message}`
     );

--- a/node-src/git/getChangedFilesWithReplacement.ts
+++ b/node-src/git/getChangedFilesWithReplacement.ts
@@ -39,41 +39,21 @@ export async function getChangedFilesWithReplacement(
       `Got error fetching commit for #${build.number}(${build.commit}): ${err.message}`
     );
 
-    if (!/(bad object|uncommitted changes)/.test(err.message)) {
-      throw err;
-    }
+    console.error(err.message);
+    if (/(bad object|uncommitted changes|timeout)/.test(err.message)) {
+      const replacementBuild = await findAncestorBuildWithCommit(ctx, build.number);
 
-    // Try to find a replacement build by checking multiple ancestor builds
-    let skip = 0;
-    const page = 10;
-    const limit = 80;
-
-    while (skip < limit) {
-      const replacementBuild = await findAncestorBuildWithCommit(ctx, build.number, {
-        page,
-        limit: Math.min(page, limit - skip),
-      });
-
-      if (!replacementBuild) {
-        break;
-      }
-
-      try {
+      if (replacementBuild) {
         ctx.log.debug(
           `Found replacement build for #${build.number}(${build.commit}): #${replacementBuild.number}(${replacementBuild.commit})`
         );
         const changedFiles = (await getChangedFiles(replacementBuild.commit)) || [];
         return { changedFiles, replacementBuild };
-      } catch (error) {
-        ctx.log.debug(
-          `Error with replacement build #${replacementBuild.number}(${replacementBuild.commit}): ${error.message}`
-        );
-        // Continue to next potential replacement build
-        skip += page;
       }
+      ctx.log.debug(`Couldn't find replacement for #${build.number}(${build.commit})`);
     }
 
-    ctx.log.debug(`Couldn't find a working replacement for #${build.number}(${build.commit})`);
+    // If we can't find a replacement or the error doesn't match, just throw
     throw err;
   }
 }


### PR DESCRIPTION
We can run into a case at times where the first replacement build times out, and it immediately throws an error and doesn't attempt to resolve the second or third parent commits for the replacement build.

This logic accounts for that and will move on to the next replacement build until a suitable one is found.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>11.29.0--canary.1178.15008534431.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@11.29.0--canary.1178.15008534431.0
  # or 
  yarn add chromatic@11.29.0--canary.1178.15008534431.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
