### PR TITLE
Only build Android ABI for x86_64

### DIFF
--- a/bin-src/reactNativeBuild.test.ts
+++ b/bin-src/reactNativeBuild.test.ts
@@ -81,7 +81,7 @@ describe('react-native-build', () => {
     );
     expect(mockedExeca).toHaveBeenCalledWith(
       './gradlew',
-      ['assembleRelease'],
+      ['assembleRelease', '-PreactNativeArchitectures=x86_64'],
       expect.objectContaining({ cwd: expect.stringContaining('android') })
     );
   });

--- a/node-src/lib/react-native/build.test.ts
+++ b/node-src/lib/react-native/build.test.ts
@@ -59,7 +59,7 @@ describe('buildAndroid', () => {
     );
     expect(execa).toHaveBeenCalledWith(
       './gradlew',
-      ['assembleRelease'],
+      ['assembleRelease', '-PreactNativeArchitectures=x86_64'],
       expect.objectContaining({ cwd: expect.stringContaining('android') })
     );
   });
@@ -71,7 +71,9 @@ describe('buildAndroid', () => {
       expect.stringContaining('[chromatic] Android build: npx expo prebuild')
     );
     expect(logStream.write).toHaveBeenCalledWith(
-      expect.stringContaining('[chromatic] Android build: ./gradlew assembleRelease')
+      expect.stringContaining(
+        '[chromatic] Android build: ./gradlew assembleRelease -PreactNativeArchitectures=x86_64'
+      )
     );
   });
 

--- a/node-src/lib/react-native/build.ts
+++ b/node-src/lib/react-native/build.ts
@@ -70,8 +70,15 @@ export async function buildAndroid(outputPath: string, logStream: WriteStream) {
   logStream.write('\n[chromatic] Android build: npx expo prebuild --platform android\n');
   await exec('npx', ['expo', 'prebuild', '--platform', 'android'], {}, logStream);
 
-  logStream.write('\n[chromatic] Android build: ./gradlew assembleRelease\n');
-  await exec('./gradlew', ['assembleRelease'], { cwd: path.resolve('android') }, logStream);
+  logStream.write(
+    '\n[chromatic] Android build: ./gradlew assembleRelease -PreactNativeArchitectures=x86_64\n'
+  );
+  await exec(
+    './gradlew',
+    ['assembleRelease', '-PreactNativeArchitectures=x86_64'],
+    { cwd: path.resolve('android') },
+    logStream
+  );
 
   const apkPath = path.resolve('android/app/build/outputs/apk/release/app-release.apk');
 


### PR DESCRIPTION
We only require x86_64, so when building specifically for Chromatic, only build that ABI.

Much like #1307, there was a lot in the main PR, so I split this into another PR. I can rebase and merge into main if we don't want to include it in https://github.com/chromaui/chromatic-cli/pull/1297
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>16.8.1--canary.1308.25383996439.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@16.8.1--canary.1308.25383996439.0
  # or 
  yarn add chromatic@16.8.1--canary.1308.25383996439.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
