### PR TITLE
Scaffold out ports skeleton and implement git port

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -255,6 +255,58 @@ export default [
       ],
     },
   },
+  // context god object refactor: nudge direct imports of to-be-ported external modules
+  // through `ctx.ports`. Permissive (warn) today; each port-extraction PR tightens
+  // its own module to `error` and adds adapter-path exceptions.
+  {
+    files: ['**/*.ts', '**/*.js'],
+    rules: {
+      'no-restricted-imports': [
+        'warn',
+        {
+          paths: [
+            {
+              name: 'execa',
+              message:
+                'Prefer ctx.ports.proc / ctx.ports.git once extracted.',
+            },
+            {
+              name: 'fs',
+              message: 'Prefer ctx.ports.fs once extracted.',
+            },
+            {
+              name: 'fs/promises',
+              message: 'Prefer ctx.ports.fs once extracted.',
+            },
+            {
+              name: 'tmp-promise',
+              message: 'Prefer ctx.ports.fs.mkdtemp once extracted.',
+            },
+            {
+              name: '@sentry/node',
+              message: 'Prefer ctx.ports.errors once extracted.',
+            },
+            {
+              name: 'pino',
+              message: 'Prefer ctx.ports.log once extracted.',
+            },
+            {
+              name: 'snyk-nodejs-lockfile-parser',
+              message: 'Prefer ctx.ports.tracer once extracted.',
+            },
+            {
+              name: 'listr',
+              message: 'Prefer ctx.ports.ui once extracted.',
+            },
+            {
+              name: 'listr2',
+              message: 'Prefer ctx.ports.ui once extracted.',
+            },
+          ],
+        },
+      ],
+    },
+  },
   // exceptions for files stuck in CJS for now
   {
     files: ['**/*.cjs'],

--- a/node-src/index.ts
+++ b/node-src/index.ts
@@ -134,7 +134,7 @@ export async function run({
     env: environment,
     log,
     sessionId,
-    ports: createDefaultPorts(),
+    ports: createDefaultPorts({ log }),
   };
 
   await runAll(ctx);

--- a/node-src/index.ts
+++ b/node-src/index.ts
@@ -26,6 +26,7 @@ import { createLogger } from './lib/log';
 import LoggingRenderer from './lib/loggingRenderer';
 import NonTTYRenderer from './lib/nonTTYRenderer';
 import parseArguments from './lib/parseArguments';
+import { createDefaultPorts } from './lib/ports';
 import { exitCodes, setExitCode } from './lib/setExitCode';
 import { uploadMetadataFiles } from './lib/uploadMetadataFiles';
 import { rewriteErrorMessage } from './lib/utilities';
@@ -77,6 +78,7 @@ export type InitialContext = Omit<
     | 'env'
     | 'log'
     | 'sessionId'
+    | 'ports'
   >,
   'options'
 >;
@@ -132,6 +134,7 @@ export async function run({
     env: environment,
     log,
     sessionId,
+    ports: createDefaultPorts(),
   };
 
   await runAll(ctx);

--- a/node-src/lib/ports/git.ts
+++ b/node-src/lib/ports/git.ts
@@ -1,0 +1,119 @@
+/** Shape of one commit as returned by {@link GitRepository.commit}. */
+export interface GitCommitInfo {
+  commit: string;
+  committedAt: number;
+  committerEmail: string | undefined;
+  committerName: string | undefined;
+}
+
+/** Options for the raw escape-hatch {@link GitRepository.execCommand}. */
+export interface ExecCommandOptions {
+  timeout?: number;
+}
+
+/**
+ * Semantic boundary over the git shell. Production callers use the shell
+ * adapter; tests use the in-memory adapter.
+ */
+export interface GitRepository {
+  /** Returns the git version string (e.g. `'2.39.5'`). */
+  version(): Promise<string | undefined>;
+
+  /** Returns the configured user email, or undefined when unset. */
+  userEmail(): Promise<string | undefined>;
+
+  /** Returns the `ownername/reponame` slug derived from origin remote URL. */
+  slug(): Promise<string | undefined>;
+
+  /**
+   * Returns commit info for the given revision (defaults to HEAD).
+   *
+   * @param revision A git revision spec (commit SHA, branch, tag). Omit for HEAD.
+   */
+  commit(revision?: string): Promise<GitCommitInfo>;
+
+  /** Returns the current branch name, or `'HEAD'` when detached. */
+  branch(): Promise<string>;
+
+  /** Returns a hash covering all uncommitted changes, or empty when clean. */
+  uncommittedHash(): Promise<string | undefined>;
+
+  /** Returns true when the current commit has a parent. */
+  hasPreviousCommit(): Promise<boolean>;
+
+  /** Returns true when the given SHA exists in the repository. */
+  commitExists(commit: string): Promise<boolean>;
+
+  /**
+   * Returns files changed between two commits. An empty `headCommit` includes
+   * uncommitted changes on top of `baseCommit`.
+   */
+  changedFiles(baseCommit: string, headCommit?: string): Promise<string[] | undefined>;
+
+  /** Returns true when the workspace matches the upstream remote. */
+  isUpToDate(): Promise<boolean>;
+
+  /** Returns true when the workspace has no staged, unstaged, or untracked changes. */
+  isClean(): Promise<boolean>;
+
+  /** Returns the portion of `git status` describing remote divergence. */
+  getUpdateMessage(): Promise<string | undefined>;
+
+  /** Returns the best common ancestor commit of `head` and `base`. */
+  findMergeBase(head: string, base: string): Promise<string | undefined>;
+
+  /** Checks out the given reference. */
+  checkout(reference: string): Promise<string | undefined>;
+
+  /** Checks a single file out of `reference` into a temporary file. */
+  checkoutFile(reference: string, fileName: string, tmpdir: string): Promise<string>;
+
+  /** Checks out the previous branch (equivalent to `git checkout -`). */
+  checkoutPrevious(): Promise<string | undefined>;
+
+  /** Discards any pending changes (`git reset --hard`). */
+  discardChanges(): Promise<string | undefined>;
+
+  /** Returns the absolute path of the repository root. */
+  repositoryRoot(): Promise<string | undefined>;
+
+  /**
+   * Returns repository-root-relative filenames matching the given patterns.
+   *
+   * @param repoRoot The absolute repository root path.
+   * @param patterns Glob patterns, resolved against `repoRoot`.
+   */
+  findFilesFromRepositoryRoot(
+    repoRoot: string,
+    ...patterns: string[]
+  ): Promise<string[] | undefined>;
+
+  /** Returns the first-ever commit's date, or undefined when unavailable. */
+  repositoryCreationDate(): Promise<Date | undefined>;
+
+  /** Returns the first commit date that touched `configDirectory`, or undefined. */
+  storybookCreationDate(configDirectory: string): Promise<Date | undefined>;
+
+  /** Returns the number of unique committers in the last 6 months. */
+  committerCount(): Promise<number | undefined>;
+
+  /**
+   * Returns the count of tracked files matching any of the name/extension pairs.
+   * Names are matched with both leading-lowercase and leading-uppercase forms.
+   *
+   * @param nameMatches Substrings to match anywhere in the filename.
+   * @param extensions Filename extensions, without the leading dot.
+   */
+  committedFileCount(nameMatches: string[], extensions: string[]): Promise<number | undefined>;
+
+  /**
+   * Escape hatch for git commands not covered by a semantic method. Used by
+   * graph-walking code (parent commits, package-file diffs) that composes
+   * multiple arbitrary git invocations. Prefer a semantic method when adding
+   * new callers.
+   *
+   * @param command The full shell command.
+   * @param options Execa-style options (timeout, etc.).
+   */
+  execCommand(command: string, options?: ExecCommandOptions): Promise<string | undefined>;
+}

--- a/node-src/lib/ports/gitContract.test.ts
+++ b/node-src/lib/ports/gitContract.test.ts
@@ -1,0 +1,326 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import * as execGit from '../../git/execGit';
+import TestLogger from '../testLogger';
+import { GitCommitInfo, GitRepository } from './git';
+import { createInMemoryGitAdapter, InMemoryGitState } from './gitInMemoryAdapter';
+import { createShellGitAdapter } from './gitShellAdapter';
+
+vi.mock('../../git/execGit');
+const execGitCommand = vi.mocked(execGit.execGitCommand);
+const execGitCommandOneLine = vi.mocked(execGit.execGitCommandOneLine);
+const execGitCommandCountLines = vi.mocked(execGit.execGitCommandCountLines);
+
+const log = new TestLogger();
+
+/**
+ * A semantic primer over a GitRepository. Each method primes the underlying
+ * adapter so that a subsequent call returns the described value. The shell
+ * adapter is primed by configuring `execGit` mocks; the in-memory adapter is
+ * primed by mutating its state.
+ */
+interface AdapterSetup {
+  adapter: GitRepository;
+  primeVersion: (version: string) => void;
+  primeUserEmail: (email: string | undefined) => void;
+  primeSlug: (origin: string, expected: string | undefined) => void;
+  primeCommit: (revision: string | undefined, info: GitCommitInfo) => void;
+  primeBranch: (branch: string) => void;
+  primeUncommittedHash: (hash: string | undefined) => void;
+  primeHasPreviousCommit: (hasParent: boolean) => void;
+  primeCommitExists: (commit: string, exists: boolean) => void;
+  primeChangedFiles: (base: string, head: string | undefined, files: string[]) => void;
+  primeIsUpToDate: (upToDate: boolean) => void;
+  primeIsClean: (clean: boolean) => void;
+  primeUpdateMessage: (status: string, expected: string) => void;
+  primeMergeBase: (head: string, base: string, mergeBase: string | undefined) => void;
+  primeRepositoryRoot: (root: string) => void;
+  primeFilesFromRoot: (root: string, patterns: string[], files: string[]) => void;
+  primeRepositoryCreationDate: (date: Date) => void;
+  primeStorybookCreationDate: (configDirectory: string, date: Date) => void;
+  primeCommitterCount: (count: number) => void;
+  primeCommittedFileCount: (names: string[], extensions: string[], count: number) => void;
+  primeExecCommand: (command: string, result: string) => void;
+}
+
+function commitLine(info: GitCommitInfo): string {
+  return `${info.commit} ## ${info.committedAt / 1000} ## ${info.committerEmail ?? ''} ## ${info.committerName ?? ''}`;
+}
+
+function shellSetup(): AdapterSetup {
+  const adapter = createShellGitAdapter({ log });
+
+  return {
+    adapter,
+    primeVersion: (version) =>
+      execGitCommand.mockResolvedValueOnce(`git version ${version} (Apple Git-154)`),
+    primeUserEmail: (email) => execGitCommand.mockResolvedValueOnce(email ?? ''),
+    primeSlug: (origin) => execGitCommand.mockResolvedValueOnce(origin),
+    primeCommit: (_revision, info) => execGitCommand.mockResolvedValueOnce(commitLine(info)),
+    primeBranch: (branch) => execGitCommand.mockResolvedValueOnce(branch),
+    primeUncommittedHash: (hash) => execGitCommand.mockResolvedValueOnce(hash ?? ''),
+    primeHasPreviousCommit: (hasParent) =>
+      execGitCommand.mockResolvedValueOnce(hasParent ? 'cafef00d\n' : ''),
+    primeCommitExists: (_commit, exists) => {
+      if (exists) {
+        execGitCommand.mockResolvedValueOnce('');
+      } else {
+        execGitCommand.mockRejectedValueOnce(new Error('bad object'));
+      }
+    },
+    primeChangedFiles: (_base, _head, files) =>
+      execGitCommand.mockResolvedValueOnce(files.join('\n')),
+    primeIsUpToDate: (upToDate) => {
+      execGitCommand.mockResolvedValueOnce(''); // git remote update
+      if (upToDate) {
+        execGitCommand.mockResolvedValueOnce('abc');
+        execGitCommand.mockResolvedValueOnce('abc');
+      } else {
+        execGitCommand.mockResolvedValueOnce('abc');
+        execGitCommand.mockResolvedValueOnce('def');
+      }
+    },
+    primeIsClean: (clean) => execGitCommand.mockResolvedValueOnce(clean ? '' : ' M file.ts'),
+    primeUpdateMessage: (status) => execGitCommand.mockResolvedValueOnce(status),
+    primeMergeBase: (_head, _base, mergeBase) =>
+      execGitCommand.mockResolvedValueOnce(mergeBase ?? ''),
+    primeRepositoryRoot: (root) => execGitCommand.mockResolvedValueOnce(root),
+    primeFilesFromRoot: (_root, _patterns, files) =>
+      execGitCommand.mockResolvedValueOnce(files.join('\0')),
+    primeRepositoryCreationDate: (date) =>
+      execGitCommandOneLine.mockResolvedValueOnce(date.toISOString()),
+    primeStorybookCreationDate: (_configDirectory, date) =>
+      execGitCommandOneLine.mockResolvedValueOnce(date.toISOString()),
+    primeCommitterCount: (count) => execGitCommandCountLines.mockResolvedValueOnce(count),
+    primeCommittedFileCount: (_names, _extensions, count) =>
+      execGitCommandCountLines.mockResolvedValueOnce(count),
+    primeExecCommand: (_command, result) => execGitCommand.mockResolvedValueOnce(result),
+  };
+}
+
+function inMemorySetup(): AdapterSetup {
+  const state: InMemoryGitState = { branch: 'main' };
+  const adapter = createInMemoryGitAdapter(state);
+
+  return {
+    adapter,
+    primeVersion: (version) => {
+      state.version = version;
+    },
+    primeUserEmail: (email) => {
+      state.userEmail = email;
+    },
+    primeSlug: (_origin, expected) => {
+      state.slug = expected;
+    },
+    primeCommit: (revision, info) => {
+      state.commits = { ...state.commits, [revision ?? '']: info };
+    },
+    primeBranch: (branch) => {
+      state.branch = branch;
+    },
+    primeUncommittedHash: (hash) => {
+      state.uncommittedHash = hash;
+    },
+    primeHasPreviousCommit: (hasParent) => {
+      state.hasPreviousCommit = hasParent;
+    },
+    primeCommitExists: (commit, exists) => {
+      state.existingCommits = new Set(state.existingCommits);
+      if (exists) state.existingCommits.add(commit);
+      else state.existingCommits.delete(commit);
+    },
+    primeChangedFiles: (base, head, files) => {
+      state.changedFilesByRange = {
+        ...state.changedFilesByRange,
+        [`${base}..${head ?? ''}`]: files,
+      };
+    },
+    primeIsUpToDate: (upToDate) => {
+      state.isUpToDate = upToDate;
+    },
+    primeIsClean: (clean) => {
+      state.isClean = clean;
+    },
+    primeUpdateMessage: (_status, expected) => {
+      state.updateMessage = expected;
+    },
+    primeMergeBase: (head, base, mergeBase) => {
+      state.mergeBases = { ...state.mergeBases, [`${head}..${base}`]: mergeBase };
+    },
+    primeRepositoryRoot: (root) => {
+      state.repositoryRoot = root;
+    },
+    primeFilesFromRoot: (root, patterns, files) => {
+      state.filesFromRoot = {
+        ...state.filesFromRoot,
+        [`${root}|${patterns.join(',')}`]: files,
+      };
+    },
+    primeRepositoryCreationDate: (date) => {
+      state.repositoryCreationDate = date;
+    },
+    primeStorybookCreationDate: (configDirectory, date) => {
+      state.storybookCreationDates = { ...state.storybookCreationDates, [configDirectory]: date };
+    },
+    primeCommitterCount: (count) => {
+      state.committerCount = count;
+    },
+    primeCommittedFileCount: (names, extensions, count) => {
+      state.committedFileCounts = {
+        ...state.committedFileCounts,
+        [`${names.join(',')}|${extensions.join(',')}`]: count,
+      };
+    },
+    primeExecCommand: (command, result) => {
+      state.execResponses = { ...state.execResponses, [command]: result };
+    },
+  };
+}
+
+const adapters = [
+  ['shell', shellSetup],
+  ['in-memory', inMemorySetup],
+] as const;
+
+describe.each(adapters)('GitRepository (%s)', (_name, makeSetup) => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns version', async () => {
+    const { adapter, primeVersion } = makeSetup();
+    primeVersion('2.39.5');
+    expect(await adapter.version()).toBe('2.39.5');
+  });
+
+  it('returns user email', async () => {
+    const { adapter, primeUserEmail } = makeSetup();
+    primeUserEmail('user@example.com');
+    expect(await adapter.userEmail()).toBe('user@example.com');
+  });
+
+  it('returns slug from origin URL', async () => {
+    const { adapter, primeSlug } = makeSetup();
+    primeSlug('git@github.com:chromaui/chromatic-cli.git', 'chromaui/chromatic-cli');
+    expect(await adapter.slug()).toBe('chromaui/chromatic-cli');
+  });
+
+  it('returns HEAD commit info', async () => {
+    const { adapter, primeCommit } = makeSetup();
+    const info: GitCommitInfo = {
+      commit: '19b6c9c5b3d34d9fc55627fcaf8a85bd5d5e5b2a',
+      committedAt: 1_696_588_814 * 1000,
+      committerEmail: 'info@ghengeveld.nl',
+      committerName: 'Gert Hengeveld',
+    };
+    primeCommit(undefined, info);
+    expect(await adapter.commit()).toEqual(info);
+  });
+
+  it('returns current branch', async () => {
+    const { adapter, primeBranch } = makeSetup();
+    primeBranch('feature/new-thing');
+    expect(await adapter.branch()).toBe('feature/new-thing');
+  });
+
+  it('returns uncommitted hash', async () => {
+    const { adapter, primeUncommittedHash } = makeSetup();
+    primeUncommittedHash('deadbeef');
+    expect(await adapter.uncommittedHash()).toBe('deadbeef');
+  });
+
+  it('reports whether HEAD has a previous commit', async () => {
+    const { adapter, primeHasPreviousCommit } = makeSetup();
+    primeHasPreviousCommit(true);
+    expect(await adapter.hasPreviousCommit()).toBe(true);
+  });
+
+  it('reports commit existence', async () => {
+    const { adapter, primeCommitExists } = makeSetup();
+    primeCommitExists('abc', true);
+    expect(await adapter.commitExists('abc')).toBe(true);
+  });
+
+  it('reports absent commits', async () => {
+    const { adapter, primeCommitExists } = makeSetup();
+    primeCommitExists('missing', false);
+    expect(await adapter.commitExists('missing')).toBe(false);
+  });
+
+  it('returns files changed between two commits', async () => {
+    const { adapter, primeChangedFiles } = makeSetup();
+    primeChangedFiles('abc', 'def', ['src/a.ts', 'src/b.ts']);
+    expect(await adapter.changedFiles('abc', 'def')).toEqual(['src/a.ts', 'src/b.ts']);
+  });
+
+  it('reports up-to-date state', async () => {
+    const { adapter, primeIsUpToDate } = makeSetup();
+    primeIsUpToDate(true);
+    expect(await adapter.isUpToDate()).toBe(true);
+  });
+
+  it('reports clean state', async () => {
+    const { adapter, primeIsClean } = makeSetup();
+    primeIsClean(true);
+    expect(await adapter.isClean()).toBe(true);
+  });
+
+  it('returns the update message', async () => {
+    const { adapter, primeUpdateMessage } = makeSetup();
+    primeUpdateMessage('On branch main\nYour branch is behind', 'Your branch is behind');
+    expect(await adapter.getUpdateMessage()).toBe('Your branch is behind');
+  });
+
+  it('returns a merge base between branches', async () => {
+    const { adapter, primeMergeBase } = makeSetup();
+    primeMergeBase('feature', 'main', 'abc');
+    expect(await adapter.findMergeBase('feature', 'main')).toBe('abc');
+  });
+
+  it('returns the repository root', async () => {
+    const { adapter, primeRepositoryRoot } = makeSetup();
+    primeRepositoryRoot('/workspace/repo');
+    expect(await adapter.repositoryRoot()).toBe('/workspace/repo');
+  });
+
+  it('returns files matching patterns from the repository root', async () => {
+    const { adapter, primeFilesFromRoot } = makeSetup();
+    primeFilesFromRoot('/repo', ['package.json'], ['/repo/package.json']);
+    expect(await adapter.findFilesFromRepositoryRoot('/repo', 'package.json')).toEqual([
+      '/repo/package.json',
+    ]);
+  });
+
+  it('returns the repository creation date', async () => {
+    const { adapter, primeRepositoryCreationDate } = makeSetup();
+    const date = new Date('2020-01-01T00:00:00.000Z');
+    primeRepositoryCreationDate(date);
+    expect(await adapter.repositoryCreationDate()).toEqual(date);
+  });
+
+  it('returns the storybook creation date for a config dir', async () => {
+    const { adapter, primeStorybookCreationDate } = makeSetup();
+    const date = new Date('2021-06-01T00:00:00.000Z');
+    primeStorybookCreationDate('.storybook', date);
+    expect(await adapter.storybookCreationDate('.storybook')).toEqual(date);
+  });
+
+  it('returns committer count for the last 6 months', async () => {
+    const { adapter, primeCommitterCount } = makeSetup();
+    primeCommitterCount(7);
+    expect(await adapter.committerCount()).toBe(7);
+  });
+
+  it('returns committed file count for name/extension pairs', async () => {
+    const { adapter, primeCommittedFileCount } = makeSetup();
+    primeCommittedFileCount(['router', 'route'], ['tsx', 'jsx'], 4);
+    expect(await adapter.committedFileCount(['router', 'route'], ['tsx', 'jsx'])).toBe(4);
+  });
+
+  it('runs an arbitrary git command through the escape hatch', async () => {
+    const { adapter, primeExecCommand } = makeSetup();
+    primeExecCommand('git log --format=%H', 'abc\ndef\n');
+    expect(await adapter.execCommand('git log --format=%H')).toBe('abc\ndef\n');
+  });
+});

