### PR TITLE
Feat:Fix outdated and incorrect links in the CLI

### DIFF
--- a/node-src/ui/messages/errors/buildFailed.ts
+++ b/node-src/ui/messages/errors/buildFailed.ts
@@ -26,7 +26,7 @@ export default (
       - Check the Storybook build log printed below.
       - Run ${suggestedRunCommands} yourself and make sure it outputs a valid Storybook by opening the generated {bold index.html} in your browser.
       - Review the build-storybook CLI options at ${link(
-        'https://storybook.js.org/docs/configurations/cli-options/#for-build-storybook'
+        'https://storybook.js.org/docs/api/cli-options#build'
       )}
     `),
     message,

--- a/node-src/ui/messages/errors/gitUserEmailNotFound.ts
+++ b/node-src/ui/messages/errors/gitUserEmailNotFound.ts
@@ -5,7 +5,7 @@ import { error } from '../../components/icons';
 import link from '../../components/link';
 
 const localBuildsDocsLink =
-  'https://www.chromatic.com/docs/branching-and-baselines#what-are-local-builds';
+  'https://www.chromatic.com/docs/visual-tests-addon/#what-are-local-builds-and-how-are-they-different-from-builds';
 
 export default () =>
   `${dedent(chalk`

--- a/node-src/ui/messages/errors/invalidPatchBuild.ts
+++ b/node-src/ui/messages/errors/invalidPatchBuild.ts
@@ -4,7 +4,7 @@ import { dedent } from 'ts-dedent';
 import { error, info } from '../../components/icons';
 import link from '../../components/link';
 
-const docsUrl = 'https://www.chromatic.com/docs/branching-and-baselines#patch-builds';
+const docsUrl = 'https://www.chromatic.com/docs/branching-and-baselines/#what-happens-when-the-merge-base-build-isnt-found-patch-builds';
 
 export default () =>
   dedent(chalk`

--- a/node-src/ui/messages/errors/invalidProjectId.ts
+++ b/node-src/ui/messages/errors/invalidProjectId.ts
@@ -8,5 +8,5 @@ export default ({ projectId }: { projectId: string }) =>
   dedent(chalk`
     ${error} Invalid project ID: ${projectId}
     You may not sufficient permissions to create builds on this project, or it may not exist.
-    ${info} Read more at ${link('https://www.chromatic.com/docs/setup')}
+    ${info} Read more at ${link('https://www.chromatic.com/docs/quickstart/')}
   `);

--- a/node-src/ui/messages/errors/invalidProjectToken.ts
+++ b/node-src/ui/messages/errors/invalidProjectToken.ts
@@ -9,5 +9,5 @@ export default ({ projectToken }: { projectToken: string }) =>
     ${error} Invalid {bold --project-token} '${projectToken}'
     You can find your project token on the Manage screen in your Chromatic project.
     Sign in to Chromatic at ${link('https://www.chromatic.com/start')}
-    ${info} Read more at ${link('https://www.chromatic.com/docs/setup')}
+    ${info} Read more at ${link('https://www.chromatic.com/docs/quickstart/')}
   `);

--- a/node-src/ui/messages/errors/mergeBaseNotFound.ts
+++ b/node-src/ui/messages/errors/mergeBaseNotFound.ts
@@ -5,7 +5,7 @@ import { error, info } from '../../components/icons';
 import link from '../../components/link';
 
 const docsUrl =
-  'https://www.chromatic.com/docs/branching-and-baselines#how-the-merge-base-is-calculated';
+  'https://www.chromatic.com/docs/branching-and-baselines#how-is-merge-base-calculated';
 
 export default ({ patchHeadRef, patchBaseRef }: any) =>
   dedent(chalk`

--- a/node-src/ui/messages/errors/missingProjectToken.ts
+++ b/node-src/ui/messages/errors/missingProjectToken.ts
@@ -13,5 +13,5 @@ export default () =>
     Set your project token as the {bold CHROMATIC_PROJECT_TOKEN} environment variable
     or pass the {bold --project-token} command line option.
 
-    ${info} Read more at ${link('https://www.chromatic.com/docs/setup')}
+    ${info} Read more at ${link('https://www.chromatic.com/docs/quickstart/')}
   `);

--- a/node-src/ui/messages/errors/missingStories.ts
+++ b/node-src/ui/messages/errors/missingStories.ts
@@ -15,7 +15,7 @@ export default ({ options, buildLogFile }: Pick<Context, 'options' | 'buildLogFi
     - Check the build log at {bold ${buildLogFile}}
     - Run {bold npm run ${buildScriptName}} or {bold yarn ${buildScriptName}} yourself and make sure it outputs a valid Storybook by opening the generated {bold index.html} in your browser.
     - Make sure you haven't accidently ignored all stories. See ${link(
-      'https://www.chromatic.com/docs/ignoring-elements#ignore-stories'
+      'https://www.chromatic.com/docs/disable-snapshots/'
     )} for details.
   `);
 };

--- a/node-src/ui/messages/errors/missingTravisInfo.ts
+++ b/node-src/ui/messages/errors/missingTravisInfo.ts
@@ -9,5 +9,5 @@ export default ({ TRAVIS_EVENT_TYPE }: { TRAVIS_EVENT_TYPE: string }) =>
     ${error} {bold Missing Travis environment variable}
     \`TRAVIS_EVENT_TYPE\` environment variable set to '${TRAVIS_EVENT_TYPE}', but
     \`TRAVIS_PULL_REQUEST_SHA\` and \`TRAVIS_PULL_REQUEST_BRANCH\` are not both set.
-    ${info} Read more at ${link('https://www.chromatic.com/docs/ci#travis-ci')}
+    ${info} Read more at ${link('https://www.chromatic.com/docs/travisci/')}
   `);

