### PR TITLE
Implement analytics interface and implementations

### DIFF
--- a/node-src/index.ts
+++ b/node-src/index.ts
@@ -276,6 +276,13 @@ async function runBuild(ctx: Context) {
       }
 
       ctx.log.flush();
+
+      try {
+        await ctx.analytics?.shutdown();
+      } catch (error) {
+        // Analytics shutdown should never crash the CLI, but we want to know about it
+        Sentry.captureException(error);
+      }
     }
   } catch (error) {
     const errors = [error].flat(); // GraphQLClient might throw an array of errors

--- a/node-src/lib/analytics/index.test.ts
+++ b/node-src/lib/analytics/index.test.ts
@@ -1,0 +1,32 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import TestLogger from '../testLogger';
+import { createAnalyticsClient } from './index';
+import { IndexAnalyticsClient } from './indexClient';
+import { LogOnlyAnalyticsClient } from './logOnly';
+
+function makeContext() {
+  return {
+    log: new TestLogger(),
+    client: { runQuery: vi.fn() },
+  } as any;
+}
+
+describe('createAnalyticsClient', () => {
+  afterEach(() => {
+    delete process.env.CHROMATIC_DISABLE_ANALYTICS;
+  });
+
+  it('returns an Index client when CHROMATIC_DISABLE_ANALYTICS is not set', () => {
+    const ctx = makeContext();
+    const client = createAnalyticsClient(ctx);
+    expect(client).toBeInstanceOf(IndexAnalyticsClient);
+  });
+
+  it('returns a log-only client when CHROMATIC_DISABLE_ANALYTICS is set', () => {
+    process.env.CHROMATIC_DISABLE_ANALYTICS = 'true';
+    const ctx = makeContext();
+    const client = createAnalyticsClient(ctx);
+    expect(client).toBeInstanceOf(LogOnlyAnalyticsClient);
+  });
+});

--- a/node-src/lib/analytics/index.ts
+++ b/node-src/lib/analytics/index.ts
@@ -1,0 +1,23 @@
+import { Context } from '../../types';
+import { IndexAnalyticsClient } from './indexClient';
+import { LogOnlyAnalyticsClient } from './logOnly';
+import type { AnalyticsClient } from './types';
+
+export type { AnalyticsClient } from './types';
+
+/**
+ * Creates an analytics client.
+ *
+ * @param ctx The context set when executing the CLI.
+ *
+ * @returns An analytics client instance.
+ */
+export function createAnalyticsClient(ctx: Context): AnalyticsClient {
+  if (process.env.CHROMATIC_DISABLE_ANALYTICS === 'true') {
+    ctx.log.debug('[analytics] disabled via CHROMATIC_DISABLE_ANALYTICS, using log-only client');
+    return new LogOnlyAnalyticsClient(ctx.log);
+  }
+
+  ctx.log.debug('[analytics] initializing Index analytics client');
+  return new IndexAnalyticsClient({ client: ctx.client, logger: ctx.log });
+}

--- a/node-src/lib/analytics/indexClient.test.ts
+++ b/node-src/lib/analytics/indexClient.test.ts
@@ -1,0 +1,102 @@
+import * as Sentry from '@sentry/node';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import TestLogger from '../testLogger';
+import { IndexAnalyticsClient } from './indexClient';
+
+vi.mock('@sentry/node', () => ({
+  captureException: vi.fn(),
+}));
+
+function makeClient(runQuery = vi.fn().mockResolvedValue({ trackEvent: { success: true } })) {
+  const gqlClient = { runQuery } as any;
+  const logger = new TestLogger();
+  const client = new IndexAnalyticsClient({ client: gqlClient, logger });
+  return { client, gqlClient, logger, runQuery };
+}
+
+describe('IndexAnalyticsClient', () => {
+  beforeEach(() => {
+    vi.mocked(Sentry.captureException).mockClear();
+  });
+
+  describe('trackEvent', () => {
+    it('calls runQuery with TrackCLITelemetryEvent mutation and input built from properties', () => {
+      const { client, runQuery } = makeClient();
+
+      client.trackEvent('CLI_STORYBOOK_BUILD_FAILED', {
+        errorCategory: 'storybook_build_failed',
+      });
+
+      expect(runQuery).toHaveBeenCalledWith(
+        expect.stringMatching(/TrackCLITelemetryEvent/),
+        {
+          input: {
+            event: 'CLI_STORYBOOK_BUILD_FAILED',
+            properties: { errorCategory: 'storybook_build_failed' },
+          },
+        },
+        { retries: 0 }
+      );
+    });
+
+    it('swallows GQL errors and reports to Sentry', async () => {
+      const error = new Error('GQL failed');
+      const { client } = makeClient(vi.fn().mockRejectedValue(error));
+
+      expect(() => client.trackEvent('some-event', {})).not.toThrow();
+
+      await client.shutdown();
+
+      expect(Sentry.captureException).toHaveBeenCalledWith(error);
+    });
+  });
+
+  describe('shutdown', () => {
+    it('awaits all pending in-flight requests', async () => {
+      const resolvers: (() => void)[] = [];
+      const runQuery = vi.fn(
+        () =>
+          new Promise((resolve) => {
+            resolvers.push(() => resolve({ trackEvent: { success: true } }));
+          })
+      );
+      const { client } = makeClient(runQuery);
+
+      client.trackEvent('event-1', {});
+      client.trackEvent('event-2', {});
+
+      let resolved = false;
+      const shutdownPromise = client.shutdown().then(() => {
+        resolved = true;
+      });
+
+      // Task flush: force `.then(() => resolved = true)` above to fire if `shutdown` has returned already resolved promise
+      await Promise.resolve();
+      expect(resolved).toBe(false);
+
+      for (const resolve of resolvers) resolve();
+      await shutdownPromise;
+      expect(resolved).toBe(true);
+    });
+
+    it('times out after 5s when requests hang', async () => {
+      vi.useFakeTimers();
+      try {
+        const runQuery = vi.fn(() => new Promise(() => {}));
+        const { client, logger } = makeClient(runQuery);
+
+        client.trackEvent('event-1', {});
+
+        const shutdownPromise = client.shutdown();
+        vi.advanceTimersByTime(5000);
+        await shutdownPromise;
+        expect(logger.debug).toHaveBeenCalledWith(
+          '[analytics] shutdown timed out before all events flushed'
+        );
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+  });
+});

--- a/node-src/lib/analytics/indexClient.ts
+++ b/node-src/lib/analytics/indexClient.ts
@@ -1,0 +1,67 @@
+import * as Sentry from '@sentry/node';
+
+import GraphQLClient from '../../io/graphqlClient';
+import { Logger } from '../log';
+import type { AnalyticsClient } from './types';
+
+const TrackCLITelemetryEventMutation = `
+  mutation TrackCLITelemetryEvent($input: TrackCLITelemetryEventInput!) {
+    trackCLITelemetryEvent(input: $input)
+  }
+`;
+
+const SHUTDOWN_TIMEOUT_MS = 5000;
+
+interface IndexAnalyticsOptions {
+  client: GraphQLClient;
+  logger: Logger;
+}
+
+/** Analytics client that sends events to the Chromatic Index via GraphQL. */
+export class IndexAnalyticsClient implements AnalyticsClient {
+  private client: GraphQLClient;
+  private logger: Logger;
+  private pending: Promise<unknown>[] = [];
+
+  constructor({ client, logger }: IndexAnalyticsOptions) {
+    this.client = client;
+    this.logger = logger;
+  }
+
+  trackEvent(eventName: string, properties?: Record<string, unknown>): void {
+    this.logger.debug(`[analytics] trackEvent: ${eventName}`, JSON.stringify(properties));
+
+    const input = { event: eventName, properties };
+
+    const promise = this.client
+      // Sending analytics is best effort, so we'll skip retries to keep things fast
+      .runQuery(TrackCLITelemetryEventMutation, { input }, { retries: 0 })
+      .catch((err) => {
+        this.logger.debug('[analytics] trackEvent failed', err);
+        Sentry.captureException(err);
+      });
+
+    this.pending.push(promise);
+  }
+
+  async shutdown(): Promise<void> {
+    // Currently no cap on the number of pending events. YAGNI. Will add batching/capping later if it becomes an issue.
+    this.logger.debug(`[analytics] shutdown: flushing ${this.pending.length} pending event(s)`);
+
+    let timeoutId: ReturnType<typeof setTimeout> | undefined;
+    const timeout = new Promise<void>((resolve) => {
+      timeoutId = setTimeout(() => {
+        this.logger.debug('[analytics] shutdown timed out before all events flushed');
+        resolve();
+      }, SHUTDOWN_TIMEOUT_MS);
+    });
+
+    await Promise.race([
+      Promise.all(this.pending).then(() => {
+        this.logger.debug('[analytics] shutdown: finished flushing pending events');
+      }),
+      timeout,
+    ]);
+    if (timeoutId) clearTimeout(timeoutId);
+  }
+}

--- a/node-src/lib/analytics/logOnly.test.ts
+++ b/node-src/lib/analytics/logOnly.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+
+import TestLogger from '../testLogger';
+import { LogOnlyAnalyticsClient } from './logOnly';
+
+describe('LogOnlyAnalyticsClient', () => {
+  it('debug-logs tracked events with properties', () => {
+    const logger = new TestLogger();
+    const client = new LogOnlyAnalyticsClient(logger);
+
+    const properties = { errorCategory: 'storybook_build_failed' };
+    client.trackEvent('CLI_STORYBOOK_BUILD_FAILED', properties);
+
+    expect(logger.debug).toHaveBeenCalledWith(
+      expect.stringContaining('CLI_STORYBOOK_BUILD_FAILED'),
+      JSON.stringify(properties)
+    );
+  });
+});

--- a/node-src/lib/analytics/logOnly.ts
+++ b/node-src/lib/analytics/logOnly.ts
@@ -1,0 +1,19 @@
+import { Logger } from '../log';
+import type { AnalyticsClient } from './types';
+
+/** Analytics client that debug-logs events. */
+export class LogOnlyAnalyticsClient implements AnalyticsClient {
+  private logger: Logger;
+
+  constructor(logger: Logger) {
+    this.logger = logger;
+  }
+
+  trackEvent(eventName: string, properties?: Record<string, unknown>): void {
+    this.logger.debug(`[analytics] trackEvent: ${eventName}`, JSON.stringify(properties));
+  }
+
+  async shutdown(): Promise<void> {
+    this.logger.debug('[analytics] shutdown');
+  }
+}

--- a/node-src/lib/analytics/types.ts
+++ b/node-src/lib/analytics/types.ts
@@ -1,0 +1,4 @@
+export interface AnalyticsClient {
+  trackEvent(eventName: string, properties?: Record<string, unknown>): void;
+  shutdown(): Promise<void>;
+}

--- a/node-src/tasks/initialize.ts
+++ b/node-src/tasks/initialize.ts
@@ -1,5 +1,6 @@
 import * as Sentry from '@sentry/node';
 
+import { createAnalyticsClient } from '../lib/analytics';
 import { emailHash } from '../lib/emailHash';
 import { getPackageManagerName, getPackageManagerVersion } from '../lib/getPackageManager';
 import { createTask, transitionTo } from '../lib/tasks';
@@ -163,6 +164,15 @@ function updateContextFromAnnouncedBuild(
 }
 
 /**
+ * Creates the analytics client and attaches it to the context.
+ *
+ * @param ctx The context set when executing the CLI.
+ */
+export const initializeAnalytics = async (ctx: Context) => {
+  ctx.analytics = createAnalyticsClient(ctx);
+};
+
+/**
  * Sets up the Listr task for announcing a new build on Chromatic.
  *
  * @param _ The context set when executing the CLI.
@@ -178,6 +188,7 @@ export default function main(_: Context) {
       transitionTo(pending),
       setEnvironment,
       setRuntimeMetadata,
+      initializeAnalytics,
       announceBuild,
       transitionTo(success, true),
     ],

--- a/node-src/types.ts
+++ b/node-src/types.ts
@@ -1,6 +1,7 @@
 import { InitialContext } from '.';
 import GraphQLClient from './io/graphqlClient';
 import HTTPClient from './io/httpClient';
+import type { AnalyticsClient } from './lib/analytics';
 import type { Configuration } from './lib/getConfiguration';
 import { Environment } from './lib/getEnvironment';
 import { Logger } from './lib/log';
@@ -201,6 +202,7 @@ export interface Context {
     packageManager?: 'npm' | 'pnpm' | 'yarn' | 'bun';
     packageManagerVersion?: string;
   };
+  analytics?: AnalyticsClient;
   environment?: Record<string, string>;
   reportPath?: string;
   isPublishOnly?: boolean;


### PR DESCRIPTION
> [!NOTE]
> This PR is merging into a feature branch for the entire analytics feature.

# Description

This PR adds the scaffolding for analytics, including:
1. An analytics client interface
2. An index analytics client implementation
3. A log-only analytics client implementation
4. Wiring into the CLI flow to initialize and then shutdown the analytics client

No analytics events are sent in this PR.

# Manual QA

Ran a build using the index client (this is against the PR deployment that contains the analytics mutation, though this isn't necessary, as we're not sending any events yet). Build was run with
```
CHROMATIC_INDEX_URL=https://chromatic-index-pr-11119.herokuapp.com \
LOG_LEVEL=debug \
npx -y chromatic@16.3.1--canary.1286.24682380091.0 \
  --project-token=chpt_e20c462beda1c89 \
  --force-rebuild \
  --no-interactive
```

The build succeeded, and the expected analytics logs were there:
```
14:11:56.609 [analytics] initializing Index analytics client
14:13:31.984 [analytics] shutdown: flushing 0 pending event(s)
14:13:31.984 [analytics] shutdown: finished flushing pending events
```

Then I ran another build using the log-only client, through the `CHROMATIC_DISABLE_ANALYTICS` env var:
```
CHROMATIC_DISABLE_ANALYTICS=true \
CHROMATIC_INDEX_URL=https://chromatic-index-pr-11119.herokuapp.com \
LOG_LEVEL=debug \
npx -y chromatic@16.3.1--canary.1286.24682380091.0 \
  --project-token=chpt_e20c462beda1c89 \
  --force-rebuild \
  --no-interactive
```

Build succeeded, expected logs were there:
```
14:14:15.469 [analytics] disabled via CHROMATIC_DISABLE_ANALYTICS, using log-only client
14:16:31.999 [analytics] shutdown
```

I also tested this with the follow-up PR that actually sends analytics events. I'll go into more detail in that PR's QA section, but I can confirm it works, data shows up in our analytics platform.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>16.3.1--canary.1286.24724933338.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@16.3.1--canary.1286.24724933338.0
  # or 
  yarn add chromatic@16.3.1--canary.1286.24724933338.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