--- a/node-src/lib/ports/gitInMemoryAdapter.ts
+++ b/node-src/lib/ports/gitInMemoryAdapter.ts
@@ -1,0 +1,145 @@
+import { GitCommitInfo, GitRepository } from './git';
+
+/**
+ * Fixture-driven state backing the in-memory {@link GitRepository} adapter.
+ * Every field is optional apart from `branch` so callers provide only what a
+ * given test exercises. Unset optional fields return `undefined`; lookup maps
+ * return `undefined` for unknown keys.
+ */
+export interface InMemoryGitState {
+  branch: string;
+
+  version?: string;
+  userEmail?: string;
+  slug?: string;
+  uncommittedHash?: string;
+  repositoryRoot?: string;
+  repositoryCreationDate?: Date;
+  committerCount?: number;
+
+  /** Keyed by revision spec. An empty-string key provides the HEAD commit. */
+  commits?: Record<string, GitCommitInfo>;
+
+  /** Whether HEAD has a parent commit. Defaults to true. */
+  hasPreviousCommit?: boolean;
+
+  /** Commits that exist in the repo (for {@link GitRepository.commitExists}). */
+  existingCommits?: Set<string>;
+
+  /** Keyed by `${baseCommit}..${headCommit ?? ''}`. */
+  changedFilesByRange?: Record<string, string[]>;
+
+  isUpToDate?: boolean;
+  isClean?: boolean;
+  updateMessage?: string;
+
+  /** Keyed by `${head}..${base}`. */
+  mergeBases?: Record<string, string | undefined>;
+
+  storybookCreationDates?: Record<string, Date>;
+
+  /** Keyed by `${repoRoot}|${patterns.join(',')}`. */
+  filesFromRoot?: Record<string, string[]>;
+
+  /**
+   * Keyed by `${nameMatches.join(',')}|${extensions.join(',')}`. Defaults to
+   * zero for unknown keys.
+   */
+  committedFileCounts?: Record<string, number>;
+
+  /** Raw command responses for the {@link GitRepository.execCommand} escape. */
+  execResponses?: Record<string, string>;
+}
+
+function rangeKey(a: string, b?: string): string {
+  return `${a}..${b ?? ''}`;
+}
+
+/**
+ * Construct a {@link GitRepository} backed by an in-memory fixture. The state
+ * object is held by reference so tests can mutate it between calls.
+ *
+ * @param state The mutable fixture driving the adapter's responses.
+ *
+ * @returns A GitRepository that reads from the provided state object.
+ */
+export function createInMemoryGitAdapter(state: InMemoryGitState): GitRepository {
+  return {
+    async version() {
+      return state.version;
+    },
+    async userEmail() {
+      return state.userEmail;
+    },
+    async slug() {
+      return state.slug;
+    },
+    async commit(revision = '') {
+      const info = state.commits?.[revision];
+      if (!info) {
+        throw new Error(`No commit fixture for revision '${revision}'`);
+      }
+      return info;
+    },
+    async branch() {
+      return state.branch;
+    },
+    async uncommittedHash() {
+      return state.uncommittedHash;
+    },
+    async hasPreviousCommit() {
+      return state.hasPreviousCommit ?? true;
+    },
+    async commitExists(commit) {
+      return state.existingCommits?.has(commit) ?? false;
+    },
+    async changedFiles(baseCommit, headCommit) {
+      return state.changedFilesByRange?.[rangeKey(baseCommit, headCommit)] ?? [];
+    },
+    async isUpToDate() {
+      return state.isUpToDate ?? true;
+    },
+    async isClean() {
+      return state.isClean ?? true;
+    },
+    async getUpdateMessage() {
+      return state.updateMessage;
+    },
+    async findMergeBase(head, base) {
+      return state.mergeBases?.[rangeKey(head, base)];
+    },
+    async checkout() {
+      return undefined;
+    },
+    async checkoutFile(_reference, fileName) {
+      return fileName;
+    },
+    async checkoutPrevious() {
+      return undefined;
+    },
+    async discardChanges() {
+      return undefined;
+    },
+    async repositoryRoot() {
+      return state.repositoryRoot;
+    },
+    async findFilesFromRepositoryRoot(repoRoot, ...patterns) {
+      return state.filesFromRoot?.[`${repoRoot}|${patterns.join(',')}`] ?? [];
+    },
+    async repositoryCreationDate() {
+      return state.repositoryCreationDate;
+    },
+    async storybookCreationDate(configDirectory) {
+      return state.storybookCreationDates?.[configDirectory];
+    },
+    async committerCount() {
+      return state.committerCount;
+    },
+    async committedFileCount(nameMatches, extensions) {
+      return state.committedFileCounts?.[`${nameMatches.join(',')}|${extensions.join(',')}`] ?? 0;
+    },
+    async execCommand(command) {
+      return state.execResponses?.[command];
+    },
+  };
+}

