### PR TITLE
Remove `corepack enable` from GitHub Actions

### DIFF
--- a/.github/workflows/chromatic-main-and-prs.yml
+++ b/.github/workflows/chromatic-main-and-prs.yml
@@ -4,7 +4,7 @@ on:
     branches:
       - main
   pull_request:
-    types: [assigned, ready_for_review, review_requested]
+    types: [ assigned, ready_for_review, review_requested ]
 
 permissions:
   contents: read
@@ -19,7 +19,6 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 22
-      - run: corepack enable
       - name: install
         run: yarn install --immutable
       - uses: chromaui/action@latest

--- a/.github/workflows/chromatic-prod.yml
+++ b/.github/workflows/chromatic-prod.yml
@@ -19,7 +19,6 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 22
-      - run: corepack enable
       - name: install
         run: yarn install --immutable
       - uses: chromaui/action@latest

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -22,7 +22,6 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 22
-      - run: corepack enable
       - name: install
         run: yarn install --immutable
 

--- a/.github/workflows/package-size-main.yml
+++ b/.github/workflows/package-size-main.yml
@@ -17,7 +17,6 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 22
-      - run: corepack enable
       - name: install
         run: yarn install --immutable
       - name: build

--- a/.github/workflows/package-size.yml
+++ b/.github/workflows/package-size.yml
@@ -23,7 +23,6 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 22
-      - run: corepack enable
       - name: install
         run: yarn install --immutable
       - name: build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,6 @@ jobs:
         # Update NPM since we're using trusted publishing and need a newer version
       - name: Update NPM
         run: npm install -g npm@latest
-      - run: corepack enable
       - name: Install dependencies
         run: yarn install --immutable
       - name: Create Release

--- a/.github/workflows/smoke-test-action-next.yml
+++ b/.github/workflows/smoke-test-action-next.yml
@@ -14,7 +14,6 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 22
-      - run: corepack enable
       - run: yarn
       - name: Push to action-next
         run: yarn run release-next

--- a/.github/workflows/smoke-test-action.yml
+++ b/.github/workflows/smoke-test-action.yml
@@ -18,7 +18,6 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 22
-      - run: corepack enable
       - run: yarn
       - run: yarn build
       - uses: ./

--- a/.github/workflows/smoke-test-node-api.yml
+++ b/.github/workflows/smoke-test-node-api.yml
@@ -19,7 +19,6 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 'lts/*'
-      - run: corepack enable
       - run: yarn
       - run: yarn build
       - name: run chromatic via node

--- a/.github/workflows/smoke-test-node18.yml
+++ b/.github/workflows/smoke-test-node18.yml
@@ -19,7 +19,6 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 18
-      - run: corepack enable
       - run: yarn
       - run: yarn build
       - uses: ./

--- a/.github/workflows/smoke-test-node20.yml
+++ b/.github/workflows/smoke-test-node20.yml
@@ -19,7 +19,6 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 20
-      - run: corepack enable
       - run: yarn
       - run: yarn build
       - uses: ./

--- a/.github/workflows/smoke-test-npx.yml
+++ b/.github/workflows/smoke-test-npx.yml
@@ -19,7 +19,6 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 22
-      - run: corepack enable
       - name: install
         run: yarn && git status --porcelain
       - run: yarn build

--- a/.github/workflows/smoke-test-windows.yml
+++ b/.github/workflows/smoke-test-windows.yml
@@ -19,7 +19,6 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 22
-      - run: corepack enable
       - name: install
         run: yarn && git status --porcelain
       - name: prep package

--- a/.github/workflows/smoke-test-yarn-berry.yml
+++ b/.github/workflows/smoke-test-yarn-berry.yml
@@ -20,7 +20,6 @@ jobs:
         with:
           node-version: 22
       - run: rm -rf subdir # remove conflicting subproject
-      - run: corepack enable
       - name: install
         run: yarn install
         env:

--- a/.github/workflows/smoke-test-yarn-canary.yml
+++ b/.github/workflows/smoke-test-yarn-canary.yml
@@ -20,7 +20,6 @@ jobs:
         with:
           node-version: 22
       - run: rm -rf subdir # remove conflicting subproject
-      - run: corepack enable
       - run: yarn set version canary
       - name: install
         run: yarn install

--- a/.github/workflows/smoke-test-yarn-classic.yml
+++ b/.github/workflows/smoke-test-yarn-classic.yml
@@ -20,7 +20,6 @@ jobs:
         with:
           node-version: 22
       - run: rm -rf subdir # remove conflicting subproject
-      - run: corepack enable
       - run: yarn set version 1.22.22
       - run: yarn install --ignore-engines
       - name: run chromatic

--- a/.github/workflows/smoke-test-yarn.yml
+++ b/.github/workflows/smoke-test-yarn.yml
@@ -19,7 +19,6 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 22
-      - run: corepack enable
       - run: yarn
       - run: yarn build
       - run: yarn chromatic --build-script-name build-test-storybook --exit-zero-on-changes --force-rebuild


### PR DESCRIPTION
# Description

According to [GitHub docs](https://docs.github.com/en/actions/tutorials/build-and-test-code/nodejs#installing-dependencies), `yarn` is available by default, and none of their examples relied on `corepack`, so I just removed it, and it looks like all the actions still work.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>13.3.3--canary.1218.18784610056.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@13.3.3--canary.1218.18784610056.0
  # or 
  yarn add chromatic@13.3.3--canary.1218.18784610056.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
