### PR TITLE
[WFL-208] Extract `refs` field from Storybook and pass when announcing build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,7 +27,3 @@ storybook-out
 coverage
 package.json.backup
 tests-file.xml
-
-# Compound Engineering plugin artifacts - not needed in repo
-docs/plans
-docs/brainstorms

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,7 @@ storybook-out
 coverage
 package.json.backup
 tests-file.xml
+
+# Compound Engineering plugin artifacts - not needed in repo
+docs/plans
+docs/brainstorms

--- a/node-src/lib/getStorybookMetadata.ts
+++ b/node-src/lib/getStorybookMetadata.ts
@@ -166,7 +166,10 @@ export const findBuilder = async (mainConfig, v7) => {
   ]);
 };
 
-export const findReferences = async (mainConfig, v7) => {
+// Only used by Chromatic - surfaces Storybook refs and is used when announcing a build.
+// The refs consumed by the MCP Addon for hosted Storybooks with composition on Chromatic.
+const findReferences = async (mainConfig, v7) => {
+  // The MCP Addon was first added within version 9; there is no need to check for older versions
   if (!mainConfig || !v7) {
     return {};
   }

--- a/node-src/lib/getStorybookMetadata.ts
+++ b/node-src/lib/getStorybookMetadata.ts
@@ -166,7 +166,6 @@ export const findBuilder = async (mainConfig, v7) => {
   ]);
 };
 
-// TODO: Remove this when we start tracking refs within the project.json file (will be redundant)
 // Only used by Chromatic - surfaces Storybook refs and is used when announcing a build.
 // The refs are consumed by the MCP Addon for hosted Storybooks with composition on Chromatic.
 const findReferences = async (mainConfig, v7) => {

--- a/node-src/lib/getStorybookMetadata.ts
+++ b/node-src/lib/getStorybookMetadata.ts
@@ -166,13 +166,13 @@ export const findBuilder = async (mainConfig, v7) => {
   ]);
 };
 
-export const findRefs = async (mainConfig, v7) => {
+export const findReferences = async (mainConfig, v7) => {
   if (!mainConfig || !v7) {
     return {};
   }
 
-  const refs = mainConfig.getSafeFieldValue(['refs']);
-  return refs ? { refs } : {};
+  const references = mainConfig.getSafeFieldValue(['refs']);
+  return references ? { refs: references } : {};
 };
 
 export const findStorybookConfigFile = async (ctx: Context, pattern: RegExp) => {
@@ -212,7 +212,7 @@ export const getStorybookMetadata = async (ctx: Context) => {
     findConfigFlags(ctx),
     findStorybookVersion(ctx),
     findBuilder(mainConfig, v7),
-    findRefs(mainConfig, v7),
+    findReferences(mainConfig, v7),
   ]);
 
   ctx.log.debug(info);

--- a/node-src/lib/getStorybookMetadata.ts
+++ b/node-src/lib/getStorybookMetadata.ts
@@ -166,6 +166,15 @@ export const findBuilder = async (mainConfig, v7) => {
   ]);
 };
 
+export const findRefs = async (mainConfig, v7) => {
+  if (!mainConfig || !v7) {
+    return {};
+  }
+
+  const refs = mainConfig.getSafeFieldValue(['refs']);
+  return refs ? { refs } : {};
+};
+
 export const findStorybookConfigFile = async (ctx: Context, pattern: RegExp) => {
   const configDirectory = ctx.options.storybookConfigDir ?? '.storybook';
   const files = await readdir(configDirectory);
@@ -203,6 +212,7 @@ export const getStorybookMetadata = async (ctx: Context) => {
     findConfigFlags(ctx),
     findStorybookVersion(ctx),
     findBuilder(mainConfig, v7),
+    findRefs(mainConfig, v7),
   ]);
 
   ctx.log.debug(info);

--- a/node-src/lib/getStorybookMetadata.ts
+++ b/node-src/lib/getStorybookMetadata.ts
@@ -166,8 +166,9 @@ export const findBuilder = async (mainConfig, v7) => {
   ]);
 };
 
+// TODO: Remove this when we start tracking refs within the project.json file (will be redundant)
 // Only used by Chromatic - surfaces Storybook refs and is used when announcing a build.
