### PR TITLE
Split upload task to allow tracing changed files with dry run

### DIFF
--- a/node-src/tasks/index.ts
+++ b/node-src/tasks/index.ts
@@ -5,6 +5,7 @@ import auth from './auth';
 import build from './build';
 import gitInfo from './gitInfo';
 import initialize from './initialize';
+import prepare from './prepare';
 import prepareWorkspace from './prepareWorkspace';
 import report from './report';
 import restoreWorkspace from './restoreWorkspace';
@@ -19,6 +20,7 @@ export const runUploadBuild = [
   storybookInfo,
   initialize,
   build,
+  prepare,
   upload,
   verify,
   snapshot,

--- a/node-src/tasks/prepare.test.ts
+++ b/node-src/tasks/prepare.test.ts
@@ -1,0 +1,224 @@
+import { traceChangedFiles as traceChangedFilesDep } from '@cli/turbosnap';
+import { access, readdirSync, readFileSync, statSync } from 'fs';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { calculateFileHashes, traceChangedFiles, validateFiles } from './prepare';
+
+vi.mock('fs');
+vi.mock('@cli/turbosnap');
+vi.mock('./readStatsFile', () => ({
+  readStatsFile: () =>
+    Promise.resolve({
+      modules: [
+        {
+          id: '../__mocks__/storybookBaseDir/test.ts',
+          name: '../__mocks__/storybookBaseDir/test.ts',
+        },
+      ],
+    }),
+}));
+
+vi.mock('../lib/getFileHashes', () => ({
+  getFileHashes: (files: string[]) =>
+    Promise.resolve(Object.fromEntries(files.map((f) => [f, 'hash']))),
+}));
+
+const traceChangedFilesTurbosnap = vi.mocked(traceChangedFilesDep);
+const accessMock = vi.mocked(access);
+const readdirSyncMock = vi.mocked(readdirSync);
+const readFileSyncMock = vi.mocked(readFileSync);
+const statSyncMock = vi.mocked(statSync);
+
+const environment = { CHROMATIC_RETRIES: 2, CHROMATIC_OUTPUT_INTERVAL: 0 };
+const log = { info: vi.fn(), warn: vi.fn(), debug: vi.fn(), error: vi.fn() };
+const http = { fetch: vi.fn() };
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('validateFiles', () => {
+  it('sets fileInfo on context', async () => {
+    readdirSyncMock.mockReturnValue(['iframe.html', 'index.html'] as any);
+    statSyncMock.mockReturnValue({ isDirectory: () => false, size: 42 } as any);
+
+    const ctx = { env: environment, log, http, sourceDir: '/static/' } as any;
+    await validateFiles(ctx);
+
+    expect(ctx.fileInfo).toEqual(
+      expect.objectContaining({
+        lengths: [
+          { contentLength: 42, knownAs: 'iframe.html', pathname: 'iframe.html' },
+          { contentLength: 42, knownAs: 'index.html', pathname: 'index.html' },
+        ],
+        paths: ['iframe.html', 'index.html'],
+        total: 84,
+      })
+    );
+  });
+
+  it("throws when index.html doesn't exist", async () => {
+    readdirSyncMock.mockReturnValue(['iframe.html'] as any);
+    statSyncMock.mockReturnValue({ isDirectory: () => false, size: 42 } as any);
+
+    const ctx = { env: environment, log, http, options: {}, sourceDir: '/static/' } as any;
+    await expect(validateFiles(ctx)).rejects.toThrow('Invalid Storybook build at /static/');
+  });
+
+  it("throws when iframe.html doesn't exist", async () => {
+    readdirSyncMock.mockReturnValue(['index.html'] as any);
+    statSyncMock.mockReturnValue({ isDirectory: () => false, size: 42 } as any);
+
+    const ctx = { env: environment, log, http, options: {}, sourceDir: '/static/' } as any;
+    await expect(validateFiles(ctx)).rejects.toThrow('Invalid Storybook build at /static/');
+  });
+
+  it('does not include the .chromatic directory in the file list', async () => {
+    readdirSyncMock.mockImplementation((path) => {
+      if (path === '.chromatic') {
+        return ['zip-unpacked.txt'] as any;
+      }
+      return ['iframe.html', 'index.html', '.chromatic'] as any;
+    });
+    statSyncMock.mockImplementation((path) => {
+      if (path === '.chromatic') {
+        return { isDirectory: () => true, size: 42 } as any;
+      }
+      return { isDirectory: () => false, size: 42 } as any;
+    });
+
+    const ctx = { env: environment, log, http, sourceDir: '.' } as any;
+    await validateFiles(ctx);
+
+    expect(ctx.fileInfo).toEqual(
+      expect.objectContaining({
+        lengths: [
+          { contentLength: 42, knownAs: 'iframe.html', pathname: 'iframe.html' },
+          { contentLength: 42, knownAs: 'index.html', pathname: 'index.html' },
+        ],
+        paths: ['iframe.html', 'index.html'],
+        total: 84,
+      })
+    );
+  });
+
+  describe('with buildLogFile', () => {
+    it('retries using outputDir from build-storybook.log', async () => {
+      readdirSyncMock.mockReturnValueOnce([]);
+      readdirSyncMock.mockReturnValueOnce(['iframe.html', 'index.html'] as any);
+      statSyncMock.mockReturnValue({ isDirectory: () => false, size: 42 } as any);
+      readFileSyncMock.mockReturnValue('info => Output directory: /var/storybook-static');
+
+      const ctx = {
+        env: environment,
+        log,
+        http,
+        sourceDir: '/static/',
+        buildLogFile: 'build-storybook.log',
+        options: {},
+        packageJson: {},
+      } as any;
+      await validateFiles(ctx);
+
+      expect(log.warn).toHaveBeenCalledWith(expect.stringContaining('Unexpected build directory'));
+      expect(ctx.sourceDir).toBe('/var/storybook-static');
+      expect(ctx.fileInfo).toEqual(
+        expect.objectContaining({
+          lengths: [
+            { contentLength: 42, knownAs: 'iframe.html', pathname: 'iframe.html' },
+            { contentLength: 42, knownAs: 'index.html', pathname: 'index.html' },
+          ],
+          paths: ['iframe.html', 'index.html'],
+          total: 84,
+        })
+      );
+    });
+  });
+});
+
+describe('traceChangedFiles', () => {
+  beforeEach(() => {
+    accessMock.mockImplementation((_path, callback) => Promise.resolve(callback(null)));
+  });
+
+  it('sets onlyStoryFiles on context', async () => {
+    const deps = { 123: ['./example.stories.js'] };
+    traceChangedFilesTurbosnap.mockResolvedValue(deps);
+
+    const ctx = {
+      env: environment,
+      log,
+      http,
+      options: {},
+      sourceDir: '/static/',
+      fileInfo: { statsPath: '/static/preview-stats.json' },
+      git: { changedFiles: ['./example.js'] },
+      turboSnap: {},
+    } as any;
+    await traceChangedFiles(ctx, {} as any);
+
+    expect(ctx.onlyStoryFiles).toStrictEqual(Object.keys(deps));
+  });
+
+  it('escapes special characters on context', async () => {
+    const deps = {
+      './$example-new.stories.js': ['./$example-new.stories.js'],
+      './+example-new.stories.js': ['./+example-new.stories.js'],
+      './example-(new).stories.js': ['./example-(new).stories.js'],
+      './example[[lang=language]].stories.js': ['./example[[lang=language]].stories.js'],
+      '[./example/[account]/[id]/[unit]/language/example.stories.tsx]': [
+        '[./example/[account]/[id]/[unit]/language/example.stories.tsx]',
+      ],
+    };
+    traceChangedFilesTurbosnap.mockResolvedValue(deps);
+
+    const ctx = {
+      env: environment,
+      log,
+      http,
+      options: {},
+      sourceDir: '/static/',
+      fileInfo: { statsPath: '/static/preview-stats.json' },
+      git: { changedFiles: ['./example.js'] },
+      turboSnap: {},
+    } as any;
+    await traceChangedFiles(ctx, {} as any);
+
+    expect(ctx.onlyStoryFiles).toStrictEqual([
+      String.raw`./\$example-new.stories.js`,
+      String.raw`./\+example-new.stories.js`,
+      String.raw`./example-\(new\).stories.js`,
+      String.raw`./example\[\[lang=language\]\].stories.js`,
+      String.raw`\[./example/\[account\]/\[id\]/\[unit\]/language/example.stories.tsx\]`,
+    ]);
+  });
+});
+
+describe('calculateFileHashes', () => {
+  it('sets hashes on context.fileInfo', async () => {
+    const fileInfo = {
+      lengths: [
+        { knownAs: 'iframe.html', contentLength: 42 },
+        { knownAs: 'index.html', contentLength: 42 },
+      ],
+      paths: ['iframe.html', 'index.html'],
+      total: 84,
+    };
+    const ctx = {
+      env: environment,
+      log,
+      http,
+      sourceDir: '/static/',
+      options: { fileHashing: true },
+      fileInfo,
+      announcedBuild: { id: '1' },
+    } as any;
+
+    await calculateFileHashes(ctx, {} as any);
+
+    expect(ctx.fileInfo.hashes).toMatchObject({
+      'iframe.html': 'hash',
+      'index.html': 'hash',
+    });
+  });
+});

--- a/node-src/tasks/prepare.ts
+++ b/node-src/tasks/prepare.ts
@@ -1,0 +1,272 @@
+import * as turbosnap from '@cli/turbosnap';
+import { readdirSync, readFileSync, statSync } from 'fs';
+import path from 'path';
+import semver from 'semver';
+import slash from 'slash';
+
+import { getFileHashes } from '../lib/getFileHashes';
+import { createTask, transitionTo } from '../lib/tasks';
+import { rewriteErrorMessage } from '../lib/utils';
+import { Context, Task } from '../types';
+import missingStatsFile from '../ui/messages/errors/missingStatsFile';
+import deviatingOutputDirectory from '../ui/messages/warnings/deviatingOutputDirectory';
+import {
+  bailed,
+  hashing,
+  initial,
+  invalid,
+  success,
+  traced,
+  tracing,
+  validating,
+} from '../ui/tasks/prepare';
+
+/**
+ * Represents a file path specification with its content length.
+ */
+interface PathSpec {
+  pathname: string;
+  contentLength: number;
+}
+
+// These are the special characters that need to be escaped in the filename
+// because they are used as special characters in picomatch
+const SPECIAL_CHARS_REGEXP = /([$()*+?[\]^])/g;
+
+/**
+ * Recursively get all file paths in a directory with their content lengths.
+ * Paths are returned relative to the root directory (e.g., if rootDir is storybook-static,
+ * paths will be like iframe.html rather than storybook-static/iframe.html).
+ * Excludes the .chromatic directory which is reserved for internal use.
+ *
+ * @param ctx - The CLI context for logging
+ * @param rootDirectory - The root directory to scan
+ * @param dirname - The current subdirectory being scanned (relative to rootDirectory)
+ *
+ * @returns Array of path specifications with pathname and content length
+ */
+function getPathSpecsInDirectory(ctx: Context, rootDirectory: string, dirname = '.'): PathSpec[] {
+  // .chromatic is a special directory reserved for internal use and should not be uploaded
+  if (dirname === '.chromatic') {
+    return [];
+  }
+
+  try {
+    return readdirSync(path.join(rootDirectory, dirname)).flatMap((p: string) => {
+      const pathname = path.join(dirname, p);
+      const stats = statSync(path.join(rootDirectory, pathname));
+      return stats.isDirectory()
+        ? getPathSpecsInDirectory(ctx, rootDirectory, pathname)
+        : [{ pathname, contentLength: stats.size }];
+    });
+  } catch (err) {
+    ctx.log.debug(err);
+    throw new Error(invalid({ ...ctx, sourceDir: rootDirectory }, err).output);
+  }
+}
+
+/**
+ * Extracts the output directory path from a Storybook build log.
+ * Looks for the last occurrence of "Output directory: " in the log.
+ *
+ * @param buildLog - The contents of the build log file
+ *
+ * @returns The output directory path if found, undefined otherwise
+ */
+function getOutputDirectory(buildLog: string) {
+  const outputString = 'Output directory: ';
+  const outputIndex = buildLog.lastIndexOf(outputString);
+  if (outputIndex === -1) return undefined;
+  const remainingLog = buildLog.slice(outputIndex + outputString.length);
+  const newlineIndex = remainingLog.indexOf('\n');
+  const outputDirectory = newlineIndex === -1 ? remainingLog : remainingLog.slice(0, newlineIndex);
+  return outputDirectory.trim();
+}
+
+/**
+ * Analyzes a directory to extract file information needed for upload.
+ * Processes all files to calculate total size, collect paths, and locate stats files.
+ *
+ * @param ctx - The CLI context for logging
+ * @param sourceDirectory - The directory to analyze
+ *
+ * @returns Object containing file lengths, paths, stats path, and total size
+ */
+function getFileInfo(ctx: Context, sourceDirectory: string) {
+  const lengths = getPathSpecsInDirectory(ctx, sourceDirectory).map((o) => ({
+    ...o,
+    knownAs: slash(o.pathname),
+  }));
+  const total = lengths.map(({ contentLength }) => contentLength).reduce((a, b) => a + b, 0);
+  const paths: string[] = [];
+  let statsPath = '';
+  for (const { knownAs } of lengths) {
+    if (knownAs.endsWith('preview-stats.json')) statsPath = path.join(sourceDirectory, knownAs);
+    else if (!knownAs.endsWith('manager-stats.json')) paths.push(knownAs);
+  }
+  return { lengths, paths, statsPath, total };
+}
+
+/**
+ * Determines if a directory contains a valid Storybook build.
+ * A valid Storybook must have non-zero total size and contain both
+ * iframe.html and index.html files, which are essential for Storybook operation.
+ *
+ * @param fileInfo - Object containing paths array and total size
+ * @param fileInfo.paths - Array of file paths in the directory
+ * @param fileInfo.total - Total size of all files in bytes
+ *
+ * @returns True if the directory contains a valid Storybook build
+ */
+const isValidStorybook = ({ paths, total }) =>
+  total > 0 && paths.includes('iframe.html') && paths.includes('index.html');
+
+/**
+ * Validates that the source directory contains a valid Storybook build.
+ * If validation fails and a build log is available, attempts to find the
+ * correct output directory from the log and retries validation.
+ *
+ * @param ctx - The CLI context containing source directory and build log info
+ *
+ * @throws Error if no valid Storybook build is found
+ */
+export async function validateFiles(ctx: Context) {
+  ctx.fileInfo = getFileInfo(ctx, ctx.sourceDir);
+
+  if (!isValidStorybook(ctx.fileInfo) && ctx.buildLogFile) {
+    try {
+      const buildLog = readFileSync(ctx.buildLogFile, 'utf8');
+      const outputDirectory = getOutputDirectory(buildLog);
+      if (outputDirectory && outputDirectory !== ctx.sourceDir) {
+        ctx.log.warn(deviatingOutputDirectory(ctx, outputDirectory));
+        ctx.sourceDir = outputDirectory;
+        ctx.fileInfo = getFileInfo(ctx, ctx.sourceDir);
+      }
+    } catch (err) {
+      ctx.log.debug(err);
+    }
+  }
+
+  if (!isValidStorybook(ctx.fileInfo)) {
+    throw new Error(invalid(ctx).output);
+  }
+}
+
+/**
+ * Traces which story files are affected by recent changes using TurboSnap.
+ * Analyzes changed files to determine which stories need to be tested.
+ *
+ * @param ctx - The CLI context containing git info and TurboSnap configuration
+ * @param task - The current Listr task for UI updates
+ *
+ * @throws Error if stats file is missing or tracing fails
+ */
+// TODO: refactor this function
+// eslint-disable-next-line complexity
+export async function traceChangedFiles(ctx: Context, task: Task) {
+  if (!ctx.turboSnap || ctx.turboSnap.unavailable) return;
+  if (!ctx.git.changedFiles) return;
+  if (!ctx.fileInfo?.statsPath) {
+    // If we don't know the SB version, we should assume we don't support `--stats-json`
+    const nonLegacyStatsSupported =
+      ctx.storybook?.version &&
+      semver.gte(semver.coerce(ctx.storybook.version) || '0.0.0', '8.0.0');
+
+    ctx.turboSnap.bailReason = { missingStatsFile: true };
+    throw new Error(missingStatsFile({ legacy: !nonLegacyStatsSupported }));
+  }
+
+  transitionTo(tracing)(ctx, task);
+
+  const { statsPath } = ctx.fileInfo;
+  const { changedFiles } = ctx.git;
+
+  try {
+    const onlyStoryFiles = await turbosnap.traceChangedFiles(ctx);
+    if (onlyStoryFiles) {
+      // Escape special characters in the filename so it does not conflict with picomatch
+      ctx.onlyStoryFiles = Object.keys(onlyStoryFiles).map((key) =>
+        key.replaceAll(SPECIAL_CHARS_REGEXP, String.raw`\$1`)
+      );
+
+      if (!ctx.options.interactive) {
+        if (!ctx.options.traceChanged) {
+          ctx.log.info(
+            `Found affected story files:\n${Object.entries(onlyStoryFiles)
+              .flatMap(([id, files]) => files.map((f) => `  ${f} [${id}]`))
+              .join('\n')}`
+          );
+        }
+        if (ctx.untracedFiles && ctx.untracedFiles.length > 0) {
+          ctx.log.info(
+            `Encountered ${ctx.untracedFiles.length} untraced files:\n${ctx.untracedFiles
+              .map((f) => `  ${f}`)
+              .join('\n')}`
+          );
+        }
+      }
+      transitionTo(traced)(ctx, task);
+    } else {
+      transitionTo(bailed)(ctx, task);
+    }
+  } catch (err) {
+    if (!ctx.options.interactive) {
+      ctx.log.info('Failed to retrieve dependent story files', { statsPath, changedFiles, err });
+    }
+    throw rewriteErrorMessage(err, `Could not retrieve dependent story files.\n${err.message}`);
+  }
+}
+
+/**
+ * Calculates file hashes for all files to be uploaded.
+ * File hashes are used for deduplication and integrity checking during upload.
+ * Skips calculation if file hashing is disabled or the task is being skipped.
+ *
+ * @param ctx - The CLI context containing file info and options
+ * @param task - The current Listr task for UI updates
+ */
+export async function calculateFileHashes(ctx: Context, task: Task) {
+  if (ctx.skip || !ctx.options.fileHashing) return;
+  transitionTo(hashing)(ctx, task);
+
+  try {
+    if (!ctx.fileInfo) {
+      throw new Error(invalid(ctx).output);
+    }
+
+    const start = Date.now();
+    ctx.fileInfo.hashes = await getFileHashes(
+      ctx.fileInfo.paths,
+      ctx.sourceDir,
+      ctx.env.CHROMATIC_HASH_CONCURRENCY
+    );
+    ctx.log.debug(`Calculated file hashes in ${Date.now() - start}ms`);
+  } catch (err) {
+    ctx.log.warn('Failed to calculate file hashes');
+    ctx.log.debug(err);
+  }
+}
+
+/**
+ * Sets up the Listr task for preparing the built storybook for upload to Chromatic.
+ *
+ * @param ctx The context set when executing the CLI.
+ *
+ * @returns A Listr task.
+ */
+export default function main(ctx: Context) {
+  return createTask({
+    name: 'prepare',
+    title: initial(ctx).title,
+    skip: (ctx: Context) => {
+      return !!ctx.skip;
+    },
+    steps: [
+      transitionTo(validating),
+      validateFiles,
+      traceChangedFiles,
+      calculateFileHashes,
+      transitionTo(success, true),
+    ],
+  });
+}

--- a/node-src/tasks/upload.test.ts
+++ b/node-src/tasks/upload.test.ts
@@ -1,33 +1,14 @@
 /* eslint-disable max-lines */
-import { traceChangedFiles as traceChangedFilesDep } from '@cli/turbosnap';
 import { FormData } from 'formdata-node';
-import { access, createReadStream, readdirSync, readFileSync, statSync } from 'fs';
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createReadStream } from 'fs';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { default as compress } from '../lib/compress';
-import {
-  calculateFileHashes,
-  traceChangedFiles,
-  uploadStorybook,
-  validateFiles,
-  waitForSentinels,
-} from './upload';
+import { uploadStorybook, waitForSentinels } from './upload';
 
 vi.mock('form-data');
 vi.mock('fs');
 vi.mock('../lib/compress');
