### PR TITLE
Skip storybook build step for react native

### DIFF
--- a/node-src/tasks/build.ts
+++ b/node-src/tasks/build.ts
@@ -14,9 +14,11 @@ import { endActivity, startActivity } from '../ui/components/activity';
 import buildFailed from '../ui/messages/errors/buildFailed';
 import e2eBuildFailed from '../ui/messages/errors/e2eBuildFailed';
 import missingDependency from '../ui/messages/errors/missingDependency';
+import missingStorybookBuildDirectory from '../ui/messages/errors/missingStorybookBuildDirectory';
 import {
   failed,
   initial,
+  missingBuildDirectoryForReactNative,
   pending,
   skipped,
   skippedForReactNative,
@@ -206,12 +208,18 @@ export default function main(ctx: Context) {
     title: initial(ctx).title,
     skip: async (ctx) => {
       if (ctx.skip) return true;
+      if (ctx.isReactNativeApp) {
+        if (!ctx.options.storybookBuildDir) {
+          ctx.log.error(missingStorybookBuildDirectory());
+          setExitCode(ctx, exitCodes.INVALID_OPTIONS, true);
+          throw new Error(missingBuildDirectoryForReactNative(ctx).output);
+        }
+        ctx.sourceDir = ctx.options.storybookBuildDir;
+        return skippedForReactNative(ctx).output;
+      }
       if (ctx.options.storybookBuildDir) {
         ctx.sourceDir = ctx.options.storybookBuildDir;
         return skipped(ctx).output;
-      }
-      if (ctx.isReactNativeApp) {
-        return skippedForReactNative(ctx).output;
       }
       return false;
     },

--- a/node-src/ui/messages/errors/missingStorybookBuildDirectory.stories.ts
+++ b/node-src/ui/messages/errors/missingStorybookBuildDirectory.stories.ts
@@ -1,0 +1,7 @@
+import missingStorybookBuildDirectory from './missingStorybookBuildDirectory';
+
+export default {
+  title: 'CLI/Messages/Errors',
+};
+
+export const MissingStorybookBuildDirectoryForReactNative = () => missingStorybookBuildDirectory();

--- a/node-src/ui/messages/errors/missingStorybookBuildDirectory.ts
+++ b/node-src/ui/messages/errors/missingStorybookBuildDirectory.ts
@@ -1,0 +1,11 @@
+import chalk from 'chalk';
+import { dedent } from 'ts-dedent';
+
+import { error } from '../../components/icons';
+
+export default () =>
+  dedent(chalk`
+    ${error} {bold Build directory required for React Native}
+    React Native Storybook requires a pre-built directory containing your .apk and manifest.json files.
+    Set the {bold --storybook-build-dir} option to the path of your React Native build output.
+  `);

--- a/node-src/ui/tasks/build.stories.ts
+++ b/node-src/ui/tasks/build.stories.ts
@@ -1,5 +1,13 @@
 import task from '../components/task';
-import { failed, initial, pending, skipped, skippedForReactNative, success } from './build';
+import {
+  failed,
+  initial,
+  missingBuildDirectoryForReactNative,
+  pending,
+  skipped,
+  skippedForReactNative,
+  success,
+} from './build';
 
 export default {
   title: 'CLI/Tasks/Build',
@@ -30,6 +38,12 @@ export const Skipped = () =>
 
 export const SkippedForReactNative = () =>
   skippedForReactNative({
+    ...ctx,
+    isReactNativeApp: true,
+  } as any);
+
+export const MissingBuildDirectoryWithReactNative = () =>
+  missingBuildDirectoryForReactNative({
     ...ctx,
     isReactNativeApp: true,
   } as any);

--- a/node-src/ui/tasks/build.ts
+++ b/node-src/ui/tasks/build.ts
@@ -31,6 +31,12 @@ export const skippedForReactNative = (ctx: Context) => ({
   output: 'Using prebuilt React Native assets',
 });
 
+export const missingBuildDirectoryForReactNative = (ctx: Context) => ({
+  status: 'error',
+  title: `Build ${buildType(ctx)}`,
+  output: 'Build directory required for React Native',
+});
+
 export const failed = (ctx: Context) => ({
   status: 'error',
   title: `Building your ${buildType(ctx)}`,


### PR DESCRIPTION
# Description

This PR implements skipping the storybook build step for React Native builds, along with the associated UI changes. Since we're skipping the build step, we don't automatically set the source directory, and the automatic source directory discovery logic is very specific to web-based storybook. 

So for now, I'm requiring users to use the `--storybook-build-dir` flag for React Native builds, pointing at the required React Native assets (apk and manifest.json). If that flag isn't used, we display an error. This seemed like the simplest solution to unlock end-to-end functionality on the CLI quickly. We can hash out automatic source directory discovery later.

# Manual QA

Happy path, with `--storybook-build-dir` pointing to a directory with the required RN assets (verification step still fails due to extract work not being implemented yet):
<img width="1746" height="704" alt="CleanShot 2025-12-17 at 11 14 29@2x" src="https://github.com/user-attachments/assets/942d4b33-565e-4e31-befb-a01e47a07169" />

Error state when the build directory (I used `storybook-static` here) doesn't include the required assets:
<img width="1936" height="658" alt="CleanShot 2025-12-17 at 11 15 41@2x" src="https://github.com/user-attachments/assets/568da97a-cc6f-48f2-8b89-9f1983fbef71" />

Note that this is a failure in the `prepare` step. The build step is still skipped. This just demonstrates that `ctx.sourceDir` is being set properly.

Error state when the build directory isn't set:
<img width="2496" height="740" alt="CleanShot 2025-12-17 at 11 18 39@2x" src="https://github.com/user-attachments/assets/986a1a58-36a3-4c16-9c06-48cf144f8d2e" />

And finally, I tested against a non-RN app, and it works as normal.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>13.3.5--canary.1225.20340306277.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@13.3.5--canary.1225.20340306277.0
  # or 
  yarn add chromatic@13.3.5--canary.1225.20340306277.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
