### PR TITLE
Migrate `setStorybookInfo` task to typed inputs and outputs

### DIFF
--- a/node-src/lib/getStorybookBaseDirectory.test.ts
+++ b/node-src/lib/getStorybookBaseDirectory.test.ts
@@ -3,7 +3,6 @@ import process from 'node:process';
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { Context } from '../types';
 import { getStorybookBaseDirectory } from './getStorybookBaseDirectory';
 
 const mockedCwd = vi.spyOn(process, 'cwd');
@@ -17,37 +16,35 @@ vi.mock('./posix', () => ({
 }));
 
 it('defaults to the configured value', () => {
-  expect(getStorybookBaseDirectory({ options: { storybookBaseDir: 'foobar' } } as Context)).toBe(
-    'foobar'
-  );
+  expect(getStorybookBaseDirectory({ storybookBaseDir: 'foobar' })).toBe('foobar');
 });
 
 it('calculates the relative path of the cwd to the git root when they are equal', () => {
   const rootPath = '/path/to/project';
   mockedCwd.mockReturnValue(rootPath);
 
-  expect(getStorybookBaseDirectory({ git: { rootPath } } as Context)).toBe('.');
+  expect(getStorybookBaseDirectory({ gitRootPath: rootPath })).toBe('.');
 });
 
 it('calculates the relative path of the cwd to the git root we are in subdir', () => {
   const rootPath = '/path/to/project';
   mockedCwd.mockReturnValue(`${rootPath}/storybook`);
 
-  expect(getStorybookBaseDirectory({ git: { rootPath } } as Context)).toBe('storybook');
+  expect(getStorybookBaseDirectory({ gitRootPath: rootPath })).toBe('storybook');
 });
 
 it('calculates the relative path of the cwd to the git root when we are outside the git root', () => {
   const rootPath = '/path/to/project';
   mockedCwd.mockReturnValue(`/path/to/elsewhere`);
 
-  expect(getStorybookBaseDirectory({ git: { rootPath } } as Context)).toBe('../elsewhere');
+  expect(getStorybookBaseDirectory({ gitRootPath: rootPath })).toBe('../elsewhere');
 });
 
 it('falls back the empty string if there is no git root', () => {
   const rootPath = '/path/to/project';
   mockedCwd.mockReturnValue(`${rootPath}/storybook`);
 
-  expect(getStorybookBaseDirectory({} as Context)).toBe('.');
+  expect(getStorybookBaseDirectory({})).toBe('.');
 });
 
 describe('with windows paths', () => {
@@ -65,6 +62,6 @@ describe('with windows paths', () => {
     const rootPath = String.raw`C:\path\to\project`;
     mockedCwd.mockReturnValue(String.raw`${rootPath}\storybook\subdir`);
 
-    expect(getStorybookBaseDirectory({ git: { rootPath } } as Context)).toBe('storybook/subdir');
+    expect(getStorybookBaseDirectory({ gitRootPath: rootPath })).toBe('storybook/subdir');
   });
 });

--- a/node-src/lib/getStorybookBaseDirectory.ts
+++ b/node-src/lib/getStorybookBaseDirectory.ts
@@ -1,29 +1,35 @@
 import path from 'path';
 
-import { Context } from '../types';
 import { posix } from './posix';
 
 /**
  * Get the storybook base directory, relative to the git root.
  * This is where you run SB from, NOT the config dir.
  *
- * @param ctx Context Regular context
+ * @param input The base directory configured by the user (if any) and the git
+ *   root path discovered by gitInfo.
+ * @param input.storybookBaseDir User-supplied base directory override.
+ * @param input.gitRootPath Absolute path of the git project root.
  *
- * @returns string The base directory
+ * @returns The base directory.
  */
