### PR TITLE
Fix crash when checking for CLI updates

### DIFF
--- a/node-src/lib/checkForUpdates.test.ts
+++ b/node-src/lib/checkForUpdates.test.ts
@@ -13,6 +13,7 @@ vi.mock('./spawn', () => ({
   default: vi.fn(),
 }));
 
+const mockedSpawn = vi.mocked(spawn);
 const http = { fetch: vi.fn() };
 
 const getContext = (skipUpdateCheck = false, version = '13.0.0') => {
@@ -44,7 +45,7 @@ describe('checkForUpdates', () => {
   describe('registry url', () => {
     it('defaults to the npm registry on error', async () => {
       const ctx = getContext();
-      vi.mocked(spawn).mockRejectedValue(new Error('spawn error'));
+      mockedSpawn.mockRejectedValue(new Error('spawn error'));
       await checkForUpdates(ctx as any);
       expect(spawn).toHaveBeenCalledWith(['config', 'get', 'registry']);
       expect(ctx.http.fetch).toHaveBeenCalledWith('https://registry.npmjs.org/chromatic');
@@ -52,7 +53,7 @@ describe('checkForUpdates', () => {
 
     it('uses custom registries', async () => {
       const ctx = getContext();
-      vi.mocked(spawn).mockResolvedValue('https://custom-registry.example.com/');
+      mockedSpawn.mockResolvedValue('https://custom-registry.example.com/');
       await checkForUpdates(ctx as any);
       expect(spawn).toHaveBeenCalledWith(['config', 'get', 'registry']);
       expect(ctx.log.info).toHaveBeenCalledWith(
@@ -65,7 +66,7 @@ describe('checkForUpdates', () => {
   describe('registry fetch errors', () => {
     it('does not report invalid URL errors', async () => {
       const ctx = getContext();
-      vi.mocked(spawn).mockResolvedValue('invalid-url');
+      mockedSpawn.mockResolvedValue('invalid-url');
       await checkForUpdates(ctx as any);
       // it should throw before the fetch
       expect(ctx.http.fetch).not.toHaveBeenCalled();
@@ -83,6 +84,23 @@ describe('checkForUpdates', () => {
       );
       await checkForUpdates(ctx as any);
       expect(Sentry.captureException).not.toHaveBeenCalled();
+    });
+
+    it('does not crash when the registry fetch times out', async () => {
+      vi.useFakeTimers();
+      try {
+        const ctx = getContext();
+        mockedSpawn.mockResolvedValue('https://registry.npmjs.org/');
+        http.fetch.mockReturnValue(new Promise(() => {}));
+        const promise = checkForUpdates(ctx as any);
+        await vi.advanceTimersByTimeAsync(5000);
+        await expect(promise).resolves.toBeUndefined();
+        expect(ctx.log.warn).toHaveBeenCalledWith(
+          expect.objectContaining({ message: expect.stringContaining('Timed out after 5000ms') })
+        );
+      } finally {
+        vi.useRealTimers();
+      }
     });
   });
 });

--- a/node-src/lib/checkForUpdates.ts
+++ b/node-src/lib/checkForUpdates.ts
@@ -6,7 +6,10 @@ import { Context } from '..';
 import outdatedPackage from '../ui/messages/warnings/outdatedPackage';
 import spawn from './spawn';
 
-const rejectIn = (ms: number) => new Promise<any>((_, reject) => setTimeout(reject, ms));
+const rejectIn = (ms: number) =>
+  new Promise<never>((_, reject) =>
+    setTimeout(() => reject(new Error(`Timed out after ${ms}ms`)), ms)
+  );
 const withTimeout = <T>(promise: Promise<T>, ms: number): Promise<T> =>
   Promise.race([promise, rejectIn(ms)]);
 
@@ -68,7 +71,9 @@ export default async function checkForUpdates(ctx: Context) {
  *
  * @returns True if we should report the error, false otherwise.
  */
-function shouldReportVersionCheckFailure(err: Error) {
+function shouldReportVersionCheckFailure(err: unknown) {
+  if (!(err instanceof Error)) return false;
+
   // npm registry was set to an invalid URL
   const isInvalidUrlError = err instanceof TypeError && err.message.includes('Invalid URL');
 

--- a/node-src/lib/checkForUpdates.ts
+++ b/node-src/lib/checkForUpdates.ts
@@ -72,7 +72,9 @@ export default async function checkForUpdates(ctx: Context) {
  * @returns True if we should report the error, false otherwise.
  */
 function shouldReportVersionCheckFailure(err: unknown) {
-  if (!(err instanceof Error)) return false;
+  if (!(err instanceof Error)) {
+    return false;
+  }
 
   // npm registry was set to an invalid URL
   const isInvalidUrlError = err instanceof TypeError && err.message.includes('Invalid URL');


### PR DESCRIPTION
PR branched from #1304

Fixes #1303, CAP-4359

It appears we were getting the following error when checking for updates:

```
Cannot read properties of undefined (reading 'message')
```

Turns out, if we hit a timeout, our `setTimeout` rejects with `undefined`, thus failing the `shouldReportVersionCheckFailure` call. To fix this, we:

1. Ensure the `err` passed to `shouldReportVersionCheckFailure` is an error
2. Reject the `setTimeout` with an error
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>16.6.3--canary.1305.25128574135.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@16.6.3--canary.1305.25128574135.0
  # or 
  yarn add chromatic@16.6.3--canary.1305.25128574135.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
