### PR TITLE
Add a React Native section to the config file

### DIFF
--- a/node-src/lib/getConfiguration.test.ts
+++ b/node-src/lib/getConfiguration.test.ts
@@ -350,3 +350,44 @@ describe('resolveConfigFileName', () => {
     }
   });
 });
+
+describe('reactNative config', () => {
+  it('accepts a valid reactNative config', async () => {
+    mockedReadFile.mockReturnValue(
+      JSON.stringify({
+        reactNative: {
+          iosBuildCommand: 'my-ios-build',
+          androidBuildCommand: 'my-android-build',
+        },
+      })
+    );
+
+    expect(await getConfiguration()).toMatchObject({
+      reactNative: {
+        iosBuildCommand: 'my-ios-build',
+        androidBuildCommand: 'my-android-build',
+      },
+    });
+  });
+
+  it('accepts a partial reactNative config', async () => {
+    mockedReadFile.mockReturnValue(
+      JSON.stringify({
+        reactNative: {
+          iosBuildCommand: 'my-ios-build',
+        },
+      })
+    );
+
+    expect(await getConfiguration()).toMatchObject({
+      reactNative: { iosBuildCommand: 'my-ios-build' },
+    });
+  });
+
+  it('accepts config without reactNative', async () => {
+    mockedReadFile.mockReturnValue(JSON.stringify({ projectId: 'project-id' }));
+
+    const config = await getConfiguration();
+    expect(config.reactNative).toBeUndefined();
+  });
+});

--- a/node-src/lib/getConfiguration.ts
+++ b/node-src/lib/getConfiguration.ts
@@ -44,6 +44,13 @@ const configurationSchema = z
     storybookLogFile: z.union([z.string(), z.boolean()]),
     logFile: z.union([z.string(), z.boolean()]),
     uploadMetadata: z.boolean(),
+
+    reactNative: z
+      .object({
+        iosBuildCommand: z.string(),
+        androidBuildCommand: z.string(),
+      })
+      .partial(),
   })
   .partial()
   .strict();


### PR DESCRIPTION
This will allow new config file options for React Native;

```
{
  "$schema": "https://www.chromatic.com/config-file.schema.json",
  "projectId": "Project:...",
  "reactNative": {
    "iosBuildCommand": "chromatic react-native-build --platform=ios",
    "androidBuildCommand": "chromatic react-native-build --platform=android"
  }
}
```

This change pending update to the schema, which I will cross-link the PR here.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>16.4.1--canary.1289.24734765458.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@16.4.1--canary.1289.24734765458.0
  # or 
  yarn add chromatic@16.4.1--canary.1289.24734765458.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
