### PR TITLE
Use `--stats-json` with storybook version guard.

### DIFF
--- a/node-src/tasks/build.test.ts
+++ b/node-src/tasks/build.test.ts
@@ -145,6 +145,62 @@ describe('setBuildCommand', () => {
       'Storybook version 6.2.0 or later is required to use the --only-changed flag'
     );
   });
+
+  it('uses the correct flag for webpack stats for < 8.5.0', async () => {
+    getCliCommand.mockReturnValue(Promise.resolve('npm run build:storybook'));
+
+    const ctx = {
+      sourceDir: './source-dir/',
+      options: { buildScriptName: 'build:storybook' },
+      storybook: { version: '8.4.0' },
+      git: { changedFiles: ['./index.js'] },
+    } as any;
+    await setBuildCommand(ctx);
+
+    expect(getCliCommand).toHaveBeenCalledWith(
+      expect.anything(),
+      ['build:storybook', '--output-dir=./source-dir/', '--webpack-stats-json=./source-dir/'],
+      { programmatic: true }
+    );
+    expect(ctx.buildCommand).toEqual('npm run build:storybook');
+  });
+
+  it('uses the correct flag for webpack stats for >= 8.5.0', async () => {
+    getCliCommand.mockReturnValue(Promise.resolve('npm run build:storybook'));
+
+    const ctx = {
+      sourceDir: './source-dir/',
+      options: { buildScriptName: 'build:storybook' },
+      storybook: { version: '8.5.0' },
+      git: { changedFiles: ['./index.js'] },
+    } as any;
+    await setBuildCommand(ctx);
+
+    expect(getCliCommand).toHaveBeenCalledWith(
+      expect.anything(),
+      ['build:storybook', '--output-dir=./source-dir/', '--stats-json=./source-dir/'],
+      { programmatic: true }
+    );
+    expect(ctx.buildCommand).toEqual('npm run build:storybook');
+  });
+
+  it('uses the old flag when it storybook version is undetected', async () => {
+    getCliCommand.mockReturnValue(Promise.resolve('npm run build:storybook'));
+
+    const ctx = {
+      sourceDir: './source-dir/',
+      options: { buildScriptName: 'build:storybook' },
+      git: { changedFiles: ['./index.js'] },
+    } as any;
+    await setBuildCommand(ctx);
+
+    expect(getCliCommand).toHaveBeenCalledWith(
+      expect.anything(),
+      ['build:storybook', '--output-dir=./source-dir/', '--webpack-stats-json=./source-dir/'],
+      { programmatic: true }
+    );
+    expect(ctx.buildCommand).toEqual('npm run build:storybook');
+  });
 });
 
 describe('buildStorybook', () => {


### PR DESCRIPTION
Second attempt at #1049.

At 8.0.0, [--webpack-stats-json was renamed to --stats-json](https://github.com/storybookjs/storybook/blob/v8.0.0/MIGRATION.md#--webpack-stats-json-option-renamed---stats-json) and is deprecated.  However the Angular build schema was not updated until 8.5.0, https://github.com/storybookjs/storybook/pull/29233, so we will only apply after that version.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>13.4.0--canary.1210.18104734621.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@13.4.0--canary.1210.18104734621.0
  # or 
  yarn add chromatic@13.4.0--canary.1210.18104734621.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