--- a/node-src/ui/messages/errors/noCSFGlobs.ts
+++ b/node-src/ui/messages/errors/noCSFGlobs.ts
@@ -19,6 +19,6 @@ export default ({ statsPath, storybookDir, storybookBuildDir, entryFile, viewLay
   return dedent(chalk`
     ${error} Did not find any CSF globs in {bold ${statsPath}}
     Check your stories configuration in {bold ${storybookDir}/main.js}
-    ${info} Read more at ${link(`https://storybook.js.org/docs/${viewLayer}/configure/overview`)}
+    ${info} Read more at ${link(`https://storybook.js.org/docs/configure?renderer=${viewLayer}`)}
   `);
 };

--- a/node-src/ui/messages/info/speedUpCI.ts
+++ b/node-src/ui/messages/info/speedUpCI.ts
@@ -15,5 +15,5 @@ export default (provider: string) =>
     ${info} {bold Speed up Continuous Integration}
     Your project is linked to ${providers[provider]} so Chromatic will report results there.
     This means you can add the option \`with: exitOnceUploaded: true\` to your workflow to skip waiting for build results.
-    Read more here: ${link('https://www.chromatic.com/docs/github-actions#available-options')}
+    Read more here: ${link('https://www.chromatic.com/docs/configure/')}
   `);

--- a/node-src/ui/messages/warnings/noAncestorBuild.ts
+++ b/node-src/ui/messages/warnings/noAncestorBuild.ts
@@ -6,7 +6,7 @@ import { info, warning } from '../../components/icons';
 import link from '../../components/link';
 
 const docsUrl =
-  'https://www.chromatic.com/docs/test#why-do-i-see-build-x-is-based-on-a-commit-without-ancestor-build';
+  'https://www.chromatic.com/docs/quickstart/#why-do-i-see-build-x-is-based-on-a-commit-without-ancestor-builds';
 
 export default ({ announcedBuild, turboSnap }: Pick<Context, 'announcedBuild' | 'turboSnap'>) =>
   turboSnap

--- a/node-src/ui/messages/warnings/travisInternalBuild.ts
+++ b/node-src/ui/messages/warnings/travisInternalBuild.ts
@@ -9,5 +9,5 @@ export default () =>
     ${warning} {bold Running on a Travis PR build from an internal branch}
     It is recommended to run Chromatic on the push builds from Travis where possible.
     We advise turning on push builds and disabling Chromatic for internal PR builds.
-    ${info} Read more at ${link('https://www.chromatic.com/docs/ci#travis-ci')}
+    ${info} Read more at ${link('https://www.chromatic.com/docs/travisci/')}
   `);


### PR DESCRIPTION
With this pull request, the links pointing at both Chromatic and Storybook documentation were updated to prevent them from redirecting to non-existent documentation or incorrect documentation.

What was done:
- Scanned and adjusted the links in the documentation to point them at their correct locations


@jmhobbs, let me know if you have any feedback, and we'll go from there. Thanks in advance