### PR TITLE
Retry file upload if file deduplication fails

### DIFF
--- a/node-src/tasks/upload.test.ts
+++ b/node-src/tasks/upload.test.ts
@@ -880,6 +880,139 @@ describe('uploadStorybook', () => {
       );
     });
   });
+
+  describe('deduplication fallback', () => {
+    it('retries without hashes when sentinel wait fails, sending all files', async () => {
+      const client = { runQuery: vi.fn() };
+      client.runQuery.mockReturnValue({
+        uploadBuild: {
+          info: {
+            sentinelUrls: ['https://asdqwe.chromatic.com/sentinel.txt'],
+            targets: [
+              {
+                contentType: 'text/html',
+                filePath: 'iframe.html',
+                formAction: 'https://s3.amazonaws.com/presigned?iframe.html',
+                formFields: {},
+              },
+              {
+                contentType: 'text/html',
+                filePath: 'index.html',
+                formAction: 'https://s3.amazonaws.com/presigned?index.html',
+                formFields: {},
+              },
+            ],
+          },
+          userErrors: [],
+        },
+      });
+
+      createReadStreamMock.mockReturnValue({ pipe: vi.fn() } as any);
+      // First sentinel check fails, second succeeds (after fallback re-upload)
+      http.fetch
+        .mockReturnValueOnce({ ok: true }) // iframe.html upload (first attempt)
+        .mockReturnValueOnce({ ok: true }) // index.html upload (first attempt)
+        .mockReturnValueOnce({ text: () => Promise.resolve('ERROR') }) // sentinel fails (not OK)
+        .mockReturnValue({ ok: true, text: () => Promise.resolve('OK') }); // fallback uploads + sentinel
+
+      const fileInfo = {
+        lengths: [
+          { knownAs: 'iframe.html', contentLength: 42 },
+          { knownAs: 'index.html', contentLength: 42 },
+        ],
+        paths: ['iframe.html', 'index.html'],
+        hashes: { 'iframe.html': 'hash1', 'index.html': 'hash2' },
+        total: 84,
+      };
+      const ctx = {
+        client,
+        env: environment,
+        log: new TestLogger(),
+        http,
+        sourceDir: '/static/',
+        options: {},
+        fileInfo,
+        announcedBuild: { id: '1' },
+      } as any;
+      await uploadStorybook(ctx, {} as any);
+
+      // First attempt uses hashes
+      expect(client.runQuery).toHaveBeenNthCalledWith(
+        1,
+        expect.stringMatching(/UploadBuildMutation/),
+        {
+          buildId: '1',
+          files: [
+            { contentHash: 'hash1', contentLength: 42, filePath: 'iframe.html' },
+            { contentHash: 'hash2', contentLength: 42, filePath: 'index.html' },
+          ],
+        }
+      );
+
+      // Fallback attempt removes file deduplication hashes, causing all files to be re-uploaded
+      expect(client.runQuery).toHaveBeenNthCalledWith(
+        2,
+        expect.stringMatching(/UploadBuildMutation/),
+        {
+          buildId: '1',
+          files: [
+            { contentHash: undefined, contentLength: 42, filePath: 'iframe.html' },
+            { contentHash: undefined, contentLength: 42, filePath: 'index.html' },
+          ],
+        }
+      );
+
+      expect(client.runQuery).toHaveBeenCalledTimes(2);
+    });
+
+    it('resets uploadedBytes and uploadedFiles before fallback retry', async () => {
+      const client = { runQuery: vi.fn() };
+      client.runQuery.mockReturnValue({
+        uploadBuild: {
+          info: {
+            sentinelUrls: ['https://asdqwe.chromatic.com/sentinel.txt'],
+            targets: [
+              {
+                contentType: 'text/html',
+                filePath: 'iframe.html',
+                formAction: 'https://s3.amazonaws.com/presigned?iframe.html',
+                formFields: {},
+              },
+            ],
+          },
+          userErrors: [],
+        },
+      });
+
+      createReadStreamMock.mockReturnValue({ pipe: vi.fn() } as any);
+      http.fetch
+        .mockReturnValueOnce({ ok: true }) // iframe.html upload (first attempt)
+        .mockReturnValueOnce({ text: () => Promise.resolve('ERROR') }) // sentinel fails (not OK)
+        .mockReturnValue({ ok: true, text: () => Promise.resolve('OK') }); // fallback upload + sentinel
+
+      const fileInfo = {
+        lengths: [{ knownAs: 'iframe.html', contentLength: 42 }],
+        paths: ['iframe.html'],
+        hashes: { 'iframe.html': 'hash1' },
+        total: 42,
+      };
+      const ctx = {
+        client,
+        env: environment,
+        log: new TestLogger(),
+        http,
+        sourceDir: '/static/',
+        options: {},
+        fileInfo,
+        announcedBuild: { id: '1' },
+      } as any;
+      await uploadStorybook(ctx, {} as any);
+
+      // After fallback completes, counts reflect the retry upload only
+      expect(ctx.uploadedFiles).toBe(1);
+      expect(ctx.uploadedBytes).toBe(42);
+    });
+  });
 });
 
 describe('waitForSentinels', () => {

--- a/node-src/tasks/upload.ts
+++ b/node-src/tasks/upload.ts
@@ -6,6 +6,7 @@ import { throttle } from '../lib/utilities';
 import { waitForSentinel } from '../lib/waitForSentinel';
 import { Context, FileDesc, Task } from '../types';
 import sentinelFileErrors from '../ui/messages/errors/sentinelFileErrors';
+import deduplicationFailed from '../ui/messages/warnings/deduplicationFailed';
 import {
   dryRun,
   failed,
@@ -17,11 +18,9 @@ import {
   uploading,
 } from '../ui/tasks/upload';
 
-export const uploadStorybook = async (ctx: Context, task: Task) => {
-  if (ctx.skip) return;
-
+const buildFileList = (ctx: Context, withHashes: boolean): FileDesc[] => {
   const files = ctx.fileInfo?.paths.map<FileDesc>((filePath) => ({
-    ...(ctx.fileInfo?.hashes && { contentHash: ctx.fileInfo.hashes[filePath] }),
+    ...(withHashes && ctx.fileInfo?.hashes && { contentHash: ctx.fileInfo.hashes[filePath] }),
     contentLength:
       ctx.fileInfo?.lengths.find(({ knownAs }) => knownAs === filePath)?.contentLength ?? -1,
     localPath: path.join(ctx.sourceDir, filePath),
@@ -32,6 +31,10 @@ export const uploadStorybook = async (ctx: Context, task: Task) => {
     throw new Error(invalid(ctx).output);
   }
 
+  return files;
+};
+
+const runUploadAndWaitForSentinels = async (ctx: Context, task: Task, files: FileDesc[]) => {
   await uploadBuild(ctx, files, {
     onProgress: throttle(
       (progress, total) => {
@@ -46,6 +49,35 @@ export const uploadStorybook = async (ctx: Context, task: Task) => {
       throw path === error.message ? new Error(failed(ctx, { path }).output) : error;
     },
   });
+
+  if (!ctx.sentinelUrls?.length) return;
+
+  transitionTo(finalizing)(ctx, task);
+
+  // Dedupe sentinels, ignoring query params
+  const sentinels = Object.fromEntries(
+    ctx.sentinelUrls.map((url) => {
+      const { host, pathname } = new URL(url);
+      return [host + pathname, { name: pathname.split('/').at(-1) || '', url }];
+    })
+  );
+
+  await Promise.all(Object.values(sentinels).map((sentinel) => waitForSentinel(ctx, sentinel)));
+};
+
+export const uploadStorybook = async (ctx: Context, task: Task) => {
+  if (ctx.skip) return;
+
+  try {
+    await runUploadAndWaitForSentinels(ctx, task, buildFileList(ctx, true));
+  } catch {
+    ctx.log.warn(deduplicationFailed());
+    // Retry without file deduplication ensuring we reset fields for a new upload
+    ctx.sentinelUrls = [];
+    ctx.uploadedBytes = 0;
+    ctx.uploadedFiles = 0;
+    await runUploadAndWaitForSentinels(ctx, task, buildFileList(ctx, false));
+  }
 };
 
 export const waitForSentinels = async (ctx: Context, task: Task) => {
@@ -84,6 +116,6 @@ export default function main(ctx: Context) {
       if (ctx.options.dryRun) return dryRun(ctx).output;
       return false;
     },
-    steps: [transitionTo(starting), uploadStorybook, waitForSentinels, transitionTo(success, true)],
+    steps: [transitionTo(starting), uploadStorybook, transitionTo(success, true)],
   });
 }

--- a/node-src/ui/messages/warnings/deduplicationFailed.stories.ts
+++ b/node-src/ui/messages/warnings/deduplicationFailed.stories.ts
@@ -1,0 +1,7 @@
+import deduplicationFailed from './deduplicationFailed';
+
+export default {
+  title: 'CLI/Messages/Warnings',
+};
+
+export const DeduplicationFailed = () => deduplicationFailed();

--- a/node-src/ui/messages/warnings/deduplicationFailed.ts
+++ b/node-src/ui/messages/warnings/deduplicationFailed.ts
@@ -1,0 +1,11 @@
+import chalk from 'chalk';
+import { dedent } from 'ts-dedent';
+
+import { warning } from '../../components/icons';
+
+export default () =>
+  dedent(chalk`
+    ${warning} {bold Deduplication failed, falling back to uploading all files}
+    An error occurred while waiting for the server to deduplicate files.
+    Retrying the upload without deduplication.
+  `);


### PR DESCRIPTION
If file deduplication fails for any reason, it fails the build entirely. This changes that logic to retry the upload without file deduplication since it's not a requirement for a build to work.

Tested with:
- With `--zip` and without `--zip`
- If it fails to upload ANY files from the backend
- If it fails to upload after successfully uploading a single file from the backend
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>16.6.4--canary.1296.25130401709.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@16.6.4--canary.1296.25130401709.0
  # or 
  yarn add chromatic@16.6.4--canary.1296.25130401709.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
