### PR TITLE
Skip notify service if there are no tests

### DIFF
--- a/node-src/tasks/snapshot.test.ts
+++ b/node-src/tasks/snapshot.test.ts
@@ -191,6 +191,31 @@ describe('takeSnapshots', () => {
       features: {},
       reportToken: 'report-token',
       id: 'build-123',
+      actualTestCount: 0,
+    };
+    const ctx = {
+      ...createBaseTestContext(),
+      build,
+    } as any;
+
+    mockWaitForBuildToComplete.mockResolvedValue();
+    ctx.client.runQuery.mockReturnValueOnce({
+      app: { build: { changeCount: 0, status: 'PASSED', completedAt: 1 } },
+    });
+
+    await takeSnapshots(ctx, {} as any);
+
+    expect(mockWaitForBuildToComplete).not.toHaveBeenCalled();
+  });
+
+  it('does not call waitForBuildToComplete if there are no tests', async () => {
+    const build = {
+      app: { repository: { provider: 'github' } },
+      number: 1,
+      features: {},
+      reportToken: 'report-token',
+      id: 'build-123',
+      actualTestCount: 1,
     };
     const ctx = {
       ...createBaseTestContext(),
@@ -222,6 +247,7 @@ describe('takeSnapshots', () => {
       features: {},
       reportToken: 'report-token',
       id: 'build-123',
+      actualTestCount: 1,
     };
     const ctx = {
       ...createBaseTestContext(),
@@ -250,6 +276,7 @@ describe('takeSnapshots', () => {
       features: {},
       reportToken: 'report-token',
       id: 'build-123',
+      actualTestCount: 1,
     };
     const ctx = {
       ...createBaseTestContext(),
@@ -283,6 +310,7 @@ describe('takeSnapshots', () => {
       features: {},
       reportToken: 'report-token',
       id: 'build-123',
+      actualTestCount: 1,
     };
     const ctx = {
       ...createBaseTestContext(),
@@ -316,6 +344,7 @@ describe('takeSnapshots', () => {
       features: {},
       reportToken: 'report-token',
       id: 'build-123',
+      actualTestCount: 1,
     };
     const ctx = {
       ...createBaseTestContext(),
@@ -344,6 +373,7 @@ describe('takeSnapshots', () => {
       features: {},
       reportToken: 'report-token',
       id: 'build-123',
+      actualTestCount: 1,
     };
     const ctx = {
       ...createBaseTestContext(),

--- a/node-src/tasks/snapshot.ts
+++ b/node-src/tasks/snapshot.ts
@@ -113,7 +113,10 @@ export const takeSnapshots = async (ctx: Context, task: Task) => {
     await delay(ctx.env.CHROMATIC_POLL_INTERVAL);
     return getCompletedBuild();
   };
-  await waitForBuildToCompleteAndHandleErrors(ctx, uiStateUpdater, reportToken);
+
+  if (actualTestCount > 0) {
+    await waitForBuildToCompleteAndHandleErrors(ctx, uiStateUpdater, reportToken);
+  }
 
   const build = await getCompletedBuild();
 


### PR DESCRIPTION
Looks like if all tests are TurboSnapped, we still connect to the notify service and wait for a message. Since the build is immediately done, we won't get message. Therefore, it sits there until we hit the timeout and falls back to polling.

This completely skips the notify connect if there are no tests.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>13.1.1--canary.1196.16036362697.1</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@13.1.1--canary.1196.16036362697.1
  # or 
  yarn add chromatic@13.1.1--canary.1196.16036362697.1
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
