### PR TITLE
Strip ' + N modules' when matching against untraced files

### DIFF
--- a/node-src/lib/turbosnap/getDependentStoryFiles.ts
+++ b/node-src/lib/turbosnap/getDependentStoryFiles.ts
@@ -207,7 +207,9 @@ export async function getDependentStoryFiles(
     staticDirectories.some((directory) => name && name.startsWith(`${directory}/`));
 
   ctx.untracedFiles = [];
+
   function untrace(filepath: string) {
+    filepath = filepath.replace(/\s\+\s\d+\smodules?$/, ''); // strip ' + N modules' from the string before matching against `untraced`
     if (untraced.some((glob) => matchesFile(glob, filepath))) {
       ctx.untracedFiles?.push(filepath);
       return false;


### PR DESCRIPTION
# Description

When tracing changes through imported files for purposes of TurboSnap, we sometimes call our `untrace` function with the `reasons` for a given file change, which takes the form of a string something like `src/foo.js + 2 modules`. This is the string that gets compared against user-provided untrace globs, e.g., `**/foo.js`. Currently, this doesn't work as expected because `**/foo.js` does not match `src/foo.js + 2 modules`. Users can work around this by passing `**/foo.js**` as the untraced value, but this PR enables the expected behavior by removing any ` + N module(s)` from the string that we compare against the values that the user has passed to the untraced flag.

# Manual QA

Reuben tested this, see details in Linear.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>13.3.4--canary.1217.18974255621.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@13.3.4--canary.1217.18974255621.0
  # or 
  yarn add chromatic@13.3.4--canary.1217.18974255621.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
