### PR TITLE
Warn on treeKill errors instead of exiting out

### DIFF
--- a/node-src/git/execGit.ts
+++ b/node-src/git/execGit.ts
@@ -32,7 +32,7 @@ export async function execGitCommand(
 ) {
   try {
     log.debug(`execGitCommand: ${command}`);
-    const { all } = await runCommand(command, { ...defaultOptions, ...options });
+    const { all } = await runCommand({ log }, command, { ...defaultOptions, ...options });
 
     if (all === undefined) {
       throw new Error(`Unexpected missing git command output for command: '${command}'`);
@@ -78,7 +78,7 @@ export async function execGitCommandOneLine(
   options?: Options
 ) {
   log.debug(`execGitCommandOneLine: ${command}`);
-  const process = runCommand(command, {
+  const process = runCommand({ log }, command, {
     ...defaultOptions,
     buffer: false,
     ...options,
@@ -124,7 +124,7 @@ export async function execGitCommandCountLines(
   options?: Options
 ) {
   log.debug(`execGitCommandCountLines: ${command}`);
-  const process = runCommand(command, {
+  const process = runCommand({ log }, command, {
     ...defaultOptions,
     buffer: false,
     ...options,

--- a/node-src/lib/getPackageManager.ts
+++ b/node-src/lib/getPackageManager.ts
@@ -1,5 +1,6 @@
 import { getCliCommand, parseNa, parseNr } from '@antfu/ni';
 
+import { Context } from '../types';
 import { runCommand } from './shell/shell';
 
 // 'npm' | 'pnpm' | 'yarn' | 'bun'
@@ -13,13 +14,16 @@ export const getPackageManagerRunCommand = async (args: string[]) => {
 };
 
 // e.g. `8.19.2`
-export const getPackageManagerVersion = async (packageManager: string) => {
+export const getPackageManagerVersion = async (
+  { log }: Pick<Context, 'log'>,
+  packageManager: string
+) => {
   if (!packageManager) {
     throw new Error('No package manager provided');
   }
 
   const command = `${packageManager} --version`;
-  const { stdout } = await runCommand(command);
+  const { stdout } = await runCommand({ log }, command);
 
   if (stdout === undefined) {
     throw new Error(`Unexpected missing output for command: '${command}'`);

--- a/node-src/lib/shell/shell.ts
+++ b/node-src/lib/shell/shell.ts
@@ -1,5 +1,8 @@
 import { execa, Options, parseCommandString, type ResultPromise } from 'execa';
+import { kill } from 'process';
 import treeKill from 'tree-kill';
+
+import { Context } from '../../types';
 
 /**
  * Run a command in the shell. This is a wrapper around `execa` so .kill() and timeouts kill the
@@ -9,12 +12,18 @@ import treeKill from 'tree-kill';
  * 1. Buffered mode: await the result to get stdout/stderr after completion
  * 2. Streaming mode: access .stdout/.stderr properties during execution (requires buffer: false)
  *
+ * @param context Standard context object.
+ * @param context.log Standard context logger.
  * @param command The command to run.
  * @param options Execa options. Note: `timeout` is handled internally.
  *
  * @returns An execa `ResultPromise` with .kill() and timeout overwritten.
  */
-export function runCommand(command: string, options: Options = {}): ResultPromise {
+export function runCommand(
+  { log }: Pick<Context, 'log'>,
+  command: string,
+  options: Options = {}
+): ResultPromise {
   const { timeout, ...optionsWithoutTimeout } = options;
   const [cmd, ...args] = parseCommandString(command);
   const subprocess = execa(cmd, args, optionsWithoutTimeout);
@@ -26,7 +35,12 @@ export function runCommand(command: string, options: Options = {}): ResultPromis
       return false;
     }
 
-    treeKill(subprocess.pid);
+    try {
+      treeKill(subprocess.pid);
+    } catch (err) {
+      log.warn(`Failed to terminate process tree for ${subprocess.pid}: ${err}`);
+      kill(subprocess.pid);
+    }
     return true;
   };
 

--- a/node-src/tasks/build.ts
+++ b/node-src/tasks/build.ts
@@ -168,7 +168,7 @@ export const buildStorybook = async (ctx: Context) => {
       throw new Error('No build command configured');
     }
 
-    await runCommand(ctx.buildCommand, {
+    await runCommand(ctx, ctx.buildCommand, {
       stdio: [undefined, logFile, undefined],
       // When `true`, this will run in the node version set by the
       // action (node20), not the version set in the workflow

--- a/node-src/tasks/initialize.ts
+++ b/node-src/tasks/initialize.ts
@@ -68,7 +68,7 @@ export const setRuntimeMetadata = async (ctx: Context) => {
     ctx.runtimeMetadata.packageManager = packageManager as any;
     Sentry.setTag('packageManager', packageManager);
 
-    const packageManagerVersion = await getPackageManagerVersion(packageManager);
+    const packageManagerVersion = await getPackageManagerVersion(ctx, packageManager);
     ctx.runtimeMetadata.packageManagerVersion = packageManagerVersion;
     Sentry.setTag('packageManagerVersion', packageManagerVersion);
   } catch (err) {


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>16.0.1--canary.1260.23662727965.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@16.0.1--canary.1260.23662727965.0
  # or 
  yarn add chromatic@16.0.1--canary.1260.23662727965.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
