### PR TITLE
Add account ID to announce build mutation

### DIFF
--- a/node-src/index.test.ts
+++ b/node-src/index.test.ts
@@ -104,6 +104,7 @@ vi.mock('node-fetch', () => ({
               status: 'ANNOUNCED',
               app: {
                 turboSnapAvailability: 'APPLIED',
+                account: { id: 'account-id' },
               },
             },
           },

--- a/node-src/tasks/initialize.test.ts
+++ b/node-src/tasks/initialize.test.ts
@@ -119,7 +119,7 @@ describe('announceBuild', () => {
       number: 1,
       status: 'ANNOUNCED',
       id: 'announced-build-id',
-      app: { id: 'announced-build-app-id' },
+      app: { id: 'announced-build-app-id', account: { id: 'account-id' } },
     };
     const client = { runQuery: vi.fn() };
     client.runQuery.mockReturnValue({ announceBuild: build });

--- a/node-src/tasks/initialize.ts
+++ b/node-src/tasks/initialize.ts
@@ -26,6 +26,9 @@ const AnnounceBuildMutation = `
       app {
         id
         turboSnapAvailability
+        account {
+          id
+        }
       }
     }
   }

--- a/node-src/types.ts
+++ b/node-src/types.ts
@@ -274,6 +274,9 @@ export interface Context {
     app: {
       id: string;
       turboSnapAvailability: string;
+      account: {
+        id: string;
+      };
     };
   };
   build: {


### PR DESCRIPTION
> [!NOTE]
> This is merging into a feature branch for the full analytics feature.

# Description

Adds account ID to the return value from the announce build mutation. We will be grouping analytics by this value, so we need to fetch it here to initialize the analytics client.

# Manual QA

Canary build works:
<img width="2532" height="1002" alt="CleanShot 2026-04-15 at 09 31 11@2x" src="https://github.com/user-attachments/assets/d1605d60-4169-41f2-ae8f-e4b4773679db" />

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>16.3.1--canary.1285.24456785440.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@16.3.1--canary.1285.24456785440.0
  # or 
  yarn add chromatic@16.3.1--canary.1285.24456785440.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
