### PR TITLE
Show setup URL on build errors when onboarding.

### DIFF
--- a/node-src/tasks/initialize.ts
+++ b/node-src/tasks/initialize.ts
@@ -125,7 +125,10 @@ export const announceBuild = async (ctx: Context) => {
 
   ctx.announcedBuild = announcedBuild;
   ctx.isOnboarding =
-    announcedBuild.number === 1 || (announcedBuild.autoAcceptChanges && !input.autoAcceptChanges);
+    // possibly set from LastBuildQuery in setGitInfo
+    ctx.isOnboarding ||
+    announcedBuild.number === 1 ||
+    (announcedBuild.autoAcceptChanges && !input.autoAcceptChanges);
 
   if (ctx.turboSnap && announcedBuild.app.turboSnapAvailability === 'UNAVAILABLE') {
     ctx.turboSnap.unavailable = true;

--- a/node-src/ui/messages/errors/buildHasErrors.stories.ts
+++ b/node-src/ui/messages/errors/buildHasErrors.stories.ts
@@ -9,17 +9,39 @@ export const BuildHasErrors = () =>
     build: {
       errorCount: 2,
       webUrl: 'https://www.chromatic.com/build?appId=59c59bd0183bd100364e1d57&number=42',
+      app: {
+        setupUrl: 'https://www.chromatic.com/setup?appId=59c59bd0183bd100364e1d57',
+      },
     },
     exitCode: 1,
+    isOnboarding: false,
   });
+
+export const OnboardingBuildHasErrors = () =>
+  buildHasErrors({
+    build: {
+      errorCount: 2,
+      webUrl: 'https://www.chromatic.com/build?appId=59c59bd0183bd100364e1d57&number=42',
+      app: {
+        setupUrl: 'https://www.chromatic.com/setup?appId=59c59bd0183bd100364e1d57',
+      },
+    },
+    exitCode: 1,
+    isOnboarding: true,
+  });
+
 export const BuildHasErrorsAndInteractionTestFailure = () =>
   buildHasErrors({
     build: {
       errorCount: 2,
       interactionTestFailuresCount: 1,
       webUrl: 'https://www.chromatic.com/build?appId=59c59bd0183bd100364e1d57&number=42',
+      app: {
+        setupUrl: 'https://www.chromatic.com/setup?appId=59c59bd0183bd100364e1d57',
+      },
     },
     exitCode: 1,
+    isOnboarding: false,
   });
 
 export const BuildHasOnlyInteractionTestFailure = () =>
@@ -28,6 +50,10 @@ export const BuildHasOnlyInteractionTestFailure = () =>
       errorCount: 2,
       interactionTestFailuresCount: 2,
       webUrl: 'https://www.chromatic.com/build?appId=59c59bd0183bd100364e1d57&number=42',
+      app: {
+        setupUrl: 'https://www.chromatic.com/setup?appId=59c59bd0183bd100364e1d57',
+      },
     },
     exitCode: 1,
+    isOnboarding: false,
   });

--- a/node-src/ui/messages/errors/buildHasErrors.ts
+++ b/node-src/ui/messages/errors/buildHasErrors.ts
@@ -5,7 +5,7 @@ import { dedent } from 'ts-dedent';
 import { error as errorIcon, info as infoIcon } from '../../components/icons';
 import link from '../../components/link';
 
-export default ({ build, exitCode }) => {
+export default ({ build, exitCode, isOnboarding }) => {
   const { errorCount, interactionTestFailuresCount, webUrl } = build;
   const hasInteractionTestFailures = interactionTestFailuresCount > 0;
   const hasOtherErrors = errorCount - interactionTestFailuresCount > 0;
@@ -25,6 +25,6 @@ export default ({ build, exitCode }) => {
 
   return dedent(chalk`
     ${errorIcon} {bold ${errorMessage}}: failing with exit code ${exitCode}
-    ${infoIcon} Review the errors at ${link(webUrl)}
+    ${infoIcon} Review the errors at ${link(isOnboarding ? build.app.setupUrl : webUrl)}
   `);
 };


### PR DESCRIPTION
Improve links and messaging when onboarding and a build has errors.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>13.1.4--canary.1201.16891761821.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@13.1.4--canary.1201.16891761821.0
  # or 
  yarn add chromatic@13.1.4--canary.1201.16891761821.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
