### PR TITLE
Revert "Add git command logging and pass `--no-relative` to `git diff`."

### DIFF
--- a/bin-src/trace.ts
+++ b/bin-src/trace.ts
@@ -2,7 +2,6 @@ import { getDependentStoryFiles } from '@cli/turbosnap';
 import meow from 'meow';
 
 import { getRepositoryRoot } from '../node-src/git/git';
-import { createLogger } from '../node-src/lib/log';
 import { isPackageManifestFile } from '../node-src/lib/utils';
 import { readStatsFile } from '../node-src/tasks/readStatsFile';
 import { Context } from '../node-src/types';
@@ -85,9 +84,8 @@ export async function main(argv: string[]) {
     }
   );
 
-  const log = createLogger({}, { logPrefix: '', logLevel: 'info' });
   const ctx: Context = {
-    log,
+    log: console,
     options: {
       storybookBaseDir: flags.storybookBaseDir,
       storybookConfigDir: flags.storybookConfigDir,
@@ -95,7 +93,7 @@ export async function main(argv: string[]) {
       traceChanged: flags.mode || true,
     },
     git: {
-      rootPath: await getRepositoryRoot({ log }),
+      rootPath: await getRepositoryRoot(),
     },
     storybook: {
       baseDir: flags.storybookBaseDir,

--- a/node-src/git/execGit.test.ts
+++ b/node-src/git/execGit.test.ts
@@ -4,7 +4,6 @@ import { beforeEach } from 'node:test';
 import { execaCommand as rawExecaCommand } from 'execa';
 import { describe, expect, it, vitest } from 'vitest';
 
-import TestLogger from '../lib/testLogger';
 import gitNoCommits from '../ui/messages/errors/gitNoCommits';
 import gitNotInitialized from '../ui/messages/errors/gitNotInitialized';
 import gitNotInstalled from '../ui/messages/errors/gitNotInstalled';
@@ -12,7 +11,6 @@ import { execGitCommand, execGitCommandCountLines, execGitCommandOneLine } from 
 
 vitest.mock('execa');
 
-const ctx = { log: new TestLogger() };
 const execaCommand = vitest.mocked(rawExecaCommand);
 beforeEach(() => {
   execaCommand.mockReset();
@@ -24,7 +22,7 @@ describe('execGitCommand', () => {
       all: Buffer.from('some output'),
     } as any);
 
-    expect(await execGitCommand(ctx, 'some command')).toEqual('some output');
+    expect(await execGitCommand('some command')).toEqual('some output');
   });
 
   it('errors if there is no output', async () => {
@@ -32,13 +30,13 @@ describe('execGitCommand', () => {
       all: undefined,
     } as any);
 
-    await expect(execGitCommand(ctx, 'some command')).rejects.toThrow(/Unexpected missing git/);
+    await expect(execGitCommand('some command')).rejects.toThrow(/Unexpected missing git/);
   });
 
   it('handles missing git error', async () => {
     execaCommand.mockRejectedValue(new Error('not a git repository'));
 
-    await expect(execGitCommand(ctx, 'some command')).rejects.toThrow(
+    await expect(execGitCommand('some command')).rejects.toThrow(
       gitNotInitialized({ command: 'some command' })
     );
   });
@@ -46,7 +44,7 @@ describe('execGitCommand', () => {
   it('handles git not found error', async () => {
     execaCommand.mockRejectedValue(new Error('git not found'));
 
-    await expect(execGitCommand(ctx, 'some command')).rejects.toThrow(
+    await expect(execGitCommand('some command')).rejects.toThrow(
       gitNotInstalled({ command: 'some command' })
     );
   });
@@ -54,14 +52,14 @@ describe('execGitCommand', () => {
   it('handles no commits yet', async () => {
     execaCommand.mockRejectedValue(new Error('does not have any commits yet'));
 
-    await expect(execGitCommand(ctx, 'some command')).rejects.toThrow(
+    await expect(execGitCommand('some command')).rejects.toThrow(
       gitNoCommits({ command: 'some command' })
     );
   });
 
   it('rethrows arbitrary errors', async () => {
     execaCommand.mockRejectedValue(new Error('something random'));
-    await expect(execGitCommand(ctx, 'some command')).rejects.toThrow('something random');
+    await expect(execGitCommand('some command')).rejects.toThrow('something random');
   });
 });
 
@@ -87,7 +85,7 @@ describe('execGitCommandOneLine', () => {
     const streamer = createExecaStreamer();
     execaCommand.mockReturnValue(streamer as any);
 
-    const promise = execGitCommandOneLine(ctx, 'some command');
+    const promise = execGitCommandOneLine('some command');
 
     streamer.stdout.write('First line\n');
     streamer.stdout.write('Second line\n');
@@ -99,7 +97,7 @@ describe('execGitCommandOneLine', () => {
     const streamer = createExecaStreamer();
     execaCommand.mockReturnValue(streamer as any);
 
-    const promise = execGitCommandOneLine(ctx, 'some command');
+    const promise = execGitCommandOneLine('some command');
 
     streamer.stdout.write('First line\n');
     streamer.stdout.end();
@@ -111,7 +109,7 @@ describe('execGitCommandOneLine', () => {
     const streamer = createExecaStreamer();
     execaCommand.mockReturnValue(streamer as any);
 
-    const promise = execGitCommandOneLine(ctx, 'some command');
+    const promise = execGitCommandOneLine('some command');
 
     streamer.kill();
 
@@ -122,7 +120,7 @@ describe('execGitCommandOneLine', () => {
     const streamer = createExecaStreamer();
     execaCommand.mockReturnValue(streamer as any);
 
-    const promise = execGitCommandOneLine(ctx, 'some command');
+    const promise = execGitCommandOneLine('some command');
 
     streamer._rejecter(new Error('some error'));
 
@@ -135,7 +133,7 @@ describe('execGitCommandCountLines', () => {
     const streamer = createExecaStreamer();
     execaCommand.mockReturnValue(streamer as any);
 
-    const promise = execGitCommandCountLines(ctx, 'some command');
+    const promise = execGitCommandCountLines('some command');
 
     streamer.stdout.write('First line\n');
     streamer.stdout.write('Second line\n');
@@ -148,7 +146,7 @@ describe('execGitCommandCountLines', () => {
     const streamer = createExecaStreamer();
     execaCommand.mockReturnValue(streamer as any);
 
-    const promise = execGitCommandCountLines(ctx, 'some command');
+    const promise = execGitCommandCountLines('some command');
 
     streamer.stdout.write('First line\n');
     streamer.kill();
@@ -160,7 +158,7 @@ describe('execGitCommandCountLines', () => {
     const streamer = createExecaStreamer();
     execaCommand.mockReturnValue(streamer as any);
 
-    const promise = execGitCommandCountLines(ctx, 'some command');
+    const promise = execGitCommandCountLines('some command');
 
     streamer.kill();
 

--- a/node-src/git/execGit.ts
+++ b/node-src/git/execGit.ts
@@ -2,7 +2,6 @@ import { createInterface } from 'node:readline';
 
 import { execaCommand } from 'execa';
 
-import { Context } from '../types';
 import gitNoCommits from '../ui/messages/errors/gitNoCommits';
 import gitNotInitialized from '../ui/messages/errors/gitNotInitialized';
 import gitNotInstalled from '../ui/messages/errors/gitNotInstalled';
@@ -17,33 +16,25 @@ const defaultOptions: Parameters<typeof execaCommand>[1] = {
 /**
  * Execute a Git command in the local terminal.
  *
- * @param context Standard context object.
- * @param context.log Standard context logger.
  * @param command The command to execute.
  * @param options Execa options
  *
  * @returns The result of the command from the terminal.
  */
 export async function execGitCommand(
-  { log }: Pick<Context, 'log'>,
   command: string,
   options?: Parameters<typeof execaCommand>[1]
 ) {
   try {
-    log.debug(`execGitCommand: ${command}`);
     const { all } = await execaCommand(command, { ...defaultOptions, ...options });
 
     if (all === undefined) {
       throw new Error(`Unexpected missing git command output for command: '${command}'`);
     }
 
-    const result = all.toString();
-    log.debug(`execGitCommand result: ${result}`);
-    return result;
+    return all.toString();
   } catch (error) {
     const { message } = error;
-
-    log.debug(`execGitCommand error: ${message}`);
 
     if (message.includes('not a git repository')) {
       throw new Error(gitNotInitialized({ command }));
@@ -64,19 +55,15 @@ export async function execGitCommand(
 /**
  * Execute a Git command in the local terminal and just get the first line.
  *
- * @param context Standard context object.
- * @param context.log Standard context logger.
  * @param command The command to execute.
  * @param options Execa options
  *
  * @returns The first line of the command from the terminal.
  */
 export async function execGitCommandOneLine(
-  { log }: Pick<Context, 'log'>,
   command: string,
   options?: Parameters<typeof execaCommand>[1]
 ) {
-  log.debug(`execGitCommandOneLine: ${command}`);
   const process = execaCommand(command, { ...defaultOptions, buffer: false, ...options });
 
   return Promise.race([
@@ -106,19 +93,15 @@ export async function execGitCommandOneLine(
 /**
  * Execute a Git command in the local terminal and count the lines in the result
  *
- * @param context Standard context object.
- * @param context.log Standard context logger.
  * @param command The command to execute.
  * @param options Execa options
  *
  * @returns The number of lines the command returned
  */
 export async function execGitCommandCountLines(
-  { log }: Pick<Context, 'log'>,
   command: string,
   options?: Parameters<typeof execaCommand>[1]
 ) {
-  log.debug(`execGitCommandCountLines: ${command}`);
   const process = execaCommand(command, { ...defaultOptions, buffer: false, ...options });
   if (!process.stdout) {
     throw new Error('Unexpected missing stdout');

--- a/node-src/git/findAncestorBuildWithCommit.ts
+++ b/node-src/git/findAncestorBuildWithCommit.ts
@@ -45,7 +45,6 @@ export interface AncestorBuildsQueryResult {
  *
  * @param ctx The context set when executing the CLI.
  * @param ctx.client The GraphQL client within the context.
- * @param ctx.log The logger within the context.
  * @param buildNumber The build number to start searching from
  * @param options Page size and limit options
  * @param options.page How many builds to fetch each time
@@ -54,13 +53,13 @@ export interface AncestorBuildsQueryResult {
  * @returns A build to be substituted
  */
 export async function findAncestorBuildWithCommit(
-  ctx: Pick<Context, 'client' | 'log'>,
+  { client }: Pick<Context, 'client'>,
   buildNumber: number,
   { page = 10, limit = 80 } = {}
 ): Promise<AncestorBuildsQueryResult['app']['build']['ancestorBuilds'][0] | undefined> {
   let skip = 0;
   while (skip < limit) {
-    const { app } = await ctx.client.runQuery<AncestorBuildsQueryResult>(AncestorBuildsQuery, {
+    const { app } = await client.runQuery<AncestorBuildsQueryResult>(AncestorBuildsQuery, {
       buildNumber,
       skip,
       limit: Math.min(page, limit - skip),
@@ -68,7 +67,7 @@ export async function findAncestorBuildWithCommit(
 
     const results = await Promise.all(
       app.build.ancestorBuilds.map(async (build) => {
-        const exists = await commitExists(ctx, build.commit);
+        const exists = await commitExists(build.commit);
         return [build, exists] as const;
       })
     );

--- a/node-src/git/getChangedFilesWithReplacement.test.ts
+++ b/node-src/git/getChangedFilesWithReplacement.test.ts
@@ -4,11 +4,11 @@ import TestLogger from '../lib/testLogger';
 import { getChangedFilesWithReplacement } from './getChangedFilesWithReplacement';
 
 vi.mock('./git', () => ({
-  getChangedFiles: (_, hash) => {
+  getChangedFiles: (hash) => {
     if (/exists/.test(hash)) return ['changed', 'files'];
     throw new Error(`fatal: bad object ${hash}`);
   },
-  commitExists: (_, hash) => hash.match(/exists/),
+  commitExists: (hash) => hash.match(/exists/),
 }));
 
 describe('getChangedFilesWithReplacements', () => {

--- a/node-src/git/getChangedFilesWithReplacement.ts
+++ b/node-src/git/getChangedFilesWithReplacement.ts
@@ -32,7 +32,7 @@ export async function getChangedFilesWithReplacement(
       throw new Error('Local build had uncommitted changes');
     }
 
-    const changedFiles = (await getChangedFiles(ctx, build.commit)) || [];
+    const changedFiles = (await getChangedFiles(build.commit)) || [];
     return { changedFiles };
   } catch (err) {
     ctx.log.debug(
@@ -46,7 +46,7 @@ export async function getChangedFilesWithReplacement(
         ctx.log.debug(
           `Found replacement build for #${build.number}(${build.commit}): #${replacementBuild.number}(${replacementBuild.commit})`
         );
-        const changedFiles = (await getChangedFiles(ctx, replacementBuild.commit)) || [];
+        const changedFiles = (await getChangedFiles(replacementBuild.commit)) || [];
         return { changedFiles, replacementBuild };
       }
       ctx.log.debug(`Couldn't find replacement for #${build.number}(${build.commit})`);

--- a/node-src/git/getCommitAndBranch.test.ts
+++ b/node-src/git/getCommitAndBranch.test.ts
@@ -74,7 +74,7 @@ describe('getCommitAndBranch', () => {
       slug: 'chromaui/env-ci',
     });
     getBranch.mockResolvedValue('HEAD');
-    getCommit.mockImplementation((_, commit) =>
+    getCommit.mockImplementation((commit) =>
       Promise.resolve({ commit: commit as string, ...commitInfo })
     );
     const info = await getCommitAndBranch(ctx);
@@ -157,7 +157,7 @@ describe('getCommitAndBranch', () => {
       process.env.CHROMATIC_SHA = 'f78db92d';
       process.env.CHROMATIC_BRANCH = 'feature';
       process.env.CHROMATIC_SLUG = 'chromaui/chromatic';
-      getCommit.mockImplementation((_, commit) =>
+      getCommit.mockImplementation((commit) =>
         Promise.resolve({ commit: commit as string, ...commitInfo })
       );
       const info = await getCommitAndBranch(ctx);
@@ -201,7 +201,7 @@ describe('getCommitAndBranch', () => {
       process.env.GITHUB_SHA = '3276c796';
       getCommit.mockResolvedValue({ commit: 'c11da9a9', ...commitInfo });
       const info = await getCommitAndBranch(ctx);
-      expect(getCommit).toHaveBeenCalledWith(ctx, 'github');
+      expect(getCommit).toHaveBeenCalledWith('github');
       expect(info).toMatchObject({
         branch: 'github',
         commit: 'c11da9a9',
@@ -235,7 +235,7 @@ describe('getCommitAndBranch', () => {
       process.env.TRAVIS_PULL_REQUEST_SHA = 'ef765ac7';
       process.env.TRAVIS_PULL_REQUEST_BRANCH = 'travis';
       process.env.TRAVIS_PULL_REQUEST_SLUG = 'chromaui/travis';
-      getCommit.mockImplementation((_, commit) =>
+      getCommit.mockImplementation((commit) =>
         Promise.resolve({ commit: commit as string, ...commitInfo })
       );
       const info = await getCommitAndBranch(ctx);

--- a/node-src/git/getCommitAndBranch.ts
+++ b/node-src/git/getCommitAndBranch.ts
@@ -44,8 +44,8 @@ export default async function getCommitAndBranch(
   }: { branchName?: string; patchBaseRef?: string; ci?: boolean } = {}
 ) {
   const { log } = ctx;
-  let commit: CommitInfo = await getCommit(ctx);
-  let branch = notHead(branchName) || notHead(patchBaseRef) || (await getBranch(ctx));
+  let commit: CommitInfo = await getCommit();
+  let branch = notHead(branchName) || notHead(patchBaseRef) || (await getBranch());
   let slug;
 
   const {
@@ -73,7 +73,7 @@ export default async function getCommitAndBranch(
   const isGitHubAction = GITHUB_ACTIONS === 'true';
   const isGitHubPrBuild = GITHUB_EVENT_NAME === 'pull_request';
 
-  if (!(await hasPreviousCommit(ctx))) {
+  if (!(await hasPreviousCommit())) {
     const message = gitOneCommit(isGitHubAction);
     if (isCi) {
       throw new Error(message);
@@ -83,7 +83,7 @@ export default async function getCommitAndBranch(
   }
 
   if (isFromEnvironmentVariable) {
-    commit = await getCommit(ctx, CHROMATIC_SHA).catch((err) => {
+    commit = await getCommit(CHROMATIC_SHA).catch((err) => {
       log.warn(noCommitDetails({ sha: CHROMATIC_SHA, env: 'CHROMATIC_SHA' }));
       log.debug(err);
       return { commit: CHROMATIC_SHA, committedAt: Date.now() };
@@ -104,7 +104,7 @@ export default async function getCommitAndBranch(
     // Travis PR builds are weird, we want to ensure we mark build against the commit that was
     // merged from, rather than the resulting "ephemeral" merge commit that doesn't stick around in the
     // history of the project (so approvals will get lost). We also have to ensure we use the right branch.
-    commit = await getCommit(ctx, TRAVIS_PULL_REQUEST_SHA).catch((err) => {
+    commit = await getCommit(TRAVIS_PULL_REQUEST_SHA).catch((err) => {
       log.warn(noCommitDetails({ sha: TRAVIS_PULL_REQUEST_SHA, env: 'TRAVIS_PULL_REQUEST_SHA' }));
       log.debug(err);
       return { commit: TRAVIS_PULL_REQUEST_SHA, committedAt: Date.now() };
@@ -129,7 +129,7 @@ export default async function getCommitAndBranch(
     // This does not apply to our GitHub Action, because it'll set CHROMATIC_SHA, -BRANCH and -SLUG.
     // We intentionally use the GITHUB_HEAD_REF (branch name) here, to retrieve the last commit on
     // the head branch rather than the merge commit (GITHUB_SHA).
-    commit = await getCommit(ctx, GITHUB_HEAD_REF).catch((err) => {
+    commit = await getCommit(GITHUB_HEAD_REF).catch((err) => {
       log.warn(noCommitDetails({ ref: GITHUB_HEAD_REF, sha: GITHUB_SHA, env: 'GITHUB_HEAD_REF' }));
       log.debug(err);
       return { commit: GITHUB_SHA, committedAt: Date.now() };
@@ -145,7 +145,7 @@ export default async function getCommitAndBranch(
   // On certain CI systems, a branch is not checked out
   // (instead a detached head is used for the commit).
   if (!notHead(branch)) {
-    commit = await getCommit(ctx, ciCommit).catch((err) => {
+    commit = await getCommit(ciCommit).catch((err) => {
       log.warn(noCommitDetails({ sha: ciCommit }));
       log.debug(err);
       return { commit: ciCommit, committedAt: Date.now() };
@@ -177,7 +177,7 @@ export default async function getCommitAndBranch(
   // To do this, GitHub creates a new commit and does a CI run with the branch changed to e.g. gh-readonly-queue/main/pr-4-da07417adc889156224d03a7466ac712c647cd36
   // If you configure merge queues to rebase in this circumstance,
   // we lose track of baselines as the branch name has changed so our usual rebase detection (based on branch name) doesn't work.
-  const mergeQueueBranchPrNumber = await mergeQueueBranchMatch(ctx, branch);
+  const mergeQueueBranchPrNumber = await mergeQueueBranchMatch(branch);
   if (mergeQueueBranchPrNumber) {
     // This is why we extract the PR number from the branch name and use it to find the branch name of the PR that was merged.
     const branchFromMergeQueuePullRequestNumber = await getBranchFromMergeQueuePullRequestNumber(

--- a/node-src/git/getParentCommits.test.ts
+++ b/node-src/git/getParentCommits.test.ts
@@ -62,7 +62,6 @@ async function checkoutCommit(name, branch, { dirname, runGit, commitMap }) {
 }
 
 const log = { debug: vi.fn() };
-const ctx = { log } as any;
 const options = {};
 
 // This is built in from TypeScript 4.5
@@ -94,7 +93,7 @@ describe('getParentCommits', () => {
     const repository = repositories.simpleLoop;
     await checkoutCommit('F', 'main', repository);
     const client = createClient({ repository, builds: [] });
-    const git = { branch: 'main', ...(await getCommit(ctx)) };
+    const git = { branch: 'main', ...(await getCommit()) };
 
     const parentCommits = await getParentCommits({ client, log, git, options } as any);
     expectCommitsToEqualNames(parentCommits, [], repository);
@@ -107,7 +106,7 @@ describe('getParentCommits', () => {
     const repository = repositories.simpleLoop;
     await checkoutCommit('F', 'main', repository);
     const client = createClient({ repository, builds: [['F', 'main']] });
-    const git = { branch: 'main', ...(await getCommit(ctx)) };
+    const git = { branch: 'main', ...(await getCommit()) };
 
     const parentCommits = await getParentCommits({ client, log, git, options } as any);
     expectCommitsToEqualNames(parentCommits, ['F'], repository);
@@ -120,7 +119,7 @@ describe('getParentCommits', () => {
     const repository = repositories.simpleLoop;
     await checkoutCommit('C', 'main', repository);
     const client = createClient({ repository, builds: [['B', 'main']] });
-    const git = { branch: 'main', ...(await getCommit(ctx)) };
+    const git = { branch: 'main', ...(await getCommit()) };
 
     const parentCommits = await getParentCommits({ client, log, git, options } as any);
     expectCommitsToEqualNames(parentCommits, ['B'], repository);
@@ -139,7 +138,7 @@ describe('getParentCommits', () => {
         ['E', 'branch'],
       ],
     });
-    const git = { branch: 'main', ...(await getCommit(ctx)) };
+    const git = { branch: 'main', ...(await getCommit()) };
 
     const parentCommits = await getParentCommits({ client, log, git, options } as any);
     expectCommitsToEqualNames(parentCommits, ['E', 'D'], repository);
@@ -161,7 +160,7 @@ describe('getParentCommits', () => {
         ['D', 'main'],
       ],
     });
-    const git = { branch: 'main', ...(await getCommit(ctx)) };
+    const git = { branch: 'main', ...(await getCommit()) };
 
     const parentCommits = await getParentCommits({ client, log, git, options } as any);
     expectCommitsToEqualNames(parentCommits, ['D', 'C', 'B'], repository);
@@ -180,7 +179,7 @@ describe('getParentCommits', () => {
         ['C', 'main'],
       ],
     });
-    const git = { branch: 'main', ...(await getCommit(ctx)) };
+    const git = { branch: 'main', ...(await getCommit()) };
 
     const parentCommits = await getParentCommits({ client, log, git, options } as any);
     expectCommitsToEqualNames(parentCommits, ['C', 'B'], repository);
@@ -202,7 +201,7 @@ describe('getParentCommits', () => {
         ['B', 'main'],
       ],
     });
-    const git = { branch: 'main', ...(await getCommit(ctx)) };
+    const git = { branch: 'main', ...(await getCommit()) };
 
     const parentCommits = await getParentCommits({ client, log, git, options } as any);
     expectCommitsToEqualNames(parentCommits, ['B'], repository);
@@ -225,7 +224,7 @@ describe('getParentCommits', () => {
         ['E', 'main'],
       ],
     });
-    const git = { branch: 'main', ...(await getCommit(ctx)) };
+    const git = { branch: 'main', ...(await getCommit()) };
 
     const parentCommits = await getParentCommits({ client, log, git, options } as any);
     expectCommitsToEqualNames(parentCommits, ['E', 'D'], repository);
@@ -240,7 +239,7 @@ describe('getParentCommits', () => {
     const repository = repositories.simpleLoop;
     await checkoutCommit('F', 'main', repository);
     const client = createClient({ repository, builds: [['C', 'main']] });
-    const git = { branch: 'main', ...(await getCommit(ctx)) };
+    const git = { branch: 'main', ...(await getCommit()) };
 
     const parentCommits = await getParentCommits({ client, log, git, options } as any);
     expectCommitsToEqualNames(parentCommits, ['C'], repository);
@@ -263,7 +262,7 @@ describe('getParentCommits', () => {
         ['D', 'main'],
       ],
     });
-    const git = { branch: 'main', ...(await getCommit(ctx)) };
+    const git = { branch: 'main', ...(await getCommit()) };
 
     const parentCommits = await getParentCommits({ client, log, git, options } as any);
     expectCommitsToEqualNames(parentCommits, ['D'], repository);
@@ -282,7 +281,7 @@ describe('getParentCommits', () => {
         ['D', 'branch'],
       ],
     });
-    const git = { branch: 'main', ...(await getCommit(ctx)) };
+    const git = { branch: 'main', ...(await getCommit()) };
 
     const parentCommits = await getParentCommits({ client, log, git, options } as any);
     expectCommitsToEqualNames(parentCommits, ['C'], repository);
@@ -295,7 +294,7 @@ describe('getParentCommits', () => {
     const repository = repositories.simpleLoop;
     await checkoutCommit('E', 'main', repository);
     const client = createClient({ repository, builds: [['D', 'branch']] });
-    const git = { branch: 'main', ...(await getCommit(ctx)) };
+    const git = { branch: 'main', ...(await getCommit()) };
 
     const parentCommits = await getParentCommits({ client, log, git, options } as any);
     expectCommitsToEqualNames(parentCommits, [], repository);
@@ -308,7 +307,7 @@ describe('getParentCommits', () => {
     const repository = repositories.simpleLoop;
     await checkoutCommit('D', 'main', repository);
     const client = createClient({ repository, builds: [['E', 'branch']] });
-    const git = { branch: 'main', ...(await getCommit(ctx)) };
+    const git = { branch: 'main', ...(await getCommit()) };
 
     const parentCommits = await getParentCommits({ client, log, git, options } as any);
     expectCommitsToEqualNames(parentCommits, [], repository);
@@ -321,7 +320,7 @@ describe('getParentCommits', () => {
     const repository = repositories.twoRoots;
     await checkoutCommit('D', 'main', repository);
     const client = createClient({ repository, builds: [['B', 'branch']] });
-    const git = { branch: 'main', ...(await getCommit(ctx)) };
+    const git = { branch: 'main', ...(await getCommit()) };
 
     const parentCommits = await getParentCommits({ client, log, git, options } as any);
     expectCommitsToEqualNames(parentCommits, [], repository);
@@ -341,7 +340,7 @@ describe('getParentCommits', () => {
       },
       builds: [['Z', 'branch']],
     });
-    const git = { branch: 'main', ...(await getCommit(ctx)) };
+    const git = { branch: 'main', ...(await getCommit()) };
 
     const parentCommits = await getParentCommits({ client, log, git, options } as any);
     expectCommitsToEqualNames(parentCommits, [], repository);
@@ -354,7 +353,7 @@ describe('getParentCommits', () => {
     const repository = repositories.simpleLoop;
     await checkoutCommit('F', 'main', repository);
     const client = createClient({ repository, builds: [['D', 'main']] });
-    const git = { branch: 'main', ...(await getCommit(ctx)) };
+    const git = { branch: 'main', ...(await getCommit()) };
 
     const parentCommits = await getParentCommits({ client, log, git, options } as any);
     expectCommitsToEqualNames(parentCommits, ['D'], repository);
@@ -367,7 +366,7 @@ describe('getParentCommits', () => {
     const repository = repositories.longLine;
     await checkoutCommit('Z', 'main', repository);
     const client = createClient({ repository, builds: [['z', 'branch']] });
-    const git = { branch: 'main', ...(await getCommit(ctx)) };
+    const git = { branch: 'main', ...(await getCommit()) };
 
     const parentCommits = await getParentCommits({ client, log, git, options } as any);
     expectCommitsToEqualNames(parentCommits, [], repository);
@@ -380,7 +379,7 @@ describe('getParentCommits', () => {
     const repository = repositories.longLine;
     await checkoutCommit('Z', 'main', repository);
     const client = createClient({ repository, builds: [['A', 'branch']] });
-    const git = { branch: 'main', ...(await getCommit(ctx)) };
+    const git = { branch: 'main', ...(await getCommit()) };
 
     const parentCommits = await getParentCommits({ client, log, git, options } as any);
     expectCommitsToEqualNames(parentCommits, ['A'], repository);
@@ -406,7 +405,7 @@ describe('getParentCommits', () => {
         return mockIndexWithNullFirstBuildCommittedAt(queryName, variables);
       },
     };
-    const git = { branch: 'branch', ...(await getCommit(ctx)) };
+    const git = { branch: 'branch', ...(await getCommit()) };
 
     const parentCommits = await getParentCommits({ client, log, git, options } as any);
     expectCommitsToEqualNames(parentCommits, ['A'], repository);
@@ -430,7 +429,7 @@ describe('getParentCommits', () => {
         ['D', 'branch'],
       ],
     });
-    const git = { branch: 'branch', ...(await getCommit(ctx)) };
+    const git = { branch: 'branch', ...(await getCommit()) };
 
     const parentCommits = await getParentCommits({ client, log, git, options } as any);
     expectCommitsToEqualNames(parentCommits, ['D'], repository);
@@ -454,7 +453,7 @@ describe('getParentCommits', () => {
         ['D', 'branch'],
       ],
     });
-    const git = { branch: 'branch', ...(await getCommit(ctx)) };
+    const git = { branch: 'branch', ...(await getCommit()) };
 
     const parentCommits = await getParentCommits({ client, log, git, options } as any);
     expectCommitsToEqualNames(parentCommits, ['D'], repository);
@@ -478,7 +477,7 @@ describe('getParentCommits', () => {
         ['E', 'branch'],
       ],
     });
-    const git = { branch: 'branch', ...(await getCommit(ctx)) };
+    const git = { branch: 'branch', ...(await getCommit()) };
 
     const parentCommits = await getParentCommits({ client, log, git, options } as any);
     expectCommitsToEqualNames(parentCommits, ['C'], repository);
@@ -501,7 +500,7 @@ describe('getParentCommits', () => {
         ['D', 'branch'],
       ],
     });
-    const git = { branch: 'branch', ...(await getCommit(ctx)) };
+    const git = { branch: 'branch', ...(await getCommit()) };
 
     const parentCommits = await getParentCommits({ client, log, git, options } as any, {
       ignoreLastBuildOnBranch: true,
@@ -533,7 +532,7 @@ describe('getParentCommits', () => {
         ['Z', 'branch'],
       ],
     });
-    const git = { branch: 'branch', ...(await getCommit(ctx)) };
+    const git = { branch: 'branch', ...(await getCommit()) };
 
     const parentCommits = await getParentCommits({ client, log, git, options } as any);
     expect(parentCommits).toEqual([Zhash, repository.commitMap.C.hash]);
@@ -558,7 +557,7 @@ describe('getParentCommits', () => {
         ['B', 'main'],
       ],
     });
-    const git = { branch: 'branch', ...(await getCommit(ctx)) };
+    const git = { branch: 'branch', ...(await getCommit()) };
 
     const parentCommits = await getParentCommits({ client, log, git, options } as any);
     expectCommitsToEqualNames(parentCommits, ['B'], repository);
@@ -581,7 +580,7 @@ describe('getParentCommits', () => {
         ['E', 'branch'],
       ],
     });
-    const git = { branch: 'branch', ...(await getCommit(ctx)) };
+    const git = { branch: 'branch', ...(await getCommit()) };
 
     const parentCommits = await getParentCommits({ client, log, git, options } as any);
     expectCommitsToEqualNames(parentCommits, ['E'], repository);
@@ -605,7 +604,7 @@ describe('getParentCommits', () => {
         ['D', 'HEAD'],
       ],
     });
-    const git = { branch: 'HEAD', ...(await getCommit(ctx)) };
+    const git = { branch: 'HEAD', ...(await getCommit()) };
 
     // We can pass 'HEAD' as the branch if we fail to find any other branch info from another source
     const parentCommits = await getParentCommits({ client, log, git, options } as any);
@@ -632,7 +631,7 @@ describe('getParentCommits', () => {
         // Talking to GH (etc) tells us that commit E is the merge commit for "branch"
         prs: [['E', 'branch']],
       });
-      const git = { branch: 'main', ...(await getCommit(ctx)) };
+      const git = { branch: 'main', ...(await getCommit()) };
 
       const parentCommits = await getParentCommits({ client, log, git, options } as any);
       // This doesn't include 'C' as D "covers" it.
@@ -656,7 +655,7 @@ describe('getParentCommits', () => {
         // Talking to GH (etc) tells us that commit E is the merge commit for "branch"
         prs: [['E', 'branch']],
       });
-      const git = { branch: 'main', ...(await getCommit(ctx)) };
+      const git = { branch: 'main', ...(await getCommit()) };
 
       const parentCommits = await getParentCommits({ client, log, git, options } as any);
       expectCommitsToEqualNames(parentCommits, ['D', 'C'], repository);
@@ -679,7 +678,7 @@ describe('getParentCommits', () => {
         // Talking to GH (etc) tells us that commit E is the merge commit for "branch"
         prs: [['E', 'branch']],
       });
-      const git = { branch: 'main', ...(await getCommit(ctx)) };
+      const git = { branch: 'main', ...(await getCommit()) };
 
       const parentCommits = await getParentCommits({ client, log, git, options } as any);
       expectCommitsToEqualNames(parentCommits, ['C', 'B'], repository);
@@ -702,7 +701,7 @@ describe('getParentCommits', () => {
         // Talking to GH (etc) tells us that commit E is the merge commit for "branch"
         prs: [['E', 'branch']],
       });
-      const git = { branch: 'main', ...(await getCommit(ctx)) };
+      const git = { branch: 'main', ...(await getCommit()) };
 
       const parentCommits = await getParentCommits({ client, log, git, options } as any);
       // This doesn't include A as B "covers" it.
@@ -723,7 +722,7 @@ describe('getParentCommits', () => {
         // Talking to GH (etc) tells us that commit E is the merge commit for "branch"
         prs: [['E', 'branch']],
       });
-      const git = { branch: 'main', ...(await getCommit(ctx)) };
+      const git = { branch: 'main', ...(await getCommit()) };
 
       const parentCommits = await getParentCommits({ client, log, git, options } as any);
       expectCommitsToEqualNames(parentCommits, ['C'], repository);
@@ -746,7 +745,7 @@ describe('getParentCommits', () => {
         // Talking to GH (etc) tells us that commit D is the merge commit for "branch" (which no longer exists)
         prs: [['D', 'branch']],
       });
-      const git = { branch: 'main', ...(await getCommit(ctx)) };
+      const git = { branch: 'main', ...(await getCommit()) };
 
       const parentCommits = await getParentCommits({ client, log, git, options } as any);
       expectCommitsToEqualNames(parentCommits, ['MISSING', 'A'], repository);
@@ -778,7 +777,7 @@ describe('getParentCommits', () => {
           ['E', 'branch2'],
         ],
       });
-      const git = { branch: 'main', ...(await getCommit(ctx)) };
+      const git = { branch: 'main', ...(await getCommit()) };
 
       const parentCommits = await getParentCommits({ client, log, git, options } as any);
       expectCommitsToEqualNames(parentCommits, ['C', 'B'], repository);
@@ -800,7 +799,7 @@ describe('getParentCommits', () => {
         // Talking to GH (etc) tells us that commit F is the merge commit for "branch"
         prs: [['F', 'branch']],
       });
-      const git = { branch: 'main', ...(await getCommit(ctx)) };
+      const git = { branch: 'main', ...(await getCommit()) };
 
       const parentCommits = await getParentCommits({ client, log, git, options } as any);
       expectCommitsToEqualNames(parentCommits, ['E', 'D'], repository);

--- a/node-src/git/getParentCommits.ts
+++ b/node-src/git/getParentCommits.ts
@@ -89,7 +89,7 @@ function commitsForCLI(commits: string[]) {
 // `commitsWithBuilds`.
 //
 async function nextCommits(
-  ctx: Pick<Context, 'log'>,
+  { log }: Pick<Context, 'log'>,
   limit: number,
   {
     firstCommittedAtSeconds,
@@ -107,8 +107,10 @@ async function nextCommits(
   const command = `git rev-list HEAD \
       ${firstCommittedAtSeconds ? `--since ${firstCommittedAtSeconds}` : ''} \
       -n ${limit + commitsWithoutBuilds.length} --not ${commitsForCLI(commitsWithBuilds)}`;
-  const commitsString = await execGitCommand(ctx, command);
+  log.debug(`running ${command}`);
+  const commitsString = await execGitCommand(command);
   const commits = commitsString?.split('\n').filter(Boolean);
+  log.debug(`command output: ${commits}`);
 
   // Later on we want to know which commits we visited on the way to finding the ancestor commits
   // The output of the above rev-list commit includes possibly commits with builds so filter them.
@@ -179,7 +181,7 @@ async function step(
 
 // Which of the listed commits are "maximally descendent":
 // ie c in commits such that there are no descendents of c in commits.
-async function maximallyDescendentCommits(ctx: Pick<Context, 'log'>, commits: string[]) {
+async function maximallyDescendentCommits({ log }: Pick<Context, 'log'>, commits: string[]) {
   if (commits.length === 0) {
     return commits;
   }
@@ -189,8 +191,10 @@ async function maximallyDescendentCommits(ctx: Pick<Context, 'log'>, commits: st
   // List the tree from <commits> not including the tree from <parentCommits>
   // This just filters any commits that are ancestors of other commits
   const command = `git rev-list ${commitsForCLI(commits)} --not ${commitsForCLI(parentCommits)}`;
-  const maxCommitsString = await execGitCommand(ctx, command);
+  log.debug(`running ${command}`);
+  const maxCommitsString = await execGitCommand(command);
   const maxCommits = maxCommitsString?.split('\n').filter(Boolean);
+  log.debug(`command output: ${maxCommits}`);
 
   return maxCommits;
 }
@@ -241,7 +245,7 @@ export async function getParentCommits(ctx: Context, { ignoreLastBuildOnBranch =
     lastBuild &&
     lastBuild.committedAt <= committedAt
   ) {
-    if (await commitExists(ctx, lastBuild.commit)) {
+    if (await commitExists(lastBuild.commit)) {
       log.debug(`Adding last branch build commit ${lastBuild.commit} to commits with builds`);
       initialCommitsWithBuilds.push(lastBuild.commit);
     } else {
@@ -284,7 +288,7 @@ export async function getParentCommits(ctx: Context, { ignoreLastBuildOnBranch =
     // @see https://www.chromatic.com/docs/branching-and-baselines#squash-and-rebase-merging
     const lastHeadBuildCommit = pullRequest.lastHeadBuild?.commit;
     if (lastHeadBuildCommit) {
-      if (await commitExists(ctx, lastHeadBuildCommit)) {
+      if (await commitExists(lastHeadBuildCommit)) {
         log.debug(`Adding merged PR build commit ${lastHeadBuildCommit} to commits with builds`);
         commitsWithBuilds.push(lastHeadBuildCommit);
       } else {

--- a/node-src/git/git.test.ts
+++ b/node-src/git/git.test.ts
@@ -1,6 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import TestLogger from '../lib/testLogger';
 import * as execGit from './execGit';
 import {
   findFilesFromRepositoryRoot,
@@ -21,8 +20,6 @@ const execGitCommand = vi.mocked(execGit.execGitCommand);
 const execGitCommandOneLine = vi.mocked(execGit.execGitCommandOneLine);
 const execGitCommandCountLines = vi.mocked(execGit.execGitCommandCountLines);
 
-const ctx = { log: new TestLogger() };
-
 afterEach(() => {
   vi.clearAllMocks();
 });
@@ -32,7 +29,7 @@ describe('getCommit', () => {
     execGitCommand.mockResolvedValue(
       `19b6c9c5b3d34d9fc55627fcaf8a85bd5d5e5b2a ## 1696588814 ## info@ghengeveld.nl ## Gert Hengeveld`
     );
-    expect(await getCommit(ctx)).toEqual({
+    expect(await getCommit()).toEqual({
       commit: '19b6c9c5b3d34d9fc55627fcaf8a85bd5d5e5b2a',
       committedAt: 1_696_588_814 * 1000,
       committerEmail: 'info@ghengeveld.nl',
@@ -47,7 +44,7 @@ gpg:                using RSA key 4AEE18F83AFDEB23
 gpg: Can't check signature: No public key
 19b6c9c5b3d34d9fc55627fcaf8a85bd5d5e5b2a ## 1696588814 ## info@ghengeveld.nl ## Gert Hengeveld`.trim()
     );
-    expect(await getCommit(ctx)).toEqual({
+    expect(await getCommit()).toEqual({
       commit: '19b6c9c5b3d34d9fc55627fcaf8a85bd5d5e5b2a',
       committedAt: 1_696_588_814 * 1000,
       committerEmail: 'info@ghengeveld.nl',
@@ -59,25 +56,25 @@ gpg: Can't check signature: No public key
 describe('getSlug', () => {
   it('returns the slug portion of the git url', async () => {
     execGitCommand.mockResolvedValue('git@github.com:chromaui/chromatic-cli.git');
-    expect(await getSlug(ctx)).toBe('chromaui/chromatic-cli');
+    expect(await getSlug()).toBe('chromaui/chromatic-cli');
 
     execGitCommand.mockResolvedValue('https://github.com/chromaui/chromatic-cli');
-    expect(await getSlug(ctx)).toBe('chromaui/chromatic-cli');
+    expect(await getSlug()).toBe('chromaui/chromatic-cli');
 
     execGitCommand.mockResolvedValue('https://gitlab.com/foo/bar.baz.git');
-    expect(await getSlug(ctx)).toBe('foo/bar.baz');
+    expect(await getSlug()).toBe('foo/bar.baz');
   });
 });
 
 describe('hasPreviousCommit', () => {
   it('returns true if a commit is found', async () => {
     execGitCommand.mockResolvedValue(`19b6c9c5b3d34d9fc55627fcaf8a85bd5d5e5b2a`);
-    expect(await hasPreviousCommit(ctx)).toEqual(true);
+    expect(await hasPreviousCommit()).toEqual(true);
   });
 
   it('returns false if no commit is found', async () => {
     execGitCommand.mockResolvedValue(``);
-    expect(await hasPreviousCommit(ctx)).toEqual(false);
+    expect(await hasPreviousCommit()).toEqual(false);
   });
 
   it('ignores gpg signature information', async () => {
@@ -88,19 +85,19 @@ gpg:                using RSA key 4AEE18F83AFDEB23
 gpg: Can't check signature: No public key
 19b6c9c5b3d34d9fc55627fcaf8a85bd5d5e5b2a`.trim()
     );
-    expect(await hasPreviousCommit(ctx)).toEqual(true);
+    expect(await hasPreviousCommit()).toEqual(true);
   });
 });
 
 describe('mergeQueueBranchMatch', () => {
   it('returns pr number if it is a merge queue branch', async () => {
     const branch = 'gh-readonly-queue/main/pr-4-da07417adc889156224d03a7466ac712c647cd36';
-    expect(await mergeQueueBranchMatch(ctx, branch)).toEqual(4);
+    expect(await mergeQueueBranchMatch(branch)).toEqual(4);
   });
 
   it('returns null if it is not a merge queue branch', async () => {
     const branch = 'develop';
-    expect(await mergeQueueBranchMatch(ctx, branch)).toBeUndefined();
+    expect(await mergeQueueBranchMatch(branch)).toBeUndefined();
   });
 });
 
@@ -112,12 +109,11 @@ describe('findFilesFromRepositoryRoot', () => {
     execGitCommand.mockResolvedValueOnce('/root');
     execGitCommand.mockResolvedValueOnce(filesFound.join(NULL_BYTE));
 
-    const results = await findFilesFromRepositoryRoot(ctx, 'package.json', '**/package.json');
+    const results = await findFilesFromRepositoryRoot('package.json', '**/package.json');
 
     expect(execGitCommand).toBeCalledTimes(2);
     expect(execGitCommand).toHaveBeenNthCalledWith(
       2,
-      ctx,
       'git ls-files --full-name -z "/root/package.json" "/root/**/package.json"'
     );
     expect(results).toEqual(filesFound);
@@ -127,28 +123,22 @@ describe('findFilesFromRepositoryRoot', () => {
 describe('getRepositoryCreationDate', () => {
   it('parses the date successfully', async () => {
     execGitCommandOneLine.mockResolvedValue(`2017-05-17 10:00:35 -0700`);
-    expect(await getRepositoryCreationDate(ctx)).toEqual(new Date('2017-05-17T17:00:35.000Z'));
+    expect(await getRepositoryCreationDate()).toEqual(new Date('2017-05-17T17:00:35.000Z'));
   });
 });
 
 describe('getStorybookCreationDate', () => {
   it('passes the config dir to the git command', async () => {
-    const ctxWithConfig = {
-      ...ctx,
-      options: { storybookConfigDir: 'special-config-dir' },
-    };
-    await getStorybookCreationDate(ctxWithConfig);
+    await getStorybookCreationDate({ options: { storybookConfigDir: 'special-config-dir' } });
     expect(execGitCommandOneLine).toHaveBeenCalledWith(
-      ctxWithConfig,
       expect.stringMatching(/special-config-dir/),
       expect.anything()
     );
   });
 
   it('defaults the config dir to the git command', async () => {
-    await getStorybookCreationDate({ ...ctx, options: {} });
+    await getStorybookCreationDate({ options: {} });
     expect(execGitCommandOneLine).toHaveBeenCalledWith(
-      { ...ctx, options: {} },
       expect.stringMatching(/.storybook/),
       expect.anything()
     );
@@ -157,7 +147,7 @@ describe('getStorybookCreationDate', () => {
   it('parses the date successfully', async () => {
     execGitCommandOneLine.mockResolvedValue(`2017-05-17 10:00:35 -0700`);
     expect(
-      await getStorybookCreationDate({ ...ctx, options: { storybookConfigDir: '.storybook' } })
+      await getStorybookCreationDate({ options: { storybookConfigDir: '.storybook' } })
     ).toEqual(new Date('2017-05-17T17:00:35.000Z'));
   });
 });
@@ -165,21 +155,20 @@ describe('getStorybookCreationDate', () => {
 describe('getNumberOfComitters', () => {
   it('parses the count successfully', async () => {
     execGitCommandCountLines.mockResolvedValue(17);
-    expect(await getNumberOfComitters(ctx)).toEqual(17);
+    expect(await getNumberOfComitters()).toEqual(17);
   });
 });
 
 describe('getCommittedFileCount', () => {
   it('constructs the correct command', async () => {
-    await getCommittedFileCount(ctx, ['page', 'screen'], ['js', 'ts']);
+    await getCommittedFileCount(['page', 'screen'], ['js', 'ts']);
     expect(execGitCommandCountLines).toHaveBeenCalledWith(
-      ctx,
       'git ls-files -- "*page*.js" "*page*.ts" "*Page*.js" "*Page*.ts" "*screen*.js" "*screen*.ts" "*Screen*.js" "*Screen*.ts"',
       expect.anything()
     );
   });
   it('parses the count successfully', async () => {
     execGitCommandCountLines.mockResolvedValue(17);
-    expect(await getCommittedFileCount(ctx, ['page', 'screen'], ['js', 'ts'])).toEqual(17);
+    expect(await getCommittedFileCount(['page', 'screen'], ['js', 'ts'])).toEqual(17);
   });
 });

--- a/node-src/index.test.ts
+++ b/node-src/index.test.ts
@@ -824,7 +824,7 @@ it('should upload metadata files if --upload-metadata is passed', async () => {
 
 describe('getGitInfo', () => {
   it('should retreive git info', async () => {
-    const result = await getGitInfo(getContext([]));
+    const result = await getGitInfo();
     expect(result).toMatchObject({
       branch: 'branch',
       commit: 'commit',
@@ -840,7 +840,7 @@ describe('getGitInfo', () => {
 
   it('should still return getInfo if no origin url', async () => {
     getSlug.mockRejectedValue(new Error('no origin set'));
-    const result = await getGitInfo(getContext([]));
+    const result = await getGitInfo();
     expect(result).toMatchObject({
       branch: 'branch',
       commit: 'commit',

--- a/node-src/index.ts
+++ b/node-src/index.ts
@@ -316,27 +316,25 @@ export interface GitInfo {
  * Although this function may not be used directly in this project, it can be used externally (such
  * as https://github.com/chromaui/addon-visual-tests).
  *
- * @param ctx The context set when executing the CLI.
- *
  * @returns Any git information we were able to gather.
  */
-export async function getGitInfo(ctx: Pick<Context, 'log'>): Promise<GitInfo> {
+export async function getGitInfo(): Promise<GitInfo> {
   let slug: string;
   try {
-    slug = await getSlug(ctx);
+    slug = await getSlug();
   } catch {
     slug = '';
   }
-  const branch = (await getBranch(ctx)) || '';
-  const commitInfo = await getCommit(ctx);
-  const userEmail = (await getUserEmail(ctx)) || '';
+  const branch = (await getBranch()) || '';
+  const commitInfo = await getCommit();
+  const userEmail = (await getUserEmail()) || '';
   const userEmailHash = emailHash(userEmail);
-  const repositoryRootDirectory = (await getRepositoryRoot(ctx)) || '';
+  const repositoryRootDirectory = (await getRepositoryRoot()) || '';
 
   const [ownerName, repoName, ...rest] = slug ? slug.split('/') : [];
   const isValidSlug = !!ownerName && !!repoName && rest.length === 0;
 
-  const uncommittedHash = (await getUncommittedHash(ctx)) || '';
+  const uncommittedHash = (await getUncommittedHash()) || '';
   return {
     slug: isValidSlug ? slug : '',
     branch,

--- a/node-src/lib/checkStorybookBaseDirectory.ts
+++ b/node-src/lib/checkStorybookBaseDirectory.ts
@@ -14,7 +14,7 @@ import { exitCodes, setExitCode } from './setExitCode';
  * @param stats The stats file information from the project's builder (Webpack, for example).
  */
 export async function checkStorybookBaseDirectory(ctx: Context, stats: Stats) {
-  const repositoryRoot = await getRepositoryRoot(ctx);
+  const repositoryRoot = await getRepositoryRoot();
 
   if (!repositoryRoot) {
     throw new Error('Failed to determine repository root');

--- a/node-src/lib/log.ts
+++ b/node-src/lib/log.ts
@@ -139,9 +139,8 @@ export const createLogger = (flags: Flags, options?: Partial<Options>) => {
   let enqueue = false;
   const queue: QueueMessage[] = [];
 
-  const logPrefixer = createPrefixer(true, options?.logPrefix ?? flags.logPrefix ?? LOG_PREFIX);
-  const filePrefixer = createPrefixer(false, options?.logPrefix ?? flags.logPrefix ?? LOG_PREFIX);
-
+  const logPrefixer = createPrefixer(true, options?.logPrefix || flags.logPrefix || LOG_PREFIX);
+  const filePrefixer = createPrefixer(false, options?.logPrefix || flags.logPrefix || LOG_PREFIX);
   const log =
     (type: LogType, logFileOnly?: boolean) =>
     (...args: any[]) => {

--- a/node-src/lib/testLogger.ts
+++ b/node-src/lib/testLogger.ts
@@ -55,12 +55,4 @@ export default class TestLogger {
   setLogFile() {
     // do nothing
   }
-
-  file() {
-    // do nothing
-  }
-
-  getLevel(): any {
-    // do nothing
-  }
 }

--- a/node-src/lib/turbosnap/findChangedDependencies.test.ts
+++ b/node-src/lib/turbosnap/findChangedDependencies.test.ts
@@ -34,7 +34,7 @@ const createChangedPackagesGraph = vi.mocked(snykGraph.createChangedPackagesGrap
 beforeEach(() => {
   getRepositoryRoot.mockResolvedValue('/root');
   // always resolve files in the root, but not subdirs
-  findFilesFromRepositoryRoot.mockImplementation((_, file) =>
+  findFilesFromRepositoryRoot.mockImplementation((file) =>
     Promise.resolve(file.startsWith('**') ? [] : [file])
   );
   // always checkout files with the result path of "<commit>.<file>"
@@ -216,7 +216,7 @@ describe('findChangedDependencies', () => {
   });
 
   it('looks for manifest and lock files in subpackages', async () => {
-    findFilesFromRepositoryRoot.mockImplementation((_, file) =>
+    findFilesFromRepositoryRoot.mockImplementation((file) =>
       Promise.resolve(file.startsWith('**') ? [file.replace('**', 'subdir')] : [file])
     );
 
@@ -267,7 +267,7 @@ describe('findChangedDependencies', () => {
   });
 
   it('uses root lockfile when subpackage lockfile is missing', async () => {
-    findFilesFromRepositoryRoot.mockImplementation((_, file) => {
+    findFilesFromRepositoryRoot.mockImplementation((file) => {
       if (file === 'subdir/yarn.lock') return Promise.resolve([]);
       return Promise.resolve(file.startsWith('**') ? [file.replace('**', 'subdir')] : [file]);
     });
@@ -300,7 +300,7 @@ describe('findChangedDependencies', () => {
   });
 
   it('ignores lockfile changes if metadata file is untraced', async () => {
-    findFilesFromRepositoryRoot.mockImplementation((_, file) => {
+    findFilesFromRepositoryRoot.mockImplementation((file) => {
       if (file === 'subdir/yarn.lock') return Promise.resolve([]);
       return Promise.resolve(file.startsWith('**') ? [file.replace('**', 'subdir')] : [file]);
     });
@@ -322,7 +322,7 @@ describe('findChangedDependencies', () => {
   });
 
   it('uses package-lock.json if yarn.lock is missing', async () => {
-    findFilesFromRepositoryRoot.mockImplementation((_, file) => {
+    findFilesFromRepositoryRoot.mockImplementation((file) => {
       if (file.endsWith('yarn.lock'))
         return Promise.resolve([file.replace('yarn.lock', 'package-lock.json')]);
       return Promise.resolve(file.startsWith('**') ? [file.replace('**', 'subdir')] : [file]);

--- a/node-src/lib/turbosnap/findChangedDependencies.ts
+++ b/node-src/lib/turbosnap/findChangedDependencies.ts
@@ -29,10 +29,9 @@ export const findChangedDependencies = async (ctx: Context) => {
     `Finding changed dependencies for ${packageMetadataChanges?.length} baselines`
   );
 
-  const rootPath = (await getRepositoryRoot(ctx)) || '';
-  const [rootManifestPath] = (await findFilesFromRepositoryRoot(ctx, PACKAGE_JSON)) || [];
-  const [rootLockfilePath] =
-    (await findFilesFromRepositoryRoot(ctx, ...SUPPORTED_LOCK_FILES)) || [];
+  const rootPath = (await getRepositoryRoot()) || '';
+  const [rootManifestPath] = (await findFilesFromRepositoryRoot(PACKAGE_JSON)) || [];
+  const [rootLockfilePath] = (await findFilesFromRepositoryRoot(...SUPPORTED_LOCK_FILES)) || [];
   if (!rootManifestPath || !rootLockfilePath) {
     ctx.log.debug(
       { rootPath, rootManifestPath, rootLockfilePath },
@@ -45,13 +44,12 @@ export const findChangedDependencies = async (ctx: Context) => {
   // Handle monorepos with (multiple) nested package.json files.
   // Note that this does not use `path.join` to concatenate the file paths because
   // git uses forward slashes, even on windows
-  const nestedManifestPaths = (await findFilesFromRepositoryRoot(ctx, `**/${PACKAGE_JSON}`)) || [];
+  const nestedManifestPaths = (await findFilesFromRepositoryRoot(`**/${PACKAGE_JSON}`)) || [];
   const metadataPathPairs = await Promise.all(
     nestedManifestPaths.map(async (manifestPath) => {
       const dirname = path.dirname(manifestPath);
       const [lockfilePath] =
         (await findFilesFromRepositoryRoot(
-          ctx,
           ...SUPPORTED_LOCK_FILES.map((lockfile) => `${dirname}/${lockfile}`)
         )) || [];
       // Fall back to the root lockfile if we can't find one in the same directory.

--- a/node-src/lib/turbosnap/findChangedPackageFiles.test.ts
+++ b/node-src/lib/turbosnap/findChangedPackageFiles.test.ts
@@ -1,7 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import * as execGit from '../../git/execGit';
-import TestLogger from '../testLogger';
 import {
   arePackageDependenciesEqual,
   clearFileCache,
@@ -10,11 +9,10 @@ import {
 
 vi.mock('../../git/execGit');
 
-const ctx = { log: new TestLogger() };
 const execGitCommand = vi.mocked(execGit.execGitCommand);
 
 const mockFileContents = (packagesCommitsByFile) => {
-  execGitCommand.mockImplementation(async (_, input) => {
+  execGitCommand.mockImplementation(async (input) => {
     const regexResults = /show\s([^:]*):(.*)/g.exec(input);
     if (!regexResults) return '';
 
@@ -34,7 +32,7 @@ beforeEach(() => {
 
 describe('findChangedPackageFiles', () => {
   it('returns empty array when there are no changed package files', async () => {
-    expect(await findChangedPackageFiles(ctx, [])).toStrictEqual([]);
+    expect(await findChangedPackageFiles([])).toStrictEqual([]);
   });
 
   it('returns empty array when there are package files with no changed dependencies', async () => {
@@ -43,7 +41,7 @@ describe('findChangedPackageFiles', () => {
     });
 
     expect(
-      await findChangedPackageFiles(ctx, [{ commit: 'A', changedFiles: ['package.json'] }])
+      await findChangedPackageFiles([{ commit: 'A', changedFiles: ['package.json'] }])
     ).toStrictEqual([]);
   });
 
@@ -53,7 +51,7 @@ describe('findChangedPackageFiles', () => {
     });
 
     expect(
-      await findChangedPackageFiles(ctx, [{ commit: 'A', changedFiles: ['package.json'] }])
+      await findChangedPackageFiles([{ commit: 'A', changedFiles: ['package.json'] }])
     ).toStrictEqual(['package.json']);
   });
 
@@ -67,7 +65,7 @@ describe('findChangedPackageFiles', () => {
     });
 
     expect(
-      await findChangedPackageFiles(ctx, [
+      await findChangedPackageFiles([
         { commit: 'A', changedFiles: ['package.json', 'src/another/package.json'] },
       ])
     ).toStrictEqual(['package.json', 'src/another/package.json']);
@@ -85,7 +83,7 @@ describe('findChangedPackageFiles', () => {
     });
 
     expect(
-      await findChangedPackageFiles(ctx, [
+      await findChangedPackageFiles([
         { commit: 'A', changedFiles: ['package.json', 'src/another/package.json'] },
       ])
     ).toStrictEqual(['src/another/package.json']);
@@ -101,7 +99,7 @@ describe('findChangedPackageFiles', () => {
     });
 
     expect(
-      await findChangedPackageFiles(ctx, [
+      await findChangedPackageFiles([
         { commit: 'A', changedFiles: [] },
         { commit: 'B', changedFiles: ['package.json'] },
       ])
@@ -118,7 +116,7 @@ describe('findChangedPackageFiles', () => {
     });
 
     expect(
-      await findChangedPackageFiles(ctx, [
+      await findChangedPackageFiles([
         { commit: 'A', changedFiles: ['package.json'] },
         { commit: 'B', changedFiles: [] },
       ])
@@ -135,7 +133,7 @@ describe('findChangedPackageFiles', () => {
     });
 
     expect(
-      await findChangedPackageFiles(ctx, [
+      await findChangedPackageFiles([
         { commit: 'A', changedFiles: ['package.json'] },
         { commit: 'B', changedFiles: ['package.json'] },
       ])
@@ -151,7 +149,7 @@ describe('findChangedPackageFiles', () => {
     });
 
     expect(
-      await findChangedPackageFiles(ctx, [{ commit: 'A', changedFiles: ['package.json'] }])
+      await findChangedPackageFiles([{ commit: 'A', changedFiles: ['package.json'] }])
     ).toStrictEqual(['package.json']);
   });
 });

--- a/node-src/lib/turbosnap/index.test.ts
+++ b/node-src/lib/turbosnap/index.test.ts
@@ -80,7 +80,7 @@ describe('traceChangedFiles', () => {
     await traceChangedFiles(ctx);
 
     expect(ctx.turboSnap.bailReason).toEqual({ changedPackageFiles: ['./package.json'] });
-    expect(findChangedPackageFiles).toHaveBeenCalledWith(ctx, packageMetadataChanges);
+    expect(findChangedPackageFiles).toHaveBeenCalledWith(packageMetadataChanges);
     expect(getDependentStoryFiles).not.toHaveBeenCalled();
   });
 
@@ -148,7 +148,7 @@ describe('traceChangedFiles', () => {
 
     expect(ctx.turboSnap.bailReason).toBeUndefined();
     expect(onlyStoryFiles).toStrictEqual(deps);
-    expect(findChangedPackageFiles).toHaveBeenCalledWith(ctx, packageMetadataChanges);
+    expect(findChangedPackageFiles).toHaveBeenCalledWith(packageMetadataChanges);
   });
 
   it('throws if stats file is not found', async () => {

--- a/node-src/lib/turbosnap/index.ts
+++ b/node-src/lib/turbosnap/index.ts
@@ -45,7 +45,7 @@ export const traceChangedFiles = async (ctx: Context) => {
     } else {
       ctx.log.warn(`Could not retrieve dependency changes from lockfiles; checking package.json`);
 
-      const changedPackageFiles = await findChangedPackageFiles(ctx, packageMetadataChanges);
+      const changedPackageFiles = await findChangedPackageFiles(packageMetadataChanges);
       if (changedPackageFiles.length > 0) {
         ctx.turboSnap.bailReason = { changedPackageFiles };
         ctx.log.warn(bailFile({ turboSnap: ctx.turboSnap }));

--- a/node-src/tasks/gitInfo.ts
+++ b/node-src/tasks/gitInfo.ts
@@ -104,30 +104,26 @@ export const setGitInfo = async (ctx: Context, task: Task) => {
   const commitAndBranchInfo = await getCommitAndBranch(ctx, { branchName, patchBaseRef, ci });
 
   ctx.git = {
-    version: await getVersion(ctx),
-    gitUserEmail: await getUserEmail(ctx).catch((err) => {
+    version: await getVersion(),
+    gitUserEmail: await getUserEmail().catch((err) => {
       ctx.log.debug('Failed to retrieve Git user email', err);
       return undefined;
     }),
-    uncommittedHash: await getUncommittedHash(ctx).catch((err) => {
+    uncommittedHash: await getUncommittedHash().catch((err) => {
       ctx.log.warn('Failed to retrieve uncommitted files hash', err);
       return undefined;
     }),
-    rootPath: await getRepositoryRoot(ctx),
+    rootPath: await getRepositoryRoot(),
     ...commitAndBranchInfo,
   };
 
   try {
     ctx.projectMetadata = {
       hasRouter: getHasRouter(ctx.packageJson),
-      creationDate: await getRepositoryCreationDate(ctx),
+      creationDate: await getRepositoryCreationDate(),
       storybookCreationDate: await getStorybookCreationDate(ctx),
-      numberOfCommitters: await getNumberOfComitters(ctx),
-      numberOfAppFiles: await getCommittedFileCount(
-        ctx,
-        ['page', 'screen'],
-        ['js', 'jsx', 'ts', 'tsx']
-      ),
+      numberOfCommitters: await getNumberOfComitters(),
+      numberOfAppFiles: await getCommittedFileCount(['page', 'screen'], ['js', 'jsx', 'ts', 'tsx']),
     };
   } catch (err) {
     ctx.log.debug('Failed to gather project metadata', err);
@@ -139,7 +135,7 @@ export const setGitInfo = async (ctx: Context, task: Task) => {
 
   if (!ctx.git.slug) {
     try {
-      ctx.git.slug = await getSlug(ctx);
+      ctx.git.slug = await getSlug();
     } catch (err) {
       ctx.log.debug('Failed to retrieve Git repository slug', err);
     }

--- a/node-src/tasks/prepareWorkspace.test.ts
+++ b/node-src/tasks/prepareWorkspace.test.ts
@@ -25,7 +25,7 @@ describe('runPrepareWorkspace', () => {
 
     await runPrepareWorkspace(ctx, {} as any);
     expect(ctx.mergeBase).toBe('1234asd');
-    expect(checkout).toHaveBeenCalledWith(ctx, '1234asd');
+    expect(checkout).toHaveBeenCalledWith('1234asd');
     expect(installDependencies).toHaveBeenCalled();
   });
 

--- a/node-src/tasks/restoreWorkspace.ts
+++ b/node-src/tasks/restoreWorkspace.ts
@@ -1,14 +1,13 @@
 import { checkoutPrevious, discardChanges } from '../git/git';
 import installDependencies from '../lib/installDependencies';
 import { createTask, transitionTo } from '../lib/tasks';
-import { Context } from '../types';
 import { initial, pending, success } from '../ui/tasks/restoreWorkspace';
 
-export const runRestoreWorkspace = async (ctx: Context) => {
-  await discardChanges(ctx); // we need a clean state before checkout
-  await checkoutPrevious(ctx);
+export const runRestoreWorkspace = async () => {
+  await discardChanges(); // we need a clean state before checkout
+  await checkoutPrevious();
   await installDependencies();
-  await discardChanges(ctx); // drop lockfile changes
+  await discardChanges(); // drop lockfile changes
 };
 
 export default createTask({


### PR DESCRIPTION
Reverts chromaui/chromatic-cli#1181

This change included a breaking change and therefore should've been a major release.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>11.28.4--canary.1183.15212967594.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@11.28.4--canary.1183.15212967594.0
  # or 
  yarn add chromatic@11.28.4--canary.1183.15212967594.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