-vi.mock('@cli/turbosnap');
-vi.mock('./readStatsFile', () => ({
-  readStatsFile: () =>
-    Promise.resolve({
-      modules: [
-        {
-          id: '../__mocks__/storybookBaseDir/test.ts',
-          name: '../__mocks__/storybookBaseDir/test.ts',
-        },
-      ],
-    }),
-}));
 
 vi.mock('../lib/fileReaderBlob', () => ({
   // eslint-disable-next-line @typescript-eslint/no-extraneous-class
@@ -39,18 +20,8 @@ vi.mock('../lib/fileReaderBlob', () => ({
   },
 }));
 
-vi.mock('../lib/getFileHashes', () => ({
-  getFileHashes: (files: string[]) =>
-    Promise.resolve(Object.fromEntries(files.map((f) => [f, 'hash']))),
-}));
-
 const makeZipFile = vi.mocked(compress);
-const traceChangedFilesTurbosnap = vi.mocked(traceChangedFilesDep);
-const accessMock = vi.mocked(access);
 const createReadStreamMock = vi.mocked(createReadStream);
-const readdirSyncMock = vi.mocked(readdirSync);
-const readFileSyncMock = vi.mocked(readFileSync);
-const statSyncMock = vi.mocked(statSync);
 
 const environment = { CHROMATIC_RETRIES: 2, CHROMATIC_OUTPUT_INTERVAL: 0 };
 const log = { info: vi.fn(), warn: vi.fn(), debug: vi.fn(), error: vi.fn() };
@@ -58,192 +29,6 @@ const http = { fetch: vi.fn() };
 
 afterEach(() => {
   vi.restoreAllMocks();
-});
-
-describe('validateFiles', () => {
-  it('sets fileInfo on context', async () => {
-    readdirSyncMock.mockReturnValue(['iframe.html', 'index.html'] as any);
-    statSyncMock.mockReturnValue({ isDirectory: () => false, size: 42 } as any);
-
-    const ctx = { env: environment, log, http, sourceDir: '/static/' } as any;
-    await validateFiles(ctx);
-
-    expect(ctx.fileInfo).toEqual(
-      expect.objectContaining({
-        lengths: [
-          { contentLength: 42, knownAs: 'iframe.html', pathname: 'iframe.html' },
-          { contentLength: 42, knownAs: 'index.html', pathname: 'index.html' },
-        ],
-        paths: ['iframe.html', 'index.html'],
-        total: 84,
-      })
-    );
-  });
-
-  it("throws when index.html doesn't exist", async () => {
-    readdirSyncMock.mockReturnValue(['iframe.html'] as any);
-    statSyncMock.mockReturnValue({ isDirectory: () => false, size: 42 } as any);
-
-    const ctx = { env: environment, log, http, options: {}, sourceDir: '/static/' } as any;
-    await expect(validateFiles(ctx)).rejects.toThrow('Invalid Storybook build at /static/');
-  });
-
-  it("throws when iframe.html doesn't exist", async () => {
-    readdirSyncMock.mockReturnValue(['index.html'] as any);
-    statSyncMock.mockReturnValue({ isDirectory: () => false, size: 42 } as any);
-
-    const ctx = { env: environment, log, http, options: {}, sourceDir: '/static/' } as any;
-    await expect(validateFiles(ctx)).rejects.toThrow('Invalid Storybook build at /static/');
-  });
-
-  it('does not include the .chromatic directory in the file list', async () => {
-    readdirSyncMock.mockImplementation((path) => {
-      if (path === '.chromatic') {
-        return ['zip-unpacked.txt'] as any;
-      }
-      return ['iframe.html', 'index.html', '.chromatic'] as any;
-    });
-    statSyncMock.mockImplementation((path) => {
-      if (path === '.chromatic') {
-        return { isDirectory: () => true, size: 42 } as any;
-      }
-      return { isDirectory: () => false, size: 42 } as any;
-    });
-
-    const ctx = { env: environment, log, http, sourceDir: '.' } as any;
-    await validateFiles(ctx);
-
-    expect(ctx.fileInfo).toEqual(
-      expect.objectContaining({
-        lengths: [
-          { contentLength: 42, knownAs: 'iframe.html', pathname: 'iframe.html' },
-          { contentLength: 42, knownAs: 'index.html', pathname: 'index.html' },
-        ],
-        paths: ['iframe.html', 'index.html'],
-        total: 84,
-      })
-    );
-  });
-
-  describe('with buildLogFile', () => {
-    it('retries using outputDir from build-storybook.log', async () => {
-      readdirSyncMock.mockReturnValueOnce([]);
-      readdirSyncMock.mockReturnValueOnce(['iframe.html', 'index.html'] as any);
-      statSyncMock.mockReturnValue({ isDirectory: () => false, size: 42 } as any);
-      readFileSyncMock.mockReturnValue('info => Output directory: /var/storybook-static');
-
-      const ctx = {
-        env: environment,
-        log,
-        http,
-        sourceDir: '/static/',
-        buildLogFile: 'build-storybook.log',
-        options: {},
-        packageJson: {},
-      } as any;
-      await validateFiles(ctx);
-
-      expect(log.warn).toHaveBeenCalledWith(expect.stringContaining('Unexpected build directory'));
-      expect(ctx.sourceDir).toBe('/var/storybook-static');
-      expect(ctx.fileInfo).toEqual(
-        expect.objectContaining({
-          lengths: [
-            { contentLength: 42, knownAs: 'iframe.html', pathname: 'iframe.html' },
-            { contentLength: 42, knownAs: 'index.html', pathname: 'index.html' },
-          ],
-          paths: ['iframe.html', 'index.html'],
-          total: 84,
-        })
-      );
-    });
-  });
-});
-
-describe('traceChangedFiles', () => {
-  beforeEach(() => {
-    accessMock.mockImplementation((_path, callback) => Promise.resolve(callback(null)));
-  });
-
-  it('sets onlyStoryFiles on context', async () => {
-    const deps = { 123: ['./example.stories.js'] };
-    traceChangedFilesTurbosnap.mockResolvedValue(deps);
-
-    const ctx = {
-      env: environment,
-      log,
-      http,
-      options: {},
-      sourceDir: '/static/',
-      fileInfo: { statsPath: '/static/preview-stats.json' },
-      git: { changedFiles: ['./example.js'] },
-      turboSnap: {},
-    } as any;
-    await traceChangedFiles(ctx, {} as any);
-
-    expect(ctx.onlyStoryFiles).toStrictEqual(Object.keys(deps));
-  });
-
-  it('escapes special characters on context', async () => {
-    const deps = {
-      './$example-new.stories.js': ['./$example-new.stories.js'],
-      './+example-new.stories.js': ['./+example-new.stories.js'],
-      './example-(new).stories.js': ['./example-(new).stories.js'],
-      './example[[lang=language]].stories.js': ['./example[[lang=language]].stories.js'],
-      '[./example/[account]/[id]/[unit]/language/example.stories.tsx]': [
-        '[./example/[account]/[id]/[unit]/language/example.stories.tsx]',
-      ],
-    };
-    traceChangedFilesTurbosnap.mockResolvedValue(deps);
-
-    const ctx = {
-      env: environment,
-      log,
-      http,
-      options: {},
-      sourceDir: '/static/',
-      fileInfo: { statsPath: '/static/preview-stats.json' },
-      git: { changedFiles: ['./example.js'] },
-      turboSnap: {},
-    } as any;
-    await traceChangedFiles(ctx, {} as any);
-
-    expect(ctx.onlyStoryFiles).toStrictEqual([
-      String.raw`./\$example-new.stories.js`,
-      String.raw`./\+example-new.stories.js`,
-      String.raw`./example-\(new\).stories.js`,
-      String.raw`./example\[\[lang=language\]\].stories.js`,
-      String.raw`\[./example/\[account\]/\[id\]/\[unit\]/language/example.stories.tsx\]`,
-    ]);
-  });
-});
-
-describe('calculateFileHashes', () => {
-  it('sets hashes on context.fileInfo', async () => {
-    const fileInfo = {
-      lengths: [
-        { knownAs: 'iframe.html', contentLength: 42 },
-        { knownAs: 'index.html', contentLength: 42 },
-      ],
-      paths: ['iframe.html', 'index.html'],
-      total: 84,
-    };
-    const ctx = {
-      env: environment,
-      log,
-      http,
-      sourceDir: '/static/',
-      options: { fileHashing: true },
-      fileInfo,
-      announcedBuild: { id: '1' },
-    } as any;
-
-    await calculateFileHashes(ctx, {} as any);
-
-    expect(ctx.fileInfo.hashes).toMatchObject({
-      'iframe.html': 'hash',
-      'index.html': 'hash',
-    });
-  });
 });
 
 describe('uploadStorybook', () => {

--- a/node-src/tasks/upload.ts
+++ b/node-src/tasks/upload.ts
@@ -1,196 +1,24 @@
-import * as turbosnap from '@cli/turbosnap';
-import { readdirSync, readFileSync, statSync } from 'fs';
 import path from 'path';
-import semver from 'semver';
-import slash from 'slash';
 
-import { getFileHashes } from '../lib/getFileHashes';
 import { createTask, transitionTo } from '../lib/tasks';
 import { uploadBuild } from '../lib/upload';
-import { rewriteErrorMessage, throttle } from '../lib/utils';
+import { throttle } from '../lib/utils';
 import { waitForSentinel } from '../lib/waitForSentinel';
 import { Context, FileDesc, Task } from '../types';
-import missingStatsFile from '../ui/messages/errors/missingStatsFile';
 import sentinelFileErrors from '../ui/messages/errors/sentinelFileErrors';
-import deviatingOutputDirectory from '../ui/messages/warnings/deviatingOutputDirectory';
 import {
-  bailed,
   dryRun,
   failed,
   finalizing,
-  hashing,
   initial,
   invalid,
   starting,
   success,
-  traced,
-  tracing,
   uploading,
-  validating,
 } from '../ui/tasks/upload';
-
-interface PathSpec {
-  pathname: string;
-  contentLength: number;
-}
-// These are the special characters that need to be escaped in the filename
-// because they are used as special characters in picomatch
-const SPECIAL_CHARS_REGEXP = /([$()*+?[\]^])/g;
-
-// Get all paths in rootDir, starting at dirname.
-// We don't want the paths to include rootDir -- so if rootDir = storybook-static,
-// paths will be like iframe.html rather than storybook-static/iframe.html
-function getPathsInDirectory(ctx: Context, rootDirectory: string, dirname = '.'): PathSpec[] {
-  // .chromatic is a special directory reserved for internal use and should not be uploaded
-  if (dirname === '.chromatic') {
-    return [];
-  }
-
-  try {
-    return readdirSync(path.join(rootDirectory, dirname)).flatMap((p: string) => {
-      const pathname = path.join(dirname, p);
-      const stats = statSync(path.join(rootDirectory, pathname));
-      return stats.isDirectory()
-        ? getPathsInDirectory(ctx, rootDirectory, pathname)
-        : [{ pathname, contentLength: stats.size }];
-    });
-  } catch (err) {
-    ctx.log.debug(err);
-    throw new Error(invalid({ ...ctx, sourceDir: rootDirectory }, err).output);
-  }
-}
-
-function getOutputDirectory(buildLog: string) {
-  const outputString = 'Output directory: ';
-  const outputIndex = buildLog.lastIndexOf(outputString);
-  if (outputIndex === -1) return undefined;
-  const remainingLog = buildLog.slice(outputIndex + outputString.length);
-  const newlineIndex = remainingLog.indexOf('\n');
-  const outputDirectory = newlineIndex === -1 ? remainingLog : remainingLog.slice(0, newlineIndex);
-  return outputDirectory.trim();
-}
-
-function getFileInfo(ctx: Context, sourceDirectory: string) {
-  const lengths = getPathsInDirectory(ctx, sourceDirectory).map((o) => ({
-    ...o,
-    knownAs: slash(o.pathname),
-  }));
-  const total = lengths.map(({ contentLength }) => contentLength).reduce((a, b) => a + b, 0);
-  const paths: string[] = [];
-  let statsPath = '';
-  for (const { knownAs } of lengths) {
-    if (knownAs.endsWith('preview-stats.json')) statsPath = path.join(sourceDirectory, knownAs);
-    else if (!knownAs.endsWith('manager-stats.json')) paths.push(knownAs);
-  }
-  return { lengths, paths, statsPath, total };
-}
-
-const isValidStorybook = ({ paths, total }) =>
-  total > 0 && paths.includes('iframe.html') && paths.includes('index.html');
-
-export const validateFiles = async (ctx: Context) => {
-  ctx.fileInfo = getFileInfo(ctx, ctx.sourceDir);
-
-  if (!isValidStorybook(ctx.fileInfo) && ctx.buildLogFile) {
-    try {
-      const buildLog = readFileSync(ctx.buildLogFile, 'utf8');
-      const outputDirectory = getOutputDirectory(buildLog);
-      if (outputDirectory && outputDirectory !== ctx.sourceDir) {
-        ctx.log.warn(deviatingOutputDirectory(ctx, outputDirectory));
-        ctx.sourceDir = outputDirectory;
-        ctx.fileInfo = getFileInfo(ctx, ctx.sourceDir);
-      }
-    } catch (err) {
-      ctx.log.debug(err);
-    }
-  }
-
-  if (!isValidStorybook(ctx.fileInfo)) {
-    throw new Error(invalid(ctx).output);
-  }
-};
-
-// TODO: refactor this function
-// eslint-disable-next-line complexity
-export const traceChangedFiles = async (ctx: Context, task: Task) => {
-  if (!ctx.turboSnap || ctx.turboSnap.unavailable) return;
-  if (!ctx.git.changedFiles) return;
-  if (!ctx.fileInfo?.statsPath) {
-    // If we don't know the SB version, we should assume we don't support `--stats-json`
-    const nonLegacyStatsSupported =
-      ctx.storybook?.version &&
-      semver.gte(semver.coerce(ctx.storybook.version) || '0.0.0', '8.0.0');
-
-    ctx.turboSnap.bailReason = { missingStatsFile: true };
-    throw new Error(missingStatsFile({ legacy: !nonLegacyStatsSupported }));
-  }
-
-  transitionTo(tracing)(ctx, task);
-
-  const { statsPath } = ctx.fileInfo;
-  const { changedFiles } = ctx.git;
-
-  try {
-    const onlyStoryFiles = await turbosnap.traceChangedFiles(ctx);
-    if (onlyStoryFiles) {
-      // Escape special characters in the filename so it does not conflict with picomatch
-      ctx.onlyStoryFiles = Object.keys(onlyStoryFiles).map((key) =>
-        key.replaceAll(SPECIAL_CHARS_REGEXP, String.raw`\$1`)
-      );
-
-      if (!ctx.options.interactive) {
-        if (!ctx.options.traceChanged) {
-          ctx.log.info(
-            `Found affected story files:\n${Object.entries(onlyStoryFiles)
-              .flatMap(([id, files]) => files.map((f) => `  ${f} [${id}]`))
-              .join('\n')}`
-          );
-        }
-        if (ctx.untracedFiles && ctx.untracedFiles.length > 0) {
-          ctx.log.info(
-            `Encountered ${ctx.untracedFiles.length} untraced files:\n${ctx.untracedFiles
-              .map((f) => `  ${f}`)
-              .join('\n')}`
-          );
-        }
-      }
-      transitionTo(traced)(ctx, task);
-    } else {
-      transitionTo(bailed)(ctx, task);
-    }
-  } catch (err) {
-    if (!ctx.options.interactive) {
-      ctx.log.info('Failed to retrieve dependent story files', { statsPath, changedFiles, err });
-    }
-    throw rewriteErrorMessage(err, `Could not retrieve dependent story files.\n${err.message}`);
-  }
-};
-
-export const calculateFileHashes = async (ctx: Context, task: Task) => {
-  if (ctx.skip || !ctx.options.fileHashing) return;
-  transitionTo(hashing)(ctx, task);
-
-  try {
-    if (!ctx.fileInfo) {
-      throw new Error(invalid(ctx).output);
-    }
-
-    const start = Date.now();
-    ctx.fileInfo.hashes = await getFileHashes(
-      ctx.fileInfo.paths,
-      ctx.sourceDir,
-      ctx.env.CHROMATIC_HASH_CONCURRENCY
-    );
-    ctx.log.debug(`Calculated file hashes in ${Date.now() - start}ms`);
-  } catch (err) {
-    ctx.log.warn('Failed to calculate file hashes');
-    ctx.log.debug(err);
-  }
-};
 
 export const uploadStorybook = async (ctx: Context, task: Task) => {
   if (ctx.skip) return;
-  transitionTo(starting)(ctx, task);
 
   const files = ctx.fileInfo?.paths.map<FileDesc>((filePath) => ({
     ...(ctx.fileInfo?.hashes && { contentHash: ctx.fileInfo.hashes[filePath] }),
@@ -256,14 +84,6 @@ export default function main(ctx: Context) {
       if (ctx.options.dryRun) return dryRun(ctx).output;
       return false;
     },
-    steps: [
-      transitionTo(validating),
-      validateFiles,
-      traceChangedFiles,
-      calculateFileHashes,
-      uploadStorybook,
-      waitForSentinels,
-      transitionTo(success, true),
-    ],
+    steps: [transitionTo(starting), uploadStorybook, waitForSentinels, transitionTo(success, true)],
   });
 }

--- a/node-src/types.ts
+++ b/node-src/types.ts
@@ -159,6 +159,7 @@ export type TaskName =
   | 'storybookInfo'
   | 'initialize'
   | 'build'
+  | 'prepare'
   | 'upload'
   | 'verify'
   | 'snapshot'

--- a/node-src/ui/tasks/prepare.stories.ts
+++ b/node-src/ui/tasks/prepare.stories.ts
@@ -1,0 +1,43 @@
+import task from '../components/task';
+import { bailed, hashing, initial, invalid, success, traced, tracing, validating } from './prepare';
+
+export default {
+  title: 'CLI/Tasks/Prepare',
+  decorators: [(storyFunction: any) => task(storyFunction())],
+};
+
+const ctx = { options: {} } as any;
+
+export const Initial = () => initial(ctx);
+
+export const Validating = () => validating(ctx);
+
+export const Invalid = () =>
+  invalid({
+    ...ctx,
+    sourceDir: '/var/folders/h3/ff9kk23958l99z2qbzfjdlxc0000gn/T/chromatic-20036LMP9FAlLEjpu',
+    buildLogFile: '/var/folders/h3/ff9kk23958l99z2qbzfjdlxc0000gn/T/build-storybook.log',
+  } as any);
+
+export const Tracing = () =>
+  tracing({ ...ctx, git: { changedFiles: Array.from({ length: 3 }) } } as any);
+
+export const BailedPackageFile = () =>
+  bailed({ ...ctx, turboSnap: { bailReason: { changedPackageFiles: ['package.json'] } } } as any);
+
+export const BailedLockfile = () =>
+  bailed({ ...ctx, turboSnap: { bailReason: { changedPackageFiles: ['yarn.lock'] } } } as any);
+
+export const BailedSiblings = () =>
+  bailed({
+    ...ctx,
+    turboSnap: {
+      bailReason: { changedStorybookFiles: ['.storybook/preview.js', '.storybook/otherfile.js'] },
+    },
+  } as any);
+
+export const Traced = () => traced({ ...ctx, onlyStoryFiles: Array.from({ length: 5 }) } as any);
+
+export const Hashing = () => hashing(ctx);
+
+export const Success = () => success(ctx);

--- a/node-src/ui/tasks/prepare.ts
+++ b/node-src/ui/tasks/prepare.ts
@@ -1,0 +1,88 @@
+import pluralize from 'pluralize';
+
+import { isE2EBuild } from '../../lib/e2eUtils';
+import { isPackageManifestFile } from '../../lib/utils';
+import { Context } from '../../types';
+import { buildType } from './utils';
+
+export const initial = (ctx: Context) => ({
+  status: 'initial',
+  title: `Prepare your built ${buildType(ctx)}`,
+});
+
+export const validating = (ctx: Context) => ({
+  status: 'pending',
+  title: `Prepare your built ${buildType(ctx)}`,
+  output: `Validating ${buildType(ctx)} files`,
+});
+
+export const invalid = (ctx: Context, error?: Error) => {
+  let output = `Invalid ${buildType(ctx)} build at ${ctx.sourceDir}`;
+  if (ctx.buildLogFile) output += ' (check the build log)';
+  if (error) output += `: ${error.message}`;
+  return {
+    status: 'error',
+    title: `Preparing your built ${buildType(ctx)}`,
+    output,
+  };
+};
+
+export const tracing = (ctx: Context) => {
+  const files = pluralize('file', ctx.git.changedFiles?.length, true);
+  const testType = isE2EBuild(ctx.options) ? 'test' : 'story';
+
+  return {
+    status: 'pending',
+    title: `Retrieving ${testType} files affected by recent changes`,
+    output: `Traversing dependencies for ${files} that changed since the last build`,
+  };
+};
+
+export const bailed = (ctx: Context) => {
+  const { changedPackageFiles, changedStorybookFiles, changedStaticFiles } =
+    ctx.turboSnap?.bailReason || {};
+  const changedFiles = changedPackageFiles || changedStorybookFiles || changedStaticFiles;
+
+  // if all changed files are package.json, message this as a dependency change.
+  const allChangedFilesArePackageJson = changedFiles?.every((changedFile) =>
+    isPackageManifestFile(changedFile)
+  );
+
+  const type = allChangedFilesArePackageJson ? 'dependency ' : '';
+
+  const [firstFile, ...otherFiles] = changedFiles || [];
+  const siblings = pluralize('sibling', otherFiles.length, true);
+  let output = `Found a ${type}change in ${firstFile}`;
+  if (otherFiles.length === 1) output += ' or its sibling';
+  if (otherFiles.length > 1) output += ` or one of its ${siblings}`;
+  return {
+    status: 'pending',
+    title: 'TurboSnap disabled',
+    output,
+  };
+};
+
+export const traced = (ctx: Context) => {
+  const testType = isE2EBuild(ctx.options) ? 'test' : 'story';
+  const files = pluralize(`${testType} file`, ctx.onlyStoryFiles?.length, true);
+
+  return {
+    status: 'pending',
+    title: `Retrieved ${testType} files affected by recent changes`,
+    output: `Found ${files} affected by recent changes`,
+  };
+};
+
+export const hashing = (ctx: Context) => ({
+  status: 'pending',
+  title: `Prepare your built ${buildType(ctx)}`,
+  output: `Calculating file hashes`,
+});
+
+export const success = (ctx: Context) => {
+  return {
+    status: 'success',
+    title: 'Preparation complete',
+    output: `${buildType(ctx)} files validated and prepared for upload`,
+  };
+};

--- a/node-src/ui/tasks/prepareE2E.stories.ts
+++ b/node-src/ui/tasks/prepareE2E.stories.ts
@@ -1,0 +1,46 @@
+import task from '../components/task';
+import { bailed, hashing, invalid, success, traced, tracing, validating } from './prepare';
+
+export default {
+  title: 'CLI/Tasks/Prepare/E2E',
+  decorators: [(storyFunction: any) => task(storyFunction())],
+};
+
+const ctx = { options: { playwright: true } } as any;
+
+export const Validating = () => validating(ctx);
+
+export const Invalid = () =>
+  invalid({
+    ...ctx,
+    sourceDir: '/var/folders/h3/ff9kk23958l99z2qbzfjdlxc0000gn/T/chromatic-20036LMP9FAlLEjpu',
+    buildLogFile: '/var/folders/h3/ff9kk23958l99z2qbzfjdlxc0000gn/T/build-storybook.log',
+  } as any);
+
+export const Tracing = () =>
+  tracing({ ...ctx, git: { changedFiles: Array.from({ length: 3 }) } } as any);
+
+export const BailedPackageFile = () =>
+  bailed({ ...ctx, turboSnap: { bailReason: { changedPackageFiles: ['package.json'] } } } as any);
+
+export const BailedLockfile = () =>
+  bailed({ ...ctx, turboSnap: { bailReason: { changedPackageFiles: ['yarn.lock'] } } } as any);
+
+export const BailedSiblings = () =>
+  bailed({
+    ...ctx,
+    turboSnap: {
+      bailReason: { changedStorybookFiles: ['.storybook/preview.js', '.storybook/otherfile.js'] },
+    },
+  } as any);
+
+export const Traced = () => traced({ ...ctx, onlyStoryFiles: Array.from({ length: 5 }) } as any);
+
+export const Hashing = () => hashing(ctx);
+
+export const Success = () =>
+  success({
+    ...ctx,
+    now: 0,
+    startedAt: -54_321,
+  } as any);

--- a/node-src/ui/tasks/upload.stories.ts
+++ b/node-src/ui/tasks/upload.stories.ts
@@ -1,18 +1,13 @@
 import task from '../components/task';
 import {
-  bailed,
   dryRun,
   failed,
   finalizing,
-  hashing,
   initial,
   invalid,
   starting,
   success,
-  traced,
-  tracing,
   uploading,
-  validating,
 } from './upload';
 
 export default {
@@ -26,35 +21,12 @@ export const Initial = () => initial(ctx);
 
 export const DryRun = () => dryRun(ctx);
 
-export const Validating = () => validating(ctx);
-
 export const Invalid = () =>
   invalid({
     ...ctx,
     sourceDir: '/var/folders/h3/ff9kk23958l99z2qbzfjdlxc0000gn/T/chromatic-20036LMP9FAlLEjpu',
     buildLogFile: '/var/folders/h3/ff9kk23958l99z2qbzfjdlxc0000gn/T/build-storybook.log',
   } as any);
-
-export const Tracing = () =>
-  tracing({ ...ctx, git: { changedFiles: Array.from({ length: 3 }) } } as any);
-
-export const BailedPackageFile = () =>
-  bailed({ ...ctx, turboSnap: { bailReason: { changedPackageFiles: ['package.json'] } } } as any);
-
-export const BailedLockfile = () =>
-  bailed({ ...ctx, turboSnap: { bailReason: { changedPackageFiles: ['yarn.lock'] } } } as any);
-
-export const BailedSiblings = () =>
-  bailed({
-    ...ctx,
-    turboSnap: {
-      bailReason: { changedStorybookFiles: ['.storybook/preview.js', '.storybook/otherfile.js'] },
-    },
-  } as any);
-
-export const Traced = () => traced({ ...ctx, onlyStoryFiles: Array.from({ length: 5 }) } as any);
-
-export const Hashing = () => hashing(ctx);
 
 export const Starting = () => starting(ctx);
 

--- a/node-src/ui/tasks/upload.ts
+++ b/node-src/ui/tasks/upload.ts
@@ -1,9 +1,8 @@
 import { filesize } from 'filesize';
 import pluralize from 'pluralize';
 
-import { isE2EBuild } from '../../lib/e2eUtils';
 import { getDuration } from '../../lib/tasks';
-import { isPackageManifestFile, progressBar } from '../../lib/utils';
+import { progressBar } from '../../lib/utils';
 import { Context } from '../../types';
 import { buildType } from './utils';
 
@@ -18,12 +17,6 @@ export const dryRun = (ctx: Context) => ({
   output: 'Skipped due to --dry-run',
 });
 
-export const validating = (ctx: Context) => ({
-  status: 'pending',
-  title: `Publish your built ${buildType(ctx)}`,
-  output: `Validating ${buildType(ctx)} files`,
-});
-
 export const invalid = (ctx: Context, error?: Error) => {
   let output = `Invalid ${buildType(ctx)} build at ${ctx.sourceDir}`;
   if (ctx.buildLogFile) output += ' (check the build log)';
@@ -34,58 +27,6 @@ export const invalid = (ctx: Context, error?: Error) => {
     output,
   };
 };
-
-export const tracing = (ctx: Context) => {
-  const files = pluralize('file', ctx.git.changedFiles?.length, true);
-  const testType = isE2EBuild(ctx.options) ? 'test' : 'story';
-
-  return {
-    status: 'pending',
-    title: `Retrieving ${testType} files affected by recent changes`,
-    output: `Traversing dependencies for ${files} that changed since the last build`,
-  };
-};
-
-export const bailed = (ctx: Context) => {
-  const { changedPackageFiles, changedStorybookFiles, changedStaticFiles } =
-    ctx.turboSnap?.bailReason || {};
-  const changedFiles = changedPackageFiles || changedStorybookFiles || changedStaticFiles;
-
-  // if all changed files are package.json, message this as a dependency change.
-  const allChangedFilesArePackageJson = changedFiles?.every((changedFile) =>
-    isPackageManifestFile(changedFile)
-  );
-
-  const type = allChangedFilesArePackageJson ? 'dependency ' : '';
-
-  const [firstFile, ...otherFiles] = changedFiles || [];
-  const siblings = pluralize('sibling', otherFiles.length, true);
-  let output = `Found a ${type}change in ${firstFile}`;
-  if (otherFiles.length === 1) output += ' or its sibling';
-  if (otherFiles.length > 1) output += ` or one of its ${siblings}`;
-  return {
-    status: 'pending',
-    title: 'TurboSnap disabled',
-    output,
-  };
-};
-
-export const traced = (ctx: Context) => {
-  const testType = isE2EBuild(ctx.options) ? 'test' : 'story';
-  const files = pluralize(`${testType} file`, ctx.onlyStoryFiles?.length, true);
-
-  return {
-    status: 'pending',
-    title: `Retrieved ${testType} files affected by recent changes`,
-    output: `Found ${files} affected by recent changes`,
-  };
-};
-
-export const hashing = (ctx: Context) => ({
-  status: 'pending',
-  title: `Publishing your built ${buildType(ctx)}`,
-  output: `Calculating file hashes`,
-});
 
 export const starting = (ctx: Context) => ({
   status: 'pending',

--- a/node-src/ui/tasks/uploadE2E.stories.ts
+++ b/node-src/ui/tasks/uploadE2E.stories.ts
@@ -1,18 +1,13 @@
 import task from '../components/task';
 import {
-  bailed,
   dryRun,
   failed,
   finalizing,
-  hashing,
   initial,
   invalid,
   starting,
   success,
-  traced,
-  tracing,
   uploading,
-  validating,
 } from './upload';
 
 export default {
@@ -26,35 +21,12 @@ export const Initial = () => initial(ctx);
 
 export const DryRun = () => dryRun(ctx);
 
-export const Validating = () => validating(ctx);
-
 export const Invalid = () =>
   invalid({
     ...ctx,
     sourceDir: '/var/folders/h3/ff9kk23958l99z2qbzfjdlxc0000gn/T/chromatic-20036LMP9FAlLEjpu',
     buildLogFile: '/var/folders/h3/ff9kk23958l99z2qbzfjdlxc0000gn/T/build-storybook.log',
   } as any);
-
-export const Tracing = () =>
-  tracing({ ...ctx, git: { changedFiles: Array.from({ length: 3 }) } } as any);
-
-export const BailedPackageFile = () =>
-  bailed({ ...ctx, turboSnap: { bailReason: { changedPackageFiles: ['package.json'] } } } as any);
-
-export const BailedLockfile = () =>
-  bailed({ ...ctx, turboSnap: { bailReason: { changedPackageFiles: ['yarn.lock'] } } } as any);
-
-export const BailedSiblings = () =>
-  bailed({
-    ...ctx,
-    turboSnap: {
-      bailReason: { changedStorybookFiles: ['.storybook/preview.js', '.storybook/otherfile.js'] },
-    },
-  } as any);
-
-export const Traced = () => traced({ ...ctx, onlyStoryFiles: Array.from({ length: 5 }) } as any);
-
-export const Hashing = () => hashing(ctx);
 
 export const Starting = () => starting(ctx);
 


### PR DESCRIPTION
# Description

This PR addresses a problem where it was not possible to trace files affected by recent changes (via `--trace-changed`) when doing a dry run (`--dry-run`). This is because the `traceChangedFiles` step was part of the `upload` task, which was skipped on dry runs.

This PR splits the `upload` task in two. There's now a new `prepare` task, responsible for validating local files, tracing changed files, and calculating file hashes. These steps were previously part of the `upload` task. The new `prepare` task is not skipped during dry runs.

The vast majority of the line count of this PR consists of moving step logic, UI states, tests, and stories from `upload` files to the new `prepare` files. Functional changes will be called out with inline comments.

Closes #964, closes CAP-2365

# Manual testing

Here's a build using `--only-changed`, `--trace-changed`, and `--dry-run`, showing the new UI state and the inclusion of the traced files:
![image](https://github.com/user-attachments/assets/5b232cbc-32f1-42f1-8f44-84ae20ea1156)

![image](https://github.com/user-attachments/assets/104794c6-765e-4c35-9b64-1167dd225c34)

I also ran a build without `--dry-run`, and all is working as expected.

The new UI states can also be seen in the Chromatic build for this PR.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>12.2.0--canary.1185.15446945773.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@12.2.0--canary.1185.15446945773.0
  # or 
  yarn add chromatic@12.2.0--canary.1185.15446945773.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
