### PR TITLE
Fix passing signal to Execa

### DIFF
--- a/node-src/tasks/build.ts
+++ b/node-src/tasks/build.ts
@@ -156,7 +156,7 @@ export const buildStorybook = async (ctx: Context) => {
       // When `true`, this will run in the node version set by the
       // action (node20), not the version set in the workflow
       preferLocal: false,
-      signal,
+      cancelSignal: signal,
       env: {
         CI: '1',
         NODE_ENV: ctx.env.STORYBOOK_NODE_ENV || 'production',


### PR DESCRIPTION
Execa [v9.0.0](https://github.com/sindresorhus/execa/releases/tag/v9.0.0) renamed `signal` to `cancelSignal`. This shows up in logs:
> The "signal" option has been renamed to "cancelSignal" instead.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>13.3.5--canary.1220.19472470647.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@13.3.5--canary.1220.19472470647.0
  # or 
  yarn add chromatic@13.3.5--canary.1220.19472470647.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
