### PR TITLE
Allow skip without a project token

### DIFF
--- a/node-src/git/getCommitAndBranch.ts
+++ b/node-src/git/getCommitAndBranch.ts
@@ -44,7 +44,7 @@ function getBranchDetailsFromEnvironmentCI(log) {
 // TODO: refactor this function
 // eslint-disable-next-line complexity, max-statements
 export default async function getCommitAndBranch(
-  ctx: Context,
+  ctx: Pick<Context, 'log'>,
   {
     branchName,
     patchBaseRef,

--- a/node-src/index.test.ts
+++ b/node-src/index.test.ts
@@ -306,7 +306,7 @@ vi.mock('fs', async (importOriginal) => {
 vi.mock('./git/git', () => ({
   hasPreviousCommit: () => Promise.resolve(true),
   getCommit: vi.fn(),
-  getBranch: () => Promise.resolve('branch'),
+  getBranch: vi.fn(() => Promise.resolve('branch')),
   getSlug: vi.fn(),
   getVersion: () => Promise.resolve('2.24.1'),
   getChangedFiles: () => Promise.resolve(['src/foo.stories.js']),
@@ -324,7 +324,15 @@ vi.mock('./git/getParentCommits', () => ({
 }));
 
 const getCommit = vi.mocked(git.getCommit);
+const getBranch = vi.mocked(git.getBranch);
 const getSlug = vi.mocked(git.getSlug);
+const expectSkipNoProjectToken = (ctx: ReturnType<typeof getContext>) => {
+  expect(ctx.exitCode).toBe(0);
+  expect(ctx.testLogger.warnings[0]).toMatch(
+    /Skipping Chromatic build locally because --skip is enabled, but no project token was available, so no build was reported to Chromatic. This may leave the Chromatic GitHub checks pending./
+  );
+  expect(ctx.testLogger.errors).toEqual([]);
+};
 
 vi.mock('./lib/emailHash');
 
@@ -366,6 +374,7 @@ beforeEach(() => {
     committerEmail: 'test@test.com',
     committerName: 'tester',
   });
+  getBranch.mockResolvedValue('branch');
   getSlug.mockResolvedValue('user/repo');
 });
 afterEach(() => {
@@ -398,6 +407,30 @@ const getContext = (argv: string[]): Context & { testLogger: TestLogger } => {
 
 it('fails on missing project token', async () => {
   const ctx = getContext([]);
+  ctx.env.CHROMATIC_PROJECT_TOKEN = '';
+  await runAll(ctx);
+  expect(ctx.exitCode).toBe(254);
+  expect(ctx.testLogger.errors[0]).toMatch(/Missing project token/);
+});
+
+it('returns 0 with a warning when skip is enabled and project token is missing', async () => {
+  const ctx = getContext(['--skip']);
+  ctx.env.CHROMATIC_PROJECT_TOKEN = '';
+  await runAll(ctx);
+  expectSkipNoProjectToken(ctx);
+});
+
+it('returns 0 with a warning when skip matches the current branch and project token is missing', async () => {
+  getBranch.mockResolvedValue('dependabot/npm-and-yarn/storybook-8');
+  const ctx = getContext(['--skip=dependabot/**']);
+  ctx.env.CHROMATIC_PROJECT_TOKEN = '';
+  await runAll(ctx);
+  expectSkipNoProjectToken(ctx);
+});
+
+it('fails on missing project token when skip does not match the current branch', async () => {
+  getBranch.mockResolvedValue('feature/my-branch');
+  const ctx = getContext(['--skip=dependabot/**']);
   ctx.env.CHROMATIC_PROJECT_TOKEN = '';
   await runAll(ctx);
   expect(ctx.exitCode).toBe(254);

--- a/node-src/index.test.ts
+++ b/node-src/index.test.ts
@@ -437,6 +437,15 @@ it('fails on missing project token when skip does not match the current branch',
   expect(ctx.testLogger.errors[0]).toMatch(/Missing project token/);
 });
 
+it('fails on missing project token when branch lookup fails during skip preflight', async () => {
+  getCommit.mockRejectedValueOnce(new Error('git failed'));
+  const ctx = getContext(['--skip=dependabot/**']);
+  ctx.env.CHROMATIC_PROJECT_TOKEN = '';
+  await runAll(ctx);
+  expect(ctx.exitCode).toBe(254);
+  expect(ctx.testLogger.errors[0]).toMatch(/Missing project token/);
+});
+
 // Note this tests options errors, but not fatal task or runtime errors.
 it('passes options error to experimental_onTaskError', async () => {
   const ctx = getContext([]);

--- a/node-src/index.ts
+++ b/node-src/index.ts
@@ -196,11 +196,13 @@ export async function runAll(ctx: InitialContext) {
       ctx.extraOptions?.configFile || ctx.flags.configFile
     );
 
-    if (await shouldSkipWithoutProjectToken(ctx)) {
+    const partialOptions = getPartialOptions(ctx);
+
+    if (await shouldSkipWithoutProjectToken(ctx, partialOptions)) {
       return;
     }
 
-    const options = getOptions(ctx);
+    const options = getOptions(ctx, partialOptions);
     (ctx as Context).options = options;
     ctx.log.setLogFile(options.logFile);
 

--- a/node-src/index.ts
+++ b/node-src/index.ts
@@ -22,7 +22,7 @@ import { isE2EBuild } from './lib/e2eUtils';
 import { emailHash } from './lib/emailHash';
 import { getConfiguration } from './lib/getConfiguration';
 import getEnvironment from './lib/getEnvironment';
-import getOptions, { getPotentialOptions } from './lib/getOptions';
+import getOptions, { getPartialOptions } from './lib/getOptions';
 import { createLogger } from './lib/log';
 import LoggingRenderer from './lib/loggingRenderer';
 import matchesBranch from './lib/matchesBranch';

--- a/node-src/index.ts
+++ b/node-src/index.ts
@@ -199,6 +199,8 @@ export async function runAll(ctx: InitialContext) {
     const partialOptions = getPartialOptions(ctx);
 
     if (await shouldSkipWithoutProjectToken(ctx, partialOptions)) {
+      ctx.log.warn(skipNoProjectToken());
+      setExitCode(ctx, exitCodes.OK);
       return;
     }
 
@@ -234,31 +236,45 @@ export async function runAll(ctx: InitialContext) {
   }
 }
 
-async function shouldSkipWithoutProjectToken(ctx: InitialContext) {
-  const preflightOptions = getPotentialOptions(ctx);
-  if (!preflightOptions.skip) {
+async function shouldSkipWithoutProjectToken(
+  ctx: InitialContext,
+  partialOptions: Partial<Options>
+) {
+  if (!partialOptions.skip) {
     return false;
   }
 
   const hasProjectCredentials =
-    !!preflightOptions.projectToken || !!(preflightOptions.projectId && preflightOptions.userToken);
+    !!partialOptions.projectToken || !!(partialOptions.projectId && partialOptions.userToken);
   if (hasProjectCredentials) {
     return false;
   }
 
-  const { branch } = await getCommitAndBranch(ctx as Context, {
-    branchName: preflightOptions.branchName,
-    patchBaseRef: preflightOptions.patchBaseRef,
-    ci: preflightOptions.fromCI,
-  });
-
-  if (!matchesBranch(branch, preflightOptions.skip)) {
+  const branch = await getBranchForSkip(ctx, partialOptions);
+  if (!branch) {
     return false;
   }
 
-  ctx.log.warn(skipNoProjectToken());
-  setExitCode(ctx, exitCodes.OK);
+  if (!matchesBranch(branch, partialOptions.skip)) {
+    return false;
+  }
+
   return true;
+}
+
+async function getBranchForSkip(ctx: InitialContext, partialOptions: Partial<Options>) {
+  try {
+    const { branch } = await getCommitAndBranch(ctx, {
+      branchName: partialOptions.branchName,
+      patchBaseRef: partialOptions.patchBaseRef,
+      ci: partialOptions.fromCI,
+    });
+
+    return branch;
+  } catch (err) {
+    ctx.log.debug('Failed to determine branch while handling --skip without a project token', err);
+    return false;
+  }
 }
 
 // TODO: refactor this function

--- a/node-src/index.ts
+++ b/node-src/index.ts
@@ -5,6 +5,7 @@ import Listr from 'listr';
 import { readPackageUp } from 'read-package-up';
 import { v4 as uuid } from 'uuid';
 
+import getCommitAndBranch from './git/getCommitAndBranch';
 import {
   getBranch,
   getCommit,
@@ -21,9 +22,10 @@ import { isE2EBuild } from './lib/e2eUtils';
 import { emailHash } from './lib/emailHash';
 import { getConfiguration } from './lib/getConfiguration';
 import getEnvironment from './lib/getEnvironment';
-import getOptions from './lib/getOptions';
+import getOptions, { getPotentialOptions } from './lib/getOptions';
 import { createLogger } from './lib/log';
 import LoggingRenderer from './lib/loggingRenderer';
+import matchesBranch from './lib/matchesBranch';
 import NonTTYRenderer from './lib/nonTTYRenderer';
 import parseArguments from './lib/parseArguments';
 import { exitCodes, setExitCode } from './lib/setExitCode';
@@ -42,6 +44,7 @@ import noPackageJson from './ui/messages/errors/noPackageJson';
 import runtimeError from './ui/messages/errors/runtimeError';
 import taskError from './ui/messages/errors/taskError';
 import intro from './ui/messages/info/intro';
+import skipNoProjectToken from './ui/messages/warnings/skipNoProjectToken';
 
 // Make keys of `T` outside of `R` optional.
 type AtLeast<T, R extends keyof T> = Partial<T> & Pick<T, R>;
@@ -192,6 +195,11 @@ export async function runAll(ctx: InitialContext) {
     ctx.configuration = await getConfiguration(
       ctx.extraOptions?.configFile || ctx.flags.configFile
     );
+
+    if (await shouldSkipWithoutProjectToken(ctx)) {
+      return;
+    }
+
     const options = getOptions(ctx);
     (ctx as Context).options = options;
     ctx.log.setLogFile(options.logFile);
@@ -222,6 +230,33 @@ export async function runAll(ctx: InitialContext) {
   if (ctx.options.uploadMetadata) {
     await uploadMetadataFiles(ctx);
   }
+}
+
+async function shouldSkipWithoutProjectToken(ctx: InitialContext) {
+  const preflightOptions = getPotentialOptions(ctx);
+  if (!preflightOptions.skip) {
+    return false;
+  }
+
+  const hasProjectCredentials =
+    !!preflightOptions.projectToken || !!(preflightOptions.projectId && preflightOptions.userToken);
+  if (hasProjectCredentials) {
+    return false;
+  }
+
+  const { branch } = await getCommitAndBranch(ctx as Context, {
+    branchName: preflightOptions.branchName,
+    patchBaseRef: preflightOptions.patchBaseRef,
+    ci: preflightOptions.fromCI,
+  });
+
+  if (!matchesBranch(branch, preflightOptions.skip)) {
+    return false;
+  }
+
+  ctx.log.warn(skipNoProjectToken());
+  setExitCode(ctx, exitCodes.OK);
+  return true;
 }
 
 // TODO: refactor this function

--- a/node-src/lib/getOptions.ts
+++ b/node-src/lib/getOptions.ts
@@ -47,17 +47,9 @@ const defaultUnlessSetOrFalse = (input: string | boolean | undefined, fallback: 
   }
 };
 
-/**
- * Parse options set when executing the CLI.
- *
- * @param ctx The context set when executing the CLI.
- *
- * @returns An object containing parsed options
- */
-// TODO: refactor this function
-// eslint-disable-next-line complexity, max-statements
-export default function getOptions(ctx: InitialContext): Options {
-  const { argv, env, flags, extraOptions, configuration, log, packageJson, packagePath } = ctx;
+// eslint-disable-next-line complexity
+export const getPotentialOptions = (ctx: InitialContext): Partial<Options> => {
+  const { argv, env, flags, extraOptions, configuration, log } = ctx;
 
   const defaultOptions = {
     projectToken: env.CHROMATIC_PROJECT_TOKEN,
@@ -114,7 +106,7 @@ export default function getOptions(ctx: InitialContext): Options {
     .split('...')
     .filter(Boolean);
   const [branchName, branchOwner] = (flags.branchName || '').split(':').reverse();
-  const [repositoryOwner, repositoryName, ...rest] = flags.repositorySlug?.split('/') || [];
+  const [repositoryOwner] = flags.repositorySlug?.split('/') || [];
 
   const DEFAULT_LOG_FILE = 'chromatic.log';
   const DEFAULT_REPORT_FILE = 'chromatic-build-{buildNumber}.xml';
@@ -212,6 +204,24 @@ export default function getOptions(ctx: InitialContext): Options {
     potentialOptions.logFile = potentialOptions.logFile ?? DEFAULT_LOG_FILE;
     potentialOptions.diagnosticsFile = potentialOptions.diagnosticsFile ?? DEFAULT_DIAGNOSTICS_FILE;
   }
+
+  return potentialOptions;
+};
+
+/**
+ * Parse options set when executing the CLI.
+ *
+ * @param ctx The context set when executing the CLI.
+ *
+ * @returns An object containing parsed options
+ */
+// TODO: refactor this function
+// eslint-disable-next-line complexity, max-statements
+export default function getOptions(ctx: InitialContext): Options {
+  const { flags, log, packageJson, packagePath } = ctx;
+  const potentialOptions = getPotentialOptions(ctx);
+  const [, branchOwner] = (flags.branchName || '').split(':').reverse();
+  const [repositoryOwner, repositoryName, ...rest] = flags.repositorySlug?.split('/') || [];
 
   if (
     !potentialOptions.projectToken &&

--- a/node-src/lib/getOptions.ts
+++ b/node-src/lib/getOptions.ts
@@ -186,7 +186,7 @@ export default function getOptions(ctx: InitialContext): Options {
     storybookLogFile: defaultUnlessSetOrFalse(storybookLogFile, DEFAULT_STORYBOOK_LOG_FILE),
   });
 
-  const potentialOptions: Partial<Options> = {
+  const partialOptions: Partial<Options> = {
     ...defaultOptions,
     ...configurationOptions,
     ...optionsFromFlags,
@@ -202,22 +202,15 @@ export default function getOptions(ctx: InitialContext): Options {
       process.env.NODE_ENV !== 'test',
   };
 
-  if (potentialOptions.debug) {
+  if (partialOptions.debug) {
     log.setLevel('debug');
     log.setInteractive(false);
   }
 
-  if (potentialOptions.debug || potentialOptions.uploadMetadata) {
+  if (partialOptions.debug || partialOptions.uploadMetadata) {
     // Implicitly enable these options unless they're already enabled or explicitly disabled
-    potentialOptions.logFile = potentialOptions.logFile ?? DEFAULT_LOG_FILE;
-    potentialOptions.diagnosticsFile = potentialOptions.diagnosticsFile ?? DEFAULT_DIAGNOSTICS_FILE;
-  }
-
-  if (
-    !potentialOptions.projectToken &&
-    !(potentialOptions.projectId && potentialOptions.userToken)
-  ) {
-    throw new Error(missingProjectToken());
+    partialOptions.logFile = partialOptions.logFile ?? DEFAULT_LOG_FILE;
+    partialOptions.diagnosticsFile = partialOptions.diagnosticsFile ?? DEFAULT_DIAGNOSTICS_FILE;
   }
 
   if (repositoryOwner && (!repositoryName || rest.length > 0)) {
@@ -229,15 +222,15 @@ export default function getOptions(ctx: InitialContext): Options {
   }
 
   if (flags.patchBuild) {
-    if (!potentialOptions.patchHeadRef || !potentialOptions.patchBaseRef) {
+    if (!partialOptions.patchHeadRef || !partialOptions.patchBaseRef) {
       throw new Error(invalidPatchBuild());
     }
-    if (potentialOptions.patchHeadRef === potentialOptions.patchBaseRef) {
+    if (partialOptions.patchHeadRef === partialOptions.patchBaseRef) {
       throw new Error(duplicatePatchBuild());
     }
   }
 
-  if (potentialOptions.onlyStoryNames?.some((glob) => !/[\w*]\/[\w*]/.test(glob))) {
+  if (partialOptions.onlyStoryNames?.some((glob) => !/[\w*]\/[\w*]/.test(glob))) {
     throw new Error(invalidOnlyStoryNames());
   }
 
@@ -252,7 +245,7 @@ export default function getOptions(ctx: InitialContext): Options {
     vitest: '--vitest',
   };
   const foundSingularOptions = Object.keys(singularOptions).filter(
-    (name) => !!potentialOptions[name]
+    (name) => !!partialOptions[name]
   );
 
   if (foundSingularOptions.length > 1) {
@@ -261,51 +254,54 @@ export default function getOptions(ctx: InitialContext): Options {
     );
   }
 
-  if (potentialOptions.onlyChanged && potentialOptions.onlyStoryFiles) {
+  if (partialOptions.onlyChanged && partialOptions.onlyStoryFiles) {
     throw new Error(invalidSingularOptions(['--only-changed', '--only-story-files']));
   }
-  if (potentialOptions.onlyChanged && potentialOptions.onlyStoryNames) {
+  if (partialOptions.onlyChanged && partialOptions.onlyStoryNames) {
     throw new Error(invalidSingularOptions(['--only-changed', '--only-story-names']));
   }
-  if (potentialOptions.onlyStoryNames && potentialOptions.onlyStoryFiles) {
+  if (partialOptions.onlyStoryNames && partialOptions.onlyStoryFiles) {
     throw new Error(invalidSingularOptions(['--only-story-files', '--only-story-names']));
   }
 
-  if (potentialOptions.untraced && !potentialOptions.onlyChanged) {
+  if (partialOptions.untraced && !partialOptions.onlyChanged) {
     throw new Error(dependentOption('--untraced', '--only-changed'));
   }
 
-  if (potentialOptions.externals && !potentialOptions.onlyChanged) {
+  if (partialOptions.externals && !partialOptions.onlyChanged) {
     throw new Error(dependentOption('--externals', '--only-changed'));
   }
 
-  if (potentialOptions.traceChanged && !potentialOptions.onlyChanged) {
+  if (partialOptions.traceChanged && !partialOptions.onlyChanged) {
     throw new Error(dependentOption('--trace-changed', '--only-changed'));
   }
 
-  if (potentialOptions.junitReport && potentialOptions.exitOnceUploaded) {
+  if (partialOptions.junitReport && partialOptions.exitOnceUploaded) {
     throw new Error(incompatibleOptions(['--junit-report', '--exit-once-uploaded']));
   }
 
-  if (potentialOptions.buildScriptName && potentialOptions.buildCommand) {
+  if (partialOptions.buildScriptName && partialOptions.buildCommand) {
     throw new Error(incompatibleOptions(['--build-script-name', '--build-command']));
   }
 
   // --build-command can put the built Storybook anywhere. Rather than reading through the value,
   // we require `--output-dir` to avoid the issue.
-  if (potentialOptions.buildCommand && !potentialOptions.outputDir) {
+  if (partialOptions.buildCommand && !partialOptions.outputDir) {
     throw new Error(dependentOption('--build-command', '--output-dir'));
   }
 
   if (
-    typeof potentialOptions.junitReport === 'string' &&
-    path.extname(potentialOptions.junitReport) !== '.xml'
+    typeof partialOptions.junitReport === 'string' &&
+    path.extname(partialOptions.junitReport) !== '.xml'
   ) {
     throw new Error(invalidReportPath());
   }
 
+  return partialOptions;
+};
+
   // All options are validated and can now be used
-  const options = potentialOptions as Options;
+  const options = partialOptions as Options;
 
   if (flags.preserveMissing) {
     log.info('');
@@ -317,7 +313,7 @@ export default function getOptions(ctx: InitialContext): Options {
     return options;
   }
 
-  if (potentialOptions.buildCommand) {
+  if (partialOptions.buildCommand) {
     return options;
   }
 

--- a/node-src/lib/getOptions.ts
+++ b/node-src/lib/getOptions.ts
@@ -56,8 +56,8 @@ const defaultUnlessSetOrFalse = (input: string | boolean | undefined, fallback: 
  */
 // TODO: refactor this function
 // eslint-disable-next-line complexity, max-statements
-export default function getOptions(ctx: InitialContext): Options {
-  const { argv, env, flags, extraOptions, configuration, log, packageJson, packagePath } = ctx;
+export const getPartialOptions = (ctx: InitialContext): Partial<Options> => {
+  const { argv, env, flags, extraOptions, configuration, log } = ctx;
 
   const defaultOptions = {
     projectToken: env.CHROMATIC_PROJECT_TOKEN,
@@ -234,9 +234,6 @@ export default function getOptions(ctx: InitialContext): Options {
     throw new Error(invalidOnlyStoryNames());
   }
 
-  const { storybookBuildDir } = potentialOptions;
-  let { buildScriptName } = potentialOptions;
-
   // We can only have one of these arguments
   const singularOptions = {
     storybookBuildDir: '--storybook-build-dir',
@@ -299,6 +296,28 @@ export default function getOptions(ctx: InitialContext): Options {
 
   return partialOptions;
 };
+
+/**
+ * Parse options set when executing the CLI.
+ *
+ * @param ctx The context set when executing the CLI.
+ * @param partialOptions Precomputed partial options used during preflight checks.
+ *
+ * @returns An object containing parsed options
+ */
+// TODO: refactor this function
+// eslint-disable-next-line complexity
+export default function getOptions(
+  ctx: InitialContext,
+  partialOptions = getPartialOptions(ctx)
+): Options {
+  const { flags, log, packageJson, packagePath } = ctx;
+  const { storybookBuildDir } = partialOptions;
+  let { buildScriptName } = partialOptions;
+
+  if (!partialOptions.projectToken && !(partialOptions.projectId && partialOptions.userToken)) {
+    throw new Error(missingProjectToken());
+  }
 
   // All options are validated and can now be used
   const options = partialOptions as Options;

--- a/node-src/lib/getOptions.ts
+++ b/node-src/lib/getOptions.ts
@@ -47,9 +47,17 @@ const defaultUnlessSetOrFalse = (input: string | boolean | undefined, fallback: 
   }
 };
 
-// eslint-disable-next-line complexity
-export const getPotentialOptions = (ctx: InitialContext): Partial<Options> => {
-  const { argv, env, flags, extraOptions, configuration, log } = ctx;
+/**
+ * Parse options set when executing the CLI.
+ *
+ * @param ctx The context set when executing the CLI.
+ *
+ * @returns An object containing parsed options
+ */
+// TODO: refactor this function
+// eslint-disable-next-line complexity, max-statements
+export default function getOptions(ctx: InitialContext): Options {
+  const { argv, env, flags, extraOptions, configuration, log, packageJson, packagePath } = ctx;
 
   const defaultOptions = {
     projectToken: env.CHROMATIC_PROJECT_TOKEN,
@@ -106,7 +114,7 @@ export const getPotentialOptions = (ctx: InitialContext): Partial<Options> => {
     .split('...')
     .filter(Boolean);
   const [branchName, branchOwner] = (flags.branchName || '').split(':').reverse();
-  const [repositoryOwner] = flags.repositorySlug?.split('/') || [];
+  const [repositoryOwner, repositoryName, ...rest] = flags.repositorySlug?.split('/') || [];
 
   const DEFAULT_LOG_FILE = 'chromatic.log';
   const DEFAULT_REPORT_FILE = 'chromatic-build-{buildNumber}.xml';
@@ -204,24 +212,6 @@ export const getPotentialOptions = (ctx: InitialContext): Partial<Options> => {
     potentialOptions.logFile = potentialOptions.logFile ?? DEFAULT_LOG_FILE;
     potentialOptions.diagnosticsFile = potentialOptions.diagnosticsFile ?? DEFAULT_DIAGNOSTICS_FILE;
   }
-
-  return potentialOptions;
-};
-
-/**
- * Parse options set when executing the CLI.
- *
- * @param ctx The context set when executing the CLI.
- *
- * @returns An object containing parsed options
- */
-// TODO: refactor this function
-// eslint-disable-next-line complexity, max-statements
-export default function getOptions(ctx: InitialContext): Options {
-  const { flags, log, packageJson, packagePath } = ctx;
-  const potentialOptions = getPotentialOptions(ctx);
-  const [, branchOwner] = (flags.branchName || '').split(':').reverse();
-  const [repositoryOwner, repositoryName, ...rest] = flags.repositorySlug?.split('/') || [];
 
   if (
     !potentialOptions.projectToken &&

--- a/node-src/lib/matchesBranch.ts
+++ b/node-src/lib/matchesBranch.ts
@@ -1,0 +1,15 @@
+import picomatch from 'picomatch';
+
+/**
+ * Checks whether a branch matches a glob pattern, or returns the boolean value directly.
+ *
+ * @param branch The git branch name to evaluate.
+ * @param glob A glob pattern to match against, or a boolean flag to allow all branches.
+ *
+ * @returns Whether the branch matches the provided glob or the boolean flag is truthy.
+ */
+export default function matchesBranch(branch: string, glob: boolean | string) {
+  return typeof glob === 'string' && glob.length > 0
+    ? picomatch(glob, { bash: true })(branch)
+    : !!glob;
+}

--- a/node-src/tasks/gitInfo.ts
+++ b/node-src/tasks/gitInfo.ts
@@ -1,5 +1,3 @@
-import picomatch from 'picomatch';
-
 import { getBaselineBuilds } from '../git/getBaselineBuilds';
 import { getChangedFilesWithReplacement } from '../git/getChangedFilesWithReplacement';
 import getCommitAndBranch from '../git/getCommitAndBranch';
@@ -16,6 +14,7 @@ import {
   getVersion,
 } from '../git/git';
 import { getHasRouter } from '../lib/getHasRouter';
+import matchesBranch from '../lib/matchesBranch';
 import { exitCodes, setExitCode } from '../lib/setExitCode';
 import { createTask, transitionTo } from '../lib/tasks';
 import { isPackageMetadataFile, matchesFile } from '../lib/utilities';
@@ -158,8 +157,7 @@ export const setGitInfo = async (ctx: Context, task: Task) => {
 
   const { branch, commit, slug } = ctx.git;
 
-  ctx.git.matchesBranch = (glob: string | boolean) =>
-    typeof glob === 'string' && glob.length > 0 ? picomatch(glob, { bash: true })(branch) : !!glob;
+  ctx.git.matchesBranch = (glob: string | boolean) => matchesBranch(branch, glob);
 
   if (ctx.git.matchesBranch?.(ctx.options.skip)) {
     transitionTo(skippingBuild)(ctx, task);

--- a/node-src/ui/messages/warnings/skipNoProjectToken.ts
+++ b/node-src/ui/messages/warnings/skipNoProjectToken.ts
@@ -1,0 +1,9 @@
+import chalk from 'chalk';
+import { dedent } from 'ts-dedent';
+
+import { warning } from '../../components/icons';
+
+export default () =>
+  dedent(chalk`
+    ${warning} {bold Skipping Chromatic build locally because --skip is enabled, but no project token was available, so no build was reported to Chromatic. This may leave the Chromatic GitHub checks pending.}
+  `);


### PR DESCRIPTION
Sometimes you want to `--skip=<branch>` on some PRs because they won't have the project token set. Those cases, will currently fail because it can't talk to the backend API. This change allows for this scenario and logs a warning if we're skipping the build _and_ we lack authentication to the Chromatic API. If we have authentication, then it'll continue as normal.

### Before:
https://github.com/codykaup/test-app-a11y/actions/runs/25187067578/job/73847045819
<img width="648" height="266" alt="image" src="https://github.com/user-attachments/assets/21df953c-3df3-4354-864b-26d27e7a89d9" />

### After:
https://github.com/codykaup/test-app-a11y/actions/runs/25187137976/job/73847288790
<img width="1196" height="220" alt="image" src="https://github.com/user-attachments/assets/02b69c50-bf20-48e0-b9b6-5a0890e62525" />

Also tested the GitHub Action (also works):
https://github.com/codykaup/test-app-a11y/actions/runs/25187384332/job/73848140108

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>16.10.0--canary.1310.25450492740.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@16.10.0--canary.1310.25450492740.0
  # or 
  yarn add chromatic@16.10.0--canary.1310.25450492740.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
