### PR TITLE
feat: skip multiple Chromatic projects in a single CLI invocation

### DIFF
--- a/action-src/main.ts
+++ b/action-src/main.ts
@@ -124,7 +124,9 @@ async function run() {
     const outputDir = getInput('outputDir');
     const playwright = getInput('playwright');
     const preserveMissing = getInput('preserveMissing');
-    const projectToken = getInput('projectToken');
+    const projectTokenInput = getInput('projectToken');
+    const projectTokens = getMultilineInput('projectToken');
+    const projectToken = projectTokens.length > 1 ? projectTokens : projectTokenInput;
     const repositorySlug = getInput('repositorySlug');
     const shaInput = getInput('chromaticSha');
     const skip = getInput('skip');

--- a/action.yml
+++ b/action.yml
@@ -81,13 +81,13 @@ inputs:
     description: 'Deprecated, use onlyChanged, onlyStoryNames or onlyStoryFiles instead'
     required: false
   projectToken:
-    description: 'Your chromatic project token (best provided via env.CHROMATIC_PROJECT_TOKEN)'
+    description: 'Your chromatic project token (best provided via env.CHROMATIC_PROJECT_TOKEN). Provide multiple tokens (one per line) with skip to skip multiple projects in one invocation.'
     required: false
   repositorySlug:
     description: 'Override the repository slug (e.g. ownerName/repositoryName)'
     required: false
   skip:
-    description: 'Skip Chromatic tests, but mark the commit as passing'
+    description: 'Skip Chromatic tests, but mark the commit as passing. When multiple project tokens are provided, all projects are skipped in one invocation.'
     required: false
   skipUpdateCheck:
     description: 'Skips Chromatic CLI update check'

--- a/node-src/lib/getOptions.test.ts
+++ b/node-src/lib/getOptions.test.ts
@@ -214,4 +214,24 @@ describe('getOptions', () => {
       diagnosticsFile: 'output.json',
     });
   });
+
+  it('populates projectTokens when multiple --project-token flags are passed', async () => {
+    const options = getOptions(
+      getContext(['--project-token', 'token-a', '--project-token', 'token-b', '--skip'])
+    );
+    expect(options.projectToken).toBe('token-b');
+    expect(options.projectTokens).toEqual(['token-a', 'token-b']);
+    expect(options.skip).toBe(true);
+  });
+
+  it('populates projectTokens with a single token', async () => {
+    const options = getOptions(getContext(['--project-token', 'token-a']));
+    expect(options.projectToken).toBe('token-a');
+    expect(options.projectTokens).toEqual(['token-a']);
+  });
+
+  it('does not require a single projectToken when multiple tokens are given with --skip', async () => {
+    const ctx = getContext(['--project-token', 'token-a', '--project-token', 'token-b', '--skip']);
+    expect(() => getOptions(ctx)).not.toThrow();
+  });
 });

