### PR TITLE
Track storybook build failed events in analytics

### DIFF
--- a/node-src/lib/analytics/events.ts
+++ b/node-src/lib/analytics/events.ts
@@ -1,0 +1,5 @@
+export const AnalyticsEvent = {
+  CLI_STORYBOOK_BUILD_FAILED: 'CLI_STORYBOOK_BUILD_FAILED',
+} as const;
+
+export type AnalyticsEvent = (typeof AnalyticsEvent)[keyof typeof AnalyticsEvent];

--- a/node-src/lib/analytics/indexClient.test.ts
+++ b/node-src/lib/analytics/indexClient.test.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import TestLogger from '../testLogger';
+import { AnalyticsEvent } from './events';
 import { IndexAnalyticsClient } from './indexClient';
 
 vi.mock('@sentry/node', () => ({
@@ -24,7 +25,7 @@ describe('IndexAnalyticsClient', () => {
     it('calls runQuery with TrackCLITelemetryEvent mutation and input built from properties', () => {
       const { client, runQuery } = makeClient();
 
-      client.trackEvent('CLI_STORYBOOK_BUILD_FAILED', {
+      client.trackEvent(AnalyticsEvent.CLI_STORYBOOK_BUILD_FAILED, {
         errorCategory: 'storybook_build_failed',
       });
 
@@ -32,7 +33,7 @@ describe('IndexAnalyticsClient', () => {
         expect.stringMatching(/TrackCLITelemetryEvent/),
         {
           input: {
-            event: 'CLI_STORYBOOK_BUILD_FAILED',
+            event: AnalyticsEvent.CLI_STORYBOOK_BUILD_FAILED,
             properties: { errorCategory: 'storybook_build_failed' },
           },
         },
@@ -44,7 +45,7 @@ describe('IndexAnalyticsClient', () => {
       const error = new Error('GQL failed');
       const { client } = makeClient(vi.fn().mockRejectedValue(error));
 
-      expect(() => client.trackEvent('some-event', {})).not.toThrow();
+      expect(() => client.trackEvent(AnalyticsEvent.CLI_STORYBOOK_BUILD_FAILED, {})).not.toThrow();
 
       await client.shutdown();
 
@@ -63,8 +64,8 @@ describe('IndexAnalyticsClient', () => {
       );
       const { client } = makeClient(runQuery);
 
-      client.trackEvent('event-1', {});
-      client.trackEvent('event-2', {});
+      client.trackEvent(AnalyticsEvent.CLI_STORYBOOK_BUILD_FAILED, {});
+      client.trackEvent(AnalyticsEvent.CLI_STORYBOOK_BUILD_FAILED, {});
 
       let resolved = false;
       const shutdownPromise = client.shutdown().then(() => {
@@ -86,7 +87,7 @@ describe('IndexAnalyticsClient', () => {
         const runQuery = vi.fn(() => new Promise(() => {}));
         const { client, logger } = makeClient(runQuery);
 
-        client.trackEvent('event-1', {});
+        client.trackEvent(AnalyticsEvent.CLI_STORYBOOK_BUILD_FAILED, {});
 
         const shutdownPromise = client.shutdown();
         vi.advanceTimersByTime(5000);

--- a/node-src/lib/analytics/indexClient.ts
+++ b/node-src/lib/analytics/indexClient.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 
 import GraphQLClient from '../../io/graphqlClient';
 import { Logger } from '../log';
+import type { AnalyticsEvent } from './events';
 import type { AnalyticsClient } from './types';
 
 const TrackCLITelemetryEventMutation = `
@@ -28,7 +29,7 @@ export class IndexAnalyticsClient implements AnalyticsClient {
     this.logger = logger;
   }
 
-  trackEvent(eventName: string, properties?: Record<string, unknown>): void {
+  trackEvent(eventName: AnalyticsEvent, properties?: Record<string, unknown>): void {
     this.logger.debug(`[analytics] trackEvent: ${eventName}`, JSON.stringify(properties));
 
     const input = { event: eventName, properties };

--- a/node-src/lib/analytics/logOnly.test.ts
+++ b/node-src/lib/analytics/logOnly.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import TestLogger from '../testLogger';
+import { AnalyticsEvent } from './events';
 import { LogOnlyAnalyticsClient } from './logOnly';
 
 describe('LogOnlyAnalyticsClient', () => {
@@ -9,10 +10,10 @@ describe('LogOnlyAnalyticsClient', () => {
     const client = new LogOnlyAnalyticsClient(logger);
 
     const properties = { errorCategory: 'storybook_build_failed' };
-    client.trackEvent('CLI_STORYBOOK_BUILD_FAILED', properties);
+    client.trackEvent(AnalyticsEvent.CLI_STORYBOOK_BUILD_FAILED, properties);
 
     expect(logger.debug).toHaveBeenCalledWith(
-      expect.stringContaining('CLI_STORYBOOK_BUILD_FAILED'),
+      expect.stringContaining(AnalyticsEvent.CLI_STORYBOOK_BUILD_FAILED),
       JSON.stringify(properties)
     );
   });

--- a/node-src/lib/analytics/logOnly.ts
+++ b/node-src/lib/analytics/logOnly.ts
@@ -1,4 +1,5 @@
 import { Logger } from '../log';
+import type { AnalyticsEvent } from './events';
 import type { AnalyticsClient } from './types';
 
 /** Analytics client that debug-logs events. */
@@ -9,7 +10,7 @@ export class LogOnlyAnalyticsClient implements AnalyticsClient {
     this.logger = logger;
   }
 
-  trackEvent(eventName: string, properties?: Record<string, unknown>): void {
+  trackEvent(eventName: AnalyticsEvent, properties?: Record<string, unknown>): void {
     this.logger.debug(`[analytics] trackEvent: ${eventName}`, JSON.stringify(properties));
   }
 

--- a/node-src/lib/analytics/sanitization.test.ts
+++ b/node-src/lib/analytics/sanitization.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest';
+
+import { sanitizeStackTrace } from './sanitization';
+
+describe('sanitizeStackTrace', () => {
+  const cases: { name: string; input: string | undefined; expected: string }[] = [
+    { name: 'undefined input', input: undefined, expected: '' },
+    { name: 'empty string input', input: '', expected: '' },
+    {
+      name: 'redacts double-quoted content',
+      input: 'Error: "secret value" found',
+      expected: 'Error: <redacted> found',
+    },
+    {
+      name: 'redacts backtick content',
+      input: 'Error: `token abc` found',
+      expected: 'Error: <redacted> found',
+    },
+    {
+      name: 'preserves single-quoted content (apostrophes)',
+      input: "Error: can't find module 'foo'",
+      expected: "Error: can't find module 'foo'",
+    },
+    {
+      name: 'redacts email addresses',
+      input: 'Error: contact user.name+tag@example.co.uk for help',
+      expected: 'Error: contact <email> for help',
+    },
+    {
+      name: 'redacts home path preserving filename and :line:col',
+      input: 'at fn ~/project/src/file.js:10:5',
+      expected: 'at fn <path>/file.js:10:5',
+    },
+    {
+      name: 'redacts home path preserving filename without line:col',
+      input: 'at fn ~/project/src/file.js',
+      expected: 'at fn <path>/file.js',
+    },
+    {
+      name: 'redacts ~user home path preserving filename',
+      input: 'at fn ~user/project/file.js:3:1',
+      expected: 'at fn <path>/file.js:3:1',
+    },
+    {
+      name: 'redacts unix absolute path preserving filename and :line:col',
+      input: 'at fn /Users/user/project/file.js:42:7',
+      expected: 'at fn <path>/file.js:42:7',
+    },
+    {
+      name: 'redacts unix absolute path preserving filename without line:col',
+      input: 'at fn /Users/user/project/file.js',
+      expected: 'at fn <path>/file.js',
+    },
+    {
+      name: 'redacts windows path preserving filename and :line:col',
+      input: String.raw`at fn C:\Users\user\project\file.js:12:4`,
+      expected: 'at fn <path>/file.js:12:4',
+    },
+    {
+      name: 'redacts windows path preserving filename without line:col',
+      input: String.raw`at fn D:\work\file.js`,
+      expected: 'at fn <path>/file.js',
+    },
+    {
+      name: 'preserves filename for single-segment absolute path',
+      input: 'at fn /foo',
+      expected: 'at fn <path>/foo', // not worth the regex complexity to handle this very unlikely weird case
+    },
+    {
+      name: 'does not eat closing paren around path',
+      input: 'at fn (/Users/alice/file.js:1:1)',
+      expected: 'at fn (<path>/file.js:1:1)',
+    },
+    {
+      name: 'handles multi-line stack trace without eating across lines',
+      input: 'at x (/a/first.js:1:1)\n    at y (/b/second.js:2:2)',
+      expected: 'at x (<path>/first.js:1:1)\n    at y (<path>/second.js:2:2)',
+    },
+    {
+      name: 'caps input at 8000 chars before sanitization',
+      input: 'a'.repeat(10_000),
+      expected: 'a'.repeat(8000),
+    },
+  ];
+
+  it.each(cases)('$name', ({ input, expected }) => {
+    expect(sanitizeStackTrace(input)).toBe(expected);
+  });
+});

--- a/node-src/lib/analytics/sanitization.ts
+++ b/node-src/lib/analytics/sanitization.ts
@@ -1,0 +1,34 @@
+const MAX_STACK_TRACE_LENGTH = 8000;
+
+function preservePathTail(match: string): string {
+  const lineCol = match.match(/:\d+(?::\d+)?$/)?.[0] ?? '';
+  const pathPart = lineCol ? match.slice(0, -lineCol.length) : match;
+  const filename = pathPart.match(/[^/\\]+$/)?.[0] ?? '';
+  return filename ? `<path>/${filename}${lineCol}` : `<path>${lineCol}`;
+}
+
+/**
+ * Remove PII and secrets from a stack trace.
+ *
+ * @param stackTrace Raw stack trace from an Error.
+ *
+ * @returns Sanitized stack trace, or empty string if none provided.
+ */
+export function sanitizeStackTrace(stackTrace: string | undefined): string {
+  if (!stackTrace) return '';
+  return (
+    stackTrace
+      .slice(0, MAX_STACK_TRACE_LENGTH)
+      // Content wrapped in double quotes or backticks (common carrier of secrets).
+      // Single quotes deliberately excluded to avoid eating apostrophes.
+      .replaceAll(/(["`]).*?\1/g, '<redacted>')
+      // Email addresses (local-part@domain.tld).
+      .replaceAll(/[\w.+-]+@[\w.-]+\.[A-Za-z]{2,}/g, '<email>')
+      // File paths:
+      //   ~/... or ~user/... — home-relative paths
+      //   /...               — unix absolute paths (also matches URL authority `//host`)
+      //   C:\...             — windows paths
+      // `[^\s)]` stops at whitespace (incl. newlines) and closing paren from stack frames.
+      .replaceAll(/~\w*\/[^\s)]+|\/[^\s)]+|[A-Za-z]:\\[^\s)]+/g, preservePathTail)
+  );
+}

--- a/node-src/lib/analytics/types.ts
+++ b/node-src/lib/analytics/types.ts
@@ -1,4 +1,6 @@
+import type { AnalyticsEvent } from './events';
+
 export interface AnalyticsClient {
-  trackEvent(eventName: string, properties?: Record<string, unknown>): void;
+  trackEvent(eventName: AnalyticsEvent, properties?: Record<string, unknown>): void;
   shutdown(): Promise<void>;
 }

--- a/node-src/tasks/build.test.ts
+++ b/node-src/tasks/build.test.ts
@@ -1,5 +1,8 @@
+/* eslint-disable max-lines */
 import { getCliCommand as getCliCommandDefault } from '@antfu/ni';
+import { AnalyticsEvent } from '@cli/analytics/events';
 import { exitCodes } from '@cli/setExitCode';
+import * as Sentry from '@sentry/node';
 import { execa as execaDefault, parseCommandString } from 'execa';
 import { beforeEach, describe, expect, it, onTestFinished, vi } from 'vitest';
 
@@ -30,6 +33,9 @@ vi.mock('fs', async (importOriginal) => {
 });
 vi.mock('../lib/react-native/generateManifest', () => ({
   generateManifest: vi.fn(() => Promise.resolve()),
+}));
+vi.mock('@sentry/node', () => ({
+  captureException: vi.fn(),
 }));
 
 const execa = vi.mocked(execaDefault);
@@ -417,6 +423,139 @@ describe('buildStorybook E2E', () => {
       expect.stringContaining('Failed to run `chromatic --playwright`')
     );
     expect(ctx.log.error).toHaveBeenCalledWith(expect.stringContaining(errorMessage));
+  });
+});
+
+function makeAnalyticsContext(overrides = {}) {
+  return {
+    ...baseContext,
+    buildCommand: 'npm run build:storybook',
+    env: { STORYBOOK_BUILD_TIMEOUT: 0 },
+    log: new TestLogger(),
+    pkg: { version: '1.0.0' },
+    storybook: { version: '8.0.0' },
+    git: { gitUserEmail: 'test@example.com', ciService: 'github-actions' },
+    announcedBuild: { app: { id: 'app-123', account: { id: 'account-456' } } },
+    analytics: { trackEvent: vi.fn(), shutdown: vi.fn() },
+    ...overrides,
+  } as any;
+}
+
+describe('buildStorybook analytics', () => {
+  it('tracks storybook_build_failed on build failure', async () => {
+    // arrange
+    const ctx = makeAnalyticsContext();
+    execa.mockRejectedValueOnce(new Error('build failed'));
+
+    // act
+    await expect(buildStorybook(ctx)).rejects.toThrow();
+
+    // assert
+    expect(ctx.analytics.trackEvent).toHaveBeenCalledWith(
+      AnalyticsEvent.CLI_STORYBOOK_BUILD_FAILED,
+      expect.objectContaining({
+        errorCategory: 'storybook_build_failed',
+        buildCommand: 'npm run build:storybook',
+        source: 'cli',
+        cliVersion: '1.0.0',
+        storybookVersion: '8.0.0',
+        isCI: expect.any(Boolean),
+        ciService: 'github-actions',
+        gitUserEmailHash: expect.any(String),
+      })
+    );
+  });
+
+  it('tracks e2e_missing_dependency when E2E dependency is not found', async () => {
+    // arrange
+    const ctx = makeAnalyticsContext({ options: { playwright: true, buildScriptName: '' } });
+    execa.mockRejectedValueOnce(new Error('Command not found: build-archive-storybook'));
+
+    // act
+    await expect(buildStorybook(ctx)).rejects.toThrow();
+
+    // assert
+    expect(ctx.analytics.trackEvent).toHaveBeenCalledWith(
+      AnalyticsEvent.CLI_STORYBOOK_BUILD_FAILED,
+      expect.objectContaining({ errorCategory: 'e2e_missing_dependency' })
+    );
+  });
+
+  it('tracks e2e_build_failed on generic E2E build failure', async () => {
+    // arrange
+    const ctx = makeAnalyticsContext({ options: { playwright: true, buildScriptName: '' } });
+    const error = 'Command failed with exit code 1: build-archive-storybook\n\nMultiple lines';
+    execa.mockRejectedValueOnce(new Error(`${error}\n\nOf error`));
+
+    // act
+    await expect(buildStorybook(ctx)).rejects.toThrow();
+
+    // assert
+    expect(ctx.analytics.trackEvent).toHaveBeenCalledWith(
+      AnalyticsEvent.CLI_STORYBOOK_BUILD_FAILED,
+      expect.objectContaining({ errorCategory: 'e2e_build_failed' })
+    );
+  });
+
+  it('tracks aborted when build is cancelled via abort signal', async () => {
+    // arrange
+    const controller = new AbortController();
+    controller.abort();
+    const ctx = makeAnalyticsContext({
+      options: { experimental_abortSignal: controller.signal, buildScriptName: '' },
+    });
+    execa.mockRejectedValueOnce(new Error('aborted'));
+
+    // act
+    await expect(buildStorybook(ctx)).rejects.toThrow();
+
+    // assert
+    expect(ctx.analytics.trackEvent).toHaveBeenCalledWith(
+      AnalyticsEvent.CLI_STORYBOOK_BUILD_FAILED,
+      expect.objectContaining({ errorCategory: 'aborted' })
+    );
+  });
+
+  it('sanitizes the stack trace before sending', async () => {
+    // arrange
+    const ctx = makeAnalyticsContext();
+    const err = new Error('build failed');
+    err.stack = 'Error: build failed\n    at x (/Users/user/secret/project/file.js:1:1)';
+    execa.mockRejectedValueOnce(err);
+
+    // act
+    await expect(buildStorybook(ctx)).rejects.toThrow();
+
+    // assert
+    expect(ctx.analytics.trackEvent).toHaveBeenCalledWith(
+      AnalyticsEvent.CLI_STORYBOOK_BUILD_FAILED,
+      expect.objectContaining({
+        stackTrace: 'Error: build failed\n    at x (<path>/file.js:1:1)',
+      })
+    );
+  });
+
+  it('reports to Sentry and still throws the build failure when analytics throws', async () => {
+    // arrange
+    vi.mocked(Sentry.captureException).mockClear();
+    const analyticsError = new Error('analytics exploded');
+    const ctx = makeAnalyticsContext({
+      analytics: {
+        trackEvent: vi.fn(() => {
+          throw analyticsError;
+        }),
+        shutdown: vi.fn(),
+      },
+    });
+    execa.mockRejectedValueOnce(new Error('build failed'));
+
+    // act
+    const thrown = await buildStorybook(ctx).catch((err) => err);
+
+    // assert: outer throw is the build failure, not the analytics failure
+    expect(thrown).toBeInstanceOf(Error);
+    expect(thrown).not.toBe(analyticsError);
+    expect(Sentry.captureException).toHaveBeenCalledWith(analyticsError);
   });
 });
 

--- a/node-src/tasks/build.ts
+++ b/node-src/tasks/build.ts
@@ -1,10 +1,14 @@
+import { AnalyticsEvent } from '@cli/analytics/events';
+import * as Sentry from '@sentry/node';
 import { createWriteStream, existsSync, readFileSync } from 'fs';
 import path from 'path';
 import semver from 'semver';
 import tmp from 'tmp-promise';
 
+import { sanitizeStackTrace } from '../lib/analytics/sanitization';
 import { buildBinName as e2eBuildBinName, getE2EBuildCommand } from '../lib/e2e';
 import { isE2EBuild } from '../lib/e2eUtils';
+import { emailHash } from '../lib/emailHash';
 import { getPackageManagerRunCommand } from '../lib/getPackageManager';
 import { generateManifest } from '../lib/react-native/generateManifest';
 import { exitCodes, setExitCode } from '../lib/setExitCode';
@@ -138,6 +142,53 @@ function e2eBuildErrorMessage(
   };
 }
 
+function handleBuildFailure(ctx: Context, err: any, signal?: AbortSignal): never {
+  if (isE2EBuild(ctx.options)) {
+    // If we tried to run the E2E package's bin directly (due to being in the action)
+    // and it failed, that means we couldn't find it. This probably means they haven't
+    // installed the right dependency or run from the right directory
+    const errorInfo = e2eBuildErrorMessage(err, process.cwd(), ctx);
+    const errorCategory =
+      errorInfo.exitCode === exitCodes.MISSING_DEPENDENCY
+        ? 'e2e_missing_dependency'
+        : 'e2e_build_failed';
+    trackBuildFailure(ctx, errorCategory, err);
+    ctx.log.error(errorInfo.message);
+    setExitCode(ctx, errorInfo.exitCode, true);
+    throw new Error(failed(ctx).output);
+  }
+
+  if (signal?.aborted) {
+    trackBuildFailure(ctx, 'aborted', err);
+    signal.throwIfAborted();
+  }
+
+  trackBuildFailure(ctx, 'storybook_build_failed', err);
+  const buildLog = ctx.buildLogFile && readFileSync(ctx.buildLogFile, 'utf8');
+  ctx.log.error(buildFailed(ctx, err, buildLog));
+  setExitCode(ctx, exitCodes.NPM_BUILD_STORYBOOK_FAILED, true);
+  throw new Error(failed(ctx).output);
+}
+
+function trackBuildFailure(ctx: Context, errorCategory: string, err: any) {
+  try {
+    ctx.analytics?.trackEvent(AnalyticsEvent.CLI_STORYBOOK_BUILD_FAILED, {
+      errorCategory,
+      stackTrace: sanitizeStackTrace(err?.stack),
+      buildCommand: ctx.buildCommand,
+      source: 'cli',
+      cliVersion: ctx.pkg?.version,
+      storybookVersion: ctx.storybook?.version,
+      isCI: !!process.env.CI,
+      ciService: ctx.git?.ciService,
+      gitUserEmailHash: ctx.git?.gitUserEmail ? emailHash(ctx.git.gitUserEmail) : undefined, // avoid hashing empty string
+    });
+  } catch (error) {
+    // Analytics should be best-effort, never fail the build, but we want to know about it
+    Sentry.captureException(error);
+  }
+}
+
 export const buildStorybook = async (ctx: Context) => {
   // We don't currently support building React Native projects so we'll skip this for now
   if (ctx.isReactNativeApp) {
@@ -177,22 +228,7 @@ export const buildStorybook = async (ctx: Context) => {
       },
     });
   } catch (err) {
-    // If we tried to run the E2E package's bin directly (due to being in the action)
-    // and it failed, that means we couldn't find it. This probably means they haven't
-    // installed the right dependency or run from the right directory
-    if (isE2EBuild(ctx.options)) {
-      const errorInfo = e2eBuildErrorMessage(err, process.cwd(), ctx);
-      ctx.log.error(errorInfo.message);
-      setExitCode(ctx, errorInfo.exitCode, true);
-      throw new Error(failed(ctx).output);
-    }
-
-    signal?.throwIfAborted();
-
-    const buildLog = ctx.buildLogFile && readFileSync(ctx.buildLogFile, 'utf8');
-    ctx.log.error(buildFailed(ctx, err, buildLog));
-    setExitCode(ctx, exitCodes.NPM_BUILD_STORYBOOK_FAILED, true);
-    throw new Error(failed(ctx).output);
+    handleBuildFailure(ctx, err, signal);
   } finally {
     logFile?.end();
   }


### PR DESCRIPTION
> [!NOTE]
> This PR is merging into a feature branch for the entire analytics feature.

# Description

This PR adds sending storybook build failed analytics events. Most of the logic is straightforward, but we're also including stack traces. I've added sanitization for file paths, emails, and double quoted strings (trying to catch secrets like API keys, etc.).

This is the final PR before the feature branch PR is ready to merge.

# Manual QA

For these tests, I ran against the PR deployment for the index PR that supports the analytics mutation (it has since been merged), using `LOG_LEVEL=debug`. For build failure tests, I hardcoded a deliberately invalid storybook build command.

## Index client build failure path

Relevant analytics logs:
```
[analytics] initializing Index analytics client
[analytics] trackEvent: CLI_STORYBOOK_BUILD_FAILED {"errorCategory":"storybook_build_failed","stackTrace":"nn: Command failed with exit code 254: yarn run build-storybook '--output-dir=<path>/chromatic--25971-CvwxUHjBp106'\n\nnpm error code ENOENT\nnpm error syscall lstat\nnpm error path <path>/lib\nnpm error errno -2\nnpm error enoent ENOENT: no such file or directory, lstat '<path>/lib'\nnpm error enoent This is related to npm not being able to find a file.\nnpm error enoent\nnpm error A complete log of this run can be found in: <path>/2026-04-21T14_50_51_491Z-debug-0.log\nerror Command failed with exit code 254.\n    at Zt (<path>/execa-CAtiFJKZ.cjs:11:8010)\n    at za (<path>/execa-CAtiFJKZ.cjs:30:1336)\n    at uf (<path>/execa-CAtiFJKZ.cjs:37:36395)\n    at lf (<path>/execa-CAtiFJKZ.cjs:37:36097)\n    at async nS (<path>/node-src-B3a3jnaQ.cjs:616:2769)\n    at async t.exports.task (<path>/node-src-B3a3jnaQ.cjs:576:2242)","buildCommand":"yarn run build-storybook --output-dir=/var/folders/gn/p0bks3451f38s12kbrmdxznh0000gn/T/chromatic--25971-CvwxUHjBp106","source":"cli","cliVersion":"16.3.1--canary.1281.24728792335.0","storybookVersion":"8.6.14","isCI":false,"gitUserEmailHash":"b09638619aecc2747c2e9d321696ea5b"}
[analytics] shutdown: flushing 1 pending event(s)
[analytics] shutdown: finished flushing pending events
```

Screenshot of event:
<img width="1824" height="1560" alt="CleanShot 2026-04-21 at 10 56 11@2x" src="https://github.com/user-attachments/assets/988a051d-1b70-4afb-ba9c-ac2a0b4c10da" />

## Index client build success path

Relevant analytics and build success logs:
```
[analytics] initializing Index analytics client
✖ Found 1 visual change
[analytics] shutdown: flushing 0 pending event(s)
[analytics] shutdown: finished flushing pending events
```

## Log only client build failure path

Relevant analytics logs:
```
[analytics] disabled via CHROMATIC_DISABLE_ANALYTICS, using log-only client
[analytics] trackEvent: CLI_STORYBOOK_BUILD_FAILED {"errorCategory":"storybook_build_failed","stackTrace":"nn: Command failed with exit code 254: yarn run build-storybook '--output-dir=<path>/chromatic--32266-KlZVW6ovG2wp'\n\nnpm error code ENOENT\nnpm error syscall lstat\nnpm error path <path>/lib\nnpm error errno -2\nnpm error enoent ENOENT: no such file or directory, lstat '<path>/lib'\nnpm error enoent This is related to npm not being able to find a file.\nnpm error enoent\nnpm error A complete log of this run can be found in: <path>/2026-04-21T15_04_44_530Z-debug-0.log\nerror Command failed with exit code 254.\n    at Zt (<path>/execa-CAtiFJKZ.cjs:11:8010)\n    at za (<path>/execa-CAtiFJKZ.cjs:30:1336)\n    at uf (<path>/execa-CAtiFJKZ.cjs:37:36395)\n    at lf (<path>/execa-CAtiFJKZ.cjs:37:36097)\n    at async nS (<path>/node-src-B3a3jnaQ.cjs:616:2769)\n    at async t.exports.task (<path>/node-src-B3a3jnaQ.cjs:576:2242)","buildCommand":"yarn run build-storybook --output-dir=/var/folders/gn/p0bks3451f38s12kbrmdxznh0000gn/T/chromatic--32266-KlZVW6ovG2wp","source":"cli","cliVersion":"16.3.1--canary.1281.24728792335.0","storybookVersion":"8.6.14","isCI":false,"gitUserEmailHash":"b09638619aecc2747c2e9d321696ea5b"}
[analytics] shutdown
```

## Log only client build success path

Relevant analytics and build success logs:
```
[analytics] disabled via CHROMATIC_DISABLE_ANALYTICS, using log-only client
✖ Found 1 visual change
[analytics] shutdown
```

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>16.5.1--canary.1281.24788887488.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@16.5.1--canary.1281.24788887488.0
  # or 
  yarn add chromatic@16.5.1--canary.1281.24788887488.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
