### PR TITLE
Make Storybook metadata output generic

### DIFF
--- a/node-src/ui/tasks/storybookInfo.stories.ts
+++ b/node-src/ui/tasks/storybookInfo.stories.ts
@@ -11,7 +11,6 @@ const storybook = {
   builder: { name: 'webpack4', packageVersion: '5.3.0' },
   addons: [],
 };
-const addons = [{ name: 'actions' }, { name: 'docs' }, { name: 'design-assets' }];
 
 const ctx = { options: {} } as any;
 
@@ -20,5 +19,3 @@ export const Initial = () => initial(ctx);
 export const Pending = () => pending(ctx);
 
 export const Success = () => success({ ...ctx, storybook } as any);
-
-export const WithAddons = () => success({ ...ctx, storybook: { ...storybook, addons } } as any);

--- a/node-src/ui/tasks/storybookInfo.ts
+++ b/node-src/ui/tasks/storybookInfo.ts
@@ -1,46 +1,5 @@
-import { isE2EBuild } from '../../lib/e2eUtils';
 import { Context } from '../../types';
 import { buildType } from './utilities';
-
-const capitalize = (string: string) =>
-  string
-    .split('-')
-    .map((str) => str.charAt(0).toUpperCase() + str.slice(1))
-    .join(' ');
-
-const e2eMessage = (ctx: Context) => {
-  if (ctx.options.playwright) {
-    return 'Playwright for E2E';
-  }
-
-  if (ctx.options.cypress) {
-    return 'Cypress for E2E';
-  }
-
-  if (ctx.options.vitest) {
-    return 'Vitest for E2E';
-  }
-
-  return 'E2E';
-};
-
-const infoMessage = (ctx: Context) => {
-  if (isE2EBuild(ctx.options)) {
-    return e2eMessage(ctx);
-  }
-
-  const { addons, version, builder } = ctx.storybook;
-  const info = version ? `Storybook ${version}` : '';
-  const builderInfo = builder
-    ? `${info}; using the ${builder.name} builder (${builder.packageVersion})`
-    : info;
-  const supportedAddons = addons?.filter((addon) => addon?.name);
-  return supportedAddons?.length
-    ? `${builderInfo}; supported addons found: ${supportedAddons
-        .map((addon) => capitalize(addon.name))
-        .join(', ')}`
-    : `${builderInfo}; no supported addons found`;
-};
 
 export const initial = (ctx: Context) => ({
   status: 'initial',
@@ -55,5 +14,5 @@ export const pending = (ctx: Context) => ({
 export const success = (ctx: Context) => ({
   status: 'success',
   title: `Collected ${buildType(ctx)} metadata`,
-  output: infoMessage(ctx),
+  output: 'Build metadata gathered',
 });

--- a/node-src/ui/tasks/storybookInfoE2E.stories.ts
+++ b/node-src/ui/tasks/storybookInfoE2E.stories.ts
@@ -6,30 +6,10 @@ export default {
   decorators: [(storyFunction: any) => task(storyFunction())],
 };
 
-const storybook = {
-  version: '5.3.0',
-  builder: { name: 'webpack4', packageVersion: '5.3.0' },
-  addons: [],
-};
-
 const ctx = { options: { playwright: true } } as any;
 
 export const Initial = () => initial(ctx);
 
 export const Pending = () => pending(ctx);
 
-export const SuccessPlaywright = () => success({ ...ctx, storybook } as any);
-
-export const SuccessCypress = () =>
-  success({
-    ...ctx,
-    options: { ...ctx.options, playwright: false, cypress: true },
-    storybook,
-  } as any);
-
-export const SuccessVitest = () =>
-  success({
-    ...ctx,
-    options: { ...ctx.options, playwright: false, vitest: true },
-    storybook,
-  } as any);
+export const Success = () => success(ctx);

--- a/node-src/ui/workflows/uploadBuildE2E.stories.ts
+++ b/node-src/ui/workflows/uploadBuildE2E.stories.ts
@@ -81,7 +81,7 @@ export const Initializing = () => [
   steps(
     auth.Authenticated,
     gitInfo.Success,
-    storybookInfo.SuccessPlaywright,
+    storybookInfo.Success,
     initialize.Pending,
     build.Initial,
     upload.Initial,
@@ -95,7 +95,7 @@ export const Building = () => [
   steps(
     auth.Authenticated,
     gitInfo.Success,
-    storybookInfo.SuccessPlaywright,
+    storybookInfo.Success,
     initialize.Success,
     build.Building,
     upload.Initial,
@@ -109,7 +109,7 @@ export const Uploading = () => [
   steps(
     auth.Authenticated,
     gitInfo.Success,
-    storybookInfo.SuccessPlaywright,
+    storybookInfo.Success,
     initialize.Success,
     build.Built,
     upload.Uploading,
@@ -123,7 +123,7 @@ export const Verifying = () => [
   steps(
     auth.Authenticated,
     gitInfo.Success,
-    storybookInfo.SuccessPlaywright,
+    storybookInfo.Success,
     initialize.Success,
     build.Built,
     upload.Success,
@@ -137,7 +137,7 @@ export const Snapshotting = () => [
   steps(
     auth.Authenticated,
     gitInfo.Success,
-    storybookInfo.SuccessPlaywright,
+    storybookInfo.Success,
     initialize.Success,
     build.Built,
     upload.Success,
@@ -151,7 +151,7 @@ export const Passed = () => [
   steps(
     auth.Authenticated,
     gitInfo.Success,
-    storybookInfo.SuccessPlaywright,
+    storybookInfo.Success,
     initialize.Success,
     build.Built,
     upload.Success,
@@ -166,7 +166,7 @@ export const ChangesFound = () => [
   steps(
     auth.Authenticated,
     gitInfo.Success,
-    storybookInfo.SuccessPlaywright,
+    storybookInfo.Success,
     initialize.Success,
     build.Built,
     upload.Success,
@@ -181,7 +181,7 @@ export const FirstBuild = () => [
   steps(
     auth.Authenticated,
     gitInfo.Success,
-    storybookInfo.SuccessPlaywright,
+    storybookInfo.Success,
     initialize.Success,
     build.Built,
     upload.Success,
@@ -196,7 +196,7 @@ export const Published = () => [
   steps(
     auth.Authenticated,
     gitInfo.Success,
-    storybookInfo.SuccessPlaywright,
+    storybookInfo.Success,
     initialize.Success,
     build.Built,
     upload.Success,


### PR DESCRIPTION
We write some Storybook metadata to the CLI UI to call out what we found in the project. This idea was called into question with React Native because it uses a different set of builders. Instead of applying the same idea to React Native, we decided to make the output generic to simplify the entire flow.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>16.7.1--canary.1311.25332156236.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@16.7.1--canary.1311.25332156236.0
  # or 
  yarn add chromatic@16.7.1--canary.1311.25332156236.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
