### PR TITLE
Add React Native asset validation

### DIFF
--- a/node-src/tasks/prepare.test.ts
+++ b/node-src/tasks/prepare.test.ts
@@ -135,6 +135,67 @@ describe('validateFiles', () => {
       );
     });
   });
+
+  describe('with isReactNativeApp', () => {
+    it('sets fileInfo on context with valid React Native build', async () => {
+      readdirSyncMock.mockReturnValue(['app.apk', 'manifest.json'] as any);
+      statSyncMock.mockReturnValue({ isDirectory: () => false, size: 42 } as any);
+
+      const ctx = {
+        env: environment,
+        log,
+        http,
+        sourceDir: '/static/',
+        isReactNativeApp: true,
+      } as any;
+      await validateFiles(ctx);
+
+      expect(ctx.fileInfo).toEqual(
+        expect.objectContaining({
+          lengths: [
+            { contentLength: 42, knownAs: 'app.apk', pathname: 'app.apk' },
+            { contentLength: 42, knownAs: 'manifest.json', pathname: 'manifest.json' },
+          ],
+          paths: ['app.apk', 'manifest.json'],
+          total: 84,
+        })
+      );
+    });
+
+    it("throws when manifest.json doesn't exist", async () => {
+      readdirSyncMock.mockReturnValue(['app.apk'] as any);
+      statSyncMock.mockReturnValue({ isDirectory: () => false, size: 42 } as any);
+
+      const ctx = {
+        env: environment,
+        log,
+        http,
+        options: {},
+        sourceDir: '/static/',
+        isReactNativeApp: true,
+      } as any;
+      await expect(validateFiles(ctx)).rejects.toThrow(
+        'Invalid React Native Storybook build at /static/'
+      );
+    });
+
+    it("throws when APK doesn't exist", async () => {
+      readdirSyncMock.mockReturnValue(['manifest.json'] as any);
+      statSyncMock.mockReturnValue({ isDirectory: () => false, size: 42 } as any);
+
+      const ctx = {
+        env: environment,
+        log,
+        http,
+        options: {},
+        sourceDir: '/static/',
+        isReactNativeApp: true,
+      } as any;
+      await expect(validateFiles(ctx)).rejects.toThrow(
+        'Invalid React Native Storybook build at /static/'
+      );
+    });
+  });
 });
 
 describe('traceChangedFiles', () => {

--- a/node-src/ui/tasks/prepare.stories.ts
+++ b/node-src/ui/tasks/prepare.stories.ts
@@ -19,6 +19,14 @@ export const Invalid = () =>
     buildLogFile: '/var/folders/h3/ff9kk23958l99z2qbzfjdlxc0000gn/T/build-storybook.log',
   } as any);
 
+export const InvalidReactNative = () =>
+  invalid({
+    ...ctx,
+    isReactNativeApp: true,
+    sourceDir: '/var/folders/h3/ff9kk23958l99z2qbzfjdlxc0000gn/T/chromatic-20036LMP9FAlLEjpu',
+    buildLogFile: '/var/folders/h3/ff9kk23958l99z2qbzfjdlxc0000gn/T/build-storybook.log',
+  } as any);
+
 export const Tracing = () =>
   tracing({ ...ctx, git: { changedFiles: Array.from({ length: 3 }) } } as any);
 

--- a/node-src/ui/tasks/utils.ts
+++ b/node-src/ui/tasks/utils.ts
@@ -1,5 +1,9 @@
 import { isE2EBuild } from '../../lib/e2eUtils';
 import { Context } from '../../types';
 
-export const buildType = (ctx: Context) => (isE2EBuild(ctx.options) ? 'test suite' : 'Storybook');
+export const buildType = (ctx: Context) => {
+  if (isE2EBuild(ctx.options)) return 'test suite';
+  if (ctx.isReactNativeApp) return 'React Native Storybook';
+  return 'Storybook';
+};
 export const capitalize = (string: string) => string.charAt(0).toUpperCase() + string.slice(1);


### PR DESCRIPTION
# Description

This PR updates the storybook validation step for React Native (RN) builds. RN builds don't have an `index.html` or `iframe.html` like web-based Storybooks. Instead, we validate that there's an APK and a `manifest.json` present.

This PR also updates the UI error message to indicate that we're working with a RN build.

# Manual QA

1. I ran a build against a non-RN app. Works as normal.
2. I updated the app to be a RN app through GQL and then ran a build. As expected, validation fails:
<img width="2418" height="806" alt="CleanShot 2025-12-16 at 15 29 04@2x" src="https://github.com/user-attachments/assets/73830105-462b-4ef7-bca2-3139ad8b797b" />
3. I added a dummy `foo.apk` and `manifest.json` with some random text and put them in a `rn-test` directory in my storybook app. I then ran a build with this config option: `--storybook-build-dir rn-test`. This is a pretty hacky test, because obviously there's not actually a RN storybook or support in the rest of the workflow, so the verify step fails. But the preparation step (what this PR works on) passes:
<img width="1636" height="718" alt="CleanShot 2025-12-16 at 15 32 13@2x" src="https://github.com/user-attachments/assets/7db392f4-568a-446e-a3df-07859b6e6ce6" />

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>13.3.6--canary.1223.20721238637.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@13.3.6--canary.1223.20721238637.0
  # or 
  yarn add chromatic@13.3.6--canary.1223.20721238637.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
