### PR TITLE
Add output environment variable to RN builds

### DIFF
--- a/node-src/tasks/buildReactNative.test.ts
+++ b/node-src/tasks/buildReactNative.test.ts
@@ -142,7 +142,11 @@ describe('buildArtifacts', () => {
     await buildArtifacts(ctx, task);
     expect(buildAndroid).not.toHaveBeenCalled();
     const [cmd, ...args] = parseCommandString('my-android-build');
-    expect(execa).toHaveBeenCalledWith(cmd, args, expect.anything());
+    expect(execa).toHaveBeenCalledWith(
+      cmd,
+      args,
+      expect.objectContaining({ env: { CHROMATIC_ARTIFACT_DIRECTORY: '/path/to/build' } })
+    );
   });
 
   it('uses iosBuildCommand when set and does not call buildIos or readExpoConfig', async () => {
@@ -157,7 +161,11 @@ describe('buildArtifacts', () => {
     expect(buildIos).not.toHaveBeenCalled();
     expect(readExpoConfig).not.toHaveBeenCalled();
     const [cmd, ...args] = parseCommandString('my-ios-build');
-    expect(execa).toHaveBeenCalledWith(cmd, args, expect.anything());
+    expect(execa).toHaveBeenCalledWith(
+      cmd,
+      args,
+      expect.objectContaining({ env: { CHROMATIC_ARTIFACT_DIRECTORY: '/path/to/build' } })
+    );
   });
 
   it('calls buildAndroid and buildIos when both are in browsers', async () => {

--- a/node-src/tasks/buildReactNative.ts
+++ b/node-src/tasks/buildReactNative.ts
@@ -46,6 +46,9 @@ const runPlatformCommand = async (
     await runCommand(command, {
       stdout: logStream,
       stderr: logStream,
+      env: {
+        CHROMATIC_ARTIFACT_DIRECTORY: ctx.sourceDir,
+      },
     });
   } catch (err) {
     throw new Error(`React Native build command failed: ${command}\n${err.message}`);


### PR DESCRIPTION
Custom scripts can use `CHROMATIC_ARTIFACT_DIRECTORY` to know where to place build outputs (i.e. storybook.app and storybook.apk)

There was a lot in the main PR, so I split this into another PR.  I can rebase and merge into main if we don't want to include it in #1297 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>16.8.1--canary.1307.25384001793.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@16.8.1--canary.1307.25384001793.0
  # or 
  yarn add chromatic@16.8.1--canary.1307.25384001793.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
