### PR TITLE
update workflow to replicate env changes

### DIFF
--- a/.github/workflows/chromatic-main-and-prs.yml
+++ b/.github/workflows/chromatic-main-and-prs.yml
@@ -15,7 +15,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          fetch-depth: 0
+          fetch-depth: 1024
+          ref: ${{ github.event.pull_request.head.ref }}
       - uses: actions/setup-node@v3
         with:
           node-version: 22

--- a/.github/workflows/chromatic-main-and-prs.yml
+++ b/.github/workflows/chromatic-main-and-prs.yml
@@ -31,6 +31,12 @@ jobs:
           traceChanged: true
           diagnostics: true
           skip: ${{ github.event.pull_request.draft == true }}
+          debug: true
+        env:
+          NODE_OPTIONS: --max_old_space_size=8192
+          CHROMATIC_SHA: ${{ github.event.pull_request.head.sha }}
+          CHROMATIC_BRANCH: ${{ github.head_ref }}
+          CHROMATIC_SLUG: ${{ github.repository }}
       - uses: actions/upload-artifact@v4
         if: always()
         with:

--- a/node-src/ui/components/link.ts
+++ b/node-src/ui/components/link.ts
@@ -1,3 +1,3 @@
 import chalk from 'chalk';
 
-export default (url: string) => chalk.cyan(url);
+export default (url: string) => chalk.red(url);

--- a/node-src/ui/components/link.ts
+++ b/node-src/ui/components/link.ts
@@ -1,3 +1,3 @@
 import chalk from 'chalk';
 
-export default (url: string) => chalk.red(url);
+export default (url: string) => chalk.cyan(url);


### PR DESCRIPTION
Testing the pull_request trigger for PRs with environment variables as per our docs.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>11.28.3--canary.1179.14892749229.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@11.28.3--canary.1179.14892749229.0
  # or 
  yarn add chromatic@11.28.3--canary.1179.14892749229.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
