### PR TITLE
Replace ad hoc test loggers with `TestLogger`

### DIFF
--- a/node-src/git/getCommitAndBranch.test.ts
+++ b/node-src/git/getCommitAndBranch.test.ts
@@ -1,7 +1,7 @@
 import envCi from 'env-ci';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import type { Logger } from '../lib/log';
+import TestLogger from '../lib/testLogger';
 import type { Context } from '../types';
 import * as mergeQueue from './getBranchFromMergeQueuePullRequestNumber';
 import getCommitAndBranch from './getCommitAndBranch';
@@ -17,7 +17,7 @@ const hasPreviousCommit = vi.mocked(git.hasPreviousCommit);
 const getBranchFromMergeQueue = vi.mocked(mergeQueue.getBranchFromMergeQueuePullRequestNumber);
 const mergeQueueBranchMatch = vi.mocked(git.mergeQueueBranchMatch);
 
-const log = { info: vi.fn(), warn: vi.fn(), debug: vi.fn() } as unknown as Logger;
+const log = new TestLogger();
 const ctx = { log } as unknown as Context;
 
 beforeEach(() => {

--- a/node-src/lib/getStorybookInfo.test.ts
+++ b/node-src/lib/getStorybookInfo.test.ts
@@ -1,3 +1,4 @@
+import TestLogger from '@cli/testLogger';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { Context } from '../types';
@@ -5,7 +6,7 @@ import getStorybookInfo from './getStorybookInfo';
 
 vi.useFakeTimers();
 
-const log = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() };
+const log = new TestLogger();
 const context: Context = { env: {}, log, options: {}, packageJson: {} } as any;
 const getContext = (ctx: any): Context => ({ ...context, ...ctx });
 

--- a/node-src/lib/testLogger.ts
+++ b/node-src/lib/testLogger.ts
@@ -1,66 +1,60 @@
+import { vi } from 'vitest';
+
+import { Logger } from './log';
+
 /**
- * A noop logger used during tests.
+ * A test logger with spy functions for testing.
  */
-export default class TestLogger {
+export default class TestLogger implements Logger {
   entries: any[];
-
   errors: any[];
-
   warnings: any[];
+  error: ReturnType<typeof vi.fn>;
+  warn: ReturnType<typeof vi.fn>;
+  info: ReturnType<typeof vi.fn>;
+  log: ReturnType<typeof vi.fn>;
+  debug: ReturnType<typeof vi.fn>;
+  file: ReturnType<typeof vi.fn>;
+  queue: ReturnType<typeof vi.fn>;
+  flush: ReturnType<typeof vi.fn>;
+  setLevel: ReturnType<typeof vi.fn>;
+  setInteractive: ReturnType<typeof vi.fn>;
+  setLogFile: ReturnType<typeof vi.fn>;
+  getLevel: ReturnType<typeof vi.fn>;
 
   constructor() {
     this.entries = [];
     this.errors = [];
     this.warnings = [];
-  }
 
-  error(...args) {
-    this.entries.push(...args);
-    this.errors.push(...args);
-  }
+    this.error = vi.fn((...args) => {
+      this.entries.push(...args);
+      this.errors.push(...args);
+    });
 
-  warn(...args) {
-    this.entries.push(...args);
-    this.warnings.push(...args);
-  }
+    this.warn = vi.fn((...args) => {
+      this.entries.push(...args);
+      this.warnings.push(...args);
+    });
 
-  info(...args) {
-    this.entries.push(...args);
-  }
+    this.info = vi.fn((...args) => {
+      this.entries.push(...args);
+    });
 
-  log(...args) {
-    this.entries.push(...args);
-  }
+    this.log = vi.fn((...args) => {
+      this.entries.push(...args);
+    });
 
-  debug(...args) {
-    this.entries.push(...args);
-  }
+    this.debug = vi.fn((...args) => {
+      this.entries.push(...args);
+    });
 
-  queue() {
-    // do nothing
-  }
-
-  flush() {
-    // do nothing
-  }
-
-  setLevel() {
-    // do nothing
-  }
-
-  setInteractive() {
-    // do nothing
-  }
-
-  setLogFile() {
-    // do nothing
-  }
-
-  file() {
-    // do nothing
-  }
-
-  getLevel(): any {
-    // do nothing
+    this.file = vi.fn();
+    this.queue = vi.fn();
+    this.flush = vi.fn();
+    this.setLevel = vi.fn();
+    this.setInteractive = vi.fn();
+    this.setLogFile = vi.fn();
+    this.getLevel = vi.fn();
   }
 }

--- a/node-src/lib/turbosnap/getDependentStoryFiles.test.ts
+++ b/node-src/lib/turbosnap/getDependentStoryFiles.test.ts
@@ -1,14 +1,15 @@
 /* eslint-disable max-lines */
 import chalk from 'chalk';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
 
 import { Context } from '../../types';
+import TestLogger from '../testLogger';
 import { getDependentStoryFiles, normalizePath } from './getDependentStoryFiles';
 
 const CSF_GLOB = String.raw`./src sync ^\.\/(?:(?!\.)(?=.)[^/]*?\.stories\.js)$`;
 const statsPath = 'preview-stats.json';
 
-const log = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() };
+const log = new TestLogger();
 const getContext: any = (
   {
     configDir,

--- a/node-src/lib/turbosnap/index.test.ts
+++ b/node-src/lib/turbosnap/index.test.ts
@@ -2,6 +2,7 @@ import { access } from 'fs';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { exitCodes } from '../setExitCode';
+import TestLogger from '../testLogger';
 import { traceChangedFiles } from '.';
 import { findChangedDependencies as findChangedDependenciesDep } from './findChangedDependencies';
 import { findChangedPackageFiles as findChangedPackageFilesDep } from './findChangedPackageFiles';
@@ -29,7 +30,7 @@ const findChangedDependencies = vi.mocked(findChangedDependenciesDep);
 const accessMock = vi.mocked(access);
 
 const environment = { CHROMATIC_RETRIES: 2, CHROMATIC_OUTPUT_INTERVAL: 0 };
-const log = { info: vi.fn(), warn: vi.fn(), debug: vi.fn(), error: vi.fn() };
+const log = new TestLogger();
 const http = { fetch: vi.fn() };
 
 afterEach(() => {

--- a/node-src/tasks/build.test.ts
+++ b/node-src/tasks/build.test.ts
@@ -4,6 +4,7 @@ import { getCliCommand as getCliCommandDefault } from '@antfu/ni';
 import { execaCommand } from 'execa';
 import { describe, expect, it, vi } from 'vitest';
 
+import TestLogger from '../lib/testLogger';
 import { buildStorybook, setBuildCommand, setSourceDirectory } from './build';
 
 vi.mock('execa');
@@ -138,7 +139,7 @@ describe('setBuildCommand', () => {
       options: { buildScriptName: 'build:storybook' },
       storybook: { version: '6.1.0' },
       git: { changedFiles: ['./index.js'] },
-      log: { warn: vi.fn() },
+      log: new TestLogger(),
     } as any;
     await setBuildCommand(ctx);
     expect(ctx.log.warn).toHaveBeenCalledWith(
@@ -153,7 +154,7 @@ describe('buildStorybook', () => {
       ...baseContext,
       buildCommand: 'npm run build:storybook --script-args',
       env: { STORYBOOK_BUILD_TIMEOUT: 1000 },
-      log: { debug: vi.fn() },
+      log: new TestLogger(),
       options: { storybookLogFile: 'build-storybook.log' },
     } as any;
     await buildStorybook(ctx);
@@ -171,7 +172,7 @@ describe('buildStorybook', () => {
       buildCommand: 'npm run build:storybook --script-args',
       options: { buildScriptName: '' },
       env: { STORYBOOK_BUILD_TIMEOUT: 0 },
-      log: { debug: vi.fn(), error: vi.fn() },
+      log: new TestLogger(),
     } as any;
     command.mockReturnValue(new Promise((resolve) => setTimeout(resolve, 100)) as any);
     await expect(buildStorybook(ctx)).rejects.toThrow('Command failed');
@@ -183,7 +184,7 @@ describe('buildStorybook', () => {
       ...baseContext,
       buildCommand: 'npm run build:storybook --script-args',
       env: { STORYBOOK_BUILD_TIMEOUT: 1000 },
-      log: { debug: vi.fn() },
+      log: new TestLogger(),
       options: { storybookLogFile: 'build-storybook.log' },
     } as any;
     await buildStorybook(ctx);

--- a/node-src/tasks/gitInfo.test.ts
+++ b/node-src/tasks/gitInfo.test.ts
@@ -6,6 +6,7 @@ import * as getCommitInfo from '../git/getCommitAndBranch';
 import { getParentCommits as getParentCommitsUnmocked } from '../git/getParentCommits';
 import * as git from '../git/git';
 import { getHasRouter as getHasRouterUnmocked } from '../lib/getHasRouter';
+import TestLogger from '../lib/testLogger';
 import { setGitInfo } from './gitInfo';
 
 vi.mock('../git/getCommitAndBranch');
@@ -30,7 +31,7 @@ const getBaselineBuilds = vi.mocked(getBaselineBuildsUnmocked);
 const getParentCommits = vi.mocked(getParentCommitsUnmocked);
 const getHasRouter = vi.mocked(getHasRouterUnmocked);
 
-const log = { info: vi.fn(), warn: vi.fn(), debug: vi.fn() };
+const log = new TestLogger();
 
 const commitInfo = {
   commit: '123asdf',

--- a/node-src/tasks/initialize.test.ts
+++ b/node-src/tasks/initialize.test.ts
@@ -1,4 +1,5 @@
 import { getCliCommand as getCliCommandDefault } from '@antfu/ni';
+import TestLogger from '@cli/testLogger';
 import { execa as execaDefault, execaCommand } from 'execa';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -15,7 +16,7 @@ process.env.GERRIT_BRANCH = 'foo/bar';
 process.env.TRAVIS_EVENT_TYPE = 'pull_request';
 
 const environment = { ENVIRONMENT_WHITELIST: [/^GERRIT/, /^TRAVIS/] };
-const log = { info: vi.fn(), warn: vi.fn(), debug: vi.fn() };
+const log = new TestLogger();
 
 describe('setEnvironment', () => {
   it('sets the environment info on context', async () => {

--- a/node-src/tasks/prepare.test.ts
+++ b/node-src/tasks/prepare.test.ts
@@ -2,6 +2,7 @@ import { traceChangedFiles as traceChangedFilesDep } from '@cli/turbosnap';
 import { access, readdirSync, readFileSync, statSync } from 'fs';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import TestLogger from '../lib/testLogger';
 import { calculateFileHashes, traceChangedFiles, validateFiles } from './prepare';
 
 vi.mock('fs');
@@ -30,7 +31,7 @@ const readFileSyncMock = vi.mocked(readFileSync);
 const statSyncMock = vi.mocked(statSync);
 
 const environment = { CHROMATIC_RETRIES: 2, CHROMATIC_OUTPUT_INTERVAL: 0 };
-const log = { info: vi.fn(), warn: vi.fn(), debug: vi.fn(), error: vi.fn() };
+const log = new TestLogger();
 const http = { fetch: vi.fn() };
 
 afterEach(() => {

--- a/node-src/tasks/prepareWorkspace.test.ts
+++ b/node-src/tasks/prepareWorkspace.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 
 import * as git from '../git/git';
 import installDeps from '../lib/installDependencies';
+import TestLogger from '../lib/testLogger';
 import { runPrepareWorkspace } from './prepareWorkspace';
 
 vi.mock('../git/git');
@@ -14,7 +15,7 @@ const isUpToDate = vi.mocked(git.isUpToDate);
 const findMergeBase = vi.mocked(git.findMergeBase);
 const installDependencies = vi.mocked(installDeps);
 
-const log = { error: vi.fn() };
+const log = new TestLogger();
 
 describe('runPrepareWorkspace', () => {
   it('retrieves the merge base, does a git checkout and installs dependencies', async () => {

--- a/node-src/tasks/report.test.ts
+++ b/node-src/tasks/report.test.ts
@@ -3,11 +3,12 @@ import path from 'path';
 import { fileURLToPath } from 'url';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import TestLogger from '../lib/testLogger';
 import { generateReport } from './report';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
-const log = { error: vi.fn(), info: vi.fn() };
+const log = new TestLogger();
 const mockTests = [
   {
     status: 'ACCEPTED',

--- a/node-src/tasks/snapshot.test.ts
+++ b/node-src/tasks/snapshot.test.ts
@@ -7,6 +7,7 @@ import waitForBuildToComplete, {
 import * as Sentry from '@sentry/node';
 import { describe, expect, it, vi } from 'vitest';
 
+import TestLogger from '../lib/testLogger';
 import { takeSnapshots } from './snapshot';
 
 vi.mock('@sentry/node', () => ({
@@ -27,7 +28,7 @@ const environment = {
   CHROMATIC_OUTPUT_INTERVAL: 0,
   CHROMATIC_NOTIFY_SERVICE_URL: 'wss://test.com',
 };
-const log = { error: vi.fn(), info: vi.fn(), debug: vi.fn() };
+const log = new TestLogger();
 const matchesBranch = () => false;
 
 const createBaseTestContext = () => ({

--- a/node-src/tasks/upload.test.ts
+++ b/node-src/tasks/upload.test.ts
@@ -4,6 +4,7 @@ import { createReadStream } from 'fs';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { default as compress } from '../lib/compress';
+import TestLogger from '../lib/testLogger';
 import { uploadStorybook, waitForSentinels } from './upload';
 
 vi.mock('form-data');
@@ -24,7 +25,7 @@ const makeZipFile = vi.mocked(compress);
 const createReadStreamMock = vi.mocked(createReadStream);
 
 const environment = { CHROMATIC_RETRIES: 2, CHROMATIC_OUTPUT_INTERVAL: 0 };
-const log = { info: vi.fn(), warn: vi.fn(), debug: vi.fn(), error: vi.fn() };
+const log = new TestLogger();
 const http = { fetch: vi.fn() };
 
 afterEach(() => {

--- a/node-src/tasks/verify.test.ts
+++ b/node-src/tasks/verify.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 
 import { exitCodes } from '../lib/setExitCode';
+import TestLogger from '../lib/testLogger';
 import { publishBuild, verifyBuild } from './verify';
 
 const environment = {
@@ -8,7 +9,7 @@ const environment = {
   CHROMATIC_UPGRADE_TIMEOUT: 100,
   STORYBOOK_VERIFY_TIMEOUT: 20,
 };
-const log = { info: vi.fn(), warn: vi.fn(), debug: vi.fn() };
+const log = new TestLogger();
 const http = { fetch: vi.fn() };
 
 describe('publishBuild', () => {


### PR DESCRIPTION
# Description

This PR updates our `TestLogger` class to wrap its logging methods (info, error, etc.) in `vi.fn` spies. This allows us to replace various ad hoc test loggers throughout our unit tests (i.e., stuff like `const log = { info: vi.fn() }` with the `TestLogger` class and maintain existing vi-based assertions, as well as maintaining existing `TestLogger` assertions that rely on the `entries` array on the `TestLogger`.

# QA

N/A. Unit tests passing without adjusting existing assertions should be indication enough that it's working.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>13.1.3--canary.1197.16058531221.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@13.1.3--canary.1197.16058531221.0
  # or 
  yarn add chromatic@13.1.3--canary.1197.16058531221.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
