### PR TITLE
Handle framework names that specify full viewlayer packages

### DIFF
--- a/bin-src/__mocks__/atFrameworkNameProjectJson/project.json
+++ b/bin-src/__mocks__/atFrameworkNameProjectJson/project.json
@@ -1,0 +1,62 @@
+{
+  "generatedAt": 1757954836694,
+  "userSince": 1748532959823,
+  "hasCustomBabel": false,
+  "hasCustomWebpack": false,
+  "hasStaticDirs": false,
+  "hasStorybookEslint": false,
+  "refCount": 0,
+  "testPackages": {
+    "@chromatic-com/storybook": "4.1.1",
+    "@storybook/addon-vitest": "10.0.0-beta.2",
+    "@vitest/browser": "3.2.4",
+    "@vitest/coverage-v8": "3.2.4",
+    "chromatic": "12.2.0",
+    "playwright": "1.55.0",
+    "vitest": "3.2.4"
+  },
+  "hasRouterPackage": false,
+  "packageManager": {
+    "type": "pnpm",
+    "version": "9.15.0",
+    "agent": "pnpm",
+    "nodeLinker": "undefined"
+  },
+  "preview": {
+    "usesGlobals": false
+  },
+  "framework": {
+    "name": "@storybook/react-vite",
+    "options": {}
+  },
+  "builder": "@storybook/builder-vite",
+  "renderer": "@storybook/react",
+  "portableStoriesFileCount": 0,
+  "applicationFileCount": 2,
+  "storybookVersion": "10.0.0-beta.2",
+  "language": "javascript",
+  "storybookPackages": {
+    "@storybook/react-vite": {
+      "version": "10.0.0-beta.2"
+    },
+    "storybook": {}
+  },
+  "addons": {
+    "@chromatic-com/storybook": {
+      "version": "4.1.1"
+    },
+    "@storybook/addon-docs": {
+      "version": "10.0.0-beta.2"
+    },
+    "@storybook/addon-a11y": {
+      "version": "10.0.0-beta.2"
+    },
+    "@storybook/addon-vitest": {
+      "version": "10.0.0-beta.2"
+    },
+    "chromatic": {
+      "version": "12.2.0",
+      "versionSpecifier": "13.1.5--canary.1204.17739984147.0"
+    }
+  }
+}

--- a/node-src/lib/getPrebuiltStorybookMetadata.test.ts
+++ b/node-src/lib/getPrebuiltStorybookMetadata.test.ts
@@ -16,6 +16,19 @@ describe('getStorybookMetadataFromProjectJson', () => {
     });
   });
 
+  it('should return the metadata from a project with @storybook framework name', async () => {
+    const projectJsonPath = 'bin-src/__mocks__/atFrameworkNameProjectJson/project.json';
+    const metadata = await getStorybookMetadataFromProjectJson(projectJsonPath);
+
+    expect(metadata).toEqual({
+      version: '10.0.0-beta.2',
+      builder: {
+        name: '@storybook/builder-vite',
+        packageVersion: undefined,
+      },
+    });
+  });
+
   it('should return the metadata from a Storybook 6 project.json file', async () => {
     const projectJsonPath = 'bin-src/__mocks__/sb6ProjectJson/project.json';
     const metadata = await getStorybookMetadataFromProjectJson(projectJsonPath);

--- a/node-src/lib/getPrebuiltStorybookMetadata.ts
+++ b/node-src/lib/getPrebuiltStorybookMetadata.ts
@@ -33,7 +33,9 @@ export const getStorybookMetadataFromProjectJson = async (
 ): Promise<Partial<Context['storybook']>> => {
   const sbProjectJson = (await readFile(projectJsonPath)) as SBProjectJson;
   const viewLayerPackage = Object.keys(viewLayers).find(
-    (viewLayer) => viewLayers[viewLayer] === sbProjectJson.framework.name
+    (viewLayer) =>
+      viewLayers[viewLayer] === sbProjectJson.framework.name ||
+      viewLayer === sbProjectJson.framework.name
   );
   const builder = getBuilder(sbProjectJson);
   const version =


### PR DESCRIPTION
# Description

This PR fixes an issue in our logic mapping view layer packages and Storybook framework names that seems (as best I can tell, anyway) to be based on outdated `storybook build` output from SB6. See inline comment for more details.

# Manual QA

I created a project that uses a prebuilt storybook in its `chromatic` call, using React, Vite, and `storybook@10.0.0-beta.2`, and verified 1) that before this fix, we see the erroneous error message referencing the `--webpack-stats-json` flag, and 2) after this fix, we get the appropriate error message:
<img width="902" height="130" alt="CleanShot 2025-09-15 at 14 49 36@2x" src="https://github.com/user-attachments/assets/e03c31ed-b3c6-454d-a9ae-b72da003018f" />

I also tested this on the customer's reproduction repo (it's private, so I can't link it), and confirmed the correct error message is shown.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>13.1.5--canary.1204.17742984995.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@13.1.5--canary.1204.17742984995.0
  # or 
  yarn add chromatic@13.1.5--canary.1204.17742984995.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
