### PR TITLE
Fix dependabot changelog output

### DIFF
--- a/scripts/publishAction.mjs
+++ b/scripts/publishAction.mjs
@@ -20,11 +20,11 @@ const publishAction = async ({ major, version, repo }) => {
   await $`git clone https://${process.env.GH_TOKEN}@github.com/${repo}.git ${path}`;
 
   await $`yarn clean-package`;
-  await copy(['action/*.js', 'action/*.json', 'action.yml', 'package.json'], path, {
+  await copy(['action/*.js', 'action/*.json', 'action.yml', 'package.json', 'CHANGELOG.md'], path, {
     parents: true, // keep directory structure (i.e. action dir)
     overwrite: true,
   });
-  await copy(['action-src/CHANGELOG.md', 'action-src/LICENSE', 'action-src/README.md'], path, {
+  await copy(['action-src/LICENSE', 'action-src/README.md'], path, {
     overwrite: true,
   });
   await $`yarn clean-package restore`;


### PR DESCRIPTION
Fixes #936 

As part of the release process, we write all the build artifacts to https://github.com/chromaui/action. However, we're not including the `CHANGELOG.md` file which helps describe what is included in a release. I believe this was the original idea but we're pointing at the wrong location for `CHANGELOG.md` so it's never uploaded.

I did some testing on our https://github.com/chromaui/action-canary and this change works just fine on my test repo!

<img width="931" height="911" alt="image" src="https://github.com/user-attachments/assets/2fb1080b-2d08-4e7b-9226-f0000337ca3d" />

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>14.0.1--canary.1227.21595854193.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@14.0.1--canary.1227.21595854193.0
  # or 
  yarn add chromatic@14.0.1--canary.1227.21595854193.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