--- a/node-src/lib/ports/gitShellAdapter.ts
+++ b/node-src/lib/ports/gitShellAdapter.ts
@@ -1,0 +1,78 @@
+import { execGitCommand } from '../../git/execGit';
+import {
+  checkout,
+  checkoutFile,
+  checkoutPrevious,
+  commitExists,
+  discardChanges,
+  findFilesFromRepositoryRoot,
+  findMergeBase,
+  getBranch,
+  getChangedFiles,
+  getCommit,
+  getCommittedFileCount,
+  getNumberOfComitters,
+  getRepositoryCreationDate,
+  getRepositoryRoot,
+  getSlug,
+  getStorybookCreationDate,
+  getUncommittedHash,
+  getUpdateMessage,
+  getUserEmail,
+  getVersion,
+  hasPreviousCommit,
+  isClean,
+  isUpToDate,
+} from '../../git/git';
+import { Logger } from '../log';
+import { ExecCommandOptions, GitRepository } from './git';
+
+interface ShellAdapterDeps {
+  log: Logger;
+}
+
+/**
+ * Construct a {@link GitRepository} backed by the local `git` executable.
+ *
+ * @param deps Runtime dependencies.
+ * @param deps.log Logger forwarded to the underlying git helpers.
+ *
+ * @returns A GitRepository that shells out to the real git CLI.
+ */
+export function createShellGitAdapter(deps: ShellAdapterDeps): GitRepository {
+  return {
+    version: () => getVersion(deps),
+    userEmail: () => getUserEmail(deps),
+    slug: () => getSlug(deps),
+    commit: (revision) => getCommit(deps, revision),
+    async branch() {
+      const result = await getBranch(deps);
+      return result ?? 'HEAD';
+    },
+    uncommittedHash: () => getUncommittedHash(deps),
+    hasPreviousCommit: () => hasPreviousCommit(deps).then(Boolean),
+    commitExists: (commit) => commitExists(deps, commit),
+    changedFiles: (baseCommit, headCommit) => getChangedFiles(deps, baseCommit, headCommit),
+    isUpToDate: () => isUpToDate(deps),
+    isClean: () => isClean(deps),
+    getUpdateMessage: () => getUpdateMessage(deps),
+    findMergeBase: (head, base) => findMergeBase(deps, head, base),
+    checkout: (reference) => checkout(deps, reference),
+    checkoutFile: (reference, fileName, tmpdir) => checkoutFile(deps, reference, fileName, tmpdir),
+    checkoutPrevious: () => checkoutPrevious(deps),
+    discardChanges: () => discardChanges(deps),
+    repositoryRoot: () => getRepositoryRoot(deps),
+    findFilesFromRepositoryRoot: (repoRoot, ...patterns) =>
+      findFilesFromRepositoryRoot(deps, repoRoot, ...patterns),
+    repositoryCreationDate: () => getRepositoryCreationDate(deps),
+    storybookCreationDate: (configDirectory) =>
+      getStorybookCreationDate({
+        ...deps,
+        options: { storybookConfigDir: configDirectory },
+      }),
+    committerCount: () => getNumberOfComitters(deps),
+    committedFileCount: (nameMatches, extensions) =>
+      getCommittedFileCount(deps, nameMatches, extensions),
+    execCommand: (command, options?: ExecCommandOptions) => execGitCommand(deps, command, options),
+  };
+}

