### PR TITLE
Add git command logging and pass `--no-relative` to `git diff`.

### DIFF
--- a/bin-src/trace.ts
+++ b/bin-src/trace.ts
@@ -93,7 +93,7 @@ export async function main(argv: string[]) {
       traceChanged: flags.mode || true,
     },
     git: {
-      rootPath: await getRepositoryRoot(),
+      rootPath: await getRepositoryRoot({ log: console as any }),
     },
     storybook: {
       baseDir: flags.storybookBaseDir,

--- a/node-src/git/execGit.ts
+++ b/node-src/git/execGit.ts
@@ -2,6 +2,7 @@ import { createInterface } from 'node:readline';
 
 import { execaCommand } from 'execa';
 
+import { Context } from '../types';
 import gitNoCommits from '../ui/messages/errors/gitNoCommits';
 import gitNotInitialized from '../ui/messages/errors/gitNotInitialized';
 import gitNotInstalled from '../ui/messages/errors/gitNotInstalled';
@@ -16,25 +17,33 @@ const defaultOptions: Parameters<typeof execaCommand>[1] = {
 /**
  * Execute a Git command in the local terminal.
  *
+ * @param context Standard context object.
+ * @param context.log Standard context logger.
  * @param command The command to execute.
  * @param options Execa options
  *
  * @returns The result of the command from the terminal.
  */
 export async function execGitCommand(
+  { log }: Pick<Context, 'log'>,
   command: string,
   options?: Parameters<typeof execaCommand>[1]
 ) {
   try {
+    log.debug(`execGitCommand: ${command}`);
     const { all } = await execaCommand(command, { ...defaultOptions, ...options });
 
     if (all === undefined) {
       throw new Error(`Unexpected missing git command output for command: '${command}'`);
     }
 
-    return all.toString();
+    const result = all.toString();
+    log.debug(`execGitCommand result: ${result}`);
+    return result;
   } catch (error) {
     const { message } = error;
+
+    log.debug(`execGitCommand error: ${message}`);
 
     if (message.includes('not a git repository')) {
       throw new Error(gitNotInitialized({ command }));
@@ -55,15 +64,19 @@ export async function execGitCommand(
 /**
  * Execute a Git command in the local terminal and just get the first line.
  *
+ * @param context Standard context object.
+ * @param context.log Standard context logger.
  * @param command The command to execute.
  * @param options Execa options
  *
  * @returns The first line of the command from the terminal.
  */
 export async function execGitCommandOneLine(
+  { log }: Pick<Context, 'log'>,
   command: string,
   options?: Parameters<typeof execaCommand>[1]
 ) {
+  log.debug(`execGitCommandOneLine: ${command}`);
   const process = execaCommand(command, { ...defaultOptions, buffer: false, ...options });
 
   return Promise.race([
@@ -93,15 +106,19 @@ export async function execGitCommandOneLine(
 /**
  * Execute a Git command in the local terminal and count the lines in the result
  *
+ * @param context Standard context object.
+ * @param context.log Standard context logger.
  * @param command The command to execute.
  * @param options Execa options
  *
  * @returns The number of lines the command returned
  */
 export async function execGitCommandCountLines(
+  { log }: Pick<Context, 'log'>,
   command: string,
   options?: Parameters<typeof execaCommand>[1]
 ) {
+  log.debug(`execGitCommandCountLines: ${command}`);
   const process = execaCommand(command, { ...defaultOptions, buffer: false, ...options });
   if (!process.stdout) {
     throw new Error('Unexpected missing stdout');

--- a/node-src/git/findAncestorBuildWithCommit.test.ts
+++ b/node-src/git/findAncestorBuildWithCommit.test.ts
@@ -1,13 +1,16 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import TestLogger from '../lib/testLogger';
 import {
   AncestorBuildsQueryResult,
   findAncestorBuildWithCommit,
 } from './findAncestorBuildWithCommit';
 
 vi.mock('./git', () => ({
-  commitExists: (hash) => hash.match(/exists/),
+  commitExists: (_, hash) => hash.match(/exists/),
 }));
+
+const ctx = { log: new TestLogger() };
 
 type Build = AncestorBuildsQueryResult['app']['build']['ancestorBuilds'][0];
 const makeBuild = (build: Partial<Build> = {}): Build => ({
@@ -32,7 +35,7 @@ describe('findAncestorBuildWithCommit', () => {
     const toFind = makeBuild({ number: 3, commit: 'exists' });
     client.runQuery.mockReturnValue(makeResult([makeBuild(), makeBuild(), toFind]));
 
-    expect(await findAncestorBuildWithCommit({ client }, 1)).toEqual(toFind);
+    expect(await findAncestorBuildWithCommit({ ...ctx, client }, 1)).toEqual(toFind);
     expect(client.runQuery).toHaveBeenCalledTimes(1);
     expect(client.runQuery.mock.calls[0][1]).toMatchObject({ buildNumber: 1 });
   });
@@ -42,7 +45,9 @@ describe('findAncestorBuildWithCommit', () => {
       makeResult([makeBuild({ commit: 'exists', uncommittedHash: 'abc123', isLocalBuild: true })])
     );
 
-    expect(await findAncestorBuildWithCommit({ client }, 1, { page: 1, limit: 1 })).toBeUndefined();
+    expect(
+      await findAncestorBuildWithCommit({ ...ctx, client }, 1, { page: 1, limit: 1 })
+    ).toBeUndefined();
   });
 
   it('DOES return a CI build with uncommitted changes', async () => {
@@ -50,7 +55,9 @@ describe('findAncestorBuildWithCommit', () => {
       makeResult([makeBuild({ commit: 'exists', uncommittedHash: 'abc123' })])
     );
 
-    expect(await findAncestorBuildWithCommit({ client }, 1, { page: 1, limit: 1 })).toMatchObject({
+    expect(
+      await findAncestorBuildWithCommit({ ...ctx, client }, 1, { page: 1, limit: 1 })
+    ).toMatchObject({
       commit: 'exists',
     });
   });
@@ -61,9 +68,9 @@ describe('findAncestorBuildWithCommit', () => {
       .mockReturnValueOnce(makeResult([makeBuild(), makeBuild()]))
       .mockReturnValueOnce(makeResult([makeBuild(), toFind]));
 
-    expect(await findAncestorBuildWithCommit({ client }, 1, { page: 2, limit: 100 })).toEqual(
-      toFind
-    );
+    expect(
+      await findAncestorBuildWithCommit({ ...ctx, client }, 1, { page: 2, limit: 100 })
+    ).toEqual(toFind);
     expect(client.runQuery).toHaveBeenCalledTimes(2);
     expect(client.runQuery.mock.calls[0][1]).toMatchObject({ buildNumber: 1, skip: 0, limit: 2 });
     expect(client.runQuery.mock.calls[1][1]).toMatchObject({ buildNumber: 1, skip: 2, limit: 2 });
@@ -74,7 +81,9 @@ describe('findAncestorBuildWithCommit', () => {
       .mockReturnValueOnce(makeResult([makeBuild(), makeBuild()]))
       .mockReturnValueOnce(makeResult([makeBuild(), makeBuild()]));
 
-    expect(await findAncestorBuildWithCommit({ client }, 1, { page: 2, limit: 3 })).toBeUndefined();
+    expect(
+      await findAncestorBuildWithCommit({ ...ctx, client }, 1, { page: 2, limit: 3 })
+    ).toBeUndefined();
     expect(client.runQuery).toHaveBeenCalledTimes(2);
     expect(client.runQuery.mock.calls[0][1]).toMatchObject({ buildNumber: 1, skip: 0, limit: 2 });
     expect(client.runQuery.mock.calls[1][1]).toMatchObject({ buildNumber: 1, skip: 2, limit: 1 });
@@ -83,7 +92,9 @@ describe('findAncestorBuildWithCommit', () => {
   it('stops querying when the results run out', async () => {
     client.runQuery.mockReturnValueOnce(makeResult([makeBuild()]));
 
-    expect(await findAncestorBuildWithCommit({ client }, 1, { page: 2, limit: 3 })).toBeUndefined();
+    expect(
+      await findAncestorBuildWithCommit({ ...ctx, client }, 1, { page: 2, limit: 3 })
+    ).toBeUndefined();
     expect(client.runQuery).toHaveBeenCalledTimes(1);
   });
 });

--- a/node-src/git/findAncestorBuildWithCommit.ts
+++ b/node-src/git/findAncestorBuildWithCommit.ts
@@ -45,6 +45,7 @@ export interface AncestorBuildsQueryResult {
  *
  * @param ctx The context set when executing the CLI.
  * @param ctx.client The GraphQL client within the context.
+ * @param ctx.log The logger within the context.
  * @param buildNumber The build number to start searching from
  * @param options Page size and limit options
  * @param options.page How many builds to fetch each time
@@ -53,13 +54,13 @@ export interface AncestorBuildsQueryResult {
  * @returns A build to be substituted
  */
 export async function findAncestorBuildWithCommit(
-  { client }: Pick<Context, 'client'>,
+  ctx: Pick<Context, 'client' | 'log'>,
   buildNumber: number,
   { page = 10, limit = 80 } = {}
 ): Promise<AncestorBuildsQueryResult['app']['build']['ancestorBuilds'][0] | undefined> {
   let skip = 0;
   while (skip < limit) {
-    const { app } = await client.runQuery<AncestorBuildsQueryResult>(AncestorBuildsQuery, {
+    const { app } = await ctx.client.runQuery<AncestorBuildsQueryResult>(AncestorBuildsQuery, {
       buildNumber,
       skip,
       limit: Math.min(page, limit - skip),
@@ -67,7 +68,7 @@ export async function findAncestorBuildWithCommit(
 
     const results = await Promise.all(
       app.build.ancestorBuilds.map(async (build) => {
-        const exists = await commitExists(build.commit);
+        const exists = await commitExists(ctx, build.commit);
         return [build, exists] as const;
       })
     );

--- a/node-src/git/getChangedFilesWithReplacement.test.ts
+++ b/node-src/git/getChangedFilesWithReplacement.test.ts
@@ -4,11 +4,11 @@ import TestLogger from '../lib/testLogger';
 import { getChangedFilesWithReplacement } from './getChangedFilesWithReplacement';
 
 vi.mock('./git', () => ({
-  getChangedFiles: (hash) => {
+  getChangedFiles: (_, hash) => {
     if (/exists/.test(hash)) return ['changed', 'files'];
     throw new Error(`fatal: bad object ${hash}`);
   },
-  commitExists: (hash) => hash.match(/exists/),
+  commitExists: (_, hash) => hash.match(/exists/),
 }));
 
 describe('getChangedFilesWithReplacements', () => {

--- a/node-src/git/getChangedFilesWithReplacement.ts
+++ b/node-src/git/getChangedFilesWithReplacement.ts
@@ -32,7 +32,7 @@ export async function getChangedFilesWithReplacement(
       throw new Error('Local build had uncommitted changes');
     }
 
-    const changedFiles = (await getChangedFiles(build.commit)) || [];
+    const changedFiles = (await getChangedFiles(ctx, build.commit)) || [];
     return { changedFiles };
   } catch (err) {
     ctx.log.debug(
@@ -46,7 +46,7 @@ export async function getChangedFilesWithReplacement(
         ctx.log.debug(
           `Found replacement build for #${build.number}(${build.commit}): #${replacementBuild.number}(${replacementBuild.commit})`
         );
-        const changedFiles = (await getChangedFiles(replacementBuild.commit)) || [];
+        const changedFiles = (await getChangedFiles(ctx, replacementBuild.commit)) || [];
         return { changedFiles, replacementBuild };
       }
       ctx.log.debug(`Couldn't find replacement for #${build.number}(${build.commit})`);

--- a/node-src/git/getCommitAndBranch.test.ts
+++ b/node-src/git/getCommitAndBranch.test.ts
@@ -74,7 +74,7 @@ describe('getCommitAndBranch', () => {
       slug: 'chromaui/env-ci',
     });
     getBranch.mockResolvedValue('HEAD');
-    getCommit.mockImplementation((commit) =>
+    getCommit.mockImplementation((_, commit) =>
       Promise.resolve({ commit: commit as string, ...commitInfo })
     );
     const info = await getCommitAndBranch(ctx);
@@ -157,7 +157,7 @@ describe('getCommitAndBranch', () => {
       process.env.CHROMATIC_SHA = 'f78db92d';
       process.env.CHROMATIC_BRANCH = 'feature';
       process.env.CHROMATIC_SLUG = 'chromaui/chromatic';
-      getCommit.mockImplementation((commit) =>
+      getCommit.mockImplementation((_, commit) =>
         Promise.resolve({ commit: commit as string, ...commitInfo })
       );
       const info = await getCommitAndBranch(ctx);
@@ -201,7 +201,7 @@ describe('getCommitAndBranch', () => {
       process.env.GITHUB_SHA = '3276c796';
       getCommit.mockResolvedValue({ commit: 'c11da9a9', ...commitInfo });
       const info = await getCommitAndBranch(ctx);
-      expect(getCommit).toHaveBeenCalledWith('github');
+      expect(getCommit).toHaveBeenCalledWith(ctx, 'github');
       expect(info).toMatchObject({
         branch: 'github',
         commit: 'c11da9a9',
@@ -235,7 +235,7 @@ describe('getCommitAndBranch', () => {
       process.env.TRAVIS_PULL_REQUEST_SHA = 'ef765ac7';
       process.env.TRAVIS_PULL_REQUEST_BRANCH = 'travis';
       process.env.TRAVIS_PULL_REQUEST_SLUG = 'chromaui/travis';
-      getCommit.mockImplementation((commit) =>
+      getCommit.mockImplementation((_, commit) =>
         Promise.resolve({ commit: commit as string, ...commitInfo })
       );
       const info = await getCommitAndBranch(ctx);

--- a/node-src/git/getCommitAndBranch.ts
+++ b/node-src/git/getCommitAndBranch.ts
@@ -44,8 +44,8 @@ export default async function getCommitAndBranch(
   }: { branchName?: string; patchBaseRef?: string; ci?: boolean } = {}
 ) {
   const { log } = ctx;
-  let commit: CommitInfo = await getCommit();
-  let branch = notHead(branchName) || notHead(patchBaseRef) || (await getBranch());
+  let commit: CommitInfo = await getCommit(ctx);
+  let branch = notHead(branchName) || notHead(patchBaseRef) || (await getBranch(ctx));
   let slug;
 
   const {
@@ -73,7 +73,7 @@ export default async function getCommitAndBranch(
   const isGitHubAction = GITHUB_ACTIONS === 'true';
   const isGitHubPrBuild = GITHUB_EVENT_NAME === 'pull_request';
 
-  if (!(await hasPreviousCommit())) {
+  if (!(await hasPreviousCommit(ctx))) {
     const message = gitOneCommit(isGitHubAction);
     if (isCi) {
       throw new Error(message);
@@ -83,7 +83,7 @@ export default async function getCommitAndBranch(
   }
 
   if (isFromEnvironmentVariable) {
-    commit = await getCommit(CHROMATIC_SHA).catch((err) => {
+    commit = await getCommit(ctx, CHROMATIC_SHA).catch((err) => {
       log.warn(noCommitDetails({ sha: CHROMATIC_SHA, env: 'CHROMATIC_SHA' }));
       log.debug(err);
       return { commit: CHROMATIC_SHA, committedAt: Date.now() };
@@ -104,7 +104,7 @@ export default async function getCommitAndBranch(
     // Travis PR builds are weird, we want to ensure we mark build against the commit that was
     // merged from, rather than the resulting "ephemeral" merge commit that doesn't stick around in the
     // history of the project (so approvals will get lost). We also have to ensure we use the right branch.
-    commit = await getCommit(TRAVIS_PULL_REQUEST_SHA).catch((err) => {
+    commit = await getCommit(ctx, TRAVIS_PULL_REQUEST_SHA).catch((err) => {
       log.warn(noCommitDetails({ sha: TRAVIS_PULL_REQUEST_SHA, env: 'TRAVIS_PULL_REQUEST_SHA' }));
       log.debug(err);
       return { commit: TRAVIS_PULL_REQUEST_SHA, committedAt: Date.now() };
@@ -129,7 +129,7 @@ export default async function getCommitAndBranch(
     // This does not apply to our GitHub Action, because it'll set CHROMATIC_SHA, -BRANCH and -SLUG.
     // We intentionally use the GITHUB_HEAD_REF (branch name) here, to retrieve the last commit on
     // the head branch rather than the merge commit (GITHUB_SHA).
-    commit = await getCommit(GITHUB_HEAD_REF).catch((err) => {
+    commit = await getCommit(ctx, GITHUB_HEAD_REF).catch((err) => {
       log.warn(noCommitDetails({ ref: GITHUB_HEAD_REF, sha: GITHUB_SHA, env: 'GITHUB_HEAD_REF' }));
       log.debug(err);
       return { commit: GITHUB_SHA, committedAt: Date.now() };
@@ -145,7 +145,7 @@ export default async function getCommitAndBranch(
   // On certain CI systems, a branch is not checked out
   // (instead a detached head is used for the commit).
   if (!notHead(branch)) {
-    commit = await getCommit(ciCommit).catch((err) => {
+    commit = await getCommit(ctx, ciCommit).catch((err) => {
       log.warn(noCommitDetails({ sha: ciCommit }));
       log.debug(err);
       return { commit: ciCommit, committedAt: Date.now() };
@@ -177,7 +177,7 @@ export default async function getCommitAndBranch(
   // To do this, GitHub creates a new commit and does a CI run with the branch changed to e.g. gh-readonly-queue/main/pr-4-da07417adc889156224d03a7466ac712c647cd36
   // If you configure merge queues to rebase in this circumstance,
   // we lose track of baselines as the branch name has changed so our usual rebase detection (based on branch name) doesn't work.
-  const mergeQueueBranchPrNumber = await mergeQueueBranchMatch(branch);
+  const mergeQueueBranchPrNumber = await mergeQueueBranchMatch(ctx, branch);
   if (mergeQueueBranchPrNumber) {
     // This is why we extract the PR number from the branch name and use it to find the branch name of the PR that was merged.
     const branchFromMergeQueuePullRequestNumber = await getBranchFromMergeQueuePullRequestNumber(

--- a/node-src/git/getParentCommits.test.ts
+++ b/node-src/git/getParentCommits.test.ts
@@ -62,6 +62,7 @@ async function checkoutCommit(name, branch, { dirname, runGit, commitMap }) {
 }
 
 const log = { debug: vi.fn() };
+const ctx = { log } as any;
 const options = {};
 
 // This is built in from TypeScript 4.5
@@ -93,7 +94,7 @@ describe('getParentCommits', () => {
     const repository = repositories.simpleLoop;
     await checkoutCommit('F', 'main', repository);
     const client = createClient({ repository, builds: [] });
-    const git = { branch: 'main', ...(await getCommit()) };
+    const git = { branch: 'main', ...(await getCommit(ctx)) };
 
     const parentCommits = await getParentCommits({ client, log, git, options } as any);
     expectCommitsToEqualNames(parentCommits, [], repository);
@@ -106,7 +107,7 @@ describe('getParentCommits', () => {
     const repository = repositories.simpleLoop;
     await checkoutCommit('F', 'main', repository);
     const client = createClient({ repository, builds: [['F', 'main']] });
-    const git = { branch: 'main', ...(await getCommit()) };
+    const git = { branch: 'main', ...(await getCommit(ctx)) };
 
     const parentCommits = await getParentCommits({ client, log, git, options } as any);
     expectCommitsToEqualNames(parentCommits, ['F'], repository);
@@ -119,7 +120,7 @@ describe('getParentCommits', () => {
     const repository = repositories.simpleLoop;
     await checkoutCommit('C', 'main', repository);
     const client = createClient({ repository, builds: [['B', 'main']] });
-    const git = { branch: 'main', ...(await getCommit()) };
+    const git = { branch: 'main', ...(await getCommit(ctx)) };
 
     const parentCommits = await getParentCommits({ client, log, git, options } as any);
     expectCommitsToEqualNames(parentCommits, ['B'], repository);
@@ -138,7 +139,7 @@ describe('getParentCommits', () => {
         ['E', 'branch'],
       ],
     });
-    const git = { branch: 'main', ...(await getCommit()) };
+    const git = { branch: 'main', ...(await getCommit(ctx)) };
 
     const parentCommits = await getParentCommits({ client, log, git, options } as any);
     expectCommitsToEqualNames(parentCommits, ['E', 'D'], repository);
@@ -160,7 +161,7 @@ describe('getParentCommits', () => {
         ['D', 'main'],
       ],
     });
-    const git = { branch: 'main', ...(await getCommit()) };
+    const git = { branch: 'main', ...(await getCommit(ctx)) };
 
     const parentCommits = await getParentCommits({ client, log, git, options } as any);
     expectCommitsToEqualNames(parentCommits, ['D', 'C', 'B'], repository);
@@ -179,7 +180,7 @@ describe('getParentCommits', () => {
         ['C', 'main'],
       ],
     });
-    const git = { branch: 'main', ...(await getCommit()) };
+    const git = { branch: 'main', ...(await getCommit(ctx)) };
 
     const parentCommits = await getParentCommits({ client, log, git, options } as any);
     expectCommitsToEqualNames(parentCommits, ['C', 'B'], repository);
@@ -201,7 +202,7 @@ describe('getParentCommits', () => {
         ['B', 'main'],
       ],
     });
-    const git = { branch: 'main', ...(await getCommit()) };
+    const git = { branch: 'main', ...(await getCommit(ctx)) };
 
     const parentCommits = await getParentCommits({ client, log, git, options } as any);
     expectCommitsToEqualNames(parentCommits, ['B'], repository);
@@ -224,7 +225,7 @@ describe('getParentCommits', () => {
         ['E', 'main'],
       ],
     });
-    const git = { branch: 'main', ...(await getCommit()) };
+    const git = { branch: 'main', ...(await getCommit(ctx)) };
 
     const parentCommits = await getParentCommits({ client, log, git, options } as any);
     expectCommitsToEqualNames(parentCommits, ['E', 'D'], repository);
@@ -239,7 +240,7 @@ describe('getParentCommits', () => {
     const repository = repositories.simpleLoop;
     await checkoutCommit('F', 'main', repository);
     const client = createClient({ repository, builds: [['C', 'main']] });
-    const git = { branch: 'main', ...(await getCommit()) };
+    const git = { branch: 'main', ...(await getCommit(ctx)) };
 
     const parentCommits = await getParentCommits({ client, log, git, options } as any);
     expectCommitsToEqualNames(parentCommits, ['C'], repository);
@@ -262,7 +263,7 @@ describe('getParentCommits', () => {
         ['D', 'main'],
       ],
     });
-    const git = { branch: 'main', ...(await getCommit()) };
+    const git = { branch: 'main', ...(await getCommit(ctx)) };
 
     const parentCommits = await getParentCommits({ client, log, git, options } as any);
     expectCommitsToEqualNames(parentCommits, ['D'], repository);
@@ -281,7 +282,7 @@ describe('getParentCommits', () => {
         ['D', 'branch'],
       ],
     });
-    const git = { branch: 'main', ...(await getCommit()) };
+    const git = { branch: 'main', ...(await getCommit(ctx)) };
 
     const parentCommits = await getParentCommits({ client, log, git, options } as any);
     expectCommitsToEqualNames(parentCommits, ['C'], repository);
@@ -294,7 +295,7 @@ describe('getParentCommits', () => {
     const repository = repositories.simpleLoop;
     await checkoutCommit('E', 'main', repository);
     const client = createClient({ repository, builds: [['D', 'branch']] });
-    const git = { branch: 'main', ...(await getCommit()) };
+    const git = { branch: 'main', ...(await getCommit(ctx)) };
 
     const parentCommits = await getParentCommits({ client, log, git, options } as any);
     expectCommitsToEqualNames(parentCommits, [], repository);
@@ -307,7 +308,7 @@ describe('getParentCommits', () => {
     const repository = repositories.simpleLoop;
     await checkoutCommit('D', 'main', repository);
     const client = createClient({ repository, builds: [['E', 'branch']] });
-    const git = { branch: 'main', ...(await getCommit()) };
+    const git = { branch: 'main', ...(await getCommit(ctx)) };
 
     const parentCommits = await getParentCommits({ client, log, git, options } as any);
     expectCommitsToEqualNames(parentCommits, [], repository);
@@ -320,7 +321,7 @@ describe('getParentCommits', () => {
     const repository = repositories.twoRoots;
     await checkoutCommit('D', 'main', repository);
     const client = createClient({ repository, builds: [['B', 'branch']] });
-    const git = { branch: 'main', ...(await getCommit()) };
+    const git = { branch: 'main', ...(await getCommit(ctx)) };
 
     const parentCommits = await getParentCommits({ client, log, git, options } as any);
     expectCommitsToEqualNames(parentCommits, [], repository);
@@ -340,7 +341,7 @@ describe('getParentCommits', () => {
       },
       builds: [['Z', 'branch']],
     });
-    const git = { branch: 'main', ...(await getCommit()) };
+    const git = { branch: 'main', ...(await getCommit(ctx)) };
 
     const parentCommits = await getParentCommits({ client, log, git, options } as any);
     expectCommitsToEqualNames(parentCommits, [], repository);
@@ -353,7 +354,7 @@ describe('getParentCommits', () => {
     const repository = repositories.simpleLoop;
     await checkoutCommit('F', 'main', repository);
     const client = createClient({ repository, builds: [['D', 'main']] });
-    const git = { branch: 'main', ...(await getCommit()) };
+    const git = { branch: 'main', ...(await getCommit(ctx)) };
 
     const parentCommits = await getParentCommits({ client, log, git, options } as any);
     expectCommitsToEqualNames(parentCommits, ['D'], repository);
@@ -366,7 +367,7 @@ describe('getParentCommits', () => {
     const repository = repositories.longLine;
     await checkoutCommit('Z', 'main', repository);
     const client = createClient({ repository, builds: [['z', 'branch']] });
-    const git = { branch: 'main', ...(await getCommit()) };
+    const git = { branch: 'main', ...(await getCommit(ctx)) };
 
     const parentCommits = await getParentCommits({ client, log, git, options } as any);
     expectCommitsToEqualNames(parentCommits, [], repository);
@@ -379,7 +380,7 @@ describe('getParentCommits', () => {
     const repository = repositories.longLine;
     await checkoutCommit('Z', 'main', repository);
     const client = createClient({ repository, builds: [['A', 'branch']] });
-    const git = { branch: 'main', ...(await getCommit()) };
+    const git = { branch: 'main', ...(await getCommit(ctx)) };
 
     const parentCommits = await getParentCommits({ client, log, git, options } as any);
     expectCommitsToEqualNames(parentCommits, ['A'], repository);
@@ -405,7 +406,7 @@ describe('getParentCommits', () => {
         return mockIndexWithNullFirstBuildCommittedAt(queryName, variables);
       },
     };
-    const git = { branch: 'branch', ...(await getCommit()) };
+    const git = { branch: 'branch', ...(await getCommit(ctx)) };
 
     const parentCommits = await getParentCommits({ client, log, git, options } as any);
     expectCommitsToEqualNames(parentCommits, ['A'], repository);
@@ -429,7 +430,7 @@ describe('getParentCommits', () => {
         ['D', 'branch'],
       ],
     });
-    const git = { branch: 'branch', ...(await getCommit()) };
+    const git = { branch: 'branch', ...(await getCommit(ctx)) };
 
     const parentCommits = await getParentCommits({ client, log, git, options } as any);
     expectCommitsToEqualNames(parentCommits, ['D'], repository);
@@ -453,7 +454,7 @@ describe('getParentCommits', () => {
         ['D', 'branch'],
       ],
     });
-    const git = { branch: 'branch', ...(await getCommit()) };
+    const git = { branch: 'branch', ...(await getCommit(ctx)) };
 
     const parentCommits = await getParentCommits({ client, log, git, options } as any);
     expectCommitsToEqualNames(parentCommits, ['D'], repository);
@@ -477,7 +478,7 @@ describe('getParentCommits', () => {
         ['E', 'branch'],
       ],
     });
-    const git = { branch: 'branch', ...(await getCommit()) };
+    const git = { branch: 'branch', ...(await getCommit(ctx)) };
 
     const parentCommits = await getParentCommits({ client, log, git, options } as any);
     expectCommitsToEqualNames(parentCommits, ['C'], repository);
@@ -500,7 +501,7 @@ describe('getParentCommits', () => {
         ['D', 'branch'],
       ],
     });
-    const git = { branch: 'branch', ...(await getCommit()) };
+    const git = { branch: 'branch', ...(await getCommit(ctx)) };
 
     const parentCommits = await getParentCommits({ client, log, git, options } as any, {
       ignoreLastBuildOnBranch: true,
@@ -532,7 +533,7 @@ describe('getParentCommits', () => {
         ['Z', 'branch'],
       ],
     });
-    const git = { branch: 'branch', ...(await getCommit()) };
+    const git = { branch: 'branch', ...(await getCommit(ctx)) };
 
     const parentCommits = await getParentCommits({ client, log, git, options } as any);
     expect(parentCommits).toEqual([Zhash, repository.commitMap.C.hash]);
@@ -557,7 +558,7 @@ describe('getParentCommits', () => {
         ['B', 'main'],
       ],
     });
-    const git = { branch: 'branch', ...(await getCommit()) };
+    const git = { branch: 'branch', ...(await getCommit(ctx)) };
 
     const parentCommits = await getParentCommits({ client, log, git, options } as any);
     expectCommitsToEqualNames(parentCommits, ['B'], repository);
@@ -580,7 +581,7 @@ describe('getParentCommits', () => {
         ['E', 'branch'],
       ],
     });
-    const git = { branch: 'branch', ...(await getCommit()) };
+    const git = { branch: 'branch', ...(await getCommit(ctx)) };
 
     const parentCommits = await getParentCommits({ client, log, git, options } as any);
     expectCommitsToEqualNames(parentCommits, ['E'], repository);
@@ -604,7 +605,7 @@ describe('getParentCommits', () => {
         ['D', 'HEAD'],
       ],
     });
-    const git = { branch: 'HEAD', ...(await getCommit()) };
+    const git = { branch: 'HEAD', ...(await getCommit(ctx)) };
 
     // We can pass 'HEAD' as the branch if we fail to find any other branch info from another source
     const parentCommits = await getParentCommits({ client, log, git, options } as any);
@@ -631,7 +632,7 @@ describe('getParentCommits', () => {
         // Talking to GH (etc) tells us that commit E is the merge commit for "branch"
         prs: [['E', 'branch']],
       });
-      const git = { branch: 'main', ...(await getCommit()) };
+      const git = { branch: 'main', ...(await getCommit(ctx)) };
 
       const parentCommits = await getParentCommits({ client, log, git, options } as any);
       // This doesn't include 'C' as D "covers" it.
@@ -655,7 +656,7 @@ describe('getParentCommits', () => {
         // Talking to GH (etc) tells us that commit E is the merge commit for "branch"
         prs: [['E', 'branch']],
       });
-      const git = { branch: 'main', ...(await getCommit()) };
+      const git = { branch: 'main', ...(await getCommit(ctx)) };
 
       const parentCommits = await getParentCommits({ client, log, git, options } as any);
       expectCommitsToEqualNames(parentCommits, ['D', 'C'], repository);
@@ -678,7 +679,7 @@ describe('getParentCommits', () => {
         // Talking to GH (etc) tells us that commit E is the merge commit for "branch"
         prs: [['E', 'branch']],
       });
-      const git = { branch: 'main', ...(await getCommit()) };
+      const git = { branch: 'main', ...(await getCommit(ctx)) };
 
       const parentCommits = await getParentCommits({ client, log, git, options } as any);
       expectCommitsToEqualNames(parentCommits, ['C', 'B'], repository);
@@ -701,7 +702,7 @@ describe('getParentCommits', () => {
         // Talking to GH (etc) tells us that commit E is the merge commit for "branch"
         prs: [['E', 'branch']],
       });
-      const git = { branch: 'main', ...(await getCommit()) };
+      const git = { branch: 'main', ...(await getCommit(ctx)) };
 
       const parentCommits = await getParentCommits({ client, log, git, options } as any);
       // This doesn't include A as B "covers" it.
@@ -722,7 +723,7 @@ describe('getParentCommits', () => {
         // Talking to GH (etc) tells us that commit E is the merge commit for "branch"
         prs: [['E', 'branch']],
       });
-      const git = { branch: 'main', ...(await getCommit()) };
+      const git = { branch: 'main', ...(await getCommit(ctx)) };
 
       const parentCommits = await getParentCommits({ client, log, git, options } as any);
       expectCommitsToEqualNames(parentCommits, ['C'], repository);
@@ -745,7 +746,7 @@ describe('getParentCommits', () => {
         // Talking to GH (etc) tells us that commit D is the merge commit for "branch" (which no longer exists)
         prs: [['D', 'branch']],
       });
-      const git = { branch: 'main', ...(await getCommit()) };
+      const git = { branch: 'main', ...(await getCommit(ctx)) };
 
       const parentCommits = await getParentCommits({ client, log, git, options } as any);
       expectCommitsToEqualNames(parentCommits, ['MISSING', 'A'], repository);
@@ -777,7 +778,7 @@ describe('getParentCommits', () => {
           ['E', 'branch2'],
         ],
       });
-      const git = { branch: 'main', ...(await getCommit()) };
+      const git = { branch: 'main', ...(await getCommit(ctx)) };
 
       const parentCommits = await getParentCommits({ client, log, git, options } as any);
       expectCommitsToEqualNames(parentCommits, ['C', 'B'], repository);
@@ -799,7 +800,7 @@ describe('getParentCommits', () => {
         // Talking to GH (etc) tells us that commit F is the merge commit for "branch"
         prs: [['F', 'branch']],
       });
-      const git = { branch: 'main', ...(await getCommit()) };
+      const git = { branch: 'main', ...(await getCommit(ctx)) };
 
       const parentCommits = await getParentCommits({ client, log, git, options } as any);
       expectCommitsToEqualNames(parentCommits, ['E', 'D'], repository);

--- a/node-src/git/git.test.ts
+++ b/node-src/git/git.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
+import TestLogger from '../lib/testLogger';
 import * as execGit from './execGit';
 import {
   findFilesFromRepositoryRoot,
@@ -20,6 +21,8 @@ const execGitCommand = vi.mocked(execGit.execGitCommand);
 const execGitCommandOneLine = vi.mocked(execGit.execGitCommandOneLine);
 const execGitCommandCountLines = vi.mocked(execGit.execGitCommandCountLines);
 
+const ctx = { log: new TestLogger() };
+
 afterEach(() => {
   vi.clearAllMocks();
 });
@@ -29,7 +32,7 @@ describe('getCommit', () => {
     execGitCommand.mockResolvedValue(
       `19b6c9c5b3d34d9fc55627fcaf8a85bd5d5e5b2a ## 1696588814 ## info@ghengeveld.nl ## Gert Hengeveld`
     );
-    expect(await getCommit()).toEqual({
+    expect(await getCommit(ctx)).toEqual({
       commit: '19b6c9c5b3d34d9fc55627fcaf8a85bd5d5e5b2a',
       committedAt: 1_696_588_814 * 1000,
       committerEmail: 'info@ghengeveld.nl',
@@ -44,7 +47,7 @@ gpg:                using RSA key 4AEE18F83AFDEB23
 gpg: Can't check signature: No public key
 19b6c9c5b3d34d9fc55627fcaf8a85bd5d5e5b2a ## 1696588814 ## info@ghengeveld.nl ## Gert Hengeveld`.trim()
     );
-    expect(await getCommit()).toEqual({
+    expect(await getCommit(ctx)).toEqual({
       commit: '19b6c9c5b3d34d9fc55627fcaf8a85bd5d5e5b2a',
       committedAt: 1_696_588_814 * 1000,
       committerEmail: 'info@ghengeveld.nl',
@@ -56,25 +59,25 @@ gpg: Can't check signature: No public key
 describe('getSlug', () => {
   it('returns the slug portion of the git url', async () => {
     execGitCommand.mockResolvedValue('git@github.com:chromaui/chromatic-cli.git');
-    expect(await getSlug()).toBe('chromaui/chromatic-cli');
+    expect(await getSlug(ctx)).toBe('chromaui/chromatic-cli');
 
     execGitCommand.mockResolvedValue('https://github.com/chromaui/chromatic-cli');
-    expect(await getSlug()).toBe('chromaui/chromatic-cli');
+    expect(await getSlug(ctx)).toBe('chromaui/chromatic-cli');
 
     execGitCommand.mockResolvedValue('https://gitlab.com/foo/bar.baz.git');
-    expect(await getSlug()).toBe('foo/bar.baz');
+    expect(await getSlug(ctx)).toBe('foo/bar.baz');
   });
 });
 
 describe('hasPreviousCommit', () => {
   it('returns true if a commit is found', async () => {
     execGitCommand.mockResolvedValue(`19b6c9c5b3d34d9fc55627fcaf8a85bd5d5e5b2a`);
-    expect(await hasPreviousCommit()).toEqual(true);
+    expect(await hasPreviousCommit(ctx)).toEqual(true);
   });
 
   it('returns false if no commit is found', async () => {
     execGitCommand.mockResolvedValue(``);
-    expect(await hasPreviousCommit()).toEqual(false);
+    expect(await hasPreviousCommit(ctx)).toEqual(false);
   });
 
   it('ignores gpg signature information', async () => {
@@ -85,19 +88,19 @@ gpg:                using RSA key 4AEE18F83AFDEB23
 gpg: Can't check signature: No public key
 19b6c9c5b3d34d9fc55627fcaf8a85bd5d5e5b2a`.trim()
     );
-    expect(await hasPreviousCommit()).toEqual(true);
+    expect(await hasPreviousCommit(ctx)).toEqual(true);
   });
 });
 
 describe('mergeQueueBranchMatch', () => {
   it('returns pr number if it is a merge queue branch', async () => {
     const branch = 'gh-readonly-queue/main/pr-4-da07417adc889156224d03a7466ac712c647cd36';
-    expect(await mergeQueueBranchMatch(branch)).toEqual(4);
+    expect(await mergeQueueBranchMatch(ctx, branch)).toEqual(4);
   });
 
   it('returns null if it is not a merge queue branch', async () => {
     const branch = 'develop';
-    expect(await mergeQueueBranchMatch(branch)).toBeUndefined();
+    expect(await mergeQueueBranchMatch(ctx, branch)).toBeUndefined();
   });
 });
 
@@ -109,11 +112,12 @@ describe('findFilesFromRepositoryRoot', () => {
     execGitCommand.mockResolvedValueOnce('/root');
     execGitCommand.mockResolvedValueOnce(filesFound.join(NULL_BYTE));
 
-    const results = await findFilesFromRepositoryRoot('package.json', '**/package.json');
+    const results = await findFilesFromRepositoryRoot(ctx, 'package.json', '**/package.json');
 
     expect(execGitCommand).toBeCalledTimes(2);
     expect(execGitCommand).toHaveBeenNthCalledWith(
       2,
+      ctx,
       'git ls-files --full-name -z "/root/package.json" "/root/**/package.json"'
     );
     expect(results).toEqual(filesFound);
@@ -123,22 +127,28 @@ describe('findFilesFromRepositoryRoot', () => {
 describe('getRepositoryCreationDate', () => {
   it('parses the date successfully', async () => {
     execGitCommandOneLine.mockResolvedValue(`2017-05-17 10:00:35 -0700`);
-    expect(await getRepositoryCreationDate()).toEqual(new Date('2017-05-17T17:00:35.000Z'));
+    expect(await getRepositoryCreationDate(ctx)).toEqual(new Date('2017-05-17T17:00:35.000Z'));
   });
 });
 
 describe('getStorybookCreationDate', () => {
   it('passes the config dir to the git command', async () => {
-    await getStorybookCreationDate({ options: { storybookConfigDir: 'special-config-dir' } });
+    const ctxWithConfig = {
+      ...ctx,
+      options: { storybookConfigDir: 'special-config-dir' },
+    };
+    await getStorybookCreationDate(ctxWithConfig);
     expect(execGitCommandOneLine).toHaveBeenCalledWith(
+      ctxWithConfig,
       expect.stringMatching(/special-config-dir/),
       expect.anything()
     );
   });
 
   it('defaults the config dir to the git command', async () => {
-    await getStorybookCreationDate({ options: {} });
+    await getStorybookCreationDate({ ...ctx, options: {} });
     expect(execGitCommandOneLine).toHaveBeenCalledWith(
+      { ...ctx, options: {} },
       expect.stringMatching(/.storybook/),
       expect.anything()
     );
@@ -147,7 +157,7 @@ describe('getStorybookCreationDate', () => {
   it('parses the date successfully', async () => {
     execGitCommandOneLine.mockResolvedValue(`2017-05-17 10:00:35 -0700`);
     expect(
-      await getStorybookCreationDate({ options: { storybookConfigDir: '.storybook' } })
+      await getStorybookCreationDate({ ...ctx, options: { storybookConfigDir: '.storybook' } })
     ).toEqual(new Date('2017-05-17T17:00:35.000Z'));
   });
 });
@@ -155,20 +165,21 @@ describe('getStorybookCreationDate', () => {
 describe('getNumberOfComitters', () => {
   it('parses the count successfully', async () => {
     execGitCommandCountLines.mockResolvedValue(17);
-    expect(await getNumberOfComitters()).toEqual(17);
+    expect(await getNumberOfComitters(ctx)).toEqual(17);
   });
 });
 
 describe('getCommittedFileCount', () => {
   it('constructs the correct command', async () => {
-    await getCommittedFileCount(['page', 'screen'], ['js', 'ts']);
+    await getCommittedFileCount(ctx, ['page', 'screen'], ['js', 'ts']);
     expect(execGitCommandCountLines).toHaveBeenCalledWith(
+      ctx,
       'git ls-files -- "*page*.js" "*page*.ts" "*Page*.js" "*Page*.ts" "*screen*.js" "*screen*.ts" "*Screen*.js" "*Screen*.ts"',
       expect.anything()
     );
   });
   it('parses the count successfully', async () => {
     execGitCommandCountLines.mockResolvedValue(17);
-    expect(await getCommittedFileCount(['page', 'screen'], ['js', 'ts'])).toEqual(17);
+    expect(await getCommittedFileCount(ctx, ['page', 'screen'], ['js', 'ts'])).toEqual(17);
   });
 });

--- a/node-src/git/git.ts
+++ b/node-src/git/git.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines */
 import { EOL } from 'os';
 import pLimit from 'p-limit';
 import path from 'path';
@@ -12,20 +13,24 @@ export const NULL_BYTE = '\0'; // Separator used when running `git ls-files` wit
 /**
  * Get the version of Git from the host.
  *
+ * @param ctx Standard context object.
+ *
  * @returns The Git version.
  */
-export async function getVersion() {
-  const result = await execGitCommand(`git --version`);
+export async function getVersion(ctx: Pick<Context, 'log'>) {
+  const result = await execGitCommand(ctx, `git --version`);
   return result?.replace('git version ', '');
 }
 
 /**
  * Get the user's email from Git.
  *
+ * @param ctx Standard context object.
+ *
  * @returns The user's email.
  */
-export async function getUserEmail() {
-  return execGitCommand(`git config user.email`);
+export async function getUserEmail(ctx: Pick<Context, 'log'>) {
+  return execGitCommand(ctx, `git config user.email`);
 }
 
 /**
@@ -33,10 +38,12 @@ export async function getUserEmail() {
  * and is typically followed by `.git`. The regex matches the last two parts between slashes, and
  * ignores the `.git` suffix if it exists, so it matches something like `ownername/reponame`.
  *
+ * @param ctx Standard context object.
+ *
  * @returns The slug of the remote URL.
  */
-export async function getSlug() {
-  const result = await execGitCommand(`git config --get remote.origin.url`);
+export async function getSlug(ctx: Pick<Context, 'log'>) {
+  const result = await execGitCommand(ctx, `git config --get remote.origin.url`);
   const downcasedResult = result?.toLowerCase() || '';
   const [, slug] = downcasedResult.match(/([^/:]+\/[^/]+?)(\.git)?$/) || [];
   return slug;
@@ -49,12 +56,14 @@ export async function getSlug() {
 /**
  * Get commit details from Git.
  *
+ * @param ctx Standard context object.
  * @param revision The argument to `git log` (usually a commit SHA).
  *
  * @returns Commit details from Git.
  */
-export async function getCommit(revision = '') {
+export async function getCommit(ctx: Pick<Context, 'log'>, revision = '') {
   const result = await execGitCommand(
+    ctx,
     // Technically this yields the author info, not committer info
     `git --no-pager log -n 1 --format="%H ## %ct ## %ae ## %an" ${revision}`
   );
@@ -71,24 +80,26 @@ export async function getCommit(revision = '') {
 /**
  * Get the current branch from Git.
  *
+ * @param ctx Standard context object.
+ *
  * @returns The branch name from Git.
  */
-export async function getBranch() {
+export async function getBranch(ctx: Pick<Context, 'log'>) {
   try {
     // Git v2.22 and above
     // Yields an empty string when in detached HEAD state
-    const branch = await execGitCommand('git branch --show-current');
+    const branch = await execGitCommand(ctx, 'git branch --show-current');
     return branch || 'HEAD';
   } catch {
     try {
       // Git v1.8 and above
       // Throws when in detached HEAD state
-      const reference = await execGitCommand('git symbolic-ref HEAD');
+      const reference = await execGitCommand(ctx, 'git symbolic-ref HEAD');
       return reference?.replace(/^refs\/heads\//, ''); // strip the "refs/heads/" prefix
     } catch {
       // Git v1.7 and above
       // Yields 'HEAD' when in detached HEAD state
-      const reference = await execGitCommand('git rev-parse --abbrev-ref HEAD');
+      const reference = await execGitCommand(ctx, 'git rev-parse --abbrev-ref HEAD');
       return reference?.replace(/^heads\//, ''); // strip the "heads/" prefix that's sometimes present
     }
   }
@@ -99,15 +110,18 @@ export async function getBranch() {
  * excluding deleted files (which can't be hashed) and ignored files. There is no one single Git
  * command to reliably get this information, so we use a combination of commands grouped together.
  *
+ * @param ctx Standard context object.
+ *
  * @returns The uncommited hash, if available.
  */
-export async function getUncommittedHash() {
+export async function getUncommittedHash(ctx: Pick<Context, 'log'>) {
   const listStagedFiles = 'git diff --name-only --diff-filter=d --cached';
   const listUnstagedFiles = 'git diff --name-only --diff-filter=d';
   const listUntrackedFiles = 'git ls-files --others --exclude-standard';
   const listUncommittedFiles = [listStagedFiles, listUnstagedFiles, listUntrackedFiles].join(';');
 
   const uncommittedHashWithPadding = await execGitCommand(
+    ctx,
     // Pass the combined list of filenames to hash-object to retrieve a list of hashes. Then pass
     // the list of hashes to hash-object again to retrieve a single hash of all hashes. We use
     // stdin to avoid the limit on command line arguments.
@@ -123,10 +137,12 @@ export async function getUncommittedHash() {
 /**
  * Determine if the current commit has at least one parent commit.
  *
+ * @param ctx Standard context object.
+ *
  * @returns True if the current commit has at least one parent.
  */
-export async function hasPreviousCommit() {
-  const result = await execGitCommand(`git --no-pager log -n 1 --skip=1 --format="%H"`);
+export async function hasPreviousCommit(ctx: Pick<Context, 'log'>) {
+  const result = await execGitCommand(ctx, `git --no-pager log -n 1 --skip=1 --format="%H"`);
 
   // Ignore lines that don't match the expected format (e.g. gpg signature info)
   const allhex = new RegExp('^[a-f0-9]+$');
@@ -136,13 +152,14 @@ export async function hasPreviousCommit() {
 /**
  * Check if a commit exists in the repository
  *
+ * @param ctx Standard context object.
  * @param commit The commit to check.
  *
  * @returns True if the commit exists.
  */
-export async function commitExists(commit: string) {
+export async function commitExists(ctx: Pick<Context, 'log'>, commit: string) {
   try {
-    await execGitCommand(`git cat-file -e "${commit}^{commit}"`);
+    await execGitCommand(ctx, `git cat-file -e "${commit}^{commit}"`);
     return true;
   } catch {
     return false;
@@ -152,12 +169,17 @@ export async function commitExists(commit: string) {
 /**
  * Get the changed files of a single commit or between two.
  *
+ * @param ctx Standard context object.
  * @param baseCommit The base commit to check.
  * @param headCommit The head commit to check.
  *
  * @returns The list of changed files of a single commit or between two commits.
  */
-export async function getChangedFiles(baseCommit: string, headCommit = '') {
+export async function getChangedFiles(
+  ctx: Pick<Context, 'log'>,
+  baseCommit: string,
+  headCommit = ''
+) {
   // Note that an empty headCommit will include uncommitted (staged or unstaged) changes.
   const files = await execGitCommand(`git --no-pager diff --name-only ${baseCommit} ${headCommit}`);
   return files?.split(newline).filter(Boolean);
@@ -175,7 +197,7 @@ export async function isUpToDate(ctx: Pick<Context, 'log'>) {
   const { log } = ctx;
 
   try {
-    await execGitCommand(`git remote update`);
+    await execGitCommand(ctx, `git remote update`);
   } catch (err) {
     log.warn(err);
     return true;
@@ -183,7 +205,7 @@ export async function isUpToDate(ctx: Pick<Context, 'log'>) {
 
   let localCommit;
   try {
-    localCommit = await execGitCommand('git rev-parse HEAD');
+    localCommit = await execGitCommand(ctx, 'git rev-parse HEAD');
     if (!localCommit) throw new Error('Failed to retrieve last local commit hash');
   } catch (err) {
     log.warn(err);
@@ -192,7 +214,7 @@ export async function isUpToDate(ctx: Pick<Context, 'log'>) {
 
   let remoteCommit;
   try {
-    remoteCommit = await execGitCommand('git rev-parse "@{upstream}"');
+    remoteCommit = await execGitCommand(ctx, 'git rev-parse "@{upstream}"');
     if (!remoteCommit) throw new Error('Failed to retrieve last remote commit hash');
   } catch (err) {
     log.warn(err);
@@ -205,10 +227,12 @@ export async function isUpToDate(ctx: Pick<Context, 'log'>) {
 /**
  * Returns a boolean indicating whether the workspace is clean (no changes, no untracked files).
  *
+ * @param ctx Standard context object.
+ *
  * @returns True if the workspace has no changes.
  */
-export async function isClean() {
-  const status = await execGitCommand('git status --porcelain');
+export async function isClean(ctx: Pick<Context, 'log'>) {
+  const status = await execGitCommand(ctx, 'git status --porcelain');
   return status === '';
 }
 
@@ -216,10 +240,12 @@ export async function isClean() {
  * Returns the "Your branch is behind by n commits (pull to update)" part of the git status message,
  * omitting any of the other stuff that may be in there. Note we expect the workspace to be clean.
  *
+ * @param ctx Standard context object.
+ *
  * @returns A message indicating how far behind the branch is from the remote.
  */
-export async function getUpdateMessage() {
-  const status = await execGitCommand('git status');
+export async function getUpdateMessage(ctx: Pick<Context, 'log'>) {
+  const status = await execGitCommand(ctx, 'git status');
   return status
     ?.split(/(\r\n|\r|\n){2}/)[0] // drop the 'nothing to commit' part
     .split(newline)
@@ -255,13 +281,21 @@ export async function getUpdateMessage() {
  * one on the base branch, but if that fails we just pick the first one and hope it works out.
  * Luckily this is an uncommon scenario.
  *
+ * @param ctx Standard context object.
  * @param headReference Name of the head branch
  * @param baseReference Name of the base branch
  *
  * @returns The best common ancestor commit between the two provided.
  */
-export async function findMergeBase(headReference: string, baseReference: string) {
-  const result = await execGitCommand(`git merge-base --all ${headReference} ${baseReference}`);
+export async function findMergeBase(
+  ctx: Pick<Context, 'log'>,
+  headReference: string,
+  baseReference: string
+) {
+  const result = await execGitCommand(
+    ctx,
+    `git merge-base --all ${headReference} ${baseReference}`
+  );
   const mergeBases =
     result?.split(newline).filter((line) => line && !line.startsWith('warning: ')) || [];
   if (mergeBases.length === 0) return undefined;
@@ -281,12 +315,13 @@ export async function findMergeBase(headReference: string, baseReference: string
 
 /**
  *
+ * @param ctx Standard context object.
  * @param reference The reference to checkout (usually a commit).
  *
  * @returns The result of the Git checkout call in the terminal.
  */
-export async function checkout(reference: string) {
-  return execGitCommand(`git checkout ${reference}`);
+export async function checkout(ctx: Pick<Context, 'log'>, reference: string) {
+  return execGitCommand(ctx, `git checkout ${reference}`);
 }
 
 const limitConcurrency = pLimit(10);
@@ -303,7 +338,7 @@ const limitConcurrency = pLimit(10);
  * @returns The temporary file path of the checked out file.
  */
 export async function checkoutFile(
-  { log }: Pick<Context, 'log'>,
+  ctx: Pick<Context, 'log'>,
   reference: string,
   fileName: string,
   tmpdir: string
@@ -316,8 +351,8 @@ export async function checkoutFile(
       tmpdir,
     });
 
-    log.debug(`Checking out file ${pathspec} at ${targetFileName}`);
-    await execGitCommand(`git show ${pathspec} > ${targetFileName}`);
+    ctx.log.debug(`Checking out file ${pathspec} at ${targetFileName}`);
+    await execGitCommand(ctx, `git show ${pathspec} > ${targetFileName}`);
 
     return targetFileName;
   });
@@ -326,39 +361,49 @@ export async function checkoutFile(
 /**
  * Check out the previous branch in the Git repository.
  *
+ * @param ctx Standard context object.
+ *
  * @returns The result of the `git checkout` command in the terminal.
  */
-export async function checkoutPrevious() {
-  return execGitCommand(`git checkout -`);
+export async function checkoutPrevious(ctx: Pick<Context, 'log'>) {
+  return execGitCommand(ctx, `git checkout -`);
 }
 
 /**
  * Reset any pending changes in the Git repository.
  *
+ * @param ctx Standard context object.
+ *
  * @returns The result of the `git reset` command in the terminal.
  */
-export async function discardChanges() {
-  return execGitCommand(`git reset --hard`);
+export async function discardChanges(ctx: Pick<Context, 'log'>) {
+  return execGitCommand(ctx, `git reset --hard`);
 }
 
 /**
  * Gather the root directory of the Git repository.
  *
+ * @param ctx Standard context object.
+ *
  * @returns The root directory of the Git repository.
  */
-export async function getRepositoryRoot() {
-  return execGitCommand(`git rev-parse --show-toplevel`);
+export async function getRepositoryRoot(ctx: Pick<Context, 'log'>) {
+  return execGitCommand(ctx, `git rev-parse --show-toplevel`);
 }
 
 /**
  * Find all files that match the given patterns within the repository.
  *
+ * @param ctx Standard context object.
  * @param patterns A list of patterns to filter file results.
  *
  * @returns A list of files matching the pattern.
  */
-export async function findFilesFromRepositoryRoot(...patterns: string[]) {
-  const repoRoot = await getRepositoryRoot();
+export async function findFilesFromRepositoryRoot(
+  ctx: Pick<Context, 'log'>,
+  ...patterns: string[]
+) {
+  const repoRoot = await getRepositoryRoot(ctx);
 
   // Ensure patterns are referenced from the repository root so that running
   // from within a subdirectory does not skip the directories above
@@ -370,18 +415,19 @@ export async function findFilesFromRepositoryRoot(...patterns: string[]) {
   // Uses `--full-name` to ensure that all files found are relative to the repository root,
   // not the directory in which this is executed from
   const gitCommand = `git ls-files --full-name -z ${patternsFromRoot.map((p) => `"${p}"`).join(' ')}`;
-  const files = await execGitCommand(gitCommand);
+  const files = await execGitCommand(ctx, gitCommand);
   return files?.split(NULL_BYTE).filter(Boolean);
 }
 
 /**
  * Determine if the branch is from a GitHub merge queue.
  *
+ * @param _ctx Standard context object.
  * @param branch The branch name in question.
  *
  * @returns The pull request number associated for the branch.
  */
-export async function mergeQueueBranchMatch(branch: string) {
+export async function mergeQueueBranchMatch(_ctx: Pick<Context, 'log'>, branch: string) {
   const mergeQueuePattern = new RegExp(/gh-readonly-queue\/.*\/pr-(\d+)-[\da-f]{30}/);
   const match = branch.match(mergeQueuePattern);
 
@@ -391,13 +437,19 @@ export async function mergeQueueBranchMatch(branch: string) {
 /**
  * Determine the date the repository was created
  *
+ * @param ctx Standard context object.
+ *
  * @returns Date The date the repository was created
  */
-export async function getRepositoryCreationDate() {
+export async function getRepositoryCreationDate(ctx: Pick<Context, 'log'>) {
   try {
-    const dateString = await execGitCommandOneLine(`git log --reverse --format=%cd --date=iso`, {
-      timeout: 5000,
-    });
+    const dateString = await execGitCommandOneLine(
+      ctx,
+      `git log --reverse --format=%cd --date=iso`,
+      {
+        timeout: 5000,
+      }
+    );
 
     return new Date(dateString);
   } catch {
@@ -414,14 +466,17 @@ export async function getRepositoryCreationDate() {
  *
  * @returns Date The date the storybook was added
  */
-export async function getStorybookCreationDate(ctx: {
-  options: {
-    storybookConfigDir?: Context['options']['storybookConfigDir'];
-  };
-}) {
+export async function getStorybookCreationDate(
+  ctx: Pick<Context, 'log'> & {
+    options: {
+      storybookConfigDir?: Context['options']['storybookConfigDir'];
+    };
+  }
+) {
   try {
     const configDirectory = ctx.options.storybookConfigDir ?? '.storybook';
     const dateString = await execGitCommandOneLine(
+      ctx,
       `git log --follow --reverse --format=%cd --date=iso -- ${configDirectory}`,
       { timeout: 5000 }
     );
@@ -434,11 +489,13 @@ export async function getStorybookCreationDate(ctx: {
 /**
  * Determine the number of committers in the last 6 months
  *
+ * @param ctx Standard context object.
+ *
  * @returns number The number of committers
  */
-export async function getNumberOfComitters() {
+export async function getNumberOfComitters(ctx: Pick<Context, 'log'>) {
   try {
-    return await execGitCommandCountLines(`git shortlog -sn --all --since="6 months ago"`, {
+    return await execGitCommandCountLines(ctx, `git shortlog -sn --all --since="6 months ago"`, {
       timeout: 5000,
     });
   } catch {
@@ -449,12 +506,17 @@ export async function getNumberOfComitters() {
 /**
  * Find the number of files in the git index that include a name with the given prefixes.
  *
+ * @param ctx Standard context object.
  * @param nameMatches The names to match - will be matched with upper and lowercase first letter
  * @param extensions The filetypes to match
  *
  * @returns The number of files matching the above
  */
-export async function getCommittedFileCount(nameMatches: string[], extensions: string[]) {
+export async function getCommittedFileCount(
+  ctx: Pick<Context, 'log'>,
+  nameMatches: string[],
+  extensions: string[]
+) {
   try {
     const bothCasesNameMatches = nameMatches.flatMap((match) => [
       match,
@@ -465,7 +527,7 @@ export async function getCommittedFileCount(nameMatches: string[], extensions: s
       extensions.map((extension) => `"*${match}*.${extension}"`)
     );
 
-    return await execGitCommandCountLines(`git ls-files -- ${globs.join(' ')}`, {
+    return await execGitCommandCountLines(ctx, `git ls-files -- ${globs.join(' ')}`, {
       timeout: 5000,
     });
   } catch {

--- a/node-src/git/git.ts
+++ b/node-src/git/git.ts
@@ -115,8 +115,8 @@ export async function getBranch(ctx: Pick<Context, 'log'>) {
  * @returns The uncommited hash, if available.
  */
 export async function getUncommittedHash(ctx: Pick<Context, 'log'>) {
-  const listStagedFiles = 'git diff --name-only --diff-filter=d --cached';
-  const listUnstagedFiles = 'git diff --name-only --diff-filter=d';
+  const listStagedFiles = 'git diff --name-only --no-relative --diff-filter=d --cached';
+  const listUnstagedFiles = 'git diff --name-only --no-relative --diff-filter=d';
   const listUntrackedFiles = 'git ls-files --others --exclude-standard';
   const listUncommittedFiles = [listStagedFiles, listUnstagedFiles, listUntrackedFiles].join(';');
 
@@ -181,7 +181,10 @@ export async function getChangedFiles(
   headCommit = ''
 ) {
   // Note that an empty headCommit will include uncommitted (staged or unstaged) changes.
-  const files = await execGitCommand(`git --no-pager diff --name-only ${baseCommit} ${headCommit}`);
+  const files = await execGitCommand(
+    ctx,
+    `git --no-pager diff --name-only --no-relative ${baseCommit} ${headCommit}`
+  );
   return files?.split(newline).filter(Boolean);
 }
 
@@ -305,7 +308,10 @@ export async function findMergeBase(
   // If we don't find a merge base on the base branch, just return the first one.
   const branchNames = await Promise.all(
     mergeBases.map(async (sha) => {
-      const name = await execGitCommand(`git name-rev --name-only --exclude="tags/*" ${sha}`);
+      const name = await execGitCommand(
+        ctx,
+        `git name-rev --name-only --no-relative --exclude="tags/*" ${sha}`
+      );
       return name?.replace(/~\d+$/, ''); // Drop the potential suffix
     })
   );

--- a/node-src/index.test.ts
+++ b/node-src/index.test.ts
@@ -824,7 +824,7 @@ it('should upload metadata files if --upload-metadata is passed', async () => {
 
 describe('getGitInfo', () => {
   it('should retreive git info', async () => {
-    const result = await getGitInfo();
+    const result = await getGitInfo(getContext([]));
     expect(result).toMatchObject({
       branch: 'branch',
       commit: 'commit',
@@ -840,7 +840,7 @@ describe('getGitInfo', () => {
 
   it('should still return getInfo if no origin url', async () => {
     getSlug.mockRejectedValue(new Error('no origin set'));
-    const result = await getGitInfo();
+    const result = await getGitInfo(getContext([]));
     expect(result).toMatchObject({
       branch: 'branch',
       commit: 'commit',

--- a/node-src/index.ts
+++ b/node-src/index.ts
@@ -316,25 +316,27 @@ export interface GitInfo {
  * Although this function may not be used directly in this project, it can be used externally (such
  * as https://github.com/chromaui/addon-visual-tests).
  *
+ * @param ctx The context set when executing the CLI.
+ *
  * @returns Any git information we were able to gather.
  */
-export async function getGitInfo(): Promise<GitInfo> {
+export async function getGitInfo(ctx: Pick<Context, 'log'>): Promise<GitInfo> {
   let slug: string;
   try {
-    slug = await getSlug();
+    slug = await getSlug(ctx);
   } catch {
     slug = '';
   }
-  const branch = (await getBranch()) || '';
-  const commitInfo = await getCommit();
-  const userEmail = (await getUserEmail()) || '';
+  const branch = (await getBranch(ctx)) || '';
+  const commitInfo = await getCommit(ctx);
+  const userEmail = (await getUserEmail(ctx)) || '';
   const userEmailHash = emailHash(userEmail);
-  const repositoryRootDirectory = (await getRepositoryRoot()) || '';
+  const repositoryRootDirectory = (await getRepositoryRoot(ctx)) || '';
 
   const [ownerName, repoName, ...rest] = slug ? slug.split('/') : [];
   const isValidSlug = !!ownerName && !!repoName && rest.length === 0;
 
-  const uncommittedHash = (await getUncommittedHash()) || '';
+  const uncommittedHash = (await getUncommittedHash(ctx)) || '';
   return {
     slug: isValidSlug ? slug : '',
     branch,

--- a/node-src/lib/checkStorybookBaseDirectory.ts
+++ b/node-src/lib/checkStorybookBaseDirectory.ts
@@ -14,7 +14,7 @@ import { exitCodes, setExitCode } from './setExitCode';
  * @param stats The stats file information from the project's builder (Webpack, for example).
  */
 export async function checkStorybookBaseDirectory(ctx: Context, stats: Stats) {
-  const repositoryRoot = await getRepositoryRoot();
+  const repositoryRoot = await getRepositoryRoot(ctx);
 
   if (!repositoryRoot) {
     throw new Error('Failed to determine repository root');

--- a/node-src/lib/testLogger.ts
+++ b/node-src/lib/testLogger.ts
@@ -55,4 +55,12 @@ export default class TestLogger {
   setLogFile() {
     // do nothing
   }
+
+  file() {
+    // do nothing
+  }
+
+  getLevel(): any {
+    // do nothing
+  }
 }

--- a/node-src/lib/turbosnap/findChangedDependencies.test.ts
+++ b/node-src/lib/turbosnap/findChangedDependencies.test.ts
@@ -34,7 +34,7 @@ const createChangedPackagesGraph = vi.mocked(snykGraph.createChangedPackagesGrap
 beforeEach(() => {
   getRepositoryRoot.mockResolvedValue('/root');
   // always resolve files in the root, but not subdirs
-  findFilesFromRepositoryRoot.mockImplementation((file) =>
+  findFilesFromRepositoryRoot.mockImplementation((_, file) =>
     Promise.resolve(file.startsWith('**') ? [] : [file])
   );
   // always checkout files with the result path of "<commit>.<file>"
@@ -216,7 +216,7 @@ describe('findChangedDependencies', () => {
   });
 
   it('looks for manifest and lock files in subpackages', async () => {
-    findFilesFromRepositoryRoot.mockImplementation((file) =>
+    findFilesFromRepositoryRoot.mockImplementation((_, file) =>
       Promise.resolve(file.startsWith('**') ? [file.replace('**', 'subdir')] : [file])
     );
 
@@ -267,7 +267,7 @@ describe('findChangedDependencies', () => {
   });
 
   it('uses root lockfile when subpackage lockfile is missing', async () => {
-    findFilesFromRepositoryRoot.mockImplementation((file) => {
+    findFilesFromRepositoryRoot.mockImplementation((_, file) => {
       if (file === 'subdir/yarn.lock') return Promise.resolve([]);
       return Promise.resolve(file.startsWith('**') ? [file.replace('**', 'subdir')] : [file]);
     });
@@ -300,7 +300,7 @@ describe('findChangedDependencies', () => {
   });
 
   it('ignores lockfile changes if metadata file is untraced', async () => {
-    findFilesFromRepositoryRoot.mockImplementation((file) => {
+    findFilesFromRepositoryRoot.mockImplementation((_, file) => {
       if (file === 'subdir/yarn.lock') return Promise.resolve([]);
       return Promise.resolve(file.startsWith('**') ? [file.replace('**', 'subdir')] : [file]);
     });
@@ -322,7 +322,7 @@ describe('findChangedDependencies', () => {
   });
 
   it('uses package-lock.json if yarn.lock is missing', async () => {
-    findFilesFromRepositoryRoot.mockImplementation((file) => {
+    findFilesFromRepositoryRoot.mockImplementation((_, file) => {
       if (file.endsWith('yarn.lock'))
         return Promise.resolve([file.replace('yarn.lock', 'package-lock.json')]);
       return Promise.resolve(file.startsWith('**') ? [file.replace('**', 'subdir')] : [file]);

--- a/node-src/lib/turbosnap/findChangedPackageFiles.test.ts
+++ b/node-src/lib/turbosnap/findChangedPackageFiles.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import * as execGit from '../../git/execGit';
+import TestLogger from '../testLogger';
 import {
   arePackageDependenciesEqual,
   clearFileCache,
@@ -9,10 +10,11 @@ import {
 
 vi.mock('../../git/execGit');
 
+const ctx = { log: new TestLogger() };
 const execGitCommand = vi.mocked(execGit.execGitCommand);
 
 const mockFileContents = (packagesCommitsByFile) => {
-  execGitCommand.mockImplementation(async (input) => {
+  execGitCommand.mockImplementation(async (_, input) => {
     const regexResults = /show\s([^:]*):(.*)/g.exec(input);
     if (!regexResults) return '';
 
@@ -32,7 +34,7 @@ beforeEach(() => {
 
 describe('findChangedPackageFiles', () => {
   it('returns empty array when there are no changed package files', async () => {
-    expect(await findChangedPackageFiles([])).toStrictEqual([]);
+    expect(await findChangedPackageFiles(ctx, [])).toStrictEqual([]);
   });
 
   it('returns empty array when there are package files with no changed dependencies', async () => {
@@ -41,7 +43,7 @@ describe('findChangedPackageFiles', () => {
     });
 
     expect(
-      await findChangedPackageFiles([{ commit: 'A', changedFiles: ['package.json'] }])
+      await findChangedPackageFiles(ctx, [{ commit: 'A', changedFiles: ['package.json'] }])
     ).toStrictEqual([]);
   });
 
@@ -51,7 +53,7 @@ describe('findChangedPackageFiles', () => {
     });
 
     expect(
-      await findChangedPackageFiles([{ commit: 'A', changedFiles: ['package.json'] }])
+      await findChangedPackageFiles(ctx, [{ commit: 'A', changedFiles: ['package.json'] }])
     ).toStrictEqual(['package.json']);
   });
 
@@ -65,7 +67,7 @@ describe('findChangedPackageFiles', () => {
     });
 
     expect(
-      await findChangedPackageFiles([
+      await findChangedPackageFiles(ctx, [
         { commit: 'A', changedFiles: ['package.json', 'src/another/package.json'] },
       ])
     ).toStrictEqual(['package.json', 'src/another/package.json']);
@@ -83,7 +85,7 @@ describe('findChangedPackageFiles', () => {
     });
 
     expect(
-      await findChangedPackageFiles([
+      await findChangedPackageFiles(ctx, [
         { commit: 'A', changedFiles: ['package.json', 'src/another/package.json'] },
       ])
     ).toStrictEqual(['src/another/package.json']);
@@ -99,7 +101,7 @@ describe('findChangedPackageFiles', () => {
     });
 
     expect(
-      await findChangedPackageFiles([
+      await findChangedPackageFiles(ctx, [
         { commit: 'A', changedFiles: [] },
         { commit: 'B', changedFiles: ['package.json'] },
       ])
@@ -116,7 +118,7 @@ describe('findChangedPackageFiles', () => {
     });
 
     expect(
-      await findChangedPackageFiles([
+      await findChangedPackageFiles(ctx, [
         { commit: 'A', changedFiles: ['package.json'] },
         { commit: 'B', changedFiles: [] },
       ])
@@ -133,7 +135,7 @@ describe('findChangedPackageFiles', () => {
     });
 
     expect(
-      await findChangedPackageFiles([
+      await findChangedPackageFiles(ctx, [
         { commit: 'A', changedFiles: ['package.json'] },
         { commit: 'B', changedFiles: ['package.json'] },
       ])
@@ -149,7 +151,7 @@ describe('findChangedPackageFiles', () => {
     });
 
     expect(
-      await findChangedPackageFiles([{ commit: 'A', changedFiles: ['package.json'] }])
+      await findChangedPackageFiles(ctx, [{ commit: 'A', changedFiles: ['package.json'] }])
     ).toStrictEqual(['package.json']);
   });
 });

--- a/node-src/lib/turbosnap/findChangedPackageFiles.ts
+++ b/node-src/lib/turbosnap/findChangedPackageFiles.ts
@@ -1,4 +1,5 @@
 import { execGitCommand } from '../../git/execGit';
+import { Context } from '../../types';
 import { isPackageMetadataFile } from '../utils';
 
 // TODO: refactor this function
@@ -50,10 +51,10 @@ export const arePackageDependenciesEqual = (
 ) => dependencyFields.every((field) => isEqual(packageJsonA[field], packageJsonB[field]));
 
 const fileCache = new Map<string, string>();
-const readGitFile = async (fileName: string, commit = 'HEAD') => {
+const readGitFile = async (ctx: Pick<Context, 'log'>, fileName: string, commit = 'HEAD') => {
   const key = `${commit}:${fileName}`;
   if (fileCache.has(key)) return fileCache.get(key);
-  const contents = await execGitCommand(`git show ${key}`);
+  const contents = await execGitCommand(ctx, `git show ${key}`);
   if (contents) fileCache.set(key, contents);
   return contents;
 };
@@ -61,12 +62,16 @@ export const clearFileCache = () => fileCache.clear();
 
 // Filters a list of manifest files by whether they have dependency-related changes compared to
 // their counterpart from another (baseline) commit.
-const getManifestFilesWithChangedDependencies = async (manifestFiles: string[], commit: string) => {
+const getManifestFilesWithChangedDependencies = async (
+  ctx: Pick<Context, 'log'>,
+  manifestFiles: string[],
+  commit: string
+) => {
   const withChangedDependencies = await Promise.all(
     manifestFiles.map(async (fileName) => {
       try {
-        const base = await readGitFile(fileName, commit);
-        const head = await readGitFile(fileName);
+        const base = await readGitFile(ctx, fileName, commit);
+        const head = await readGitFile(ctx, fileName);
 
         if (!base || !head) {
           throw new Error('Failed to read git file');
@@ -84,13 +89,14 @@ const getManifestFilesWithChangedDependencies = async (manifestFiles: string[], 
 
 // Yields a list of package.json files with dependency-related changes compared to the baseline.
 export const findChangedPackageFiles = async (
+  ctx: Pick<Context, 'log'>,
   packageMetadataChanges: { changedFiles: string[]; commit: string }[]
 ) => {
   const changedManifestFiles = await Promise.all(
     packageMetadataChanges.map(({ changedFiles, commit }) => {
       const changedManifestFiles = changedFiles.filter((f) => isPackageMetadataFile(f));
       if (!changedManifestFiles) return [];
-      return getManifestFilesWithChangedDependencies(changedManifestFiles, commit);
+      return getManifestFilesWithChangedDependencies(ctx, changedManifestFiles, commit);
     })
   );
   // Remove duplicate entries (in case multiple ancestor builds changed the same package.json)

--- a/node-src/lib/turbosnap/index.test.ts
+++ b/node-src/lib/turbosnap/index.test.ts
@@ -80,7 +80,7 @@ describe('traceChangedFiles', () => {
     await traceChangedFiles(ctx);
 
     expect(ctx.turboSnap.bailReason).toEqual({ changedPackageFiles: ['./package.json'] });
-    expect(findChangedPackageFiles).toHaveBeenCalledWith(packageMetadataChanges);
+    expect(findChangedPackageFiles).toHaveBeenCalledWith(ctx, packageMetadataChanges);
     expect(getDependentStoryFiles).not.toHaveBeenCalled();
   });
 
@@ -148,7 +148,7 @@ describe('traceChangedFiles', () => {
 
     expect(ctx.turboSnap.bailReason).toBeUndefined();
     expect(onlyStoryFiles).toStrictEqual(deps);
-    expect(findChangedPackageFiles).toHaveBeenCalledWith(packageMetadataChanges);
+    expect(findChangedPackageFiles).toHaveBeenCalledWith(ctx, packageMetadataChanges);
   });
 
   it('throws if stats file is not found', async () => {

--- a/node-src/lib/turbosnap/index.ts
+++ b/node-src/lib/turbosnap/index.ts
@@ -45,7 +45,7 @@ export const traceChangedFiles = async (ctx: Context) => {
     } else {
       ctx.log.warn(`Could not retrieve dependency changes from lockfiles; checking package.json`);
 
-      const changedPackageFiles = await findChangedPackageFiles(packageMetadataChanges);
+      const changedPackageFiles = await findChangedPackageFiles(ctx, packageMetadataChanges);
       if (changedPackageFiles.length > 0) {
         ctx.turboSnap.bailReason = { changedPackageFiles };
         ctx.log.warn(bailFile({ turboSnap: ctx.turboSnap }));

--- a/node-src/tasks/gitInfo.ts
+++ b/node-src/tasks/gitInfo.ts
@@ -104,26 +104,30 @@ export const setGitInfo = async (ctx: Context, task: Task) => {
   const commitAndBranchInfo = await getCommitAndBranch(ctx, { branchName, patchBaseRef, ci });
 
   ctx.git = {
-    version: await getVersion(),
-    gitUserEmail: await getUserEmail().catch((err) => {
+    version: await getVersion(ctx),
+    gitUserEmail: await getUserEmail(ctx).catch((err) => {
       ctx.log.debug('Failed to retrieve Git user email', err);
       return undefined;
     }),
-    uncommittedHash: await getUncommittedHash().catch((err) => {
+    uncommittedHash: await getUncommittedHash(ctx).catch((err) => {
       ctx.log.warn('Failed to retrieve uncommitted files hash', err);
       return undefined;
     }),
-    rootPath: await getRepositoryRoot(),
+    rootPath: await getRepositoryRoot(ctx),
     ...commitAndBranchInfo,
   };
 
   try {
     ctx.projectMetadata = {
       hasRouter: getHasRouter(ctx.packageJson),
-      creationDate: await getRepositoryCreationDate(),
+      creationDate: await getRepositoryCreationDate(ctx),
       storybookCreationDate: await getStorybookCreationDate(ctx),
-      numberOfCommitters: await getNumberOfComitters(),
-      numberOfAppFiles: await getCommittedFileCount(['page', 'screen'], ['js', 'jsx', 'ts', 'tsx']),
+      numberOfCommitters: await getNumberOfComitters(ctx),
+      numberOfAppFiles: await getCommittedFileCount(
+        ctx,
+        ['page', 'screen'],
+        ['js', 'jsx', 'ts', 'tsx']
+      ),
     };
   } catch (err) {
     ctx.log.debug('Failed to gather project metadata', err);
@@ -135,7 +139,7 @@ export const setGitInfo = async (ctx: Context, task: Task) => {
 
   if (!ctx.git.slug) {
     try {
-      ctx.git.slug = await getSlug();
+      ctx.git.slug = await getSlug(ctx);
     } catch (err) {
       ctx.log.debug('Failed to retrieve Git repository slug', err);
     }

--- a/node-src/tasks/prepareWorkspace.test.ts
+++ b/node-src/tasks/prepareWorkspace.test.ts
@@ -25,7 +25,7 @@ describe('runPrepareWorkspace', () => {
 
     await runPrepareWorkspace(ctx, {} as any);
     expect(ctx.mergeBase).toBe('1234asd');
-    expect(checkout).toHaveBeenCalledWith('1234asd');
+    expect(checkout).toHaveBeenCalledWith(ctx, '1234asd');
     expect(installDependencies).toHaveBeenCalled();
   });
 

--- a/node-src/tasks/prepareWorkspace.ts
+++ b/node-src/tasks/prepareWorkspace.ts
@@ -20,7 +20,7 @@ export const runPrepareWorkspace = async (ctx: Context, task: Task) => {
   const { patchHeadRef, patchBaseRef } = ctx.options;
 
   // Make sure the git repo is in a clean state (no changes / untracked files).
-  if (!(await isClean())) {
+  if (!(await isClean(ctx))) {
     setExitCode(ctx, exitCodes.GIT_NOT_CLEAN, true);
     ctx.log.error(workspaceNotClean());
     throw new Error('Working directory is not clean');
@@ -29,14 +29,14 @@ export const runPrepareWorkspace = async (ctx: Context, task: Task) => {
   // Make sure both the head and base branches are up-to-date with the remote.
   if (!(await isUpToDate(ctx))) {
     setExitCode(ctx, exitCodes.GIT_OUT_OF_DATE, true);
-    ctx.log.error(workspaceNotUpToDate(await getUpdateMessage()));
+    ctx.log.error(workspaceNotUpToDate(await getUpdateMessage(ctx)));
     throw new Error('Workspace not up-to-date with remote');
   }
 
   transitionTo(lookupMergeBase)(ctx, task);
 
   // Get the merge base commit hash.
-  ctx.mergeBase = await findMergeBase(patchHeadRef, patchBaseRef);
+  ctx.mergeBase = await findMergeBase(ctx, patchHeadRef, patchBaseRef);
   if (!ctx.mergeBase) {
     setExitCode(ctx, exitCodes.GIT_NO_MERGE_BASE, true);
     ctx.log.error(mergeBaseNotFound(ctx.options));
@@ -44,7 +44,7 @@ export const runPrepareWorkspace = async (ctx: Context, task: Task) => {
   }
 
   transitionTo(checkoutMergeBase)(ctx, task);
-  await checkout(ctx.mergeBase);
+  await checkout(ctx, ctx.mergeBase);
 
   try {
     transitionTo(installingDependencies)(ctx, task);
@@ -53,7 +53,7 @@ export const runPrepareWorkspace = async (ctx: Context, task: Task) => {
     ctx.mergeBase = undefined;
     setExitCode(ctx, exitCodes.NPM_INSTALL_FAILED);
     ctx.log.error(err);
-    await runRestoreWorkspace(); // make sure we clean up even when something breaks
+    await runRestoreWorkspace(ctx); // make sure we clean up even when something breaks
     throw new Error('Failed to install dependencies');
   }
 };

--- a/node-src/tasks/restoreWorkspace.ts
+++ b/node-src/tasks/restoreWorkspace.ts
@@ -1,13 +1,14 @@
 import { checkoutPrevious, discardChanges } from '../git/git';
 import installDependencies from '../lib/installDependencies';
 import { createTask, transitionTo } from '../lib/tasks';
+import { Context } from '../types';
 import { initial, pending, success } from '../ui/tasks/restoreWorkspace';
 
-export const runRestoreWorkspace = async () => {
-  await discardChanges(); // we need a clean state before checkout
-  await checkoutPrevious();
+export const runRestoreWorkspace = async (ctx: Context) => {
+  await discardChanges(ctx); // we need a clean state before checkout
+  await checkoutPrevious(ctx);
   await installDependencies();
-  await discardChanges(); // drop lockfile changes
+  await discardChanges(ctx); // drop lockfile changes
 };
 
 export default createTask({


### PR DESCRIPTION
Ensure that we always `log.debug()` every git command we run -- this will make debugging weird git behaviour much easier.

Also pass `--no-relative` to git diff, in case the user has `diff.relative` set in their git config.

I can split these up into two PRs if that is preferred.