### PR TITLE
Updated the mapping for the storybook entry with a recent change in storybook-rsbuild

### DIFF
--- a/node-src/lib/turbosnap/getDependentStoryFiles.test.ts
+++ b/node-src/lib/turbosnap/getDependentStoryFiles.test.ts
@@ -170,6 +170,7 @@ describe('getDependentStoryFiles', () => {
     ['./node_modules/.cache/storybook-rsbuild-builder/storybook-stories.js'],
     [`./node_modules/.cache/storybook/storybook-rsbuild-builder/storybook-config-entry.js`],
     [`./node_modules/.cache/storybook-rsbuild-builder/storybook-config-entry.js`],
+    [`./storybook-config-entry.js`],
   ])('detects direct changes to CSF files, rspack (%s)', async (resolvedModule) => {
     const changedFiles = ['src/foo.stories.js'];
     const modules = [

--- a/node-src/lib/turbosnap/getDependentStoryFiles.ts
+++ b/node-src/lib/turbosnap/getDependentStoryFiles.ts
@@ -128,6 +128,7 @@ export async function getDependentStoryFiles(
     './node_modules/.cache/storybook-rsbuild-builder/storybook-stories.js',
     `./node_modules/.cache/storybook/storybook-rsbuild-builder/storybook-config-entry.js`,
     `./node_modules/.cache/storybook-rsbuild-builder/storybook-config-entry.js`,
+    `./storybook-config-entry.js`,
   ].map((file) => normalize(file));
 
   const modulesByName = new Map<NormalizedName, Module>();


### PR DESCRIPTION
Recently, the dependency graph being built in the Storybook-rsbuild community package has changed, as has the dependency graph entry point.
https://github.com/rspack-contrib/storybook-rsbuild/issues/332

This results in users getting the Chromatic CLI error message `Did not find any CSF globs in **`.

This is the new format for the entry point:
```
{
      "id": "./storybook-config-entry.js",
      "name": "./storybook-config-entry.js + 1 modules",
      "modules": [
        { "name": "./storybook-config-entry.js" },
        { "name": "./storybook-stories.js" }
      ],
      "reasons": []
    },
```

To accommodate this, I've added the `storybook-config-entry.js` to the mapping in our getDependentStoryFiles.
I also added the file to the test to ensure it's passing.

I tested it out locally on the chromatic-cli repo with the stats file I have and I get the correct response now:
```
ℹ Traced 1 changed file to 1 affected story file:

— cdn/src/components/HostContent.stories.tsx + 3 modules [changed]
  ∟ [story index]

Set --trace-changed to 'expanded' to reveal underlying modules.
```
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>13.2.0--canary.1206.17862049123.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@13.2.0--canary.1206.17862049123.0
  # or 
  yarn add chromatic@13.2.0--canary.1206.17862049123.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