--- a/node-src/lib/getOptions.ts
+++ b/node-src/lib/getOptions.ts
@@ -124,6 +124,7 @@ export default function getOptions(ctx: InitialContext): Options {
   // We need to strip out undefined because they otherwise they override anyway
   const optionsFromFlags = stripUndefined({
     projectToken: takeLast(flags.projectToken),
+    projectTokens: undefinedIfEmpty(ensureArray(flags.projectToken)),
 
     onlyChanged: trueIfSet(flags.onlyChanged),
     onlyStoryFiles: undefinedIfEmpty(ensureArray(flags.onlyStoryFiles)),
@@ -213,7 +214,8 @@ export default function getOptions(ctx: InitialContext): Options {
 
   if (
     !potentialOptions.projectToken &&
-    !(potentialOptions.projectId && potentialOptions.userToken)
+    !(potentialOptions.projectId && potentialOptions.userToken) &&
+    !(potentialOptions.projectTokens?.length && potentialOptions.skip)
   ) {
     throw new Error(missingProjectToken());
   }

--- a/node-src/lib/parseArguments.ts
+++ b/node-src/lib/parseArguments.ts
@@ -20,7 +20,7 @@ export default function parseArguments(argv: string[]) {
       $ chromatic --project-token <token>
 
     Required options
-      --project-token, -t <token>               The unique code for your project. Alternatively, set CHROMATIC_PROJECT_TOKEN.
+      --project-token, -t <token>               The unique code for your project. Alternatively, set CHROMATIC_PROJECT_TOKEN. Can be specified multiple times with --skip to skip multiple projects in one invocation.
 
     Storybook options
       --build-script-name, -b [name]            The npm script that builds your Storybook we should take snapshots against. Use this if your Storybook build script is named differently. [build-storybook]
@@ -42,7 +42,7 @@ export default function parseArguments(argv: string[]) {
       --only-story-names <storypath>            Only run a single story or a subset of stories. Story paths typically look like "Path/To/Story". Globs are supported via picomatch. This flag can be specified multiple times.
       --patch-build <headbranch...basebranch>   Create a patch build to fix a missing PR comparison.
       --repository-slug <slug>                  Override the repository slug. Only meant to be used for unsupported CI integrations and fixing cross-fork PR comparisons. Format: <ownerName>/<repoName>.
-      --skip [branch]                           Skip Chromatic tests, but mark the commit as passing. Avoids blocking PRs due to required merge checks. Only for [branch], if specified. Globs are supported via picomatch.
+      --skip [branch]                           Skip Chromatic tests, but mark the commit as passing. Avoids blocking PRs due to required merge checks. Only for [branch], if specified. Globs are supported via picomatch. When multiple --project-token values are provided, all projects are skipped in one invocation.
       --storybook-base-dir <dirname>            Relative path from repository root to Storybook project root. Use with --only-changed and --storybook-build-dir when running Chromatic from a different directory than your Storybook.
       --storybook-config-dir <dirname>          Relative path from where you run Chromatic to your Storybook config directory ('.storybook'). Use with --only-changed and --storybook-build-dir when using a custom --config-dir (-c) flag for Storybook. [.storybook]
       --untraced <filepath>                     Disregard these files and their dependencies when tracing dependent stories for TurboSnap. Globs are supported via picomatch. This flag can be specified multiple times. Requires --only-changed.

--- a/node-src/tasks/gitInfo.test.ts
+++ b/node-src/tasks/gitInfo.test.ts
@@ -202,4 +202,118 @@ describe('setGitInfo', () => {
       numberOfAppFiles: 100,
     });
   });
+
+  describe('skip with multiple project tokens', () => {
+    it('skips all projects when multiple tokens are provided with --skip', async () => {
+      client.runQuery.mockImplementation((query, variables) => {
+        if (query.includes('CreateAppTokenMutation')) {
+          return { appToken: `token-for-${variables.projectToken}` };
+        }
+        if (query.includes('SkipBuildMutation')) {
+          return { skipBuild: true };
+        }
+        return { app: { isOnboarding: false } };
+      });
+
+      const ctx = {
+        log,
+        options: {
+          skip: true,
+          projectToken: 'token-c',
+          projectTokens: ['token-a', 'token-b', 'token-c'],
+        },
+        client,
+      } as any;
+      await setGitInfo(ctx, {} as any);
+
+      expect(ctx.skip).toBe(true);
+
+      const createAppTokenCalls = client.runQuery.mock.calls.filter(([q]) =>
+        q.includes('CreateAppTokenMutation')
+      );
+      expect(createAppTokenCalls).toHaveLength(3);
+      expect(createAppTokenCalls[0][1]).toEqual({ projectToken: 'token-a' });
+      expect(createAppTokenCalls[1][1]).toEqual({ projectToken: 'token-b' });
+      expect(createAppTokenCalls[2][1]).toEqual({ projectToken: 'token-c' });
+
+      const skipBuildCalls = client.runQuery.mock.calls.filter(([q]) =>
+        q.includes('SkipBuildMutation')
+      );
+      expect(skipBuildCalls).toHaveLength(3);
+    });
+
+    it('still skips when some tokens fail and others succeed', async () => {
+      let callCount = 0;
+      client.runQuery.mockImplementation((query, variables) => {
+        if (query.includes('CreateAppTokenMutation')) {
+          callCount++;
+          if (callCount === 1) throw new Error('Invalid token');
+          return { appToken: `token-for-${variables.projectToken}` };
+        }
+        if (query.includes('SkipBuildMutation')) {
+          return { skipBuild: true };
+        }
+        return { app: { isOnboarding: false } };
+      });
+
+      const ctx = {
+        log,
+        options: {
+          skip: true,
+          projectToken: 'token-b',
+          projectTokens: ['bad-token', 'token-b'],
+        },
+        client,
+      } as any;
+      await setGitInfo(ctx, {} as any);
+
+      expect(ctx.skip).toBe(true);
+    });
+
+    it('throws when all tokens fail', async () => {
+      client.runQuery.mockImplementation((query) => {
+        if (query.includes('CreateAppTokenMutation')) {
+          throw new Error('Invalid token');
+        }
+        return { app: { isOnboarding: false } };
+      });
+
+      const ctx = {
+        log,
+        options: {
+          skip: true,
+          projectToken: 'bad-a',
+          projectTokens: ['bad-a', 'bad-b'],
+        },
+        client,
+      } as any;
+
+      await expect(setGitInfo(ctx, {} as any)).rejects.toThrow('Failed to skip build');
+    });
+
+    it('uses single-token path when only one token is provided', async () => {
+      client.runQuery.mockImplementation((query) => {
+        if (query.includes('SkipBuildMutation')) {
+          return { skipBuild: true };
+        }
+        return { app: { isOnboarding: false } };
+      });
+
+      const ctx = {
+        log,
+        options: {
+          skip: true,
+          projectToken: 'single-token',
+        },
+        client,
+      } as any;
+      await setGitInfo(ctx, {} as any);
+
+      expect(ctx.skip).toBe(true);
+      const createAppTokenCalls = client.runQuery.mock.calls.filter(([q]) =>
+        q.includes('CreateAppTokenMutation')
+      );
+      expect(createAppTokenCalls).toHaveLength(0);
+    });
+  });
 });

--- a/node-src/tasks/gitInfo.ts
+++ b/node-src/tasks/gitInfo.ts
@@ -39,6 +39,14 @@ import {
 
 const UNDEFINED_BRANCH_PREFIX_REGEXP = /^undefined:/;
 
+const mask = (secret: string) => '*'.repeat(secret.length - 4) + secret.slice(-4);
+
+const CreateAppTokenMutation = `
+  mutation CreateAppTokenMutation($projectToken: String!) {
+    appToken: createAppToken(code: $projectToken)
+  }
+`;
+
 const SkipBuildMutation = `
   mutation SkipBuildMutation($commit: String!, $branch: String, $slug: String) {
     skipBuild(commit: $commit, branch: $branch, slug: $slug)
@@ -163,7 +171,40 @@ export const setGitInfo = async (ctx: Context, task: Task) => {
 
   if (ctx.git.matchesBranch?.(ctx.options.skip)) {
     transitionTo(skippingBuild)(ctx, task);
-    // The SkipBuildMutation ensures the commit is tagged properly.
+
+    const tokens = ctx.options.projectTokens?.length
+      ? ctx.options.projectTokens
+      : [ctx.options.projectToken];
+
+    if (tokens.length > 1) {
+      let skippedCount = 0;
+      for (const token of tokens) {
+        try {
+          const { appToken } = await ctx.client.runQuery<{ appToken: string }>(
+            CreateAppTokenMutation,
+            { projectToken: token }
+          );
+          const result = await ctx.client.runQuery(
+            SkipBuildMutation,
+            { commit, branch, slug },
+            { headers: { Authorization: `Bearer ${appToken}` } }
+          );
+          if (result) skippedCount++;
+        } catch (err) {
+          ctx.log.warn(`Failed to skip project with token '${mask(token)}': ${err.message || err}`);
+        }
+      }
+
+      if (skippedCount > 0) {
+        ctx.skip = true;
+        transitionTo(skippedForCommit, true)(ctx, task);
+        setExitCode(ctx, exitCodes.OK);
+        return;
+      }
+      throw new Error(skipFailed().output);
+    }
+
+    // Single token: existing behavior
     if (await ctx.client.runQuery(SkipBuildMutation, { commit, branch, slug })) {
       ctx.skip = true;
       transitionTo(skippedForCommit, true)(ctx, task);

--- a/node-src/types.ts
+++ b/node-src/types.ts
@@ -64,6 +64,7 @@ export interface Flags {
 
 export interface Options extends Configuration {
   projectToken: string;
+  projectTokens?: string[];
   userToken?: string;
 
   configFile?: Flags['configFile'];

--- a/node-src/ui/tasks/gitInfo.ts
+++ b/node-src/ui/tasks/gitInfo.ts
@@ -36,11 +36,15 @@ export const skippingBuild = (ctx: Context) => ({
   output: `Skipping build for commit ${ctx.git.commit.slice(0, 7)}`,
 });
 
-export const skippedForCommit = (ctx: Context) => ({
-  status: 'success',
-  title: 'Skipping build',
-  output: `Skipped build for commit ${ctx.git.commit.slice(0, 7)} due to --skip`,
-});
+export const skippedForCommit = (ctx: Context) => {
+  const tokenCount = ctx.options.projectTokens?.length || 1;
+  const suffix = tokenCount > 1 ? ` (${tokenCount} projects)` : '';
+  return {
+    status: 'success',
+    title: 'Skipping build',
+    output: `Skipped build for commit ${ctx.git.commit.slice(0, 7)} due to --skip${suffix}`,
+  };
+};
 
 export const skipFailed = () => ({
   status: 'error',


### PR DESCRIPTION
## Summary
Adds the ability to skip multiple Chromatic projects in one CLI invocation by passing multiple `--project-token` values alongside `--skip`. Previously, skipping N projects required N separate CLI calls — now it can be done with a single command.
## Motivation
In monorepo setups with many Chromatic projects, skipping builds (e.g. on certain branches) required invoking the CLI once per project. This was slow, verbose, and hard to maintain in CI configurations. This change collapses all those invocations into one.
## How it works
When `--skip` is set and multiple `--project-token` values are provided, the CLI:
1. Gathers git info (commit, branch, slug) once.
2. For each token: authenticates and calls the `SkipBuild` mutation.
3. Reports how many projects were skipped and exits with code 0.
If some tokens fail, the CLI logs warnings but continues with the rest. It only throws an error if *all* tokens fail.
When a single token is provided, existing behavior is completely unchanged.
## Usage
### CLI
```bash
npx chromatic \
  --project-token token-app-a \
  --project-token token-app-b \
  --project-token token-app-c \
  --skip
