### PR TITLE
Remove requirement for an accepted build

### DIFF
--- a/node-src/ui/messages/warnings/turboSnapUnavailable.ts
+++ b/node-src/ui/messages/warnings/turboSnapUnavailable.ts
@@ -8,8 +8,7 @@ export default ({ build }) =>
   dedent(chalk`
     ${warning} {bold TurboSnap not available for your account}
     To ensure your project is fully setup and baselines are properly established,
-    TurboSnap is not available until at least 10 builds are created from CI and one
-    of those builds is accepted.
+    TurboSnap is not available until at least 10 builds are created from CI.
 
     ${info} Review your TurboSnap availability on the Manage screen:
     ${link(build.app.manageUrl)}


### PR DESCRIPTION
Since chromaui/chromatic#9741 we no longer need an accepted build to allow TS

See also https://github.com/chromaui/chromatic-docs/pull/677