### PR TITLE
Setup permissions for NPM trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,9 +34,15 @@ jobs:
         uses: actions/checkout@v3
         with:
           token: ${{ secrets.GH_TOKEN }}
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
 
       - name: Prepare repository
         run: git fetch --unshallow --tags
+        # Update NPM since we're using trusted publishing and need a newer version
+      - name: Update NPM
+        run: npm install -g npm@latest
       - run: corepack enable
       - name: Install dependencies
         run: yarn install --immutable
@@ -44,7 +50,6 @@ jobs:
         run: yarn run release
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           SENTRY_ORG: chromatic-lt
           SENTRY_PROJECT: cli


### PR DESCRIPTION
We're moving to use NPM trusted publishing instead of our current token setup. This adds the necessary permissions for that!

Reference: https://docs.npmjs.com/trusted-publishers#github-actions-configuration
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>13.3.3--canary.1216.18784609009.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@13.3.3--canary.1216.18784609009.0
  # or 
  yarn add chromatic@13.3.3--canary.1216.18784609009.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