-// The refs consumed by the MCP Addon for hosted Storybooks with composition on Chromatic.
+// The refs are consumed by the MCP Addon for hosted Storybooks with composition on Chromatic.
 const findReferences = async (mainConfig, v7) => {
   // The MCP Addon was first added within version 9; there is no need to check for older versions
   if (!mainConfig || !v7) {

--- a/node-src/lib/getStorybookMetadata.ts
+++ b/node-src/lib/getStorybookMetadata.ts
@@ -166,6 +166,7 @@ export const findBuilder = async (mainConfig, v7) => {
   ]);
 };
 
+// TODO: Update this when we start tracking refs within the project.json file; if refs are tracked there, we can skip this logic
 // Only used by Chromatic - surfaces Storybook refs and is used when announcing a build.
 // The refs are consumed by the MCP Addon for hosted Storybooks with composition on Chromatic.
 const findReferences = async (mainConfig, v7) => {

--- a/node-src/tasks/initialize.test.ts
+++ b/node-src/tasks/initialize.test.ts
@@ -141,6 +141,7 @@ describe('announceBuild', () => {
           packageVersion: ctx.pkg.version,
           rebuildForBuildId: undefined,
           storybookAddons: ctx.storybook.addons,
+          storybookRefs: ctx.storybook.refs,
           storybookVersion: ctx.storybook.version,
           projectMetadata: {
             storybookBaseDir: '',

--- a/node-src/tasks/initialize.test.ts
+++ b/node-src/tasks/initialize.test.ts
@@ -105,7 +105,14 @@ describe('announceBuild', () => {
     environment: ':environment',
     git: { version: 'whatever', matchesBranch: () => false, committedAt: 0 },
     pkg: { version: '1.0.0' },
-    storybook: { baseDir: '', version: '2.0.0', addons: [] },
+    storybook: {
+      baseDir: '',
+      version: '2.0.0',
+      addons: [],
+      refs: {
+        design: { title: 'Design System', url: 'https://design.example.com' },
+      },
+    },
     runtimeMetadata: {
       nodePlatform: 'darwin',
       nodeVersion: '18.12.1',

--- a/node-src/tasks/initialize.ts
+++ b/node-src/tasks/initialize.ts
@@ -110,6 +110,7 @@ const announceBuildInput = (ctx: Context) => {
     ...ctx.runtimeMetadata,
     rebuildForBuildId,
     storybookAddons: ctx.storybook.addons,
+    storybookRefs: ctx.storybook.refs,
     storybookVersion: ctx.storybook.version,
     projectMetadata: {
       ...ctx.projectMetadata,

--- a/node-src/types.ts
+++ b/node-src/types.ts
@@ -150,6 +150,18 @@ export interface Options extends Configuration {
   skipUpdateCheck: Flags['skipUpdateCheck'];
 }
 
+interface StorybookReferenceConfig {
+  title: string;
+  url: string;
+  expanded?: boolean;
+  sourceUrl?: string;
+}
+
+type StorybookReference =
+  | StorybookReferenceConfig
+  | ((config: StorybookReferenceConfig & { sourceUrl: string }) => StorybookReferenceConfig)
+  | { disable: boolean };
+
 export type TaskName =
   | 'auth'
   | 'gitInfo'
@@ -250,7 +262,7 @@ export interface Context {
       packageVersion?: string;
     };
     mainConfigFilePath?: string;
-    refs?: Record<string, unknown>;
+    refs?: Record<string, StorybookReference>;
   };
   projectMetadata: {
     hasRouter?: boolean;

--- a/node-src/types.ts
+++ b/node-src/types.ts
@@ -250,6 +250,7 @@ export interface Context {
       packageVersion?: string;
     };
     mainConfigFilePath?: string;
+    refs?: Record<string, unknown>;
   };
   projectMetadata: {
     hasRouter?: boolean;


### PR DESCRIPTION
## Summary

Extract the `refs` configuration when announcing a build and pass it to Chromatic.

This is necessary for supporting composed Storybooks' MCP servers hosted on Chromatic.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>16.6.0--canary.1283.24742543830.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@16.6.0--canary.1283.24742543830.0
  # or 
  yarn add chromatic@16.6.0--canary.1283.24742543830.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
