### PR TITLE
fix(checkForUpdates): prevent crash on registry timeout

### DIFF
--- a/node-src/lib/checkForUpdates.ts
+++ b/node-src/lib/checkForUpdates.ts
@@ -6,7 +6,10 @@ import { Context } from '..';
 import outdatedPackage from '../ui/messages/warnings/outdatedPackage';
 import spawn from './spawn';
 
-const rejectIn = (ms: number) => new Promise<any>((_, reject) => setTimeout(reject, ms));
+const rejectIn = (ms: number) =>
+  new Promise<never>((_, reject) =>
+    setTimeout(() => reject(new Error(`Timed out after ${ms}ms`)), ms)
+  );
 const withTimeout = <T>(promise: Promise<T>, ms: number): Promise<T> =>
   Promise.race([promise, rejectIn(ms)]);
 
@@ -68,7 +71,9 @@ export default async function checkForUpdates(ctx: Context) {
  *
  * @returns True if we should report the error, false otherwise.
  */
-function shouldReportVersionCheckFailure(err: Error) {
+function shouldReportVersionCheckFailure(err: unknown) {
+  if (!(err instanceof Error)) return false;
+
   // npm registry was set to an invalid URL
   const isInvalidUrlError = err instanceof TypeError && err.message.includes('Invalid URL');
 


### PR DESCRIPTION
Fixes https://github.com/chromaui/chromatic-cli/issues/1303

`rejectIn` was calling `setTimeout(reject, ms)`, which invoked `reject()` with no argument — rejecting the promise with `undefined`. The catch block then passed `undefined` into `shouldReportVersionCheckFailure`, which read `.message` without a guard and crashed the entire CLI with `Cannot read properties of undefined (reading 'message')` after a successful build/skip.

Fixes:
- `rejectIn` now rejects with a real `Error` describing the timeout.
- `shouldReportVersionCheckFailure` accepts `unknown` and bails early when the value isn't an `Error`, so non-Error rejections from any future code path can no longer crash the helper.