### PR TITLE
Make Storybook metadata output generic

### DIFF
--- a/node-src/ui/tasks/storybookInfo.ts
+++ b/node-src/ui/tasks/storybookInfo.ts
@@ -1,46 +1,5 @@
-import { isE2EBuild } from '../../lib/e2eUtils';
 import { Context } from '../../types';
 import { buildType } from './utilities';
-
-const capitalize = (string: string) =>
-  string
-    .split('-')
-    .map((str) => str.charAt(0).toUpperCase() + str.slice(1))
-    .join(' ');
-
-const e2eMessage = (ctx: Context) => {
-  if (ctx.options.playwright) {
-    return 'Playwright for E2E';
-  }
-
-  if (ctx.options.cypress) {
-    return 'Cypress for E2E';
-  }
-
-  if (ctx.options.vitest) {
-    return 'Vitest for E2E';
-  }
-
-  return 'E2E';
-};
-
-const infoMessage = (ctx: Context) => {
-  if (isE2EBuild(ctx.options)) {
-    return e2eMessage(ctx);
-  }
-
-  const { addons, version, builder } = ctx.storybook;
-  const info = version ? `Storybook ${version}` : '';
-  const builderInfo = builder
-    ? `${info}; using the ${builder.name} builder (${builder.packageVersion})`
-    : info;
-  const supportedAddons = addons?.filter((addon) => addon?.name);
-  return supportedAddons?.length
-    ? `${builderInfo}; supported addons found: ${supportedAddons
-        .map((addon) => capitalize(addon.name))
-        .join(', ')}`
-    : `${builderInfo}; no supported addons found`;
-};
 
 export const initial = (ctx: Context) => ({
   status: 'initial',
@@ -55,5 +14,5 @@ export const pending = (ctx: Context) => ({
 export const success = (ctx: Context) => ({
   status: 'success',
   title: `Collected ${buildType(ctx)} metadata`,
-  output: infoMessage(ctx),
+  output: 'Build metadata gathered',
 });


### PR DESCRIPTION
We write some Storybook metadata to the CLI UI to call out what we found in the project. This idea was called into question with React Native because it uses a different set of builders. Instead of applying the same idea to React Native, we decided to make the output generic to simplify the entire flow.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>16.6.4--canary.1309.25177225808.1</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@16.6.4--canary.1309.25177225808.1
  # or 
  yarn add chromatic@16.6.4--canary.1309.25177225808.1
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
