### PR TITLE
Dynamically generate `CHROMATIC_NOTIFY_SERVICE_URL`

### DIFF
--- a/node-src/lib/getEnvironment.test.ts
+++ b/node-src/lib/getEnvironment.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it, vi } from 'vitest';
+
+describe('CHROMATIC_NOTIFY_SERVICE_URL', () => {
+  it('returns production url by default', async () => {
+    const { default: getEnvironment } = await import('./getEnvironment');
+    expect(getEnvironment().CHROMATIC_NOTIFY_SERVICE_URL).toBe('wss://notify.chromatic.com');
+  });
+
+  it('returns dev url if index url is dev', async () => {
+    vi.stubEnv('CHROMATIC_INDEX_URL', 'https://index.dev-chromatic.com');
+    vi.resetModules();
+
+    const { default: getEnvironment } = await import('./getEnvironment');
+    expect(getEnvironment().CHROMATIC_NOTIFY_SERVICE_URL).toBe('wss://notify.dev-chromatic.com');
+  });
+
+  it('returns staging url if index url is staging', async () => {
+    vi.stubEnv('CHROMATIC_INDEX_URL', 'https://index.staging-chromatic.com');
+    vi.resetModules();
+
+    const { default: getEnvironment } = await import('./getEnvironment');
+    expect(getEnvironment().CHROMATIC_NOTIFY_SERVICE_URL).toBe(
+      'wss://notify.staging-chromatic.com'
+    );
+  });
+
+  it('returns the configured CHROMATIC_NOTIFY_SERVICE_URL if it is set', async () => {
+    vi.stubEnv('CHROMATIC_NOTIFY_SERVICE_URL', 'wss://notify.other-chromatic.com');
+    vi.resetModules();
+
+    const { default: getEnvironment } = await import('./getEnvironment');
+    expect(getEnvironment().CHROMATIC_NOTIFY_SERVICE_URL).toBe('wss://notify.other-chromatic.com');
+  });
+});

--- a/node-src/lib/getEnvironment.ts
+++ b/node-src/lib/getEnvironment.ts
@@ -25,7 +25,7 @@ const {
   CHROMATIC_DNS_SERVERS = '',
   CHROMATIC_HASH_CONCURRENCY = '48',
   CHROMATIC_INDEX_URL = 'https://index.chromatic.com',
-  CHROMATIC_NOTIFY_SERVICE_URL = 'wss://notify.chromatic.com',
+  CHROMATIC_NOTIFY_SERVICE_URL,
   CHROMATIC_OUTPUT_INTERVAL = String(10 * 1000),
   CHROMATIC_POLL_INTERVAL = String(1000),
   CHROMATIC_PROJECT_TOKEN,
@@ -62,7 +62,8 @@ export default function getEnvironment(): Environment {
       .filter(Boolean),
     CHROMATIC_HASH_CONCURRENCY: Number.parseInt(CHROMATIC_HASH_CONCURRENCY, 10),
     CHROMATIC_INDEX_URL,
-    CHROMATIC_NOTIFY_SERVICE_URL,
+    CHROMATIC_NOTIFY_SERVICE_URL:
+      CHROMATIC_NOTIFY_SERVICE_URL || getNotifyServiceUrl(CHROMATIC_INDEX_URL),
     CHROMATIC_OUTPUT_INTERVAL: Number.parseInt(CHROMATIC_OUTPUT_INTERVAL, 10),
     CHROMATIC_POLL_INTERVAL: Number.parseInt(CHROMATIC_POLL_INTERVAL, 10),
     CHROMATIC_PROJECT_TOKEN,
@@ -78,4 +79,16 @@ export default function getEnvironment(): Environment {
     STORYBOOK_VERIFY_TIMEOUT: Number.parseInt(STORYBOOK_VERIFY_TIMEOUT, 10),
     STORYBOOK_NODE_ENV,
   };
+}
+
+function getNotifyServiceUrl(indexUrl: string) {
+  if (indexUrl.includes('dev')) {
+    return 'wss://notify.dev-chromatic.com';
+  }
+
+  if (indexUrl.includes('staging')) {
+    return 'wss://notify.staging-chromatic.com';
+  }
+
+  return 'wss://notify.chromatic.com';
 }


### PR DESCRIPTION
We want to ensure we're always attempting to connect to the notify service (even in dev/staging). Therefore, we decided to make this a generated field based on the Index URL.

With this change you can run without setting `CHROMATIC_NOTIFY_SERVICE_URL` and it will still use the notify service! 🎉 

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>13.0.2--canary.1194.16005096843.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@13.0.2--canary.1194.16005096843.0
  # or 
  yarn add chromatic@13.0.2--canary.1194.16005096843.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