--- a/node-src/lib/ports/index.ts
+++ b/node-src/lib/ports/index.ts
@@ -1,17 +1,31 @@
+import { Logger } from '../log';
+import { GitRepository } from './git';
+import { createShellGitAdapter } from './gitShellAdapter';
+
 /**
  * The collection of external-dependency boundaries ("ports") used by the
  * Chromatic CLI domain code. Each field is filled in by a dedicated
  * port-extraction PR as part of an ongoing refactoring project to eliminate
  * the context god object.
  */
-// eslint-disable-next-line @typescript-eslint/no-empty-interface
-export interface Ports {}
+export interface Ports {
+  git: GitRepository;
+}
+
+interface DefaultPortsDeps {
+  log: Logger;
+}
 
 /**
  * Construct the production `Ports` bundle with real adapters wired up.
  *
+ * @param deps Shared runtime dependencies the adapters need.
+ * @param deps.log The logger forwarded to adapters that need it.
+ *
  * @returns A `Ports` record wired with production adapters.
  */
-export function createDefaultPorts(): Ports {
-  return {};
+export function createDefaultPorts(deps: DefaultPortsDeps): Ports {
+  return {
+    git: createShellGitAdapter({ log: deps.log }),
+  };
 }

--- a/node-src/lib/ports/index.ts
+++ b/node-src/lib/ports/index.ts
@@ -1,0 +1,17 @@
+/**
+ * The collection of external-dependency boundaries ("ports") used by the
+ * Chromatic CLI domain code. Each field is filled in by a dedicated
+ * port-extraction PR as part of an ongoing refactoring project to eliminate
+ * the context god object.
+ */
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+export interface Ports {}
+
+/**
+ * Construct the production `Ports` bundle with real adapters wired up.
+ *
+ * @returns A `Ports` record wired with production adapters.
+ */
+export function createDefaultPorts(): Ports {
+  return {};
+}

--- a/node-src/types.ts
+++ b/node-src/types.ts
@@ -5,6 +5,7 @@ import type { AnalyticsClient } from './lib/analytics';
 import type { Configuration } from './lib/getConfiguration';
 import { Environment } from './lib/getEnvironment';
 import { Logger } from './lib/log';
+import type { Ports } from './lib/ports';
 
 type FilePath = string;
 
@@ -224,6 +225,7 @@ export interface Context {
 
   http: HTTPClient;
   client: GraphQLClient;
+  ports: Ports;
 
   git: {
     version?: string;


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>16.6.2--canary.1298.25070862207.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@16.6.2--canary.1298.25070862207.0
  # or 
  yarn add chromatic@16.6.2--canary.1298.25070862207.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
