### PR TITLE
Log redacted environment before running build command.

### DIFF
--- a/node-src/lib/environment.test.ts
+++ b/node-src/lib/environment.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+
+import { redactEnvironment } from './environment';
+
+describe('redactEnvironment', () => {
+  it('redacts environment variable values', () => {
+    expect(
+      redactEnvironment({
+        EMPTY: '',
+        UNDEF: undefined,
+        SMALL: '0123',
+        LONG: '0123456789ABCDEF',
+      })
+    ).toEqual({
+      EMPTY: '...',
+      UNDEF: '...',
+      SMALL: '0...',
+      LONG: '01...EF',
+    });
+  });
+});

--- a/node-src/lib/environment.ts
+++ b/node-src/lib/environment.ts
@@ -1,0 +1,26 @@
+/**
+ * Return a redacted form of visible environment variables.
+ *
+ * @param environment A map of environment variable names to their values.
+ *
+ * @returns The redacted map.
+ */
+export function redactEnvironment(environment: Record<string, string | undefined>) {
+  return Object.fromEntries(
+    Object.entries(environment).map(([name, value]) => {
+      return [name, redacted(value)];
+    })
+  );
+}
+
+function redacted(value: string | undefined): string {
+  if (value) {
+    if (value.length > 10) {
+      return `${value.slice(0, 2)}...${value.slice(-2)}`;
+    }
+    if (value.length > 3) {
+      return `${value[0]}...`;
+    }
+  }
+  return '...';
+}


### PR DESCRIPTION
For debugging, log the environment variables visible at storybook build time. Redacting, as we do not know what variables are sensitive.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>13.0.2--canary.1192.15854914121.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@13.0.2--canary.1192.15854914121.0
  # or 
  yarn add chromatic@13.0.2--canary.1192.15854914121.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
