### PR TITLE
Export `createLogger` and make all arguments optional

### DIFF
--- a/node-src/index.ts
+++ b/node-src/index.ts
@@ -349,4 +349,4 @@ export async function getGitInfo(ctx: Pick<Context, 'log'>): Promise<GitInfo> {
 }
 
 export { getConfiguration } from './lib/getConfiguration';
-export { Logger } from './lib/log';
+export { createLogger, Logger } from './lib/log';

--- a/node-src/lib/log.test.ts
+++ b/node-src/lib/log.test.ts
@@ -35,7 +35,7 @@ const timestamp = expect.stringMatching(/\d\d:\d\d:\d\d.\d\d\d/);
 describe('log prefix', () => {
   it('should use the log prefix from environment variables', () => {
     process.env.LOG_PREFIX = 'env-prefix';
-    const logger = createLogger({});
+    const logger = createLogger();
     logger.info('message');
     expect(consoleInfo).toHaveBeenCalledWith('env-prefix', 'message');
   });
@@ -55,14 +55,14 @@ describe('log prefix', () => {
   });
 
   it('should use a timestamp as prefix by default', () => {
-    const logger = createLogger({});
+    const logger = createLogger();
     logger.info('message');
     expect(consoleInfo).toHaveBeenCalledWith(timestamp, 'message');
   });
 
   it('should not use a prefix if set to an empty string', () => {
     process.env.LOG_PREFIX = '';
-    const logger = createLogger({});
+    const logger = createLogger();
     logger.info('message');
     expect(consoleInfo).toHaveBeenCalledWith('message');
   });
@@ -77,7 +77,7 @@ describe('log prefix', () => {
 
 describe('log levels', () => {
   it('should ignore debug messages by default', () => {
-    const logger = createLogger({});
+    const logger = createLogger();
 
     logger.error('error', 1, 2);
     expect(consoleError).toHaveBeenCalledWith(timestamp, 'error', '1', '2');
@@ -94,7 +94,7 @@ describe('log levels', () => {
 
   it('should use the log level from environment variables', () => {
     process.env.LOG_LEVEL = 'debug';
-    const logger = createLogger({});
+    const logger = createLogger();
 
     logger.error('error');
     expect(consoleError).toHaveBeenCalledWith(timestamp, 'error');
@@ -153,7 +153,7 @@ describe('log levels', () => {
 });
 
 it('stringifies non-primitive values', () => {
-  const logger = createLogger({});
+  const logger = createLogger();
   logger.info('message', 1, true, null, undefined, { key: 'value' });
   expect(consoleInfo).toHaveBeenCalledWith(
     timestamp,

--- a/node-src/lib/log.ts
+++ b/node-src/lib/log.ts
@@ -122,12 +122,12 @@ const fileLogger = {
 };
 
 /* eslint-disable-next-line complexity */
-export const createLogger = (flags: Flags, options?: Partial<Options>) => {
+export const createLogger = (flags?: Flags, options?: Partial<Options>) => {
   const { DISABLE_LOGGING, LOG_LEVEL = '', LOG_PREFIX } = process.env;
 
   let level =
     options?.logLevel ||
-    flags.logLevel ||
+    flags?.logLevel ||
     (LOG_LEVEL.toLowerCase() as Flags['logLevel']) ||
     DEFAULT_LEVEL;
 
@@ -135,12 +135,13 @@ export const createLogger = (flags: Flags, options?: Partial<Options>) => {
     level = 'silent';
   }
 
-  let interactive = (options?.interactive || flags.interactive) && !(options?.debug || flags.debug);
+  let interactive =
+    (options?.interactive || flags?.interactive) && !(options?.debug || flags?.debug);
   let enqueue = false;
   const queue: QueueMessage[] = [];
 
-  const logPrefixer = createPrefixer(true, options?.logPrefix ?? flags.logPrefix ?? LOG_PREFIX);
-  const filePrefixer = createPrefixer(false, options?.logPrefix ?? flags.logPrefix ?? LOG_PREFIX);
+  const logPrefixer = createPrefixer(true, options?.logPrefix ?? flags?.logPrefix ?? LOG_PREFIX);
+  const filePrefixer = createPrefixer(false, options?.logPrefix ?? flags?.logPrefix ?? LOG_PREFIX);
 
   const log =
     (type: LogType, logFileOnly?: boolean) =>

--- a/node-src/lib/writeChromaticDiagnostics.test.ts
+++ b/node-src/lib/writeChromaticDiagnostics.test.ts
@@ -37,7 +37,7 @@ describe('getDiagnostics', () => {
 describe('writeChromaticDiagnostics', () => {
   it('should create the parent directory if it does not exist', async () => {
     const ctx = {
-      log: createLogger({}),
+      log: createLogger(),
       options: { diagnosticsFile: '/tmp/doesnotexist/diagnostics.json' },
     };
     await writeChromaticDiagnostics(ctx as any);


### PR DESCRIPTION
Makes `createLogger` available as a Node.js API so that it can be used to provide the required `log` property for `getGitInfo` introduced in #1181.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>11.29.0--canary.1182.15213361592.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@11.29.0--canary.1182.15213361592.0
  # or 
  yarn add chromatic@11.29.0--canary.1182.15213361592.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
