### PR TITLE
Copy package files with absolute paths

### DIFF
--- a/node-src/lib/turbosnap/findChangedDependencies.ts
+++ b/node-src/lib/turbosnap/findChangedDependencies.ts
@@ -112,11 +112,13 @@ export const findChangedDependencies = async (ctx: Context) => {
         const tmpdir = fs.mkdtempSync(path.join(os.tmpdir(), 'chromatic'));
         tmpdirsCreated.add(tmpdir);
 
+        const absoluteManifestPath = path.join(rootPath, manifestPath);
+        const absoluteLockfilePath = path.join(rootPath, lockfilePath);
         const temporaryManifestPath = path.join(tmpdir, path.basename(manifestPath));
         const temporaryLockfilePath = path.join(tmpdir, path.basename(lockfilePath));
 
-        fs.copyFileSync(manifestPath, temporaryManifestPath);
-        fs.copyFileSync(lockfilePath, temporaryLockfilePath);
+        fs.copyFileSync(absoluteManifestPath, temporaryManifestPath);
+        fs.copyFileSync(absoluteLockfilePath, temporaryLockfilePath);
 
         const headDependencies = await getDependencies(ctx, {
           rootPath: tmpdir,


### PR DESCRIPTION
When running TurboSnap, we copy a bunch of files to a temp directory which is based on _relative_ paths of those files. These file paths are based on the repository root which works unless the process is sitting in a different working directory relative to those files.

This updates our paths to use absolute file paths instead. :tada:

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>13.1.1--canary.1195.16035468380.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@13.1.1--canary.1195.16035468380.0
  # or 
  yarn add chromatic@13.1.1--canary.1195.16035468380.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
