### PR TITLE
Remove notify service message logs

### DIFF
--- a/node-src/lib/waitForBuildToComplete.test.ts
+++ b/node-src/lib/waitForBuildToComplete.test.ts
@@ -225,26 +225,6 @@ describe('waitForBuildToComplete', () => {
     ).rejects.toThrow(NotifyServiceError);
   });
 
-  it('logs progress messages', async () => {
-    const testMessage = {
-      completedAt: Date.now(),
-      inProgressCount: 0,
-      status: 'PASSED',
-    };
-
-    server.on('connection', (ws) => {
-      ws.send(JSON.stringify(testMessage));
-    });
-
-    await waitForBuildToComplete({
-      notifyServiceUrl: testUrl,
-      buildId: 'test-build',
-      log,
-    });
-
-    expect(log.entries).toContain(`notify service message: ${JSON.stringify(testMessage)}`);
-  });
-
   it('throws NotifyServiceMessageTimeoutError on 408 request timeout', async () => {
     server.on('connection', (ws) => {
       // Close with normal status code but 408 Request Timeout message, like the notify service

--- a/node-src/lib/waitForBuildToComplete.ts
+++ b/node-src/lib/waitForBuildToComplete.ts
@@ -190,7 +190,6 @@ export default async function waitForBuildToComplete({
 
     subscriber.on('message', (message: WebSocket.Data) => {
       try {
-        log.debug(`notify service message: ${message}`);
         const parsedMessage = BuildProgressMessageSchema.parse(JSON.parse(message.toString()));
         if (progressMessageCallback) {
           progressMessageCallback(parsedMessage);


### PR DESCRIPTION
We added some debug logs for `notify service message` to help with the rollout of the Notify service to ensure requests were flowing properly. This is great for debugging but is rather verbose (especially for larger Storybooks) and generates a ton of noise. Now that things are more stable, we decided to remove that log line!

<img width="877" height="206" alt="image" src="https://github.com/user-attachments/assets/b90b4e38-79c8-4caf-af00-c00cf19d4dee" />