-export function getStorybookBaseDirectory(ctx: Context) {
-  const { storybookBaseDir } = ctx.options || {};
+export function getStorybookBaseDirectory({
+  storybookBaseDir,
+  gitRootPath,
+}: {
+  storybookBaseDir?: string;
+  gitRootPath?: string;
+}) {
   if (storybookBaseDir) {
     return storybookBaseDir;
   }
 
-  const { rootPath } = ctx.git || {};
-  if (!rootPath) {
+  if (!gitRootPath) {
     return '.';
   }
 
   // NOTE:
   //  - path.relative does not have a leading '.', unless it starts with '../'
   //  - path.join('.', '') === '.' and path.join('.', '../x') = '../x'
-  return posix(path.join('.', path.relative(rootPath, '')));
+  return posix(path.join('.', path.relative(gitRootPath, '')));
 }

--- a/node-src/lib/getStorybookInfo.test.ts
+++ b/node-src/lib/getStorybookInfo.test.ts
@@ -1,14 +1,13 @@
 import TestLogger from '@cli/testLogger';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { Context } from '../types';
 import getStorybookInfo from './getStorybookInfo';
 
 vi.useFakeTimers();
 
 const log = new TestLogger();
-const context: Context = { env: {}, log, options: {}, packageJson: {} } as any;
-const getContext = (ctx: any): Context => ({ ...context, ...ctx });
+const baseDeps = { env: {}, log, options: {}, packageJson: {} } as any;
+const getContext = (overrides: any) => ({ ...baseDeps, ...overrides });
 
 const REACT = { '@storybook/react': '1.2.3' };
 const VUE = { '@storybook/vue': '1.2.3' };
@@ -66,7 +65,7 @@ describe('getStorybookInfo', () => {
   });
 
   it('looks up package in node_modules on missing dependency', async () => {
-    await expect(getStorybookInfo(context)).resolves.toEqual(
+    await expect(getStorybookInfo(baseDeps)).resolves.toEqual(
       // We're getting the result of tracing chromatic-cli's node_modules here.
       expect.objectContaining({
         version: expect.any(String),

--- a/node-src/lib/getStorybookInfo.ts
+++ b/node-src/lib/getStorybookInfo.ts
@@ -1,24 +1,25 @@
 import { pathExistsSync } from 'fs-extra';
 import path from 'path';
 
-import { Context } from '../types';
+import type { StorybookInfoDeps } from '../tasks/storybookInfo';
+import { Storybook } from '../types';
 import { getStorybookMetadataFromProjectJson } from './getPrebuiltStorybookMetadata';
 import { getStorybookMetadata } from './getStorybookMetadata';
 
 /**
  * Get Storybook information from the user's local project.
  *
- * @param ctx The context set when executing the CLI.
+ * @param deps Dependencies needed to detect Storybook metadata.
  *
  * @returns Any Storybook information we can find from the user's local project (which may be
  * nothing).
  */
 export default async function getStorybookInfo(
-  ctx: Context
-): Promise<Partial<Context['storybook']>> {
+  deps: StorybookInfoDeps
+): Promise<Partial<Storybook>> {
   try {
-    if (ctx.options.storybookBuildDir) {
-      const projectJsonPath = path.resolve(ctx.options.storybookBuildDir, 'project.json');
+    if (deps.options.storybookBuildDir) {
+      const projectJsonPath = path.resolve(deps.options.storybookBuildDir, 'project.json');
       // This test makes sure we fall through if the file does not exist.
       if (pathExistsSync(projectJsonPath)) {
         /*
@@ -29,9 +30,9 @@ export default async function getStorybookInfo(
       }
     }
     // Same for this await.
-    return await getStorybookMetadata(ctx);
+    return await getStorybookMetadata(deps);
   } catch (err) {
-    ctx.log.debug(err);
+    deps.log.debug(err);
     return {};
   }
 }

--- a/node-src/lib/getStorybookMetadata.ts
+++ b/node-src/lib/getStorybookMetadata.ts
@@ -6,7 +6,8 @@ import semver from 'semver';
 import { printConfig, readConfig } from 'storybook/internal/csf-tools';
 import { parseArgsStringToArgv } from 'string-argv';
 
-import { Context } from '../types';
+import type { StorybookInfoDeps } from '../tasks/storybookInfo';
+import { Storybook } from '../types';
 import packageDoesNotExist from '../ui/messages/errors/noViewLayerPackage';
 import { builders } from './builders';
 import { raceFulfilled, timeout } from './promises';
@@ -22,7 +23,7 @@ export const resolvePackageJson = (pkg: string) => {
 };
 
 const findDependency = (
-  { dependencies, devDependencies, peerDependencies },
+  { dependencies, devDependencies, peerDependencies }: StorybookInfoDeps['packageJson'],
   predicate: (key: string) => string
 ) => [
   Object.keys(dependencies || {}).find((dependency) => predicate(dependency)),
@@ -30,7 +31,10 @@ const findDependency = (
   Object.keys(peerDependencies || {}).find((dependency) => predicate(dependency)),
 ];
 
-const getDependencyInfo = ({ packageJson, log }, dependencyMap: Record<string, string>) => {
+const getDependencyInfo = (
+  { packageJson, log }: Pick<StorybookInfoDeps, 'packageJson' | 'log'>,
+  dependencyMap: Record<string, string>
+) => {
   // eslint-disable-next-line unicorn/prevent-abbreviations
   const [dep, devDep, peerDep] = findDependency(packageJson, (key) => dependencyMap[key]);
   const [pkg, version] = dep || devDep || peerDep || [];
@@ -49,7 +53,7 @@ const getDependencyInfo = ({ packageJson, log }, dependencyMap: Record<string, s
   return { dependency, version, dependencyPackage: pkg };
 };
 
-const findStorybookVersion = async ({ env, log, options, packageJson }) => {
+const findStorybookVersion = async ({ env, log, options, packageJson }: StorybookInfoDeps) => {
   // Allow setting Storybook version via CHROMATIC_STORYBOOK_VERSION='@storybook/react@4.0-alpha.8' for unusual cases
   if (env.CHROMATIC_STORYBOOK_VERSION) {
     const [, p, v] = env.CHROMATIC_STORYBOOK_VERSION.match(/(.+)@(.+)$/) || [];
@@ -109,7 +113,10 @@ const findStorybookVersion = async ({ env, log, options, packageJson }) => {
   ]);
 };
 
-const findConfigFlags = async ({ options, packageJson }) => {
+const findConfigFlags = async ({
+  options,
+  packageJson,
+}: Pick<StorybookInfoDeps, 'options' | 'packageJson'>) => {
   const { scripts = {} } = packageJson;
   if (!options.buildScriptName || !scripts[options.buildScriptName]) return {};
 
@@ -179,15 +186,20 @@ const findReferences = async (mainConfig, v7) => {
   return references ? { refs: references } : {};
 };
 
-export const findStorybookConfigFile = async (ctx: Context, pattern: RegExp) => {
-  const configDirectory = ctx.options.storybookConfigDir ?? '.storybook';
+export const findStorybookConfigFile = async (
+  storybookConfigDirectory: string | undefined,
+  pattern: RegExp
+) => {
+  const configDirectory = storybookConfigDirectory ?? '.storybook';
   const files = await readdir(configDirectory);
   const configFile = files.find((file) => pattern.test(file));
   return configFile && path.join(configDirectory, configFile);
 };
 
-export const getStorybookMetadata = async (ctx: Context) => {
-  const configDirectory = ctx.options.storybookConfigDir ?? '.storybook';
+export const getStorybookMetadata = async (
+  deps: StorybookInfoDeps
+): Promise<Partial<Storybook>> => {
+  const configDirectory = deps.options.storybookConfigDir ?? '.storybook';
 
   // @ts-expect-error __non_webpack_require__ is only defined when bundled with webpack, and allows us to bypass webpack's module system to require files at runtime
   // eslint-disable-next-line unicorn/prefer-module
@@ -197,31 +209,34 @@ export const getStorybookMetadata = async (ctx: Context) => {
   let v7 = false;
   try {
     mainConfig = await r(path.resolve(configDirectory, 'main'));
-    ctx.log.debug({ configDirectory, mainConfig });
+    deps.log.debug({ configDirectory, mainConfig });
   } catch (err) {
-    ctx.log.debug({ storybookV6error: err });
+    deps.log.debug({ storybookV6error: err });
     try {
-      const storybookConfig = await findStorybookConfigFile(ctx, /^main\.[jt]sx?$/);
+      const storybookConfig = await findStorybookConfigFile(
+        deps.options.storybookConfigDir,
+        /^main\.[jt]sx?$/
+      );
       if (!storybookConfig) {
         throw new Error('Failed to locate Storybook config file');
       }
 
       mainConfig = await readConfig(storybookConfig);
-      ctx.log.debug({ configDirectory, mainConfig: printConfig(mainConfig) });
+      deps.log.debug({ configDirectory, mainConfig: printConfig(mainConfig) });
       v7 = true;
     } catch (err) {
-      ctx.log.debug({ storybookV7error: err });
+      deps.log.debug({ storybookV7error: err });
     }
   }
 
   const info = await Promise.allSettled([
-    findConfigFlags(ctx),
-    findStorybookVersion(ctx),
+    findConfigFlags(deps),
+    findStorybookVersion(deps),
     findBuilder(mainConfig, v7),
     findReferences(mainConfig, v7),
   ]);
 
-  ctx.log.debug(info);
+  deps.log.debug(info);
   let metadata = {};
   for (const sbItem of info) {
     if (sbItem.status === 'fulfilled') {

--- a/node-src/lib/uploadMetadataFiles.ts
+++ b/node-src/lib/uploadMetadataFiles.ts
@@ -30,8 +30,12 @@ export async function uploadMetadataFiles(ctx: Context) {
       ctx.options.logFile,
       ctx.options.diagnosticsFile,
       ctx.options.storybookLogFile,
-      await findStorybookConfigFile(ctx, /^main\.[jt]sx?$/).catch(() => undefined),
-      await findStorybookConfigFile(ctx, /^preview\.[jt]sx?$/).catch(() => undefined),
+      await findStorybookConfigFile(ctx.options.storybookConfigDir, /^main\.[jt]sx?$/).catch(
+        () => undefined
+      ),
+      await findStorybookConfigFile(ctx.options.storybookConfigDir, /^preview\.[jt]sx?$/).catch(
+        () => undefined
+      ),
       ctx.fileInfo?.statsPath && (await trimStatsFile([ctx.fileInfo.statsPath])),
     ].filter((m): m is string => !!m);
 

--- a/node-src/tasks/storybookInfo.test.ts
+++ b/node-src/tasks/storybookInfo.test.ts
@@ -1,26 +1,110 @@
+import * as Sentry from '@sentry/node';
 import { describe, expect, it, vi } from 'vitest';
 
 import { getStorybookBaseDirectory } from '../lib/getStorybookBaseDirectory';
 import storybookInfo from '../lib/getStorybookInfo';
-import { setStorybookInfo } from './storybookInfo';
+import { Storybook } from '../types';
+import { applyStorybookInfoOutput, setStorybookInfo, StorybookInfoDeps } from './storybookInfo';
 
 vi.mock('../lib/getStorybookInfo');
 vi.mock('../lib/getStorybookBaseDirectory');
+vi.mock('@sentry/node', () => ({ setTag: vi.fn(), setContext: vi.fn() }));
 
 const getStorybookInfo = vi.mocked(storybookInfo);
 const mockedGetStorybookBaseDirectory = vi.mocked(getStorybookBaseDirectory);
+const mockedSentrySetTag = vi.mocked(Sentry.setTag);
+const mockedSentrySetContext = vi.mocked(Sentry.setContext);
 
-describe('storybookInfo', () => {
-  it('retrieves Storybook metadata and sets it on context', async () => {
+const buildDeps = (overrides: Partial<StorybookInfoDeps> = {}): StorybookInfoDeps =>
+  ({
+    log: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    options: {},
+    env: {},
+    packageJson: {},
+    ...overrides,
+  }) as StorybookInfoDeps;
+
+describe('setStorybookInfo', () => {
+  it('returns Storybook metadata combined with the resolved baseDir', async () => {
     const storybook = { version: '1.0.0', addons: [] };
     getStorybookInfo.mockResolvedValue(storybook);
     mockedGetStorybookBaseDirectory.mockReturnValue('');
 
-    const ctx = { packageJson: {}, git: { rootDir: process.cwd() } } as any;
-    await setStorybookInfo(ctx);
-    expect(ctx.storybook).toEqual({
-      ...storybook,
-      baseDir: '',
+    const result = await setStorybookInfo(buildDeps(), { gitRootPath: '/some/git/root' });
+
+    expect(result).toEqual({
+      kind: 'continue',
+      output: { storybook: { ...storybook, baseDir: '' } },
     });
+  });
+
+  it('passes gitRootPath through to getStorybookBaseDirectory', async () => {
+    getStorybookInfo.mockResolvedValue({ version: '1.0.0', addons: [] });
+    mockedGetStorybookBaseDirectory.mockReturnValue('packages/storybook');
+
+    await setStorybookInfo(buildDeps({ options: { storybookBaseDir: 'override' } as any }), {
+      gitRootPath: '/repo/root',
+    });
+
+    expect(mockedGetStorybookBaseDirectory).toHaveBeenCalledWith({
+      storybookBaseDir: 'override',
+      gitRootPath: '/repo/root',
+    });
+  });
+
+  it('returns a continue result with only baseDir when getStorybookInfo resolves to {}', async () => {
+    getStorybookInfo.mockResolvedValue({});
+    mockedGetStorybookBaseDirectory.mockReturnValue('.');
+
+    const result = await setStorybookInfo(buildDeps(), { gitRootPath: '/repo/root' });
+
+    expect(result).toEqual({
+      kind: 'continue',
+      output: { storybook: { baseDir: '.' } },
+    });
+  });
+});
+
+const buildStorybook = (overrides: Partial<Storybook> = {}): Storybook =>
+  ({
+    version: '1.0.0',
+    baseDir: 'packages/sb',
+    addons: [],
+    ...overrides,
+  }) as Storybook;
+
+describe('applyStorybookInfoOutput', () => {
+  it('assigns the storybook output onto ctx', () => {
+    const ctx = {} as any;
+    const storybook = buildStorybook();
+
+    applyStorybookInfoOutput(ctx, { storybook });
+
+    expect(ctx.storybook).toBe(storybook);
+  });
+
+  it('tags the Sentry scope with the Storybook version', () => {
+    mockedSentrySetTag.mockClear();
+    applyStorybookInfoOutput({} as any, { storybook: buildStorybook({ version: '7.6.1' }) });
+
+    expect(mockedSentrySetTag).toHaveBeenCalledWith('storybookVersion', '7.6.1');
+  });
+
+  it('does not set a Sentry version tag when the version is missing', () => {
+    mockedSentrySetTag.mockClear();
+    applyStorybookInfoOutput({} as any, {
+      storybook: buildStorybook({ version: undefined as any }),
+    });
+
+    expect(mockedSentrySetTag).not.toHaveBeenCalled();
+  });
+
+  it('attaches the storybook object as Sentry context', () => {
+    mockedSentrySetContext.mockClear();
+    const storybook = buildStorybook();
+
+    applyStorybookInfoOutput({} as any, { storybook });
+
+    expect(mockedSentrySetContext).toHaveBeenCalledWith('storybook', { ...storybook });
   });
 });

--- a/node-src/tasks/storybookInfo.ts
+++ b/node-src/tasks/storybookInfo.ts
@@ -2,22 +2,42 @@ import * as Sentry from '@sentry/node';
 
 import { getStorybookBaseDirectory } from '../lib/getStorybookBaseDirectory';
 import getStorybookInfo from '../lib/getStorybookInfo';
-import { createTask, transitionTo } from '../lib/tasks';
-import { Context } from '../types';
+import { createTask } from '../lib/tasks';
+import { Context, Deps, Storybook, TaskFunction } from '../types';
 import { initial, pending, success } from '../ui/tasks/storybookInfo';
 
-export const setStorybookInfo = async (ctx: Context) => {
-  ctx.storybook = {
-    ...((await getStorybookInfo(ctx)) as Context['storybook']),
-    baseDir: getStorybookBaseDirectory(ctx),
-  };
+export type StorybookInfoDeps = Pick<Deps, 'log' | 'options' | 'env' | 'packageJson'>;
 
-  if (ctx.storybook) {
-    if (ctx.storybook.version) {
-      Sentry.setTag('storybookVersion', ctx.storybook.version);
-    }
-    Sentry.setContext('storybook', ctx.storybook);
+export interface StorybookInfoInput {
+  gitRootPath?: string;
+}
+
+export interface StorybookInfoOutput {
+  storybook: Storybook;
+}
+
+export const setStorybookInfo: TaskFunction<
+  StorybookInfoInput,
+  StorybookInfoOutput,
+  StorybookInfoDeps
+> = async (deps, input) => {
+  const storybook: Storybook = {
+    ...((await getStorybookInfo(deps)) as Storybook),
+    baseDir: getStorybookBaseDirectory({
+      storybookBaseDir: deps.options.storybookBaseDir,
+      gitRootPath: input.gitRootPath,
+    }),
+  };
+  return { kind: 'continue', output: { storybook } };
+};
+
+// extracted so we can test it more easily
+export const applyStorybookInfoOutput = (ctx: Context, { storybook }: StorybookInfoOutput) => {
+  ctx.storybook = storybook;
+  if (storybook.version) {
+    Sentry.setTag('storybookVersion', storybook.version);
   }
+  Sentry.setContext('storybook', { ...storybook });
 };
 
 /**
@@ -32,6 +52,12 @@ export default function main(ctx: Context) {
     name: 'storybookInfo',
     title: initial(ctx).title,
     skip: (ctx: Context) => ctx.skip,
-    steps: [transitionTo(pending), setStorybookInfo, transitionTo(success, true)],
+    transitions: { pending, success },
+    extractInput: (ctx): StorybookInfoInput => ({
+      // git.rootPath is truly optional here, so we don't need to verify that it's present
+      gitRootPath: ctx.git?.rootPath,
+    }),
+    applyOutput: applyStorybookInfoOutput,
+    run: setStorybookInfo,
   });
 }

--- a/node-src/types.ts
+++ b/node-src/types.ts
@@ -163,6 +163,25 @@ type StorybookReference =
   | ((config: StorybookReferenceConfig & { sourceUrl: string }) => StorybookReferenceConfig)
   | { disable: boolean };
 
+export interface Storybook {
+  version: string;
+  baseDir?: string;
+  configDir: string;
+  staticDir: string[];
+  addons: {
+    name: string;
+    packageName?: string;
+    packageVersion?: string;
+  }[];
+  builder: {
+    name: string;
+    packageName?: string;
+    packageVersion?: string;
+  };
+  mainConfigFilePath?: string;
+  refs?: Record<string, StorybookReference>;
+}
+
 export type TaskName =
   | 'auth'
   | 'gitInfo'
@@ -285,24 +304,7 @@ export interface Context {
     matchesBranch?: (glob: boolean | string) => boolean;
     packageMetadataChanges?: { changedFiles: string[]; commit: string }[];
   };
-  storybook: {
-    version: string;
-    baseDir?: string;
-    configDir: string;
-    staticDir: string[];
-    addons: {
-      name: string;
-      packageName?: string;
-      packageVersion?: string;
-    }[];
-    builder: {
-      name: string;
-      packageName?: string;
-      packageVersion?: string;
-    };
-    mainConfigFilePath?: string;
-    refs?: Record<string, StorybookReference>;
-  };
+  storybook: Storybook;
   projectMetadata: {
     hasRouter?: boolean;
     creationDate?: Date;


### PR DESCRIPTION
# Follows

#1302

# Description

This PR continues the migration of CLI tasks to the new, typed structure established in #1302, migrating `setStorybookInfo`. There are three main changes:
1. Adds a `Storybook` type. This is just hoisting the object already defined on `Context.storybook` as a new type so we can export it and use it as a return value in the new task.
2. Updates the `setStorybookInfo` task definition to use the new structure
3. Updates all the functions called by  `setStorybookInfo` to use the narrower types and dependencies defined by `StorybookInfoDeps` and `StorybookInfoInput`

# Manual QA

Staging build: https://www.staging-chromatic.com/build?appId=686421bc987fc91fe84cd22e&number=132

Added a log line locally to the `applyStorybookInfoOutput` function to verify that the storybook is piped through as expected.
```
11:31:46.980 {"sanitizedErr":{"storybook":{"version":"8.6.14","builder":{"name":"@storybook/react-vite","packageVersion":"8.6.14"},"baseDir":"."}}} TEST: showing storybook info
```
The `sanitizedError` bit is just because I used `ctx.log.error`.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>16.7.1--canary.1306.25332158423.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@16.7.1--canary.1306.25332158423.0
  # or 
  yarn add chromatic@16.7.1--canary.1306.25332158423.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
