### PR TITLE
Scaffolding for removing `Context` from CLI task bodies

### DIFF
--- a/node-src/index.ts
+++ b/node-src/index.ts
@@ -78,10 +78,10 @@ export type InitialContext = Omit<
     | 'log'
     | 'sessionId'
   >,
-  'options'
+  'options' | 'runtime'
 >;
 
-const isContext = (ctx: InitialContext): ctx is Context => 'options' in ctx;
+const isContext = (ctx: InitialContext): ctx is Context => 'options' in ctx && 'runtime' in ctx;
 
 /**
  * Entry point for the CLI, GitHub Action, and Node API
@@ -194,6 +194,7 @@ export async function runAll(ctx: InitialContext) {
     );
     const options = getOptions(ctx);
     (ctx as Context).options = options;
+    (ctx as Context).runtime = { forceRebuild: options.forceRebuild };
     ctx.log.setLogFile(options.logFile);
 
     setExitCode(ctx, exitCodes.OK);

--- a/node-src/lib/tasks.test.ts
+++ b/node-src/lib/tasks.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { Context } from '../types';
+import { createTask } from './tasks';
+
+const baseContext = (): Context =>
+  ({
+    options: {},
+    runtime: {},
+    log: { debug: vi.fn() },
+  }) as any;
+
+describe('createTask (typed shape)', () => {
+  it('extracts input, runs, applies output', async () => {
+    const ctx = baseContext();
+    const run = vi.fn().mockResolvedValue({ kind: 'continue', output: { token: 'abc' } });
+    const applyOutput = vi.fn();
+
+    const listrTask = createTask<{ x: number }, { token: string }>({
+      name: 'auth',
+      title: 'Test',
+      extractInput: () => ({ x: 1 }),
+      applyOutput,
+      run,
+    });
+
+    await (listrTask.task as any)(ctx, {});
+
+    expect(run).toHaveBeenCalledWith(expect.any(Object), { x: 1 });
+    expect(applyOutput).toHaveBeenCalledWith(ctx, { token: 'abc' });
+  });
+
+  it('sets ctx.skip on skip result by default and does not call apply callbacks', async () => {
+    const ctx = baseContext();
+    const run = vi.fn().mockResolvedValue({ kind: 'skip', reason: 'no work' });
+    const applyOutput = vi.fn();
+    const applyPartial = vi.fn();
+
+    const listrTask = createTask({
+      name: 'auth',
+      title: 'Test',
+      extractInput: () => ({}),
+      applyOutput,
+      applyPartial,
+      run,
+    });
+
+    await (listrTask.task as any)(ctx, {});
+
+    expect(applyOutput).not.toHaveBeenCalled();
+    expect(applyPartial).not.toHaveBeenCalled();
+    expect(ctx.skip).toBe(true);
+  });
+
+  it('applies partial output and sets ctx.skip on partial result by default', async () => {
+    const ctx = baseContext();
+    const run = vi
+      .fn()
+      .mockResolvedValue({ kind: 'partial', output: { partial: 'data' }, reason: 'rebuild' });
+    const applyOutput = vi.fn();
+    const applyPartial = vi.fn();
+
+    const listrTask = createTask({
+      name: 'gitInfo',
+      title: 'Test',
+      extractInput: () => ({}),
+      applyOutput,
+      applyPartial,
+      run,
+    });
+
+    await (listrTask.task as any)(ctx, {});
+
+    expect(applyOutput).not.toHaveBeenCalled();
+    expect(applyPartial).toHaveBeenCalledWith(ctx, { partial: 'data' });
+    expect(ctx.skip).toBe(true);
+  });
+
+  it('still supports legacy steps[] config for unmigrated tasks', async () => {
+    const ctx = baseContext();
+    const step1 = vi.fn();
+    const step2 = vi.fn();
+
+    const listrTask = createTask({
+      name: 'auth',
+      title: 'Test',
+      steps: [step1, step2],
+    });
+
+    await (listrTask.task as any)(ctx, {});
+
+    expect(step1).toHaveBeenCalled();
+    expect(step2).toHaveBeenCalled();
+  });
+});

--- a/node-src/lib/tasks.ts
+++ b/node-src/lib/tasks.ts
@@ -2,38 +2,127 @@ import chalk from 'chalk';
 import Listr from 'listr';
 import pluralize from 'pluralize';
 
-import { Context, Task, TaskName } from '../types';
+import { Context, Deps, Task, TaskFunction, TaskName, TaskResult } from '../types';
 
 type ValueFunction = string | ((ctx: Context, task: Task) => string);
 
-type TaskInput = Omit<Listr.ListrTask<Context>, 'task'> & {
+type ListrTaskExtras = Pick<Listr.ListrTask<Context>, 'skip' | 'enabled'>;
+
+type LegacyTaskConfig = ListrTaskExtras & {
   name: TaskName;
+  title: string;
   steps: ((ctx: Context, task: Listr.ListrTaskWrapper<Context> | Task) => void | Promise<void>)[];
 };
 
-export const createTask = ({
-  name,
-  title,
-  steps,
-  ...config
-}: TaskInput): Listr.ListrTask<Context> => ({
-  title,
-  task: async (ctx: Context, task: Listr.ListrTaskWrapper<Context>) => {
-    ctx.task = name;
-    ctx.title = title;
-    ctx.startedAt = Number.isInteger(ctx.now) ? ctx.now : Date.now();
+type AdaptedTaskConfig<TInput, TOutput, TPartial = never> = ListrTaskExtras & {
+  name: TaskName;
+  title: string;
+  transitions?: {
+    pending?: (ctx: Context) => Task;
+    success?: (ctx: Context) => Task;
+  };
+  extractInput: (ctx: Context) => TInput;
+  applyOutput?: (ctx: Context, output: TOutput) => void;
+  applyPartial?: (ctx: Context, output: TPartial) => void;
+  run: TaskFunction<TInput, TOutput, Deps, TPartial>;
+};
 
-    ctx.options.experimental_onTaskStart?.({ ...ctx });
-
-    for (const step of steps) {
-      ctx.options.experimental_abortSignal?.throwIfAborted();
-      await step(ctx, task);
-    }
-
-    ctx.options.experimental_onTaskComplete?.({ ...ctx });
-  },
-  ...config,
+const buildDeps = (ctx: Context): Deps => ({
+  log: ctx.log,
+  client: ctx.client,
+  http: ctx.http,
+  env: ctx.env,
+  options: ctx.options,
+  runtime: ctx.runtime,
+  analytics: ctx.analytics,
+  pkg: ctx.pkg,
+  sessionId: ctx.sessionId,
+  packageJson: ctx.packageJson,
 });
+
+function applyAdaptedResult<TInput, TOutput, TPartial>(
+  config: AdaptedTaskConfig<TInput, TOutput, TPartial>,
+  ctx: Context,
+  listrTask: Listr.ListrTaskWrapper<Context>,
+  result: TaskResult<TOutput, TPartial>
+) {
+  switch (result.kind) {
+    case 'continue':
+      config.applyOutput?.(ctx, result.output);
+      if (config.transitions?.success)
+        transitionTo(config.transitions.success, true)(ctx, listrTask);
+      return;
+    case 'partial':
+      config.applyPartial?.(ctx, result.output);
+      ctx.skip = true;
+      return;
+    case 'skip':
+      ctx.skip = true;
+      return;
+    default:
+      result satisfies never;
+  }
+}
+
+async function runAdaptedTask<TInput, TOutput, TPartial>(
+  config: AdaptedTaskConfig<TInput, TOutput, TPartial>,
+  ctx: Context,
+  listrTask: Listr.ListrTaskWrapper<Context>
+) {
+  ctx.options.experimental_abortSignal?.throwIfAborted();
+  if (config.transitions?.pending) transitionTo(config.transitions.pending)(ctx, listrTask);
+  const input = config.extractInput(ctx);
+  const result = await config.run(buildDeps(ctx), input);
+  applyAdaptedResult(config, ctx, listrTask, result);
+}
+
+async function runLegacyTask(
+  config: LegacyTaskConfig,
+  ctx: Context,
+  listrTask: Listr.ListrTaskWrapper<Context>
+) {
+  for (const step of config.steps) {
+    ctx.options.experimental_abortSignal?.throwIfAborted();
+    await step(ctx, listrTask);
+  }
+}
+
+/**
+ * Creates a Listr task wrapper that supports two config shapes: a legacy `steps[]` shape
+ * for unmigrated tasks, and a typed `(deps, input) => Promise<TaskResult<output>>` shape
+ * (with `transitions` for UI title/output state changes) that decouples task bodies from
+ * the Context god object.
+ *
+ * @param config Either a LegacyTaskConfig or an AdaptedTaskConfig.
+ *
+ * @returns A Listr.ListrTask suitable for inclusion in the pipeline.
+ */
+export function createTask<TInput, TOutput, TPartial = never>(
+  config: AdaptedTaskConfig<TInput, TOutput, TPartial>
+): Listr.ListrTask<Context>;
+export function createTask(config: LegacyTaskConfig): Listr.ListrTask<Context>;
+export function createTask<TInput, TOutput, TPartial = never>(
+  config: LegacyTaskConfig | AdaptedTaskConfig<TInput, TOutput, TPartial>
+): Listr.ListrTask<Context> {
+  const { name, title, skip, enabled } = config;
+  return {
+    title,
+    skip,
+    enabled,
+    task: async (ctx: Context, listrTask: Listr.ListrTaskWrapper<Context>) => {
+      ctx.task = name;
+      ctx.title = title;
+      ctx.startedAt = Number.isInteger(ctx.now) ? ctx.now : Date.now();
+      ctx.options.experimental_onTaskStart?.({ ...ctx });
+
+      await ('run' in config
+        ? runAdaptedTask(config, ctx, listrTask)
+        : runLegacyTask(config, ctx, listrTask));
+
+      ctx.options.experimental_onTaskComplete?.({ ...ctx });
+    },
+  };
+}
 
 export const setTitle =
   (title: ValueFunction, subtitle?: ValueFunction) => (ctx: Context, task: Task) => {

--- a/node-src/tasks/auth.test.ts
+++ b/node-src/tasks/auth.test.ts
@@ -1,25 +1,63 @@
 import { describe, expect, it, vi } from 'vitest';
 
-import { setAuthorizationToken } from './auth';
+import { AuthDeps, AuthInput, runAuth } from './auth';
 
-describe('setAuthorizationToken', () => {
+const buildDeps = (overrides: Partial<AuthDeps> = {}): AuthDeps => ({
+  client: { runQuery: vi.fn(), setAuthorization: vi.fn() } as any,
+  env: { CHROMATIC_INDEX_URL: 'https://index.chromatic.com' } as any,
+  ...overrides,
+});
+
+describe('runAuth', () => {
   it('updates the GraphQL client with an app token from the index', async () => {
     const client = { runQuery: vi.fn(), setAuthorization: vi.fn() };
-    client.runQuery.mockReturnValue({ appToken: 'app-token' });
+    client.runQuery.mockResolvedValue({ appToken: 'app-token' });
+    const deps = buildDeps({ client: client as any });
 
-    await setAuthorizationToken({ client, options: { projectToken: 'test' } } as any);
+    const input: AuthInput = { mode: 'app', projectToken: 'test' };
+    const result = await runAuth(deps, input);
+
     expect(client.setAuthorization).toHaveBeenCalledWith('app-token');
+    expect(result).toEqual({ kind: 'continue', output: undefined });
   });
 
-  it('supports projectId + userToken', async () => {
+  it('supports projectId + userToken (cli mode)', async () => {
     const client = { runQuery: vi.fn(), setAuthorization: vi.fn() };
-    client.runQuery.mockReturnValue({ cliToken: 'cli-token' });
+    client.runQuery.mockResolvedValue({ cliToken: 'cli-token' });
+    const deps = buildDeps({ client: client as any });
 
-    await setAuthorizationToken({
-      client,
-      env: { CHROMATIC_INDEX_URL: 'https://index.chromatic.com' },
-      options: { projectId: 'Project:abc123', userToken: 'user-token' },
-    } as any);
+    const input: AuthInput = {
+      mode: 'cli',
+      projectId: 'Project:abc123',
+      userToken: 'user-token',
+      projectToken: 'test',
+    };
+    const result = await runAuth(deps, input);
+
     expect(client.setAuthorization).toHaveBeenCalledWith('cli-token');
+    expect(result).toEqual({ kind: 'continue', output: undefined });
+  });
+
+  it('throws invalidProjectId on "Must login" / "No Access"', async () => {
+    const client = { runQuery: vi.fn(), setAuthorization: vi.fn() };
+    client.runQuery.mockRejectedValue([{ message: 'Must login' }]);
+    const deps = buildDeps({ client: client as any });
+
+    const input: AuthInput = {
+      mode: 'cli',
+      projectId: 'Project:abc',
+      userToken: 'tok',
+      projectToken: 'test',
+    };
+    await expect(runAuth(deps, input)).rejects.toThrow(/Project:abc/);
+  });
+
+  it('throws invalidProjectToken on "No app with code"', async () => {
+    const client = { runQuery: vi.fn(), setAuthorization: vi.fn() };
+    client.runQuery.mockRejectedValue([{ message: 'No app with code' }]);
+    const deps = buildDeps({ client: client as any });
+
+    const input: AuthInput = { mode: 'app', projectToken: 'bad-token' };
+    await expect(runAuth(deps, input)).rejects.toThrow(/bad-token/);
   });
 });

--- a/node-src/tasks/auth.ts
+++ b/node-src/tasks/auth.ts
@@ -1,5 +1,5 @@
-import { createTask, transitionTo } from '../lib/tasks';
-import { Context } from '../types';
+import { createTask } from '../lib/tasks';
+import { Context, Deps, TaskFunction } from '../types';
 import invalidProjectId from '../ui/messages/errors/invalidProjectId';
 import invalidProjectToken from '../ui/messages/errors/invalidProjectToken';
 import { authenticated, authenticating, initial } from '../ui/tasks/auth';
@@ -17,46 +17,70 @@ const CreateAppTokenMutation = `
   }
 `;
 
-const getToken = async (ctx: Context) => {
-  const { projectId, projectToken, userToken } = ctx.options;
+export type AuthDeps = Pick<Deps, 'client' | 'env'>;
 
-  if (projectId && userToken) {
-    const { cliToken } = await ctx.client.runQuery<{ cliToken: string }>(
-      CreateCLITokenMutation,
-      { projectId },
-      {
-        endpoint: `${ctx.env.CHROMATIC_INDEX_URL}/api`,
-        headers: { Authorization: `Bearer ${userToken}` },
-      }
-    );
-    return cliToken;
+export type AuthInput =
+  | { mode: 'cli'; projectId: string; userToken: string; projectToken: string }
+  | { mode: 'app'; projectToken: string };
+
+/**
+ * Retrieves an authentication token based on the specified mode.
+ *
+ * In 'cli' mode, creates a CLI token by authenticating with a user token against
+ * the Chromatic API, scoped to a specific project.
+ *
+ * In 'app' mode, creates an app token by authenticating directly with a project token.
+ *
+ * @param deps - The authentication dependencies, including the GraphQL client and environment config.
+ * @param input - The authentication input, which determines the mode and supplies the required credentials.
+ *
+ * @returns A promise resolving to the authentication token string.
+ */
+const getToken = async (deps: AuthDeps, input: AuthInput): Promise<string> => {
+  switch (input.mode) {
+    case 'cli': {
+      const { cliToken } = await deps.client.runQuery<{ cliToken: string }>(
+        CreateCLITokenMutation,
+        { projectId: input.projectId },
+        {
+          endpoint: `${deps.env.CHROMATIC_INDEX_URL}/api`,
+          headers: { Authorization: `Bearer ${input.userToken}` },
+        }
+      );
+      return cliToken;
+    }
+    case 'app': {
+      const { appToken } = await deps.client.runQuery<{ appToken: string }>(
+        CreateAppTokenMutation,
+        {
+          projectToken: input.projectToken,
+        }
+      );
+      return appToken;
+    }
+    default: {
+      // Need to ensure input is exhaustive but also return a Promise<string> from the default branch to satisfy function return type
+      const _exhaustiveCheck: never = input;
+      return _exhaustiveCheck;
+    }
   }
-
-  if (projectToken) {
-    const { appToken } = await ctx.client.runQuery<{ appToken: string }>(CreateAppTokenMutation, {
-      projectToken,
-    });
-    return appToken;
-  }
-
-  // Should never happen since we check for this in getOptions
-  throw new Error('No projectId or projectToken');
 };
 
-export const setAuthorizationToken = async (ctx: Context) => {
+export const runAuth: TaskFunction<AuthInput, void, AuthDeps> = async (deps, input) => {
   try {
-    const token = await getToken(ctx);
-    ctx.client.setAuthorization(token);
+    const token = await getToken(deps, input);
+    deps.client.setAuthorization(token);
   } catch (errors) {
     const message = errors[0]?.message;
     if (message?.match('Must login') || message?.match('No Access')) {
-      throw new Error(invalidProjectId({ projectId: ctx.options.projectId || '' }));
+      throw new Error(invalidProjectId({ projectId: input.mode === 'cli' ? input.projectId : '' }));
     }
     if (message?.match('No app with code')) {
-      throw new Error(invalidProjectToken({ projectToken: ctx.options.projectToken }));
+      throw new Error(invalidProjectToken({ projectToken: input.projectToken }));
     }
     throw errors;
   }
+  return { kind: 'continue', output: undefined };
 };
 
 /**
@@ -70,6 +94,14 @@ export default function main(_: Context) {
   return createTask({
     name: 'auth',
     title: initial.title,
-    steps: [transitionTo(authenticating), setAuthorizationToken, transitionTo(authenticated, true)],
+    transitions: { pending: authenticating, success: authenticated },
+    extractInput: (ctx): AuthInput => {
+      const { projectId, projectToken, userToken } = ctx.options;
+      if (projectId && userToken) {
+        return { mode: 'cli', projectId, userToken, projectToken };
+      }
+      return { mode: 'app', projectToken };
+    },
+    run: runAuth,
   });
 }

--- a/node-src/tasks/gitInfo.test.ts
+++ b/node-src/tasks/gitInfo.test.ts
@@ -150,9 +150,9 @@ describe('setGitInfo', () => {
 
   it('forces rebuild automatically if app is onboarding', async () => {
     client.runQuery.mockReturnValue({ app: { isOnboarding: true } });
-    const ctx = { log, options: { ownerName: 'org' }, client } as any;
+    const ctx = { log, options: { ownerName: 'org' }, runtime: {}, client } as any;
     await setGitInfo(ctx, {} as any);
-    expect(ctx.options.forceRebuild).toBe(true);
+    expect(ctx.runtime.forceRebuild).toBe(true);
   });
 
   it('sets storybookUrl and rebuildForBuild on skipped rebuild', async () => {
@@ -175,7 +175,7 @@ describe('setGitInfo', () => {
     getParentCommits.mockResolvedValue([commitInfo.commit]);
     client.runQuery.mockReturnValue({ app: { lastBuild } });
 
-    const ctx = { log, options: {}, client } as any;
+    const ctx = { log, options: {}, runtime: {}, client } as any;
     await setGitInfo(ctx, {} as any);
     expect(ctx.rebuildForBuild).toEqual(lastBuild);
     expect(ctx.storybookUrl).toEqual(lastBuild.storybookUrl);

--- a/node-src/tasks/gitInfo.ts
+++ b/node-src/tasks/gitInfo.ts
@@ -185,7 +185,7 @@ export const setGitInfo = async (ctx: Context, task: Task) => {
   });
   ctx.isOnboarding = result.app.isOnboarding;
   if (result.app.isOnboarding) {
-    ctx.options.forceRebuild = true;
+    ctx.runtime.forceRebuild = true;
   }
   // If we're running against the same commit as the sole parent, then this is likely a rebuild (rerun of CI job).
   // If the MRA is all green, there's no need to rerun the build, we just want the CLI to exit 0 so the CI job succeeds.
@@ -197,7 +197,7 @@ export const setGitInfo = async (ctx: Context, task: Task) => {
       ctx.rebuildForBuildId = mostRecentAncestor.id;
       if (
         ['PASSED', 'ACCEPTED'].includes(mostRecentAncestor.status) &&
-        !ctx.git.matchesBranch(ctx.options.forceRebuild)
+        !ctx.git.matchesBranch(ctx.runtime.forceRebuild)
       ) {
         ctx.skip = true;
         ctx.rebuildForBuild = result.app.lastBuild;

--- a/node-src/types.ts
+++ b/node-src/types.ts
@@ -177,6 +177,15 @@ export type TaskName =
   | 'prepareWorkspace'
   | 'restoreWorkspace';
 
+/**
+ * Mutable runtime state that overrides Options mid-pipeline. Tasks write
+ * Runtime; Options stays as the user's original spec and is treated as read-only.
+ *
+ * Each field is seeded from its Options counterpart at init time, then may be
+ * overridden later by tasks that need to change effective behavior.
+ */
+export type Runtime = Pick<Options, 'forceRebuild'>;
+
 export interface Context {
   env: Environment;
   log: Logger;
@@ -196,6 +205,7 @@ export interface Context {
   extraOptions?: Partial<Options>;
   configuration: Configuration;
   options: Options;
+  runtime: Runtime;
   task: TaskName;
   title: string;
   skip?: boolean;

--- a/node-src/types.ts
+++ b/node-src/types.ts
@@ -186,6 +186,33 @@ export type TaskName =
  */
 export type Runtime = Pick<Options, 'forceRebuild'>;
 
+/**
+ * Cross-cutting dependencies passed to every task. Individual tasks will
+ * `Pick` the dependencies they need.
+ */
+export interface Deps {
+  log: Logger;
+  client: GraphQLClient;
+  http: HTTPClient;
+  env: Environment;
+  options: Readonly<Options>;
+  runtime: Runtime;
+  analytics?: AnalyticsClient;
+  pkg: Context['pkg'];
+  sessionId: string;
+  packageJson: Record<string, any>;
+}
+
+export type TaskResult<TOutput, TPartial = never> =
+  | { kind: 'continue'; output: TOutput }
+  | { kind: 'partial'; output: TPartial; reason?: string }
+  | { kind: 'skip'; reason?: string };
+
+export type TaskFunction<TInput, TOutput, TDeps = Deps, TPartial = never> = (
+  deps: TDeps,
+  input: TInput
+) => Promise<TaskResult<TOutput, TPartial>>;
+
 export interface Context {
   env: Environment;
   log: Logger;


### PR DESCRIPTION
# Description

## The Problem

This PR establishes a pattern for an incremental migration away from the `Context` god object that's currently threaded throughout the CLI code. Current, ctx accumulates user input configuration, shared dependencies (log, client, http, env, etc.), and progressively-filled-in output of every pipeline phase (i.e., the `gitInfo` task populates `ctx.git`, the `storybookInfo` task populates `ctx.storybook`, etc.). Because this is a single mutable bag of properties, callers can't tell via the type system what values are set at any given point (example pain point: you're in the `storybookInfo` task. Is `ctx.git` set? Who knows? Go look at pipeline ordering, verify that `gitInfo` runs before `storybookInfo`, and then read `gitInfo` code to be sure it sets the properties you need). Another pain point is that it's impossible to tell what a task's dependencies actually are. Example: the `auth` task accepts `ctx`. Of the literally hundreds of fields on `ctx`, what does `auth` actually depend on? (Answer: `options`, `client`, and `env`.)

It would be nice to just rip out `Context` altogether, but that has some problems. First, it would be a massive undertaking. It's threaded throughout the entire codebase, so we'd have to rethink everything, from our entrypoints, down through every function, including our UI rendering logic. This is likely not feasible on any reasonable timescale.

Additionally, `Context` is publicly exported, as are programmatic entrypoints to run a Chromatic build that take `Context` as their argument. So any backwards incompatible change would be a major version bump. We should probably explore a deprecation timeline before doing anything so drastic.

## A Potential Solution

This PR attempts to address the pain points I raised above without ripping out `Context` altogether. There are two broad goals. First, phase-specific type safety. Each task in the pipeline produces a set type. Example: the `storybookInfo` task produces a `Storybook` type, so you know exactly what data is coming out of a given task. Tasks also have narrowly defined parameters. Instead of taking the entire `Context`, I propose to define two types per task: input and dependencies. Input represents the data (either from the initial run config or previous tasks) that the task needs, and dependencies likewise represent the minimal dependencies required by the task.

The second goal is that task bodies and helpers are decoupled from context. So instead of `ctx` fields being mutated multiple callers deep into some call stack that originates in a top-level task, tasks now just return the data that they generate. The top level orchestration layer is responsible for 1) parsing `ctx` into the dependencies/input a task requires, and 2) mutating `ctx` with the result from the task.

The end result is that only the top-level task orchestration layer is allowed to touch `ctx`. `ctx` still gets mutated along the way, and there are still places where we have to lie to the type system ("yes, `ctx.git` is defined, I promise"). But these interactions happen in narrowly defined places, rather than threaded throughout the entire codebase.

Note that this assumes we can always cleanly accumulate data throughout the task and return it to the top layer. In some cases, this may get tricky, but from a cursory overview of the tasks, I believe it can be done. And if we run into somewhere where it can't, we can think about some sort of escape hatch back to context. But I hope to avoid that if at all possible.

## Implementation in this PR

This PR sets up the initial scaffolding of this pattern, as well as migrating the `auth` task, just as a proof of concept. `auth` is the first task in the pipeline and is extremely simple. Notably, it has no return type, so that part of the process isn't visible in this PR, but the overall task orchestration is present here.

I also have a working refactor of the `storybookInfo` task in PR #1306. This is a more complex task and includes a return type, if you want to see what that looks like. This PR is subject to change and is not review ready, but the core of the refactoring work is there and tests are all passing.

I recommend reviewing commit by commit.
1. First commit is a small bit of groundwork: adding a `Runtime` bag of settings. This is a concession to one line of code that mutates `ctx.options`. Mutating this value feels like an antipattern to me, as it represents (or should, anyway) the options that a user passed to the CLI invocation. Mutating it, therefore, feels odd, and I added a `runtime` field to track runtime changes to these values.
2. Second commit sets up the task orchestration. The gist is that we define `TaskInput` and `TaskResult` types, which themselves are generic over input and output. This is done so that we can type overload `createTask` to handle legacy and refactored task inputs. The refactored version of `createTask` is the orchestration layer responsible for handling `ctx`. The type generics here might be a lot, so it might help to just get a cursory overview of this commit, then look at the next commit, where we plug it all together in the `auth` task. That should make the overall structure of how this works much more clear.
3. Third commit migrates the `auth` task. Here you can see the setup of auth input and dependencies, and get a feel for how this refactoring effectively lets us limit what parts of `ctx` a task has access to.

> [!NOTE]
> The diffs on this PR are rather confusing. I recommend reviewing the old and new versions of files side-by-side, without diff.

I considered an alternative where we simple add some `Pick<Context, ...>` type annotations throughout the tasks and helper functions, and while this helps with narrowing down what a task actually depends on, it doesn't help with context mutation, and so seemed not good enough to be worth the bother, in my opinion. Happy to discuss, however.

## Future work

If we like this pattern, the plan is to migrate each task in the pipeline, one-by-one, until done. Once they're all done, we can remove the legacy `createTask` type overload. Removing `Context` altogether can be explored at a later time.

# Manual QA

Successful build, auth works, UI for auth is correct:
<img width="1764" height="932" alt="CleanShot 2026-04-30 at 12 42 31@2x" src="https://github.com/user-attachments/assets/b4efabc4-0afb-4c92-b56c-9216aaf071c2" />

Deliberately wrong project token, auth errors, UI for auth is correct:
<img width="1460" height="704" alt="image" src="https://github.com/user-attachments/assets/545daaa2-a7a0-4f74-977c-7cee645cffd9" />

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>16.7.1--canary.1302.25332160078.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@16.7.1--canary.1302.25332160078.0
  # or 
  yarn add chromatic@16.7.1--canary.1302.25332160078.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
