### PR TITLE
Migrate `gitInfo` task to typed inputs and outputs

### DIFF
--- a/node-src/git/execGit.ts
+++ b/node-src/git/execGit.ts
@@ -3,7 +3,7 @@ import { createInterface } from 'node:readline';
 import type { Options } from 'execa';
 
 import { runCommand } from '../lib/shell/shell';
-import { Context } from '../types';
+import { Deps } from '../types';
 import gitNoCommits from '../ui/messages/errors/gitNoCommits';
 import gitNotInitialized from '../ui/messages/errors/gitNotInitialized';
 import gitNotInstalled from '../ui/messages/errors/gitNotInstalled';
@@ -26,7 +26,7 @@ const defaultOptions: Options = {
  * @returns The result of the command from the terminal.
  */
 export async function execGitCommand(
-  { log }: Pick<Context, 'log'>,
+  { log }: Pick<Deps, 'log'>,
   command: string,
   options?: Options
 ) {
@@ -73,7 +73,7 @@ export async function execGitCommand(
  * @returns The first line of the command from the terminal.
  */
 export async function execGitCommandOneLine(
-  { log }: Pick<Context, 'log'>,
+  { log }: Pick<Deps, 'log'>,
   command: string,
   options?: Options
 ) {
@@ -119,7 +119,7 @@ export async function execGitCommandOneLine(
  * @returns The number of lines the command returned
  */
 export async function execGitCommandCountLines(
-  { log }: Pick<Context, 'log'>,
+  { log }: Pick<Deps, 'log'>,
   command: string,
   options?: Options
 ) {

--- a/node-src/git/findAncestorBuildWithCommit.ts
+++ b/node-src/git/findAncestorBuildWithCommit.ts
@@ -1,6 +1,6 @@
 import gql from 'fake-tag';
 
-import { Context } from '../types';
+import { Deps } from '../types';
 import { commitExists } from './git';
 
 const AncestorBuildsQuery = gql`
@@ -43,24 +43,22 @@ export interface AncestorBuildsQueryResult {
  *
  * The purpose here is to allow us to substitute a build with a known clean commit for TurboSnap.
  *
- * @param ctx The context set when executing the CLI.
- * @param ctx.client The GraphQL client within the context.
- * @param ctx.log The logger within the context.
- * @param buildNumber The build number to start searching from
- * @param options Page size and limit options
- * @param options.page How many builds to fetch each time
+ * @param deps Dependencies (client, log).
+ * @param buildNumber The build number to start searching from.
+ * @param options Page size and limit options.
+ * @param options.page How many builds to fetch each time.
  * @param options.limit How many builds to gather per query.
  *
  * @returns A build to be substituted
  */
 export async function findAncestorBuildWithCommit(
-  ctx: Pick<Context, 'client' | 'log'>,
+  deps: Pick<Deps, 'client' | 'log'>,
   buildNumber: number,
   { page = 10, limit = 80 } = {}
 ): Promise<AncestorBuildsQueryResult['app']['build']['ancestorBuilds'][0] | undefined> {
   let skip = 0;
   while (skip < limit) {
-    const { app } = await ctx.client.runQuery<AncestorBuildsQueryResult>(AncestorBuildsQuery, {
+    const { app } = await deps.client.runQuery<AncestorBuildsQueryResult>(AncestorBuildsQuery, {
       buildNumber,
       skip,
       limit: Math.min(page, limit - skip),
@@ -68,7 +66,7 @@ export async function findAncestorBuildWithCommit(
 
     const results = await Promise.all(
       app.build.ancestorBuilds.map(async (build) => {
-        const exists = await commitExists(ctx, build.commit);
+        const exists = await commitExists(deps, build.commit);
         return [build, exists] as const;
       })
     );

--- a/node-src/git/getBaselineBuilds.ts
+++ b/node-src/git/getBaselineBuilds.ts
@@ -1,7 +1,7 @@
 import gql from 'fake-tag';
 
 import { localBuildsSpecifier } from '../lib/localBuildsSpecifier';
-import { Context } from '../types';
+import { BaselineBuild, Deps, Git } from '../types';
 
 const BaselineCommitsQuery = gql`
   query BaselineCommitsQuery(
@@ -25,37 +25,29 @@ const BaselineCommitsQuery = gql`
 `;
 interface BaselineCommitsQueryResult {
   app: {
-    baselineBuilds: {
-      id: string;
-      number: number;
-      status: string;
-      commit: string;
-      committedAt: number;
-      uncommittedHash: string;
-      isLocalBuild: boolean;
-      changeCount: number;
-    }[];
+    baselineBuilds: BaselineBuild[];
   };
 }
 
 /**
  * Get a list of baseline builds from the Index service
  *
- * @param ctx The context set when executing the CLI.
+ * @param deps Dependencies (options, client).
  * @param options Options to pass to the Index query.
  * @param options.branch The branch name.
  * @param options.parentCommits A list of parent commit hashes.
+ * @param options.git Git information for the current build.
  *
  * @returns A list of baseline builds, if available.
  */
 export async function getBaselineBuilds(
-  ctx: Pick<Context, 'options' | 'client' | 'git'>,
-  { branch, parentCommits }: { branch: string; parentCommits: string[] }
+  deps: Pick<Deps, 'options' | 'client'>,
+  { branch, parentCommits, git }: { branch: string; parentCommits: string[]; git: Git }
 ) {
-  const { app } = await ctx.client.runQuery<BaselineCommitsQueryResult>(BaselineCommitsQuery, {
+  const { app } = await deps.client.runQuery<BaselineCommitsQueryResult>(BaselineCommitsQuery, {
     branch,
     parentCommits,
-    localBuilds: localBuildsSpecifier(ctx),
+    localBuilds: localBuildsSpecifier(deps, git),
   });
   return app.baselineBuilds;
 }

--- a/node-src/git/getChangedFilesWithReplacement.ts
+++ b/node-src/git/getChangedFilesWithReplacement.ts
@@ -1,4 +1,4 @@
-import { Context } from '../types';
+import { Deps } from '../types';
 import { findAncestorBuildWithCommit } from './findAncestorBuildWithCommit';
 import { getChangedFiles } from './git';
 
@@ -18,13 +18,13 @@ export interface BuildWithCommitInfo {
  * pushed away), find the nearest ancestor build that *does* have a valid commit, and return
  * the differences, along with the two builds (for tracking purposes).
  *
- * @param ctx The context set when executing the CLI.
+ * @param deps Dependencies (log, client).
  * @param build The build details for gathering changed files.
  *
  * @returns A list of changed files for the build, adding a replacement build if necessary.
  */
 export async function getChangedFilesWithReplacement(
-  ctx: Context,
+  deps: Pick<Deps, 'log' | 'client'>,
   build: BuildWithCommitInfo
 ): Promise<{ changedFiles: string[]; replacementBuild?: BuildWithCommitInfo }> {
   try {
@@ -32,24 +32,24 @@ export async function getChangedFilesWithReplacement(
       throw new Error('Local build had uncommitted changes');
     }
 
-    const changedFiles = (await getChangedFiles(ctx, build.commit)) || [];
+    const changedFiles = (await getChangedFiles(deps, build.commit)) || [];
     return { changedFiles };
   } catch (err) {
-    ctx.log.debug(
+    deps.log.debug(
       `Got error fetching commit for #${build.number}(${build.commit}): ${err.message}`
     );
 
     if (/(bad object|uncommitted changes)/.test(err.message)) {
-      const replacementBuild = await findAncestorBuildWithCommit(ctx, build.number);
+      const replacementBuild = await findAncestorBuildWithCommit(deps, build.number);
 
       if (replacementBuild) {
-        ctx.log.debug(
+        deps.log.debug(
           `Found replacement build for #${build.number}(${build.commit}): #${replacementBuild.number}(${replacementBuild.commit})`
         );
-        const changedFiles = (await getChangedFiles(ctx, replacementBuild.commit)) || [];
+        const changedFiles = (await getChangedFiles(deps, replacementBuild.commit)) || [];
         return { changedFiles, replacementBuild };
       }
-      ctx.log.debug(`Couldn't find replacement for #${build.number}(${build.commit})`);
+      deps.log.debug(`Couldn't find replacement for #${build.number}(${build.commit})`);
     }
 
     // If we can't find a replacement or the error doesn't match, just throw

--- a/node-src/git/getCommitAndBranch.ts
+++ b/node-src/git/getCommitAndBranch.ts
@@ -1,6 +1,6 @@
 import envCi from 'env-ci';
 
-import { Context } from '../types';
+import { Deps } from '../types';
 import forksUnsupported from '../ui/messages/errors/forksUnsupported';
 import gitOneCommit from '../ui/messages/errors/gitOneCommit';
 import missingGitHubInfo from '../ui/messages/errors/missingGitHubInfo';
@@ -33,7 +33,7 @@ function getBranchDetailsFromEnvironmentCI(log) {
 /**
  *  Gather commit and branch information from Git and the local environment.
  *
- * @param ctx The context set when executing the CLI.
+ * @param deps Dependencies (logger).
  * @param options Some extra details about the repository.
  * @param options.branchName The name of the branch.
  * @param options.patchBaseRef The reference to the base side of a patch.
@@ -44,16 +44,16 @@ function getBranchDetailsFromEnvironmentCI(log) {
 // TODO: refactor this function
 // eslint-disable-next-line complexity, max-statements
 export default async function getCommitAndBranch(
-  ctx: Pick<Context, 'log'>,
+  deps: Pick<Deps, 'log'>,
   {
     branchName,
     patchBaseRef,
     ci,
   }: { branchName?: string; patchBaseRef?: string; ci?: boolean } = {}
 ) {
-  const { log } = ctx;
-  let commit: CommitInfo = await getCommit(ctx);
-  let branch = notHead(branchName) || notHead(patchBaseRef) || (await getBranch(ctx));
+  const { log } = deps;
+  let commit: CommitInfo = await getCommit(deps);
+  let branch = notHead(branchName) || notHead(patchBaseRef) || (await getBranch(deps));
   let slug;
 
   const {
@@ -89,7 +89,7 @@ export default async function getCommitAndBranch(
   const isGitHubAction = GITHUB_ACTIONS === 'true';
   const isGitHubPrBuild = GITHUB_EVENT_NAME === 'pull_request';
 
-  if (!(await hasPreviousCommit(ctx))) {
+  if (!(await hasPreviousCommit(deps))) {
     const message = gitOneCommit(isGitHubAction);
     if (isCi) {
       throw new Error(message);
@@ -99,7 +99,7 @@ export default async function getCommitAndBranch(
   }
 
   if (isFromEnvironmentVariable) {
-    commit = await getCommit(ctx, CHROMATIC_SHA).catch((err) => {
+    commit = await getCommit(deps, CHROMATIC_SHA).catch((err) => {
       log.warn(noCommitDetails({ sha: CHROMATIC_SHA, env: 'CHROMATIC_SHA' }));
       log.debug(err);
       return { commit: CHROMATIC_SHA, committedAt: Date.now() };
@@ -120,7 +120,7 @@ export default async function getCommitAndBranch(
     // Travis PR builds are weird, we want to ensure we mark build against the commit that was
     // merged from, rather than the resulting "ephemeral" merge commit that doesn't stick around in the
     // history of the project (so approvals will get lost). We also have to ensure we use the right branch.
-    commit = await getCommit(ctx, TRAVIS_PULL_REQUEST_SHA).catch((err) => {
+    commit = await getCommit(deps, TRAVIS_PULL_REQUEST_SHA).catch((err) => {
       log.warn(noCommitDetails({ sha: TRAVIS_PULL_REQUEST_SHA, env: 'TRAVIS_PULL_REQUEST_SHA' }));
       log.debug(err);
       return { commit: TRAVIS_PULL_REQUEST_SHA, committedAt: Date.now() };
@@ -145,7 +145,7 @@ export default async function getCommitAndBranch(
     // This does not apply to our GitHub Action, because it'll set CHROMATIC_SHA, -BRANCH and -SLUG.
     // We intentionally use the GITHUB_HEAD_REF (branch name) here, to retrieve the last commit on
     // the head branch rather than the merge commit (GITHUB_SHA).
-    commit = await getCommit(ctx, GITHUB_HEAD_REF).catch((err) => {
+    commit = await getCommit(deps, GITHUB_HEAD_REF).catch((err) => {
       log.warn(noCommitDetails({ ref: GITHUB_HEAD_REF, sha: GITHUB_SHA, env: 'GITHUB_HEAD_REF' }));
       log.debug(err);
       return { commit: GITHUB_SHA, committedAt: Date.now() };
@@ -161,7 +161,7 @@ export default async function getCommitAndBranch(
   // On certain CI systems, a branch is not checked out
   // (instead a detached head is used for the commit).
   if (!notHead(branch)) {
-    commit = await getCommit(ctx, ciCommit).catch((err) => {
+    commit = await getCommit(deps, ciCommit).catch((err) => {
       log.warn(noCommitDetails({ sha: ciCommit }));
       log.debug(err);
       return { commit: ciCommit, committedAt: Date.now() };

--- a/node-src/git/getParentCommits.test.ts
+++ b/node-src/git/getParentCommits.test.ts
@@ -54,6 +54,11 @@ function expectCommitsToEqualNames(hashes, names, { commitMap }) {
   return expect(hashes).toEqual(names.map((name) => commitMap[name]?.hash || name));
 }
 
+// Helper to reduce `{ git: git as any }` boilerplate duplication
+function withGit(git: unknown, extra: Record<string, unknown> = {}) {
+  return { git: git as any, ...extra };
+}
+
 async function checkoutCommit(name, branch, { dirname, runGit, commitMap }) {
   process.chdir(dirname);
   await runGit(`git checkout ${branch === 'HEAD' ? '' : `-B ${branch}`} ${commitMap[name].hash}`);
@@ -96,7 +101,7 @@ describe('getParentCommits', () => {
     const client = createClient({ repository, builds: [] });
     const git = { branch: 'main', ...(await getCommit(ctx)) };
 
-    const parentCommits = await getParentCommits({ client, log, git, options } as any);
+    const parentCommits = await getParentCommits({ client, log, options } as any, withGit(git));
     expectCommitsToEqualNames(parentCommits, [], repository);
   });
 
@@ -109,7 +114,7 @@ describe('getParentCommits', () => {
     const client = createClient({ repository, builds: [['F', 'main']] });
     const git = { branch: 'main', ...(await getCommit(ctx)) };
 
-    const parentCommits = await getParentCommits({ client, log, git, options } as any);
+    const parentCommits = await getParentCommits({ client, log, options } as any, withGit(git));
     expectCommitsToEqualNames(parentCommits, ['F'], repository);
   });
 
@@ -122,7 +127,7 @@ describe('getParentCommits', () => {
     const client = createClient({ repository, builds: [['B', 'main']] });
     const git = { branch: 'main', ...(await getCommit(ctx)) };
 
-    const parentCommits = await getParentCommits({ client, log, git, options } as any);
+    const parentCommits = await getParentCommits({ client, log, options } as any, withGit(git));
     expectCommitsToEqualNames(parentCommits, ['B'], repository);
   });
 
@@ -141,7 +146,7 @@ describe('getParentCommits', () => {
     });
     const git = { branch: 'main', ...(await getCommit(ctx)) };
 
-    const parentCommits = await getParentCommits({ client, log, git, options } as any);
+    const parentCommits = await getParentCommits({ client, log, options } as any, withGit(git));
     expectCommitsToEqualNames(parentCommits, ['E', 'D'], repository);
   });
 
@@ -163,7 +168,7 @@ describe('getParentCommits', () => {
     });
     const git = { branch: 'main', ...(await getCommit(ctx)) };
 
-    const parentCommits = await getParentCommits({ client, log, git, options } as any);
+    const parentCommits = await getParentCommits({ client, log, options } as any, withGit(git));
     expectCommitsToEqualNames(parentCommits, ['D', 'C', 'B'], repository);
   });
 
@@ -182,7 +187,7 @@ describe('getParentCommits', () => {
     });
     const git = { branch: 'main', ...(await getCommit(ctx)) };
 
-    const parentCommits = await getParentCommits({ client, log, git, options } as any);
+    const parentCommits = await getParentCommits({ client, log, options } as any, withGit(git));
     expectCommitsToEqualNames(parentCommits, ['C', 'B'], repository);
   });
 
@@ -204,7 +209,7 @@ describe('getParentCommits', () => {
     });
     const git = { branch: 'main', ...(await getCommit(ctx)) };
 
-    const parentCommits = await getParentCommits({ client, log, git, options } as any);
+    const parentCommits = await getParentCommits({ client, log, options } as any, withGit(git));
     expectCommitsToEqualNames(parentCommits, ['B'], repository);
   });
 
@@ -227,7 +232,7 @@ describe('getParentCommits', () => {
     });
     const git = { branch: 'main', ...(await getCommit(ctx)) };
 
-    const parentCommits = await getParentCommits({ client, log, git, options } as any);
+    const parentCommits = await getParentCommits({ client, log, options } as any, withGit(git));
     expectCommitsToEqualNames(parentCommits, ['E', 'D'], repository);
   });
 
@@ -242,7 +247,7 @@ describe('getParentCommits', () => {
     const client = createClient({ repository, builds: [['C', 'main']] });
     const git = { branch: 'main', ...(await getCommit(ctx)) };
 
-    const parentCommits = await getParentCommits({ client, log, git, options } as any);
+    const parentCommits = await getParentCommits({ client, log, options } as any, withGit(git));
     expectCommitsToEqualNames(parentCommits, ['C'], repository);
   });
 
@@ -265,7 +270,7 @@ describe('getParentCommits', () => {
     });
     const git = { branch: 'main', ...(await getCommit(ctx)) };
 
-    const parentCommits = await getParentCommits({ client, log, git, options } as any);
+    const parentCommits = await getParentCommits({ client, log, options } as any, withGit(git));
     expectCommitsToEqualNames(parentCommits, ['D'], repository);
   });
 
@@ -284,7 +289,7 @@ describe('getParentCommits', () => {
     });
     const git = { branch: 'main', ...(await getCommit(ctx)) };
 
-    const parentCommits = await getParentCommits({ client, log, git, options } as any);
+    const parentCommits = await getParentCommits({ client, log, options } as any, withGit(git));
     expectCommitsToEqualNames(parentCommits, ['C'], repository);
   });
 
@@ -297,7 +302,7 @@ describe('getParentCommits', () => {
     const client = createClient({ repository, builds: [['D', 'branch']] });
     const git = { branch: 'main', ...(await getCommit(ctx)) };
 
-    const parentCommits = await getParentCommits({ client, log, git, options } as any);
+    const parentCommits = await getParentCommits({ client, log, options } as any, withGit(git));
     expectCommitsToEqualNames(parentCommits, [], repository);
   });
 
@@ -310,7 +315,7 @@ describe('getParentCommits', () => {
     const client = createClient({ repository, builds: [['E', 'branch']] });
     const git = { branch: 'main', ...(await getCommit(ctx)) };
 
-    const parentCommits = await getParentCommits({ client, log, git, options } as any);
+    const parentCommits = await getParentCommits({ client, log, options } as any, withGit(git));
     expectCommitsToEqualNames(parentCommits, [], repository);
   });
 
@@ -323,7 +328,7 @@ describe('getParentCommits', () => {
     const client = createClient({ repository, builds: [['B', 'branch']] });
     const git = { branch: 'main', ...(await getCommit(ctx)) };
 
-    const parentCommits = await getParentCommits({ client, log, git, options } as any);
+    const parentCommits = await getParentCommits({ client, log, options } as any, withGit(git));
     expectCommitsToEqualNames(parentCommits, [], repository);
   });
 
@@ -343,7 +348,7 @@ describe('getParentCommits', () => {
     });
     const git = { branch: 'main', ...(await getCommit(ctx)) };
 
-    const parentCommits = await getParentCommits({ client, log, git, options } as any);
+    const parentCommits = await getParentCommits({ client, log, options } as any, withGit(git));
     expectCommitsToEqualNames(parentCommits, [], repository);
   });
 
@@ -356,7 +361,7 @@ describe('getParentCommits', () => {
     const client = createClient({ repository, builds: [['D', 'main']] });
     const git = { branch: 'main', ...(await getCommit(ctx)) };
 
-    const parentCommits = await getParentCommits({ client, log, git, options } as any);
+    const parentCommits = await getParentCommits({ client, log, options } as any, withGit(git));
     expectCommitsToEqualNames(parentCommits, ['D'], repository);
   });
 
@@ -369,7 +374,7 @@ describe('getParentCommits', () => {
     const client = createClient({ repository, builds: [['z', 'branch']] });
     const git = { branch: 'main', ...(await getCommit(ctx)) };
 
-    const parentCommits = await getParentCommits({ client, log, git, options } as any);
+    const parentCommits = await getParentCommits({ client, log, options } as any, withGit(git));
     expectCommitsToEqualNames(parentCommits, [], repository);
   });
 
@@ -382,7 +387,7 @@ describe('getParentCommits', () => {
     const client = createClient({ repository, builds: [['A', 'branch']] });
     const git = { branch: 'main', ...(await getCommit(ctx)) };
 
-    const parentCommits = await getParentCommits({ client, log, git, options } as any);
+    const parentCommits = await getParentCommits({ client, log, options } as any, withGit(git));
     expectCommitsToEqualNames(parentCommits, ['A'], repository);
   });
 
@@ -408,7 +413,7 @@ describe('getParentCommits', () => {
     };
     const git = { branch: 'branch', ...(await getCommit(ctx)) };
 
-    const parentCommits = await getParentCommits({ client, log, git, options } as any);
+    const parentCommits = await getParentCommits({ client, log, options } as any, withGit(git));
     expectCommitsToEqualNames(parentCommits, ['A'], repository);
   });
 
@@ -432,7 +437,7 @@ describe('getParentCommits', () => {
     });
     const git = { branch: 'branch', ...(await getCommit(ctx)) };
 
-    const parentCommits = await getParentCommits({ client, log, git, options } as any);
+    const parentCommits = await getParentCommits({ client, log, options } as any, withGit(git));
     expectCommitsToEqualNames(parentCommits, ['D'], repository);
   });
 
@@ -456,7 +461,7 @@ describe('getParentCommits', () => {
     });
     const git = { branch: 'branch', ...(await getCommit(ctx)) };
 
-    const parentCommits = await getParentCommits({ client, log, git, options } as any);
+    const parentCommits = await getParentCommits({ client, log, options } as any, withGit(git));
     expectCommitsToEqualNames(parentCommits, ['D'], repository);
   });
 
@@ -480,7 +485,7 @@ describe('getParentCommits', () => {
     });
     const git = { branch: 'branch', ...(await getCommit(ctx)) };
 
-    const parentCommits = await getParentCommits({ client, log, git, options } as any);
+    const parentCommits = await getParentCommits({ client, log, options } as any, withGit(git));
     expectCommitsToEqualNames(parentCommits, ['C'], repository);
   });
 
@@ -503,9 +508,10 @@ describe('getParentCommits', () => {
     });
     const git = { branch: 'branch', ...(await getCommit(ctx)) };
 
-    const parentCommits = await getParentCommits({ client, log, git, options } as any, {
-      ignoreLastBuildOnBranch: true,
-    });
+    const parentCommits = await getParentCommits(
+      { client, log, options } as any,
+      withGit(git, { ignoreLastBuildOnBranch: true })
+    );
     expectCommitsToEqualNames(parentCommits, ['C'], repository);
   });
 
@@ -535,7 +541,7 @@ describe('getParentCommits', () => {
     });
     const git = { branch: 'branch', ...(await getCommit(ctx)) };
 
-    const parentCommits = await getParentCommits({ client, log, git, options } as any);
+    const parentCommits = await getParentCommits({ client, log, options } as any, withGit(git));
     expect(parentCommits).toEqual([Zhash, repository.commitMap.C.hash]);
   });
 
@@ -560,7 +566,7 @@ describe('getParentCommits', () => {
     });
     const git = { branch: 'branch', ...(await getCommit(ctx)) };
 
-    const parentCommits = await getParentCommits({ client, log, git, options } as any);
+    const parentCommits = await getParentCommits({ client, log, options } as any, withGit(git));
     expectCommitsToEqualNames(parentCommits, ['B'], repository);
   });
 
@@ -583,7 +589,7 @@ describe('getParentCommits', () => {
     });
     const git = { branch: 'branch', ...(await getCommit(ctx)) };
 
-    const parentCommits = await getParentCommits({ client, log, git, options } as any);
+    const parentCommits = await getParentCommits({ client, log, options } as any, withGit(git));
     expectCommitsToEqualNames(parentCommits, ['E'], repository);
   });
 
@@ -608,7 +614,7 @@ describe('getParentCommits', () => {
     const git = { branch: 'HEAD', ...(await getCommit(ctx)) };
 
     // We can pass 'HEAD' as the branch if we fail to find any other branch info from another source
-    const parentCommits = await getParentCommits({ client, log, git, options } as any);
+    const parentCommits = await getParentCommits({ client, log, options } as any, withGit(git));
     expectCommitsToEqualNames(parentCommits, ['C'], repository);
   });
 
@@ -634,7 +640,7 @@ describe('getParentCommits', () => {
       });
       const git = { branch: 'main', ...(await getCommit(ctx)) };
 
-      const parentCommits = await getParentCommits({ client, log, git, options } as any);
+      const parentCommits = await getParentCommits({ client, log, options } as any, withGit(git));
       // This doesn't include 'C' as D "covers" it.
       expectCommitsToEqualNames(parentCommits, ['D'], repository);
     });
@@ -658,7 +664,7 @@ describe('getParentCommits', () => {
       });
       const git = { branch: 'main', ...(await getCommit(ctx)) };
 
-      const parentCommits = await getParentCommits({ client, log, git, options } as any);
+      const parentCommits = await getParentCommits({ client, log, options } as any, withGit(git));
       expectCommitsToEqualNames(parentCommits, ['D', 'C'], repository);
     });
 
@@ -681,7 +687,7 @@ describe('getParentCommits', () => {
       });
       const git = { branch: 'main', ...(await getCommit(ctx)) };
 
-      const parentCommits = await getParentCommits({ client, log, git, options } as any);
+      const parentCommits = await getParentCommits({ client, log, options } as any, withGit(git));
       expectCommitsToEqualNames(parentCommits, ['C', 'B'], repository);
     });
 
@@ -704,7 +710,7 @@ describe('getParentCommits', () => {
       });
       const git = { branch: 'main', ...(await getCommit(ctx)) };
 
-      const parentCommits = await getParentCommits({ client, log, git, options } as any);
+      const parentCommits = await getParentCommits({ client, log, options } as any, withGit(git));
       // This doesn't include A as B "covers" it.
       expectCommitsToEqualNames(parentCommits, ['B'], repository);
     });
@@ -725,7 +731,7 @@ describe('getParentCommits', () => {
       });
       const git = { branch: 'main', ...(await getCommit(ctx)) };
 
-      const parentCommits = await getParentCommits({ client, log, git, options } as any);
+      const parentCommits = await getParentCommits({ client, log, options } as any, withGit(git));
       expectCommitsToEqualNames(parentCommits, ['C'], repository);
     });
 
@@ -748,7 +754,7 @@ describe('getParentCommits', () => {
       });
       const git = { branch: 'main', ...(await getCommit(ctx)) };
 
-      const parentCommits = await getParentCommits({ client, log, git, options } as any);
+      const parentCommits = await getParentCommits({ client, log, options } as any, withGit(git));
       expectCommitsToEqualNames(parentCommits, ['MISSING', 'A'], repository);
     });
 
@@ -780,7 +786,7 @@ describe('getParentCommits', () => {
       });
       const git = { branch: 'main', ...(await getCommit(ctx)) };
 
-      const parentCommits = await getParentCommits({ client, log, git, options } as any);
+      const parentCommits = await getParentCommits({ client, log, options } as any, withGit(git));
       expectCommitsToEqualNames(parentCommits, ['C', 'B'], repository);
     });
 
@@ -802,7 +808,7 @@ describe('getParentCommits', () => {
       });
       const git = { branch: 'main', ...(await getCommit(ctx)) };
 
-      const parentCommits = await getParentCommits({ client, log, git, options } as any);
+      const parentCommits = await getParentCommits({ client, log, options } as any, withGit(git));
       expectCommitsToEqualNames(parentCommits, ['E', 'D'], repository);
     });
   });

--- a/node-src/git/getParentCommits.ts
+++ b/node-src/git/getParentCommits.ts
@@ -1,7 +1,7 @@
 import gql from 'fake-tag';
 
 import { localBuildsSpecifier } from '../lib/localBuildsSpecifier';
-import { Context } from '../types';
+import { Deps, Git } from '../types';
 import { execGitCommand } from './execGit';
 import { commitExists } from './git';
 
@@ -89,7 +89,7 @@ function commitsForCLI(commits: string[]) {
 // `commitsWithBuilds`.
 //
 async function nextCommits(
-  ctx: Pick<Context, 'log'>,
+  deps: Pick<Deps, 'log'>,
   limit: number,
   {
     firstCommittedAtSeconds,
@@ -107,7 +107,7 @@ async function nextCommits(
   const command = `git rev-list HEAD \
       ${firstCommittedAtSeconds ? `--since ${firstCommittedAtSeconds}` : ''} \
       -n ${limit + commitsWithoutBuilds.length} --not ${commitsForCLI(commitsWithBuilds)}`;
-  const commitsString = await execGitCommand(ctx, command);
+  const commitsString = await execGitCommand(deps, command);
   const commits = commitsString?.split('\n').filter(Boolean);
 
   // Later on we want to know which commits we visited on the way to finding the ancestor commits
@@ -126,7 +126,8 @@ async function nextCommits(
 
 // Exponentially iterate `limit` up to infinity to find a "covering" set of commits with builds
 async function step(
-  { options, client, log, git }: Pick<Context, 'options' | 'client' | 'log' | 'git'>,
+  deps: Pick<Deps, 'options' | 'client' | 'log'>,
+  git: Git,
   limit: number,
   {
     firstCommittedAtSeconds,
@@ -138,6 +139,7 @@ async function step(
     commitsWithoutBuilds: string[];
   }
 ) {
+  const { options, client, log } = deps;
   log.debug(`step: checking ${limit} up to ${firstCommittedAtSeconds}`);
   log.debug(`step: commitsWithBuilds: ${commitsWithBuilds}`);
   log.debug(`step: commitsWithoutBuilds: ${commitsWithoutBuilds}`);
@@ -162,7 +164,7 @@ async function step(
     app: { hasBuildsWithCommits: newCommitsWithBuilds },
   } = await client.runQuery<HasBuildsWithCommitsQueryResult>(HasBuildsWithCommitsQuery, {
     commits: candidateCommits,
-    localBuilds: localBuildsSpecifier({ options, git }),
+    localBuilds: localBuildsSpecifier({ options }, git),
   });
   log.debug(`step: newCommitsWithBuilds: ${newCommitsWithBuilds}`);
 
@@ -170,7 +172,7 @@ async function step(
     (commit) => !newCommitsWithBuilds.includes(commit)
   );
 
-  return step({ options, client, log, git }, limit * 2, {
+  return step(deps, git, limit * 2, {
     firstCommittedAtSeconds,
     commitsWithBuilds: [...commitsWithBuilds, ...newCommitsWithBuilds],
     commitsWithoutBuilds: [...commitsWithoutBuilds, ...(newCommitsWithoutBuilds || [])],
@@ -179,7 +181,7 @@ async function step(
 
 // Which of the listed commits are "maximally descendent":
 // ie c in commits such that there are no descendents of c in commits.
-async function maximallyDescendentCommits(ctx: Pick<Context, 'log'>, commits: string[]) {
+async function maximallyDescendentCommits(deps: Pick<Deps, 'log'>, commits: string[]) {
   if (commits.length === 0) {
     return commits;
   }
@@ -189,7 +191,7 @@ async function maximallyDescendentCommits(ctx: Pick<Context, 'log'>, commits: st
   // List the tree from <commits> not including the tree from <parentCommits>
   // This just filters any commits that are ancestors of other commits
   const command = `git rev-list ${commitsForCLI(commits)} --not ${commitsForCLI(parentCommits)}`;
-  const maxCommitsString = await execGitCommand(ctx, command);
+  const maxCommitsString = await execGitCommand(deps, command);
   const maxCommits = maxCommitsString?.split('\n').filter(Boolean);
 
   return maxCommits;
@@ -198,8 +200,9 @@ async function maximallyDescendentCommits(ctx: Pick<Context, 'log'>, commits: st
 /**
  * Gather the parent commits from Git.
  *
- * @param ctx The context set when executing the CLI.
+ * @param deps Dependencies (log, client, options).
  * @param options Additional options for changing function flow.
+ * @param options.git Git information for the current build.
  * @param options.ignoreLastBuildOnBranch Ignore the last Chromatic build associated with this
  * branch.
  *
@@ -207,14 +210,17 @@ async function maximallyDescendentCommits(ctx: Pick<Context, 'log'>, commits: st
  */
 // TODO: refactor this function
 // eslint-disable-next-line complexity, max-statements
-export async function getParentCommits(ctx: Context, { ignoreLastBuildOnBranch = false } = {}) {
-  const { options, client, git, log } = ctx;
+export async function getParentCommits(
+  deps: Pick<Deps, 'options' | 'client' | 'log'>,
+  { git, ignoreLastBuildOnBranch = false }: { git: Git; ignoreLastBuildOnBranch?: boolean | string }
+) {
+  const { options, client, log } = deps;
   const { branch, committedAt } = git;
 
   // Include the latest build from this branch as an ancestor of the current build
   const { app } = await client.runQuery<FirstCommittedAtQueryResult>(
     FirstCommittedAtQuery,
-    { branch, localBuilds: localBuildsSpecifier({ options, git }) },
+    { branch, localBuilds: localBuildsSpecifier({ options }, git) },
     { retries: 5 } // This query requires a request to an upstream provider which may fail
   );
   const { firstBuild, lastBuild } = app;
@@ -241,7 +247,7 @@ export async function getParentCommits(ctx: Context, { ignoreLastBuildOnBranch =
     lastBuild &&
     lastBuild.committedAt <= committedAt
   ) {
-    if (await commitExists(ctx, lastBuild.commit)) {
+    if (await commitExists(deps, lastBuild.commit)) {
       log.debug(`Adding last branch build commit ${lastBuild.commit} to commits with builds`);
       initialCommitsWithBuilds.push(lastBuild.commit);
     } else {
@@ -258,7 +264,8 @@ export async function getParentCommits(ctx: Context, { ignoreLastBuildOnBranch =
   //   - an ancestor of a commit in commitsWithBuilds
   //   - has no build
   const { commitsWithBuilds, visitedCommitsWithoutBuilds } = await step(
-    { options, client, log, git },
+    deps,
+    git,
     FETCH_N_INITIAL_BUILD_COMMITS,
     {
       firstCommittedAtSeconds: firstBuild.committedAt && firstBuild.committedAt / 1000,
@@ -284,7 +291,7 @@ export async function getParentCommits(ctx: Context, { ignoreLastBuildOnBranch =
     // @see https://www.chromatic.com/docs/branching-and-baselines#squash-and-rebase-merging
     const lastHeadBuildCommit = pullRequest.lastHeadBuild?.commit;
     if (lastHeadBuildCommit) {
-      if (await commitExists(ctx, lastHeadBuildCommit)) {
+      if (await commitExists(deps, lastHeadBuildCommit)) {
         log.debug(`Adding merged PR build commit ${lastHeadBuildCommit} to commits with builds`);
         commitsWithBuilds.push(lastHeadBuildCommit);
       } else {

--- a/node-src/git/git.ts
+++ b/node-src/git/git.ts
@@ -4,7 +4,7 @@ import pLimit from 'p-limit';
 import path from 'path';
 import { file as temporaryFile } from 'tmp-promise';
 
-import { Context } from '../types';
+import { Deps } from '../types';
 import { execGitCommand, execGitCommandCountLines, execGitCommandOneLine } from './execGit';
 
 const newline = /\r\n|\r|\n/; // Git may return \n even on Windows, so we can't use EOL
@@ -13,24 +13,24 @@ export const NULL_BYTE = '\0'; // Separator used when running `git ls-files` wit
 /**
  * Get the version of Git from the host.
  *
- * @param ctx Standard context object.
+ * @param deps Function dependencies.
  *
  * @returns The Git version.
  */
-export async function getVersion(ctx: Pick<Context, 'log'>) {
-  const result = await execGitCommand(ctx, `git --version`);
+export async function getVersion(deps: Pick<Deps, 'log'>) {
+  const result = await execGitCommand(deps, `git --version`);
   return result?.replace('git version ', '').replace(/\s*\(.*\)/, '');
 }
 
 /**
  * Get the user's email from Git.
  *
- * @param ctx Standard context object.
+ * @param deps Function dependencies.
  *
  * @returns The user's email.
  */
-export async function getUserEmail(ctx: Pick<Context, 'log'>) {
-  return execGitCommand(ctx, `git config user.email`);
+export async function getUserEmail(deps: Pick<Deps, 'log'>) {
+  return execGitCommand(deps, `git config user.email`);
 }
 
 /**
@@ -38,12 +38,12 @@ export async function getUserEmail(ctx: Pick<Context, 'log'>) {
  * and is typically followed by `.git`. The regex matches the last two parts between slashes, and
  * ignores the `.git` suffix if it exists, so it matches something like `ownername/reponame`.
  *
- * @param ctx Standard context object.
+ * @param deps Function dependencies.
  *
  * @returns The slug of the remote URL.
  */
-export async function getSlug(ctx: Pick<Context, 'log'>) {
-  const result = await execGitCommand(ctx, `git config --get remote.origin.url`);
+export async function getSlug(deps: Pick<Deps, 'log'>) {
+  const result = await execGitCommand(deps, `git config --get remote.origin.url`);
   const downcasedResult = result?.toLowerCase() || '';
   const [, slug] = downcasedResult.match(/([^/:]+\/[^/]+?)(\.git)?$/) || [];
   return slug;
@@ -56,14 +56,14 @@ export async function getSlug(ctx: Pick<Context, 'log'>) {
 /**
  * Get commit details from Git.
  *
- * @param ctx Standard context object.
+ * @param deps Function dependencies.
  * @param revision The argument to `git log` (usually a commit SHA).
  *
  * @returns Commit details from Git.
  */
-export async function getCommit(ctx: Pick<Context, 'log'>, revision = '') {
+export async function getCommit(deps: Pick<Deps, 'log'>, revision = '') {
   const result = await execGitCommand(
-    ctx,
+    deps,
     // Technically this yields the author info, not committer info
     `git --no-pager log -n 1 --format="%H ## %ct ## %ae ## %an" ${revision}`
   );
@@ -80,26 +80,26 @@ export async function getCommit(ctx: Pick<Context, 'log'>, revision = '') {
 /**
  * Get the current branch from Git.
  *
- * @param ctx Standard context object.
+ * @param deps Function dependencies.
  *
  * @returns The branch name from Git.
  */
-export async function getBranch(ctx: Pick<Context, 'log'>) {
+export async function getBranch(deps: Pick<Deps, 'log'>) {
   try {
     // Git v2.22 and above
     // Yields an empty string when in detached HEAD state
-    const branch = await execGitCommand(ctx, 'git branch --show-current');
+    const branch = await execGitCommand(deps, 'git branch --show-current');
     return branch || 'HEAD';
   } catch {
     try {
       // Git v1.8 and above
       // Throws when in detached HEAD state
-      const reference = await execGitCommand(ctx, 'git symbolic-ref HEAD');
+      const reference = await execGitCommand(deps, 'git symbolic-ref HEAD');
       return reference?.replace(/^refs\/heads\//, ''); // strip the "refs/heads/" prefix
     } catch {
       // Git v1.7 and above
       // Yields 'HEAD' when in detached HEAD state
-      const reference = await execGitCommand(ctx, 'git rev-parse --abbrev-ref HEAD');
+      const reference = await execGitCommand(deps, 'git rev-parse --abbrev-ref HEAD');
       return reference?.replace(/^heads\//, ''); // strip the "heads/" prefix that's sometimes present
     }
   }
@@ -110,18 +110,18 @@ export async function getBranch(ctx: Pick<Context, 'log'>) {
  * excluding deleted files (which can't be hashed) and ignored files. There is no one single Git
  * command to reliably get this information, so we use a combination of commands grouped together.
  *
- * @param ctx Standard context object.
+ * @param deps Function dependencies.
  *
  * @returns The uncommited hash, if available.
  */
-export async function getUncommittedHash(ctx: Pick<Context, 'log'>) {
+export async function getUncommittedHash(deps: Pick<Deps, 'log'>) {
   const listStagedFiles = 'git diff --name-only --no-relative --diff-filter=d --cached';
   const listUnstagedFiles = 'git diff --name-only --no-relative --diff-filter=d';
   const listUntrackedFiles = 'git ls-files --others --exclude-standard';
   const listUncommittedFiles = [listStagedFiles, listUnstagedFiles, listUntrackedFiles].join(';');
 
   const uncommittedHashWithPadding = await execGitCommand(
-    ctx,
+    deps,
     // Pass the combined list of filenames to hash-object to retrieve a list of hashes. Then pass
     // the list of hashes to hash-object again to retrieve a single hash of all hashes. We use
     // stdin to avoid the limit on command line arguments.
@@ -137,12 +137,12 @@ export async function getUncommittedHash(ctx: Pick<Context, 'log'>) {
 /**
  * Determine if the current commit has at least one parent commit.
  *
- * @param ctx Standard context object.
+ * @param deps Function dependencies.
  *
  * @returns True if the current commit has at least one parent.
  */
-export async function hasPreviousCommit(ctx: Pick<Context, 'log'>) {
-  const result = await execGitCommand(ctx, `git --no-pager log -n 1 --skip=1 --format="%H"`);
+export async function hasPreviousCommit(deps: Pick<Deps, 'log'>) {
+  const result = await execGitCommand(deps, `git --no-pager log -n 1 --skip=1 --format="%H"`);
 
   // Ignore lines that don't match the expected format (e.g. gpg signature info)
   const allhex = new RegExp('^[a-f0-9]+$');
@@ -152,14 +152,14 @@ export async function hasPreviousCommit(ctx: Pick<Context, 'log'>) {
 /**
  * Check if a commit exists in the repository
  *
- * @param ctx Standard context object.
+ * @param deps Function dependencies.
  * @param commit The commit to check.
  *
  * @returns True if the commit exists.
  */
-export async function commitExists(ctx: Pick<Context, 'log'>, commit: string) {
+export async function commitExists(deps: Pick<Deps, 'log'>, commit: string) {
   try {
-    await execGitCommand(ctx, `git cat-file -e "${commit}^{commit}"`);
+    await execGitCommand(deps, `git cat-file -e "${commit}^{commit}"`);
     return true;
   } catch {
     return false;
@@ -169,20 +169,20 @@ export async function commitExists(ctx: Pick<Context, 'log'>, commit: string) {
 /**
  * Get the changed files of a single commit or between two.
  *
- * @param ctx Standard context object.
+ * @param deps Function dependencies.
  * @param baseCommit The base commit to check.
  * @param headCommit The head commit to check.
  *
  * @returns The list of changed files of a single commit or between two commits.
  */
 export async function getChangedFiles(
-  ctx: Pick<Context, 'log'>,
+  deps: Pick<Deps, 'log'>,
   baseCommit: string,
   headCommit = ''
 ) {
   // Note that an empty headCommit will include uncommitted (staged or unstaged) changes.
   const files = await execGitCommand(
-    ctx,
+    deps,
     `git --no-pager diff --name-only --no-relative ${baseCommit} ${headCommit}`
   );
   return files?.split(newline).filter(Boolean);
@@ -192,15 +192,15 @@ export async function getChangedFiles(
  * Returns a boolean indicating whether the workspace is up-to-date (neither ahead nor behind) with
  * the remote. Returns true on error, assuming the workspace is up-to-date.
  *
- * @param ctx The context set when executing the CLI.
+ * @param deps Function dependencies.
  *
  * @returns True if the workspace is up-to-date.
  */
-export async function isUpToDate(ctx: Pick<Context, 'log'>) {
-  const { log } = ctx;
+export async function isUpToDate(deps: Pick<Deps, 'log'>) {
+  const { log } = deps;
 
   try {
-    await execGitCommand(ctx, `git remote update`);
+    await execGitCommand(deps, `git remote update`);
   } catch (err) {
     log.warn(err);
     return true;
@@ -208,7 +208,7 @@ export async function isUpToDate(ctx: Pick<Context, 'log'>) {
 
   let localCommit;
   try {
-    localCommit = await execGitCommand(ctx, 'git rev-parse HEAD');
+    localCommit = await execGitCommand(deps, 'git rev-parse HEAD');
     if (!localCommit) throw new Error('Failed to retrieve last local commit hash');
   } catch (err) {
     log.warn(err);
@@ -217,7 +217,7 @@ export async function isUpToDate(ctx: Pick<Context, 'log'>) {
 
   let remoteCommit;
   try {
-    remoteCommit = await execGitCommand(ctx, 'git rev-parse "@{upstream}"');
+    remoteCommit = await execGitCommand(deps, 'git rev-parse "@{upstream}"');
     if (!remoteCommit) throw new Error('Failed to retrieve last remote commit hash');
   } catch (err) {
     log.warn(err);
@@ -230,12 +230,12 @@ export async function isUpToDate(ctx: Pick<Context, 'log'>) {
 /**
  * Returns a boolean indicating whether the workspace is clean (no changes, no untracked files).
  *
- * @param ctx Standard context object.
+ * @param deps Function dependencies.
  *
  * @returns True if the workspace has no changes.
  */
-export async function isClean(ctx: Pick<Context, 'log'>) {
-  const status = await execGitCommand(ctx, 'git status --porcelain');
+export async function isClean(deps: Pick<Deps, 'log'>) {
+  const status = await execGitCommand(deps, 'git status --porcelain');
   return status === '';
 }
 
@@ -243,12 +243,12 @@ export async function isClean(ctx: Pick<Context, 'log'>) {
  * Returns the "Your branch is behind by n commits (pull to update)" part of the git status message,
  * omitting any of the other stuff that may be in there. Note we expect the workspace to be clean.
  *
- * @param ctx Standard context object.
+ * @param deps Function dependencies.
  *
  * @returns A message indicating how far behind the branch is from the remote.
  */
-export async function getUpdateMessage(ctx: Pick<Context, 'log'>) {
-  const status = await execGitCommand(ctx, 'git status');
+export async function getUpdateMessage(deps: Pick<Deps, 'log'>) {
+  const status = await execGitCommand(deps, 'git status');
   return status
     ?.split(/(\r\n|\r|\n){2}/)[0] // drop the 'nothing to commit' part
     .split(newline)
@@ -284,19 +284,19 @@ export async function getUpdateMessage(ctx: Pick<Context, 'log'>) {
  * one on the base branch, but if that fails we just pick the first one and hope it works out.
  * Luckily this is an uncommon scenario.
  *
- * @param ctx Standard context object.
+ * @param deps Function dependencies.
  * @param headReference Name of the head branch
  * @param baseReference Name of the base branch
  *
  * @returns The best common ancestor commit between the two provided.
  */
 export async function findMergeBase(
-  ctx: Pick<Context, 'log'>,
+  deps: Pick<Deps, 'log'>,
   headReference: string,
   baseReference: string
 ) {
   const result = await execGitCommand(
-    ctx,
+    deps,
     `git merge-base --all ${headReference} ${baseReference}`
   );
   const mergeBases =
@@ -309,7 +309,7 @@ export async function findMergeBase(
   const branchNames = await Promise.all(
     mergeBases.map(async (sha) => {
       const name = await execGitCommand(
-        ctx,
+        deps,
         `git name-rev --name-only --no-relative --exclude="tags/*" ${sha}`
       );
       return name?.replace(/~\d+$/, ''); // Drop the potential suffix
@@ -321,13 +321,13 @@ export async function findMergeBase(
 
 /**
  *
- * @param ctx Standard context object.
+ * @param deps Function dependencies.
  * @param reference The reference to checkout (usually a commit).
  *
  * @returns The result of the Git checkout call in the terminal.
  */
-export async function checkout(ctx: Pick<Context, 'log'>, reference: string) {
-  return execGitCommand(ctx, `git checkout ${reference}`);
+export async function checkout(deps: Pick<Deps, 'log'>, reference: string) {
+  return execGitCommand(deps, `git checkout ${reference}`);
 }
 
 const limitConcurrency = pLimit(10);
@@ -335,8 +335,8 @@ const limitConcurrency = pLimit(10);
 /**
  * Checkout a file at the given reference and write the results to a temporary file.
  *
- * @param ctx The context set when executing the CLI.
- * @param ctx.log The logger found on the context object.
+ * @param deps Function dependencies.
+ * @param deps.log The logger found on the context object.
  * @param reference The reference (usually a commit or branch) to the file version in Git.
  * @param fileName The name of the file to check out.
  * @param tmpdir The directory to write the temporary file to.
@@ -344,7 +344,7 @@ const limitConcurrency = pLimit(10);
  * @returns The temporary file path of the checked out file.
  */
 export async function checkoutFile(
-  ctx: Pick<Context, 'log'>,
+  deps: Pick<Deps, 'log'>,
   reference: string,
   fileName: string,
   tmpdir: string
@@ -357,8 +357,8 @@ export async function checkoutFile(
       tmpdir,
     });
 
-    ctx.log.debug(`Checking out file ${pathspec} at ${targetFileName}`);
-    await execGitCommand(ctx, `git show ${pathspec} > ${targetFileName}`);
+    deps.log.debug(`Checking out file ${pathspec} at ${targetFileName}`);
+    await execGitCommand(deps, `git show ${pathspec} > ${targetFileName}`);
 
     return targetFileName;
   });
@@ -367,47 +367,47 @@ export async function checkoutFile(
 /**
  * Check out the previous branch in the Git repository.
  *
- * @param ctx Standard context object.
+ * @param deps Function dependencies.
  *
  * @returns The result of the `git checkout` command in the terminal.
  */
-export async function checkoutPrevious(ctx: Pick<Context, 'log'>) {
-  return execGitCommand(ctx, `git checkout -`);
+export async function checkoutPrevious(deps: Pick<Deps, 'log'>) {
+  return execGitCommand(deps, `git checkout -`);
 }
 
 /**
  * Reset any pending changes in the Git repository.
  *
- * @param ctx Standard context object.
+ * @param deps Function dependencies.
  *
  * @returns The result of the `git reset` command in the terminal.
  */
-export async function discardChanges(ctx: Pick<Context, 'log'>) {
-  return execGitCommand(ctx, `git reset --hard`);
+export async function discardChanges(deps: Pick<Deps, 'log'>) {
+  return execGitCommand(deps, `git reset --hard`);
 }
 
 /**
  * Gather the root directory of the Git repository.
  *
- * @param ctx Standard context object.
+ * @param deps Function dependencies.
  *
  * @returns The root directory of the Git repository.
  */
-export async function getRepositoryRoot(ctx: Pick<Context, 'log'>) {
-  return execGitCommand(ctx, `git rev-parse --show-toplevel`);
+export async function getRepositoryRoot(deps: Pick<Deps, 'log'>) {
+  return execGitCommand(deps, `git rev-parse --show-toplevel`);
 }
 
 /**
  * Find all files that match the given patterns within the repository.
  *
- * @param ctx Standard context object.
+ * @param deps Function dependencies.
  * @param repoRoot The root path of the repository (usually from `getRepositoryRoot()`).
  * @param patterns A list of patterns to filter file results.
  *
  * @returns A list of files matching the pattern.
  */
 export async function findFilesFromRepositoryRoot(
-  ctx: Pick<Context, 'log'>,
+  deps: Pick<Deps, 'log'>,
   repoRoot: string,
   ...patterns: string[]
 ) {
@@ -421,21 +421,21 @@ export async function findFilesFromRepositoryRoot(
   // Uses `--full-name` to ensure that all files found are relative to the repository root,
   // not the directory in which this is executed from
   const gitCommand = `git ls-files --full-name -z ${patternsFromRoot.map((p) => `"${p}"`).join(' ')}`;
-  const files = await execGitCommand(ctx, gitCommand);
+  const files = await execGitCommand(deps, gitCommand);
   return files?.split(NULL_BYTE).filter(Boolean);
 }
 
 /**
  * Determine the date the repository was created
  *
- * @param ctx Standard context object.
+ * @param deps Function dependencies.
  *
  * @returns Date The date the repository was created
  */
-export async function getRepositoryCreationDate(ctx: Pick<Context, 'log'>) {
+export async function getRepositoryCreationDate(deps: Pick<Deps, 'log'>) {
   try {
     const dateString = await execGitCommandOneLine(
-      ctx,
+      deps,
       `git log --reverse --format=%cd --date=iso`,
       {
         timeout: 5000,
@@ -451,23 +451,23 @@ export async function getRepositoryCreationDate(ctx: Pick<Context, 'log'>) {
 /**
  * Determine the date the storybook was added to the repository
  *
- * @param ctx Context The context set when executing the CLI.
- * @param ctx.options Object standard context options
- * @param ctx.options.storybookConfigDir Configured Storybook config dir, if set
+ * @param deps Function dependencies.
+ * @param deps.options Object standard context options
+ * @param deps.options.storybookConfigDir Configured Storybook config dir, if set
  *
  * @returns Date The date the storybook was added
  */
 export async function getStorybookCreationDate(
-  ctx: Pick<Context, 'log'> & {
+  deps: Pick<Deps, 'log'> & {
     options: {
-      storybookConfigDir?: Context['options']['storybookConfigDir'];
+      storybookConfigDir?: Deps['options']['storybookConfigDir'];
     };
   }
 ) {
   try {
-    const configDirectory = ctx.options.storybookConfigDir ?? '.storybook';
+    const configDirectory = deps.options.storybookConfigDir ?? '.storybook';
     const dateString = await execGitCommandOneLine(
-      ctx,
+      deps,
       `git log --follow --reverse --format=%cd --date=iso -- ${configDirectory}`,
       { timeout: 5000 }
     );
@@ -480,13 +480,13 @@ export async function getStorybookCreationDate(
 /**
  * Determine the number of committers in the last 6 months
  *
- * @param ctx Standard context object.
+ * @param deps Function dependencies.
  *
  * @returns number The number of committers
  */
-export async function getNumberOfComitters(ctx: Pick<Context, 'log'>) {
+export async function getNumberOfComitters(deps: Pick<Deps, 'log'>) {
   try {
-    return await execGitCommandCountLines(ctx, `git shortlog -sn --all --since="6 months ago"`, {
+    return await execGitCommandCountLines(deps, `git shortlog -sn --all --since="6 months ago"`, {
       timeout: 5000,
     });
   } catch {
@@ -497,14 +497,14 @@ export async function getNumberOfComitters(ctx: Pick<Context, 'log'>) {
 /**
  * Find the number of files in the git index that include a name with the given prefixes.
  *
- * @param ctx Standard context object.
+ * @param deps Function dependencies.
  * @param nameMatches The names to match - will be matched with upper and lowercase first letter
  * @param extensions The filetypes to match
  *
  * @returns The number of files matching the above
  */
 export async function getCommittedFileCount(
-  ctx: Pick<Context, 'log'>,
+  deps: Pick<Deps, 'log'>,
   nameMatches: string[],
   extensions: string[]
 ) {
@@ -518,7 +518,7 @@ export async function getCommittedFileCount(
       extensions.map((extension) => `"*${match}*.${extension}"`)
     );
 
-    return await execGitCommandCountLines(ctx, `git ls-files -- ${globs.join(' ')}`, {
+    return await execGitCommandCountLines(deps, `git ls-files -- ${globs.join(' ')}`, {
       timeout: 5000,
     });
   } catch {

--- a/node-src/lib/getHasRouter.ts
+++ b/node-src/lib/getHasRouter.ts
@@ -1,4 +1,4 @@
-import type { Context } from '../types';
+import type { Deps } from '../types';
 
 const routerPackages = new Set([
   'react-router',
@@ -30,7 +30,7 @@ const routerPackages = new Set([
  *
  * @returns boolean Does this project use a routing package?
  */
-export function getHasRouter(packageJson: Context['packageJson']) {
+export function getHasRouter(packageJson: Deps['packageJson']) {
   // NOTE: we just check real dependencies; if it is in dev dependencies, it may just be an example
   return Object.keys(packageJson?.dependencies ?? {}).some((depName) =>
     routerPackages.has(depName)

--- a/node-src/lib/localBuildsSpecifier.ts
+++ b/node-src/lib/localBuildsSpecifier.ts
@@ -1,19 +1,20 @@
-import { Context } from '../types';
+import { Deps, Git } from '../types';
 import { emailHash } from './emailHash';
 
 /**
  * Include local build information when querying Chromatic for build information.
  *
- * @param ctx The context set when executing the CLI.
+ * @param deps Dependencies (options).
+ * @param deps.options CLI options.
+ * @param git Git information for the current build.
  *
  * @returns Local build information used in GraphQL queries for build information.
  */
-export function localBuildsSpecifier(ctx: Pick<Context, 'options' | 'git'>) {
-  if (ctx.options.isLocalBuild)
-    return { localBuildEmailHash: emailHash(ctx.git.gitUserEmail || '') };
+export function localBuildsSpecifier({ options }: Pick<Deps, 'options'>, git: Git) {
+  if (options.isLocalBuild) return { localBuildEmailHash: emailHash(git.gitUserEmail || '') };
 
   // For global builds, we only want local builds from the committer (besides global builds)
-  if (ctx.git.committerEmail) return { localBuildEmailHash: emailHash(ctx.git.committerEmail) };
+  if (git.committerEmail) return { localBuildEmailHash: emailHash(git.committerEmail) };
 
   // If we don't know, we fall back to *no local builds at all*
   return { isLocalBuild: false };

--- a/node-src/lib/tasks.test.ts
+++ b/node-src/lib/tasks.test.ts
@@ -76,6 +76,50 @@ describe('createTask (typed shape)', () => {
     expect(ctx.skip).toBe(true);
   });
 
+  it('fires transitions.partial after applyPartial on partial result', async () => {
+    const ctx = baseContext();
+    const partialOutput = { phase: 'rebuild-noop' };
+    const run = vi.fn().mockResolvedValue({ kind: 'partial', output: partialOutput });
+    const applyPartial = vi.fn();
+    const partialTransition = vi
+      .fn()
+      .mockReturnValue({ status: 'success', title: 'Skipped', output: 'rebuilt' });
+    const listrTask = createTask({
+      name: 'gitInfo',
+      title: 'Test',
+      transitions: { partial: partialTransition },
+      extractInput: () => ({}),
+      applyPartial,
+      run,
+    });
+
+    const taskWrapper: any = {};
+    await (listrTask.task as any)(ctx, taskWrapper);
+
+    expect(applyPartial).toHaveBeenCalledWith(ctx, partialOutput);
+    expect(partialTransition).toHaveBeenCalledWith(ctx, partialOutput);
+    expect(taskWrapper.title).toContain('Skipped');
+    expect(ctx.skip).toBe(true);
+  });
+
+  it('passes listrTask to extractInput', async () => {
+    const ctx = baseContext();
+    const extractInput = vi.fn().mockReturnValue({});
+    const run = vi.fn().mockResolvedValue({ kind: 'continue', output: {} });
+
+    const listrTask = createTask({
+      name: 'auth',
+      title: 'Test',
+      extractInput,
+      run,
+    });
+
+    const taskWrapper = { title: '' };
+    await (listrTask.task as any)(ctx, taskWrapper);
+
+    expect(extractInput).toHaveBeenCalledWith(ctx, taskWrapper);
+  });
+
   it('still supports legacy steps[] config for unmigrated tasks', async () => {
     const ctx = baseContext();
     const step1 = vi.fn();

--- a/node-src/lib/tasks.ts
+++ b/node-src/lib/tasks.ts
@@ -20,8 +20,9 @@ type AdaptedTaskConfig<TInput, TOutput, TPartial = never> = ListrTaskExtras & {
   transitions?: {
     pending?: (ctx: Context) => Task;
     success?: (ctx: Context) => Task;
+    partial?: (ctx: Context, partial: TPartial) => Task;
   };
-  extractInput: (ctx: Context) => TInput;
+  extractInput: (ctx: Context, listrTask: Listr.ListrTaskWrapper<Context>) => TInput;
   applyOutput?: (ctx: Context, output: TOutput) => void;
   applyPartial?: (ctx: Context, output: TPartial) => void;
   run: TaskFunction<TInput, TOutput, Deps, TPartial>;
@@ -54,6 +55,10 @@ function applyAdaptedResult<TInput, TOutput, TPartial>(
       return;
     case 'partial':
       config.applyPartial?.(ctx, result.output);
+      if (config.transitions?.partial) {
+        const { title, output } = config.transitions.partial(ctx, result.output);
+        setTitle(title, output)(ctx, listrTask);
+      }
       ctx.skip = true;
       return;
     case 'skip':
@@ -71,7 +76,7 @@ async function runAdaptedTask<TInput, TOutput, TPartial>(
 ) {
   ctx.options.experimental_abortSignal?.throwIfAborted();
   if (config.transitions?.pending) transitionTo(config.transitions.pending)(ctx, listrTask);
-  const input = config.extractInput(ctx);
+  const input = config.extractInput(ctx, listrTask);
   const result = await config.run(buildDeps(ctx), input);
   applyAdaptedResult(config, ctx, listrTask, result);
 }

--- a/node-src/tasks/gitInfo.test.ts
+++ b/node-src/tasks/gitInfo.test.ts
@@ -7,7 +7,32 @@ import { getParentCommits as getParentCommitsUnmocked } from '../git/getParentCo
 import * as git from '../git/git';
 import { getHasRouter as getHasRouterUnmocked } from '../lib/getHasRouter';
 import TestLogger from '../lib/testLogger';
-import { setGitInfo } from './gitInfo';
+import {
+  applyGitInfoOutput,
+  applyGitInfoPartial,
+  extractGitInfoInput,
+  gatherGitInfo,
+  GitInfoDeps,
+  GitInfoInput,
+  GitInfoOutput,
+} from './gitInfo';
+
+// Helper that `expect`s a result kind and asserts on the kind to type narrow the result,
+// allowing later lines to access other result properties without casting
+function expectKind<R extends { kind: 'continue' | 'partial' | 'skip' }, K extends R['kind']>(
+  result: R,
+  kind: K
+): asserts result is Extract<R, { kind: K }> {
+  expect(result.kind).toBe(kind);
+}
+
+// Helper that narrows a discriminated `phase` field on a partial result output.
+function expectPhase<O extends { phase: string }, P extends O['phase']>(
+  output: O,
+  phase: P
+): asserts output is Extract<O, { phase: P }> {
+  expect(output.phase).toBe(phase);
+}
 
 vi.mock('../git/getCommitAndBranch');
 vi.mock('../git/git');
@@ -47,6 +72,25 @@ const commitInfo = {
 
 const client = { runQuery: vi.fn(), setAuthorization: vi.fn() };
 
+const buildDeps = (overrides: Partial<GitInfoDeps> = {}): GitInfoDeps => ({
+  log,
+  client: client as any,
+  options: {} as any,
+  runtime: {} as any,
+  packageJson: {},
+  ...overrides,
+});
+
+const buildInput = (overrides: Partial<GitInfoInput> = {}): GitInfoInput => ({
+  fromCI: false,
+  interactive: false,
+  isLocalBuild: false,
+  skip: false,
+  onlyChanged: false,
+  onSkippingBuild: vi.fn(),
+  ...overrides,
+});
+
 beforeEach(() => {
   getCommitAndBranch.mockResolvedValue(commitInfo);
   getUncommittedHash.mockResolvedValue('abc123');
@@ -66,11 +110,11 @@ beforeEach(() => {
   client.runQuery.mockReturnValue({ app: { isOnboarding: false } });
 });
 
-describe('setGitInfo', () => {
-  it('sets the git info on context', async () => {
-    const ctx = { log, options: {}, client } as any;
-    await setGitInfo(ctx, {} as any);
-    expect(ctx.git).toMatchObject({
+describe('gatherGitInfo', () => {
+  it('returns continue with the git info', async () => {
+    const result = await gatherGitInfo(buildDeps(), buildInput());
+    expectKind(result, 'continue');
+    expect(result.output.git).toMatchObject({
       rootPath: '/path/to/project',
       commit: '123asdf',
       branch: 'something',
@@ -81,17 +125,15 @@ describe('setGitInfo', () => {
   });
 
   it('sets gitUserEmail to current user for local builds', async () => {
-    const ctx = { log, options: { isLocalBuild: true }, client } as any;
-    await setGitInfo(ctx, {} as any);
-    expect(ctx.git).toMatchObject({
-      gitUserEmail: 'user@email.com',
-    });
+    const result = await gatherGitInfo(buildDeps(), buildInput({ isLocalBuild: true }));
+    expectKind(result, 'continue');
+    expect(result.output.git).toMatchObject({ gitUserEmail: 'user@email.com' });
   });
 
   it('supports overriding the owner name in the slug', async () => {
-    const ctx = { log, options: { ownerName: 'org' }, client } as any;
-    await setGitInfo(ctx, {} as any);
-    expect(ctx.git).toMatchObject({ slug: 'org/repo' });
+    const result = await gatherGitInfo(buildDeps(), buildInput({ ownerName: 'org' }));
+    expectKind(result, 'continue');
+    expect(result.output.git).toMatchObject({ slug: 'org/repo' });
   });
 
   it('sets changedFiles', async () => {
@@ -99,25 +141,22 @@ describe('setGitInfo', () => {
     getChangedFilesWithReplacement.mockResolvedValue({
       changedFiles: ['styles/main.scss', 'lib/utils.js'],
     });
-    const ctx = { log, options: { onlyChanged: true }, client } as any;
-    await setGitInfo(ctx, {} as any);
-    expect(ctx.git.changedFiles).toEqual(['styles/main.scss', 'lib/utils.js']);
-    expect(ctx.git.replacementBuildIds).toEqual([]);
+    const result = await gatherGitInfo(buildDeps(), buildInput({ onlyChanged: true }));
+    expectKind(result, 'continue');
+    expect(result.output.git.changedFiles).toEqual(['styles/main.scss', 'lib/utils.js']);
+    expect(result.output.git.replacementBuildIds).toEqual([]);
   });
 
   it('sets changedFiles on a branch name containing a slash', async () => {
-    getCommitAndBranch.mockResolvedValue({
-      ...commitInfo,
-      branch: 'something/else',
-    });
+    getCommitAndBranch.mockResolvedValue({ ...commitInfo, branch: 'something/else' });
     getBaselineBuilds.mockResolvedValue([{ commit: '012qwes' } as any]);
     getChangedFilesWithReplacement.mockResolvedValue({
       changedFiles: ['styles/main.scss', 'lib/utils.js'],
     });
-    const ctx = { log, options: { onlyChanged: '!(main)' }, client } as any;
-    await setGitInfo(ctx, {} as any);
-    expect(ctx.git.changedFiles).toEqual(['styles/main.scss', 'lib/utils.js']);
-    expect(ctx.git.replacementBuildIds).toEqual([]);
+    const result = await gatherGitInfo(buildDeps(), buildInput({ onlyChanged: '!(main)' }));
+    expectKind(result, 'continue');
+    expect(result.output.git.changedFiles).toEqual(['styles/main.scss', 'lib/utils.js']);
+    expect(result.output.git.replacementBuildIds).toEqual([]);
   });
 
   it('sets replacementBuildIds when found', async () => {
@@ -132,10 +171,10 @@ describe('setGitInfo', () => {
         isLocalBuild: false,
       },
     });
-    const ctx = { log, options: { onlyChanged: true }, client } as any;
-    await setGitInfo(ctx, {} as any);
-    expect(ctx.git.changedFiles).toEqual(['styles/main.scss', 'lib/utils.js']);
-    expect(ctx.git.replacementBuildIds).toEqual([['rebased', 'parent']]);
+    const result = await gatherGitInfo(buildDeps(), buildInput({ onlyChanged: true }));
+    expectKind(result, 'continue');
+    expect(result.output.git.changedFiles).toEqual(['styles/main.scss', 'lib/utils.js']);
+    expect(result.output.git.replacementBuildIds).toEqual([['rebased', 'parent']]);
   });
 
   it('drops changedFiles when matching --externals', async () => {
@@ -143,19 +182,37 @@ describe('setGitInfo', () => {
     getChangedFilesWithReplacement.mockResolvedValue({
       changedFiles: ['styles/main.scss', 'lib/utils.js'],
     });
-    const ctx = { log, options: { onlyChanged: true, externals: ['**/*.scss'] }, client } as any;
-    await setGitInfo(ctx, {} as any);
-    expect(ctx.git.changedFiles).toBeUndefined();
+    const result = await gatherGitInfo(
+      buildDeps(),
+      buildInput({ onlyChanged: true, externals: ['**/*.scss'] })
+    );
+    expectKind(result, 'continue');
+    expect(result.output.git.changedFiles).toBeUndefined();
   });
 
   it('forces rebuild automatically if app is onboarding', async () => {
     client.runQuery.mockReturnValue({ app: { isOnboarding: true } });
-    const ctx = { log, options: { ownerName: 'org' }, runtime: {}, client } as any;
-    await setGitInfo(ctx, {} as any);
-    expect(ctx.runtime.forceRebuild).toBe(true);
+    const result = await gatherGitInfo(buildDeps(), buildInput({ ownerName: 'org' }));
+    expectKind(result, 'continue');
+    expect(result.output.setForceRebuild).toBe(true);
+    expect(result.output.isOnboarding).toBe(true);
   });
 
-  it('sets storybookUrl and rebuildForBuild on skipped rebuild', async () => {
+  it('returns continue with rebuildForBuildId when force-rebuild prevents skip', async () => {
+    const lastBuild = { id: 'last-build-id', status: 'PASSED', storybookUrl: 'https://x' };
+    getParentCommits.mockResolvedValue([commitInfo.commit]);
+    client.runQuery.mockReturnValue({ app: { isOnboarding: false, lastBuild } });
+
+    const result = await gatherGitInfo(
+      buildDeps({ runtime: { forceRebuild: true } as any }),
+      buildInput()
+    );
+
+    expectKind(result, 'continue');
+    expect(result.output.rebuildForBuildId).toBe('last-build-id');
+  });
+
+  it('returns rebuild-noop partial when ancestor is fully passed', async () => {
     const lastBuild = {
       id: 'parent',
       status: 'ACCEPTED',
@@ -175,31 +232,198 @@ describe('setGitInfo', () => {
     getParentCommits.mockResolvedValue([commitInfo.commit]);
     client.runQuery.mockReturnValue({ app: { lastBuild } });
 
-    const ctx = { log, options: {}, runtime: {}, client } as any;
-    await setGitInfo(ctx, {} as any);
-    expect(ctx.rebuildForBuild).toEqual(lastBuild);
-    expect(ctx.storybookUrl).toEqual(lastBuild.storybookUrl);
+    const result = await gatherGitInfo(buildDeps(), buildInput());
+    expectKind(result, 'partial');
+    expectPhase(result.output, 'rebuild-noop');
+    expect(result.output.rebuildForBuild).toEqual(lastBuild);
+    expect(result.output.storybookUrl).toEqual(lastBuild.storybookUrl);
+  });
+
+  it('returns skip-commit partial when skip matches branch and mutation succeeds', async () => {
+    client.runQuery.mockResolvedValue(true);
+    const onSkippingBuild = vi.fn();
+    const result = await gatherGitInfo(buildDeps(), buildInput({ skip: true, onSkippingBuild }));
+
+    expectKind(result, 'partial');
+    expectPhase(result.output, 'skip-commit');
+    expect(result.output.git.commit).toBe(commitInfo.commit);
+    expect(result.output.projectMetadata).toMatchObject({ hasRouter: true });
+    expect(onSkippingBuild).toHaveBeenCalledWith(result.output.git);
+  });
+
+  it('throws when skip matches branch but mutation returns falsy', async () => {
+    client.runQuery.mockResolvedValue(false);
+    await expect(gatherGitInfo(buildDeps(), buildInput({ skip: true }))).rejects.toThrow(
+      /Failed to skip build/
+    );
   });
 
   it('removes undefined owner prefix from branch', async () => {
-    const ctx = { log, options: {}, client } as any;
-    getCommitAndBranch.mockResolvedValue({
-      ...commitInfo,
-      branch: 'undefined:repo',
-    });
-    await setGitInfo(ctx, {} as any);
-    expect(ctx.git.branch).toBe('repo');
+    getCommitAndBranch.mockResolvedValue({ ...commitInfo, branch: 'undefined:repo' });
+    const result = await gatherGitInfo(buildDeps(), buildInput());
+    expectKind(result, 'continue');
+    expect(result.output.git.branch).toBe('repo');
   });
 
-  it('sets projectMetadata on context', async () => {
-    const ctx = { log, options: { isLocalBuild: true }, client } as any;
-    await setGitInfo(ctx, {} as any);
-    expect(ctx.projectMetadata).toMatchObject({
+  it('returns projectMetadata', async () => {
+    const result = await gatherGitInfo(buildDeps(), buildInput({ isLocalBuild: true }));
+    expectKind(result, 'continue');
+    expect(result.output.projectMetadata).toMatchObject({
       hasRouter: true,
       creationDate: new Date('2024-11-01'),
       storybookCreationDate: new Date('2025-11-01'),
       numberOfCommitters: 17,
       numberOfAppFiles: 100,
     });
+  });
+});
+
+describe('applyGitInfoPartial', () => {
+  it('writes git, projectMetadata, and exit code on skip-commit', () => {
+    const ctx = { runtime: {} } as any;
+    const git = { commit: 'abc' } as any;
+    const projectMetadata = { hasRouter: true };
+    applyGitInfoPartial(ctx, { phase: 'skip-commit', git, projectMetadata });
+
+    expect(ctx.git).toBe(git);
+    expect(ctx.projectMetadata).toBe(projectMetadata);
+    expect(ctx.exitCode).toBe(0);
+    expect(ctx.rebuildForBuildId).toBeUndefined();
+    expect(ctx.rebuildForBuild).toBeUndefined();
+    expect(ctx.runtime.forceRebuild).toBeUndefined();
+  });
+
+  it('writes rebuild-noop fields including rebuildForBuildId, storybookUrl, and forceRebuild', () => {
+    const ctx = { runtime: {} } as any;
+    const partial = {
+      phase: 'rebuild-noop' as const,
+      git: { commit: 'abc' } as any,
+      projectMetadata: {},
+      isOnboarding: true,
+      rebuildForBuildId: 'b1',
+      rebuildForBuild: { id: 'b1' } as any,
+      storybookUrl: 'https://x',
+      setForceRebuild: true,
+    };
+    applyGitInfoPartial(ctx, partial);
+
+    expect(ctx.rebuildForBuildId).toBe('b1');
+    expect(ctx.rebuildForBuild).toBe(partial.rebuildForBuild);
+    expect(ctx.storybookUrl).toBe('https://x');
+    expect(ctx.isOnboarding).toBe(true);
+    expect(ctx.runtime.forceRebuild).toBe(true);
+    expect(ctx.exitCode).toBe(0);
+  });
+
+  it('does not toggle forceRebuild on rebuild-noop when setForceRebuild is false', () => {
+    const ctx = { runtime: {} } as any;
+    applyGitInfoPartial(ctx, {
+      phase: 'rebuild-noop',
+      git: {} as any,
+      projectMetadata: {},
+      isOnboarding: false,
+      rebuildForBuildId: 'b1',
+      rebuildForBuild: { id: 'b1' } as any,
+      storybookUrl: 'https://x',
+      setForceRebuild: false,
+    });
+
+    expect(ctx.runtime.forceRebuild).toBeUndefined();
+  });
+});
+
+const baseOutput = (overrides: Partial<GitInfoOutput> = {}): GitInfoOutput => ({
+  git: { commit: 'abc' } as any,
+  projectMetadata: { hasRouter: true },
+  isOnboarding: false,
+  turboSnap: undefined,
+  build: undefined,
+  setForceRebuild: false,
+  rebuildForBuildId: undefined,
+  ...overrides,
+});
+
+describe('applyGitInfoOutput', () => {
+  it('writes git, projectMetadata, and isOnboarding on continue', () => {
+    const ctx = { runtime: {} } as any;
+    const output = baseOutput({ isOnboarding: true });
+    applyGitInfoOutput(ctx, output);
+
+    expect(ctx.git).toBe(output.git);
+    expect(ctx.projectMetadata).toBe(output.projectMetadata);
+    expect(ctx.isOnboarding).toBe(true);
+  });
+
+  it('writes turboSnap, build, and rebuildForBuildId when provided', () => {
+    const ctx = { runtime: {} } as any;
+    const turboSnap = { bailReason: { rebuild: true as const } };
+    const build = { id: 'baseline' } as any;
+    applyGitInfoOutput(ctx, baseOutput({ turboSnap, build, rebuildForBuildId: 'r1' }));
+
+    expect(ctx.turboSnap).toBe(turboSnap);
+    expect(ctx.build).toBe(build);
+    expect(ctx.rebuildForBuildId).toBe('r1');
+  });
+
+  it('sets runtime.forceRebuild only when setForceRebuild is true', () => {
+    const ctx = { runtime: {} } as any;
+    applyGitInfoOutput(ctx, baseOutput({ setForceRebuild: true }));
+    expect(ctx.runtime.forceRebuild).toBe(true);
+
+    const ctx2 = { runtime: {} } as any;
+    applyGitInfoOutput(ctx2, baseOutput({ setForceRebuild: false }));
+    expect(ctx2.runtime.forceRebuild).toBeUndefined();
+  });
+});
+
+describe('extractGitInfoInput', () => {
+  it('sets expected fields on context', () => {
+    const ctx = {
+      runtime: {},
+      options: {
+        branchName: 'branch',
+        ownerName: 'owner',
+        repositorySlug: 'repo',
+        patchBaseRef: 'base',
+        fromCI: true,
+        interactive: false,
+        isLocalBuild: false,
+        skip: false,
+        ignoreLastBuildOnBranch: false,
+        onlyChanged: false,
+        externals: ['foo'],
+        untraced: ['bar'],
+      },
+    } as any;
+    const listrTask: any = {};
+
+    const input = extractGitInfoInput(ctx, listrTask);
+
+    expect(input).toMatchObject({
+      branchName: 'branch',
+      ownerName: 'owner',
+      repositorySlug: 'repo',
+      patchBaseRef: 'base',
+      fromCI: true,
+      interactive: false,
+      isLocalBuild: false,
+      skip: false,
+      ignoreLastBuildOnBranch: false,
+      onlyChanged: false,
+      externals: ['foo'],
+      untraced: ['bar'],
+    });
+  });
+
+  it('onSkippingBuild writes git to ctx and transitions the listr task title', () => {
+    const ctx = { options: {}, log } as any;
+    const listrTask: any = { title: 'initial' };
+
+    const input = extractGitInfoInput(ctx, listrTask);
+    const git = { commit: 'abc', branch: 'main' } as any;
+    input.onSkippingBuild(git);
+
+    expect(ctx.git).toBe(git);
+    expect(listrTask.title).not.toBe('initial');
   });
 });

--- a/node-src/tasks/gitInfo.ts
+++ b/node-src/tasks/gitInfo.ts
@@ -172,6 +172,7 @@ export const setGitInfo = async (ctx: Context, task: Task) => {
   }
 
   const parentCommits = await getParentCommits(ctx, {
+    git: ctx.git,
     ignoreLastBuildOnBranch: ctx.git.matchesBranch?.(ctx.options.ignoreLastBuildOnBranch || false),
   });
   ctx.git.parentCommits = parentCommits;
@@ -229,7 +230,7 @@ export const setGitInfo = async (ctx: Context, task: Task) => {
       return;
     }
 
-    const baselineBuilds = await getBaselineBuilds(ctx, { branch, parentCommits });
+    const baselineBuilds = await getBaselineBuilds(ctx, { branch, parentCommits, git: ctx.git });
     ctx.git.baselineCommits = baselineBuilds.map((build) => build.commit);
     ctx.log.debug(`Found baselineCommits: ${ctx.git.baselineCommits.join(', ')}`);
 

--- a/node-src/tasks/gitInfo.ts
+++ b/node-src/tasks/gitInfo.ts
@@ -1,3 +1,5 @@
+import type Listr from 'listr';
+
 import { getBaselineBuilds } from '../git/getBaselineBuilds';
 import { getChangedFilesWithReplacement } from '../git/getChangedFilesWithReplacement';
 import getCommitAndBranch from '../git/getCommitAndBranch';
@@ -18,7 +20,15 @@ import matchesBranch from '../lib/matchesBranch';
 import { exitCodes, setExitCode } from '../lib/setExitCode';
 import { createTask, transitionTo } from '../lib/tasks';
 import { isPackageMetadataFile, matchesFile } from '../lib/utilities';
-import { Context, Task } from '../types';
+import {
+  BaselineBuild,
+  Context,
+  Deps,
+  Git,
+  ProjectMetadata,
+  TaskResult,
+  TurboSnap,
+} from '../types';
 import gitUserEmailNotFound from '../ui/messages/errors/gitUserEmailNotFound';
 import forceRebuildHint from '../ui/messages/info/forceRebuildHint';
 import replacedBuild from '../ui/messages/info/replacedBuild';
@@ -35,6 +45,49 @@ import {
   skippingBuild,
   success,
 } from '../ui/tasks/gitInfo';
+
+export type GitInfoDeps = Pick<Deps, 'log' | 'client' | 'options' | 'runtime' | 'packageJson'>;
+
+export interface GitInfoInput {
+  branchName?: string;
+  ownerName?: string;
+  repositorySlug?: string;
+  patchBaseRef?: string;
+  fromCI: boolean;
+  interactive: boolean;
+  isLocalBuild: boolean;
+  skip: boolean | string;
+  ignoreLastBuildOnBranch?: string;
+  onlyChanged: boolean | string;
+  externals?: string[];
+  untraced?: string[];
+  onSkippingBuild: (git: Git) => void;
+}
+
+type LastBuild = NonNullable<Context['rebuildForBuild']>;
+
+export interface GitInfoOutput {
+  git: Git;
+  projectMetadata: ProjectMetadata;
+  isOnboarding: boolean;
+  turboSnap?: TurboSnap;
+  build?: BaselineBuild;
+  setForceRebuild: boolean;
+  rebuildForBuildId?: string;
+}
+
+export type GitInfoPartial =
+  | { phase: 'skip-commit'; git: Git; projectMetadata: ProjectMetadata }
+  | {
+      phase: 'rebuild-noop';
+      git: Git;
+      projectMetadata: ProjectMetadata;
+      isOnboarding: boolean;
+      rebuildForBuildId: string;
+      rebuildForBuild: LastBuild;
+      storybookUrl: string;
+      setForceRebuild: boolean;
+    };
 
 const UNDEFINED_BRANCH_PREFIX_REGEXP = /^undefined:/;
 
@@ -69,196 +122,241 @@ const LastBuildQuery = `
 interface LastBuildQueryResult {
   app: {
     isOnboarding: boolean;
-    lastBuild: {
-      id: string;
-      status: string;
-      storybookUrl: string;
-      webUrl: string;
-      specCount: number;
-      componentCount: number;
-      testCount: number;
-      changeCount: number;
-      errorCount: number;
-      actualTestCount: number;
-      actualCaptureCount: number;
-      inheritedCaptureCount: number;
-      interactionTestFailuresCount: number;
-    };
+    lastBuild: LastBuild;
   };
 }
 
-// TODO: refactor this function
+/**
+ * Gather all the git information needed for the build.
+ *
+ * @param deps Narrow set of cross-cutting dependencies the task needs.
+ * @param input Per-pipeline-run input extracted from Context at the seam.
+ *
+ * @returns A TaskResult conveying the produced git/projectMetadata/turboSnap
+ * state, or a partial outcome (skip-for-commit or rebuild-noop).
+ */
 // eslint-disable-next-line complexity, max-statements
-export const setGitInfo = async (ctx: Context, task: Task) => {
+export async function gatherGitInfo(
+  deps: GitInfoDeps,
+  input: GitInfoInput
+): Promise<TaskResult<GitInfoOutput, GitInfoPartial>> {
+  const { log, client, options, runtime, packageJson } = deps;
   const {
     branchName,
     ownerName,
     repositorySlug,
     patchBaseRef,
-    fromCI: ci,
+    fromCI,
     interactive,
     isLocalBuild,
-  } = ctx.options;
+    skip,
+    ignoreLastBuildOnBranch,
+    onlyChanged,
+    externals,
+    untraced,
+    onSkippingBuild,
+  } = input;
 
-  const version = await getVersion(ctx);
+  const version = await getVersion({ log });
+  const commitAndBranchInfo = await getCommitAndBranch(
+    { log },
+    { branchName, patchBaseRef, ci: fromCI }
+  );
 
-  const commitAndBranchInfo = await getCommitAndBranch(ctx, { branchName, patchBaseRef, ci });
-
-  ctx.git = {
+  const git: Git = {
     version,
-    gitUserEmail: await getUserEmail(ctx).catch((err) => {
-      ctx.log.debug('Failed to retrieve Git user email', err);
+    gitUserEmail: await getUserEmail({ log }).catch((err) => {
+      log.debug('Failed to retrieve Git user email', err);
       return undefined;
     }),
-    uncommittedHash: await getUncommittedHash(ctx).catch((err) => {
-      ctx.log.warn('Failed to retrieve uncommitted files hash', err);
+    uncommittedHash: await getUncommittedHash({ log }).catch((err) => {
+      log.warn('Failed to retrieve uncommitted files hash', err);
       return undefined;
     }),
-    rootPath: await getRepositoryRoot(ctx),
+    rootPath: await getRepositoryRoot({ log }),
     ...commitAndBranchInfo,
   };
 
+  let projectMetadata: ProjectMetadata = {};
   try {
-    ctx.projectMetadata = {
-      hasRouter: getHasRouter(ctx.packageJson),
-      creationDate: await getRepositoryCreationDate(ctx),
-      storybookCreationDate: await getStorybookCreationDate(ctx),
-      numberOfCommitters: await getNumberOfComitters(ctx),
+    projectMetadata = {
+      hasRouter: getHasRouter(packageJson),
+      creationDate: await getRepositoryCreationDate({ log }),
+      storybookCreationDate: await getStorybookCreationDate({ log, options }),
+      numberOfCommitters: await getNumberOfComitters({ log }),
       numberOfAppFiles: await getCommittedFileCount(
-        ctx,
+        { log },
         ['page', 'screen'],
         ['js', 'jsx', 'ts', 'tsx']
       ),
     };
   } catch (err) {
-    ctx.log.debug('Failed to gather project metadata', err);
+    log.debug('Failed to gather project metadata', err);
   }
 
-  if (isLocalBuild && !ctx.git.gitUserEmail) {
+  if (isLocalBuild && !git.gitUserEmail) {
     throw new Error(gitUserEmailNotFound());
   }
 
-  if (!ctx.git.slug) {
+  if (!git.slug) {
     try {
-      ctx.git.slug = await getSlug(ctx);
+      git.slug = await getSlug({ log });
     } catch (err) {
-      ctx.log.debug('Failed to retrieve Git repository slug', err);
+      log.debug('Failed to retrieve Git repository slug', err);
     }
   }
 
   if (ownerName) {
-    ctx.git.branch = ctx.git.branch.replace(/[^:]+:/, '');
-    ctx.git.slug = repositorySlug || ctx.git.slug?.replace(/[^/]+/, ownerName);
-  } else if (UNDEFINED_BRANCH_PREFIX_REGEXP.test(ctx.git.branch)) {
+    git.branch = git.branch.replace(/[^:]+:/, '');
+    git.slug = repositorySlug || git.slug?.replace(/[^/]+/, ownerName);
+  } else if (UNDEFINED_BRANCH_PREFIX_REGEXP.test(git.branch)) {
     // Strip off `undefined:` owner prefix that we have seen in some CI systems.
-    ctx.log.warn(undefinedBranchOwner());
-    ctx.git.branch = ctx.git.branch.replace(UNDEFINED_BRANCH_PREFIX_REGEXP, '');
+    log.warn(undefinedBranchOwner());
+    git.branch = git.branch.replace(UNDEFINED_BRANCH_PREFIX_REGEXP, '');
   }
 
-  const { branch, commit, slug } = ctx.git;
+  const { branch, commit, slug } = git;
 
-  ctx.git.matchesBranch = (glob: string | boolean) => matchesBranch(branch, glob);
+  git.matchesBranch = (glob: string | boolean) => matchesBranch(branch, glob);
 
-  if (ctx.git.matchesBranch?.(ctx.options.skip)) {
-    transitionTo(skippingBuild)(ctx, task);
+  if (git.matchesBranch(skip)) {
+    onSkippingBuild(git);
     // The SkipBuildMutation ensures the commit is tagged properly.
-    if (await ctx.client.runQuery(SkipBuildMutation, { commit, branch, slug })) {
-      ctx.skip = true;
-      transitionTo(skippedForCommit, true)(ctx, task);
-      setExitCode(ctx, exitCodes.OK);
-      return;
+    if (await client.runQuery(SkipBuildMutation, { commit, branch, slug })) {
+      return {
+        kind: 'partial',
+        output: { phase: 'skip-commit', git, projectMetadata },
+        reason: 'skipped-for-commit',
+      };
     }
     throw new Error(skipFailed().output);
   }
 
-  const parentCommits = await getParentCommits(ctx, {
-    git: ctx.git,
-    ignoreLastBuildOnBranch: ctx.git.matchesBranch?.(ctx.options.ignoreLastBuildOnBranch || false),
-  });
-  ctx.git.parentCommits = parentCommits;
-  ctx.log.debug(`Found parentCommits: ${parentCommits.join(', ')}`);
+  const parentCommits = await getParentCommits(
+    { log, client, options },
+    {
+      git,
+      ignoreLastBuildOnBranch: git.matchesBranch(ignoreLastBuildOnBranch || false),
+    }
+  );
+  git.parentCommits = parentCommits;
+  log.debug(`Found parentCommits: ${parentCommits.join(', ')}`);
 
-  const result = await ctx.client.runQuery<LastBuildQueryResult>(LastBuildQuery, {
+  const result = await client.runQuery<LastBuildQueryResult>(LastBuildQuery, {
     commit,
     branch,
   });
-  ctx.isOnboarding = result.app.isOnboarding;
-  if (result.app.isOnboarding) {
-    ctx.runtime.forceRebuild = true;
-  }
+  const isOnboarding = result.app.isOnboarding;
+
   // If we're running against the same commit as the sole parent, then this is likely a rebuild (rerun of CI job).
   // If the MRA is all green, there's no need to rerun the build, we just want the CLI to exit 0 so the CI job succeeds.
   // This is especially relevant for (unlinked) projects that don't use --exit-zero-on-changes.
   // There's no need for a SkipBuildMutation because we don't have to tag the commit again.
+  let rebuildForBuildId: string | undefined;
   if (parentCommits.length === 1 && parentCommits[0] === commit) {
-    const mostRecentAncestor = result && result.app && result.app.lastBuild;
+    const mostRecentAncestor = result?.app?.lastBuild;
     if (mostRecentAncestor) {
-      ctx.rebuildForBuildId = mostRecentAncestor.id;
+      rebuildForBuildId = mostRecentAncestor.id;
       if (
         ['PASSED', 'ACCEPTED'].includes(mostRecentAncestor.status) &&
-        !ctx.git.matchesBranch(ctx.runtime.forceRebuild)
+        !git.matchesBranch(isOnboarding ? true : runtime.forceRebuild)
       ) {
-        ctx.skip = true;
-        ctx.rebuildForBuild = result.app.lastBuild;
-        ctx.storybookUrl = result.app.lastBuild.storybookUrl;
-        transitionTo(skippedRebuild, true)(ctx, task);
-        setExitCode(ctx, exitCodes.OK);
-        ctx.log.info(forceRebuildHint());
-        return;
+        log.info(forceRebuildHint());
+        return {
+          kind: 'partial',
+          output: {
+            phase: 'rebuild-noop',
+            git,
+            projectMetadata,
+            isOnboarding,
+            rebuildForBuildId,
+            rebuildForBuild: result.app.lastBuild,
+            storybookUrl: result.app.lastBuild.storybookUrl,
+            setForceRebuild: isOnboarding,
+          },
+          reason: 'rebuild-noop',
+        };
       }
     }
   }
 
-  ctx.turboSnap = ctx.git.matchesBranch(ctx.options.onlyChanged) ? {} : undefined;
+  const turboSnap: TurboSnap | undefined = git.matchesBranch(onlyChanged) ? {} : undefined;
+  let build: BaselineBuild | undefined;
 
   // Retrieve a list of changed file paths since the actual baseline commit(s), which will be used
   // to determine affected story files later.
   // In the unlikely scenario that this list is empty (and not a rebuild), we can skip the build
   // since we know for certain it wouldn't have any effect. We do want to tag the commit.
-  if (ctx.turboSnap) {
+  if (turboSnap) {
     if (parentCommits.length === 0) {
-      ctx.turboSnap.bailReason = { noAncestorBuild: true };
+      turboSnap.bailReason = { noAncestorBuild: true };
       // Log warning after checking for isOnboarding
-      transitionTo(success, true)(ctx, task);
-      return;
+      return {
+        kind: 'continue',
+        output: {
+          git,
+          projectMetadata,
+          isOnboarding,
+          turboSnap,
+          build,
+          setForceRebuild: isOnboarding,
+          rebuildForBuildId,
+        },
+      };
     }
 
-    if (ctx.rebuildForBuildId) {
-      ctx.turboSnap.bailReason = { rebuild: true };
-      ctx.log.warn(isRebuild());
-      transitionTo(success, true)(ctx, task);
-      return;
+    if (rebuildForBuildId) {
+      turboSnap.bailReason = { rebuild: true };
+      log.warn(isRebuild());
+      return {
+        kind: 'continue',
+        output: {
+          git,
+          projectMetadata,
+          isOnboarding,
+          turboSnap,
+          build,
+          setForceRebuild: isOnboarding,
+          rebuildForBuildId,
+        },
+      };
     }
 
-    const baselineBuilds = await getBaselineBuilds(ctx, { branch, parentCommits, git: ctx.git });
-    ctx.git.baselineCommits = baselineBuilds.map((build) => build.commit);
-    ctx.log.debug(`Found baselineCommits: ${ctx.git.baselineCommits.join(', ')}`);
+    const baselineBuilds = await getBaselineBuilds(
+      { options, client },
+      { branch, parentCommits, git }
+    );
+    git.baselineCommits = baselineBuilds.map((build) => build.commit);
+    log.debug(`Found baselineCommits: ${git.baselineCommits.join(', ')}`);
 
     // Use the most recent baseline to determine final CLI output if we end up skipping the build.
     // Note this will get overwritten if we end up not skipping the build.
-    ctx.build = baselineBuilds.sort((a, b) => b.committedAt - a.committedAt)[0] as any;
+    build = baselineBuilds.sort((a, b) => b.committedAt - a.committedAt)[0];
 
     try {
       // Map the baseline builds to their changed files, falling back to an earlier "replacement"
       // build if the baseline commit no longer exists or the baseline had uncommitted changes.
       const changedFilesWithInfo = await Promise.all(
         baselineBuilds.map(async (build) => {
-          const changedFilesWithReplacement = await getChangedFilesWithReplacement(ctx, build);
+          const changedFilesWithReplacement = await getChangedFilesWithReplacement(
+            { log, client },
+            build
+          );
           return { build, ...changedFilesWithReplacement };
         })
       );
 
       // Take the distinct union of changed files across all baselines.
-      ctx.git.changedFiles = [
+      git.changedFiles = [
         ...new Set(changedFilesWithInfo.flatMap(({ changedFiles }) => changedFiles)),
       ];
 
       // Track changed package manifest files along with the commit they were changed in.
-      const { untraced = [] } = ctx.options;
-      ctx.git.packageMetadataChanges = changedFilesWithInfo.flatMap(
+      const untracedList = untraced ?? [];
+      git.packageMetadataChanges = changedFilesWithInfo.flatMap(
         ({ build, changedFiles, replacementBuild }) => {
           const metadataFiles = changedFiles
-            .filter((f) => !untraced.some((glob) => matchesFile(glob, f)))
+            .filter((f) => !untracedList.some((glob) => matchesFile(glob, f)))
             .filter((f) => isPackageMetadataFile(f));
 
           return metadataFiles.length > 0
@@ -268,11 +366,11 @@ export const setGitInfo = async (ctx: Context, task: Task) => {
       );
 
       // Track replacement build info to pass along when we create the new build later on.
-      ctx.git.replacementBuildIds = changedFilesWithInfo
+      git.replacementBuildIds = changedFilesWithInfo
         .filter((r) => !!r.replacementBuild)
         .map(({ build, replacementBuild }) => {
-          ctx.log.info('');
-          ctx.log.info(replacedBuild({ replacedBuild: build, replacementBuild }));
+          log.info('');
+          log.info(replacedBuild({ replacedBuild: build, replacementBuild }));
           // `replacementBuild` is filtered above
           // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
           return [build.id, replacementBuild!.id];
@@ -280,34 +378,96 @@ export const setGitInfo = async (ctx: Context, task: Task) => {
 
       if (!interactive) {
         const list =
-          ctx.git.changedFiles.length > 0
-            ? `:\n${ctx.git.changedFiles.map((f) => `  ${f}`).join('\n')}`
+          git.changedFiles.length > 0
+            ? `:\n${git.changedFiles.map((f) => `  ${f}`).join('\n')}`
             : '';
-        ctx.log.info(`Found ${ctx.git.changedFiles.length} changed files${list}`);
+        log.info(`Found ${git.changedFiles.length} changed files${list}`);
       }
     } catch (err) {
-      ctx.turboSnap.bailReason = { invalidChangedFiles: true };
-      delete ctx.git.changedFiles;
-      delete ctx.git.replacementBuildIds;
-      ctx.log.warn(invalidChangedFiles());
-      ctx.log.debug(err);
+      turboSnap.bailReason = { invalidChangedFiles: true };
+      git.changedFiles = undefined;
+      git.replacementBuildIds = undefined;
+      log.warn(invalidChangedFiles());
+      log.debug(err);
     }
 
-    if (ctx.options.externals && ctx.git.changedFiles && ctx.git.changedFiles.length > 0) {
-      for (const glob of ctx.options.externals) {
-        const matches = ctx.git.changedFiles.filter((filepath) => matchesFile(glob, filepath));
+    if (externals && git.changedFiles && git.changedFiles.length > 0) {
+      for (const glob of externals) {
+        const matches = git.changedFiles.filter((filepath) => matchesFile(glob, filepath));
         if (matches.length > 0) {
-          ctx.turboSnap.bailReason = { changedExternalFiles: matches };
-          ctx.log.warn(externalsChanged(matches));
-          delete ctx.git.changedFiles;
-          delete ctx.git.replacementBuildIds;
+          turboSnap.bailReason = { changedExternalFiles: matches };
+          log.warn(externalsChanged(matches));
+          git.changedFiles = undefined;
+          git.replacementBuildIds = undefined;
           break;
         }
       }
     }
   }
 
-  transitionTo(success, true)(ctx, task);
+  return {
+    kind: 'continue',
+    output: {
+      git,
+      projectMetadata,
+      isOnboarding,
+      turboSnap,
+      build,
+      setForceRebuild: isOnboarding,
+      rebuildForBuildId,
+    },
+  };
+}
+
+export const extractGitInfoInput = (
+  ctx: Context,
+  listrTask: Listr.ListrTaskWrapper<Context>
+): GitInfoInput => ({
+  branchName: ctx.options.branchName,
+  ownerName: ctx.options.ownerName,
+  repositorySlug: ctx.options.repositorySlug,
+  patchBaseRef: ctx.options.patchBaseRef,
+  fromCI: ctx.options.fromCI,
+  interactive: ctx.options.interactive,
+  isLocalBuild: ctx.options.isLocalBuild,
+  skip: ctx.options.skip,
+  ignoreLastBuildOnBranch: ctx.options.ignoreLastBuildOnBranch,
+  onlyChanged: ctx.options.onlyChanged,
+  externals: ctx.options.externals,
+  untraced: ctx.options.untraced,
+  onSkippingBuild: (git) => {
+    // Kind of a gross escape hatch here. The `skippingBuild` UI function needs `git` on the context to construct its message,
+    // so we have to mutate context in this callback. Can't put this in applyGitInfoPartial because it's an intermediate UI
+    // transition: it's called before running the GQL mutation that skips the build. Having one escape hatch here seemed better
+    // than abstracting it away at this stage, but if this keeps coming up, we should find a better pattern for this.
+    ctx.git = git;
+    transitionTo(skippingBuild)(ctx, listrTask);
+  },
+});
+
+export const applyGitInfoOutput = (ctx: Context, output: GitInfoOutput) => {
+  ctx.git = output.git;
+  ctx.projectMetadata = output.projectMetadata;
+  ctx.isOnboarding = output.isOnboarding;
+  if (output.turboSnap) ctx.turboSnap = output.turboSnap;
+  // Have to cast as unknown first here, as there's not enough overlap to direct cast. This value gets overwritten
+  // by the full build later in the pipeline. Could be worth a refactor to split out these types.
+  if (output.build) ctx.build = output.build as unknown as Context['build'];
+  if (output.rebuildForBuildId) ctx.rebuildForBuildId = output.rebuildForBuildId;
+  if (output.setForceRebuild) ctx.runtime.forceRebuild = true;
+};
+
+export const applyGitInfoPartial = (ctx: Context, partial: GitInfoPartial) => {
+  ctx.git = partial.git;
+  ctx.projectMetadata = partial.projectMetadata;
+  setExitCode(ctx, exitCodes.OK);
+  if (partial.phase === 'rebuild-noop') {
+    ctx.isOnboarding = partial.isOnboarding;
+    ctx.rebuildForBuildId = partial.rebuildForBuildId;
+    ctx.rebuildForBuild = partial.rebuildForBuild;
+    ctx.storybookUrl = partial.storybookUrl;
+    if (partial.setForceRebuild) ctx.runtime.forceRebuild = true;
+  }
 };
 
 /**
@@ -321,6 +481,15 @@ export default function main(_: Context) {
   return createTask({
     name: 'gitInfo',
     title: initial.title,
-    steps: [transitionTo(pending), setGitInfo],
+    transitions: {
+      pending,
+      success,
+      partial: (ctx, partial) =>
+        partial.phase === 'skip-commit' ? skippedForCommit(ctx) : skippedRebuild(),
+    },
+    extractInput: extractGitInfoInput,
+    applyOutput: applyGitInfoOutput,
+    applyPartial: applyGitInfoPartial,
+    run: gatherGitInfo,
   });
 }

--- a/node-src/tasks/initialize.ts
+++ b/node-src/tasks/initialize.ts
@@ -154,7 +154,7 @@ function updateContextFromAnnouncedBuild(
 ) {
   ctx.announcedBuild = announcedBuild;
   ctx.isOnboarding =
-    // possibly set from LastBuildQuery in setGitInfo
+    // possibly set from LastBuildQuery in gatherGitInfo
     ctx.isOnboarding ||
     announcedBuild.number === 1 ||
     (announcedBuild.autoAcceptChanges && !input.autoAcceptChanges);

--- a/node-src/types.ts
+++ b/node-src/types.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines */
 import { InitialContext } from '.';
 import GraphQLClient from './io/graphqlClient';
 import HTTPClient from './io/httpClient';
@@ -163,6 +164,49 @@ type StorybookReference =
   | ((config: StorybookReferenceConfig & { sourceUrl: string }) => StorybookReferenceConfig)
   | { disable: boolean };
 
+export interface Git {
+  version?: string;
+  /** The absolute location on disk of the git project */
+  rootPath?: string;
+  /** The current user's email as per git config */
+  gitUserEmail?: string;
+  branch: string;
+  commit: string;
+  committerEmail?: string;
+  committedAt: number;
+  slug?: string;
+  fromCI: boolean;
+  ciService?: string;
+  mergeCommit?: string;
+  uncommittedHash?: string;
+  parentCommits?: string[];
+  baselineCommits?: string[];
+  changedFiles?: string[];
+  changedDependencyNames?: string[];
+  replacementBuildIds?: [string, string][];
+  matchesBranch?: (glob: boolean | string) => boolean;
+  packageMetadataChanges?: { changedFiles: string[]; commit: string }[];
+}
+
+export interface ProjectMetadata {
+  hasRouter?: boolean;
+  creationDate?: Date;
+  storybookCreationDate?: Date;
+  numberOfCommitters?: number;
+  numberOfAppFiles?: number;
+}
+
+export interface BaselineBuild {
+  id: string;
+  number: number;
+  status: string;
+  commit: string;
+  committedAt: number;
+  uncommittedHash: string;
+  isLocalBuild: boolean;
+  changeCount: number;
+}
+
 export interface Storybook {
   version: string;
   baseDir?: string;
@@ -281,37 +325,9 @@ export interface Context {
   http: HTTPClient;
   client: GraphQLClient;
 
-  git: {
-    version?: string;
-    /** The absolute location on disk of the git project */
-    rootPath?: string;
-    /** The current user's email as pre git config */
-    gitUserEmail?: string;
-    branch: string;
-    commit: string;
-    committerEmail?: string;
-    committedAt: number;
-    slug?: string;
-    fromCI: boolean;
-    ciService?: string;
-    mergeCommit?: string;
-    uncommittedHash?: string;
-    parentCommits?: string[];
-    baselineCommits?: string[];
-    changedFiles?: string[];
-    changedDependencyNames?: string[];
-    replacementBuildIds?: [string, string][];
-    matchesBranch?: (glob: boolean | string) => boolean;
-    packageMetadataChanges?: { changedFiles: string[]; commit: string }[];
-  };
+  git: Git;
   storybook: Storybook;
-  projectMetadata: {
-    hasRouter?: boolean;
-    creationDate?: Date;
-    storybookCreationDate?: Date;
-    numberOfCommitters?: number;
-    numberOfAppFiles?: number;
-  };
+  projectMetadata: ProjectMetadata;
   storybookUrl?: string;
   announcedBuild: {
     id: string;


### PR DESCRIPTION
# Follows

#1302

# Description

This PR continues the migration of CLI tasks to the new, typed structure established in https://github.com/chromaui/chromatic-cli/pull/1302, migrating the `gitInfo` task. There are four main changes:
1. Extended the `createTask` wrapper to support partial UI transitions. This is necessary here, as the gitInfo task makes different UI transitions when it returns partial output. And in one unfortunate edge case, it transitions the UI in the middle of the task body, while waiting for a GQL query. This required an escape hatch for passing a UI-related callback into the task body. I'm hopeful this is a one-off. If it comes up again, I'll think about a cleaner abstraction.
2. Hoists git-related types off of `Context` and exports them for use in task output type signatures
3. Narrows git helpers to take minimal dependencies from the `Deps` type, drops references to `Context` in all helpers
4. Refactors the task body itself to typed inputs/outputs, moving all Context mutations to the apply output functions (both partial and full, for this task)

Each of those changes corresponds to one commit, and I recommend reviewing commit-by-commit.

# Manual QA

Note I didn't test every possible code path, as there are a lot. But I did the big ones, including all the UI transitions.

## Paths tested

1. Happy path: just a regular, working build
2. Partial: `rebuild-noop`: same commit as parent + last build PASSED → CLI exits early with `storybookUrl` and `rebuildForBuild` set. `applyGitInfoPartial` writes ctx fields.
3. `--force-rebuild` bypass: same commit but `runtime.forceRebuild` set → bypasses rebuild-noop path, falls through to a normal build.
4. Partial: `skip-commit`: `--skip` matches branch → `SkipBuildMutation` runs, exits early. Exercises the `onSkippingBuild` callback (the explicit "escape hatch" that mutates ctx mid-task to drive the `skippingBuild` UI transition).

## Setup

Minimal project with a fresh git repo and 2 commits. Fake remote set so the slug is defined. New Chromatic project on staging: https://www.staging-chromatic.com/builds?appId=69f9f2b4e332d90366475882.

```bash
git log --oneline && echo '---' && git remote -v && echo '---' && git rev-parse --abbrev-ref HEAD
```

Output:
```output
99f1d85 Add note to README
921b8e4 Initial scaffold: vite + react-ts + storybook
---
origin	git@github.com:test-user/gitinfo-qa-fake.git (fetch)
origin	git@github.com:test-user/gitinfo-qa-fake.git (push)
---
master
```

## Build 1: happy path

Expected path: `gatherGitInfo` returns `{ kind: 'continue', output: { ..., isOnboarding: true, setForceRebuild: true } }`. This is the first build on this project, so we're onboarding at this stage.

```bash
CHROMATIC_INDEX_URL=https://index.staging-chromatic.com npx chromatic@16.7.1--canary.1314.25379321801.0 --project-token=chpt_916394ded3a5885 --no-interactive 2>&1 | tail -80
```

Output:
```output
npm warn exec The following package was not found and will be installed: chromatic@16.7.1--canary.1314.25379321801.0

09:54:13.984 Chromatic CLI v16.7.1--canary.1314.25379321801.0
             https://www.chromatic.com/docs/cli

09:54:13.987 Authenticating with Chromatic [staging]
09:54:13.987     → Connecting to https://index.staging-chromatic.com
09:54:14.161 Authenticated with Chromatic [staging]
                 → Using project token '****************5885'
09:54:14.162 Retrieving git information
09:54:14.663 Retrieved git information
                 → Commit '99f1d85' on branch 'master'; no ancestor found
09:54:14.663 Collecting Storybook metadata
09:54:14.680 No viewlayer package listed in dependencies. Checking transitive dependencies.
09:54:14.682 Collected Storybook metadata
                 → Build metadata gathered
09:54:14.682 Initializing build
09:54:14.956 Initialized build
                 → Build 1 initialized
09:54:14.960 Building your Storybook
09:54:14.960     → Running command: npm run build-storybook -- --output-dir=/private/var/folders/gn/p0bks3451f38s12kbrmdxznh0000gn/T/chromatic--18094-DB5iFBGorXwO
09:54:14.961     → [*                   ]
09:54:17.975 Storybook built in 3 seconds
                 → View build log at /private/tmp/gitinfo-qa/build-storybook.log
09:54:17.975 Prepare your built Storybook
09:54:17.975     → Validating Storybook files
09:54:17.977 Prepare your built Storybook
09:54:17.977     → Calculating file hashes
09:54:17.981 Preparation complete
                 → Storybook files validated and prepared for upload
09:54:17.981 Publishing your built Storybook
09:54:17.981     → Starting publish
09:54:18.210     → [                    ] 1%
09:54:22.313 Publish complete in 4 seconds
                 → Uploaded 69 files (9.76 MB)
09:54:22.313 Verifying your Storybook
09:54:22.314     → This may take a few minutes
09:54:22.314     → [*                   ]
09:54:27.844 ✔ Storybook published
             We found 3 components with 8 stories.
             ℹ View your Storybook at https://69f9f2b4e332d90366475882-bnwiobgyfr.staging-chromatic.com/
09:54:27.845 Started build 1
                 → Continue setup at https://www.staging-chromatic.com/setup?appId=69f9f2b4e332d90366475882
09:54:27.845 Running 8 tests
09:54:27.845     → This may take a few minutes
09:54:32.124     → [===                 ] 1/8  
09:54:42.361     → [========            ] 3/8  
09:54:52.499     → [===============     ] 6/8  
09:55:02.635 ✔ Build passed. Welcome to Chromatic!
             We found 3 components with 8 stories and took 8 snapshots.
             ℹ Please continue setup at https://www.staging-chromatic.com/setup?appId=69f9f2b4e332d90366475882
09:55:02.635 Build 1 auto-accepted
                 → Tested 8 stories across 3 components; captured 8 snapshots in 35 seconds
```

### Results Summary

Gathered git info (commit `99f1d85` on branch `master`). Note the logs at the end of the output showing various onboarding-related messages, showing that the context propagation is moving throughout the pipeline as expected.

Notable lines exercising the migrated task:
- `Retrieving git information` / `Retrieved git information` — pending → success transitions still wired up via the new `transitions` map in `createTask`.
- `Commit '99f1d85' on branch 'master'; no ancestor found` — `success` UI message reads from `ctx.git` populated by `applyGitInfoOutput`.

## Build 2: same commit, expect rebuild-noop partial path

No code changes since build 1. Expected path: `parentCommits === [HEAD]` and last build status === `PASSED` → `gatherGitInfo` returns `{ kind: 'partial', output: { phase: 'rebuild-noop', rebuildForBuild, storybookUrl, ... } }`. The CLI should exit 0 early with a *Skipped rebuild* message and `ctx.exitCode = 0`. We do **not** pass `--force-rebuild` here.

```bash
CHROMATIC_INDEX_URL=https://index.staging-chromatic.com npx chromatic@16.7.1--canary.1314.25379321801.0 --project-token=chpt_916394ded3a5885 --no-interactive 2>&1; echo "---exit=$?---"
```

Output:
```output

09:55:27.315 Chromatic CLI v16.7.1--canary.1314.25379321801.0
             https://www.chromatic.com/docs/cli

09:55:27.320 Authenticating with Chromatic [staging]
09:55:27.321     → Connecting to https://index.staging-chromatic.com
09:55:27.468 Authenticated with Chromatic [staging]
                 → Using project token '****************5885'
09:55:27.468 Retrieving git information
09:55:28.215 ℹ Skipping rebuild of an already fully passed/accepted build
             A build for the same commit as the last build on the branch is considered a rebuild.
             If the last build is passed or accepted, the rebuild is skipped because it shouldn't change anything.
             You can override this using the --force-rebuild flag.
09:55:28.216 Skipping build
                 → Skipping rebuild of an already fully passed/accepted build
---exit=0---
```

### Results Summary

`rebuild-noop` partial path fires. CLI exits with code 0. UI message `Skipping rebuild of an already fully passed/accepted build` is the `skippedRebuild` transition, dispatched through the new `transitions.partial` callback in `createTask`. The `forceRebuildHint` ("You can override this using the --force-rebuild flag.") still fires, confirming `log.info(forceRebuildHint())` ran in `gatherGitInfo` before the partial return.

## Build 3: `--force-rebuild` bypasses rebuild-noop

Same commit as build 2. With `--force-rebuild`, `runtime.forceRebuild` is true. The check `!git.matchesBranch(isOnboarding ? true : runtime.forceRebuild)` evaluates falsy, so the partial path is skipped and the task returns `{ kind: 'continue', output: { ..., rebuildForBuildId } }` (rebuildForBuildId is still set, but flow continues). `applyGitInfoOutput` writes the output. Adding `--exit-once-uploaded` since we don't need test results.

```bash
CHROMATIC_INDEX_URL=https://index.staging-chromatic.com npx chromatic@16.7.1--canary.1314.25379321801.0 --project-token=chpt_916394ded3a5885 --no-interactive --force-rebuild --exit-once-uploaded 2>&1; echo "---exit=$?---"
```

Output:
```output

09:55:49.863 Chromatic CLI v16.7.1--canary.1314.25379321801.0
             https://www.chromatic.com/docs/cli

09:55:49.867 Authenticating with Chromatic [staging]
09:55:49.868     → Connecting to https://index.staging-chromatic.com
09:55:49.997 Authenticated with Chromatic [staging]
                 → Using project token '****************5885'
09:55:49.997 Retrieving git information
09:55:50.901 Retrieved git information
                 → Commit '99f1d85' on branch 'master'; found 1 parent build
09:55:50.901 Collecting Storybook metadata
09:55:50.923 No viewlayer package listed in dependencies. Checking transitive dependencies.
09:55:50.926 Collected Storybook metadata
                 → Build metadata gathered
09:55:50.926 Initializing build
09:55:51.203 Initialized build
                 → Build 2 initialized
09:55:51.207 Building your Storybook
09:55:51.207     → Running command: npm run build-storybook -- --output-dir=/private/var/folders/gn/p0bks3451f38s12kbrmdxznh0000gn/T/chromatic--18823-XJLitCH7z8WC
09:55:51.208     → [*                   ]
09:55:54.003 Storybook built in 3 seconds
                 → View build log at /private/tmp/gitinfo-qa/build-storybook.log
09:55:54.004 Prepare your built Storybook
09:55:54.004     → Validating Storybook files
09:55:54.005 Prepare your built Storybook
09:55:54.005     → Calculating file hashes
09:55:54.009 Preparation complete
                 → Storybook files validated and prepared for upload
09:55:54.010 Publishing your built Storybook
09:55:54.010     → Starting publish
09:55:54.191     → [                    ] 1%
09:55:58.318 Publish complete in 4 seconds
                 → Uploaded 69 files (9.76 MB)
09:55:58.319 Verifying your Storybook
09:55:58.319     → This may take a few minutes
09:55:58.320     → [*                   ]
09:56:02.659 ✔ Storybook published
             We found 3 components with 8 stories.
             ℹ View your Storybook at https://69f9f2b4e332d90366475882-ypxzkuxwst.staging-chromatic.com/
09:56:02.659 Started build 2
                 → View build details at https://www.staging-chromatic.com/build?appId=69f9f2b4e332d90366475882&number=2
---exit=0---
```

### Results Summary

`--force-rebuild` bypasses rebuild-noop. With same commit as build 2, the gitInfo task takes the `continue` branch instead of the `rebuild-noop` partial. `Retrieved git information → Commit '99f1d85' on branch 'master'; found 1 parent build` is the `success` UI transition message (driven by `ctx.git.parentCommits.length === 1`). The pipeline continues all the way to upload.

## Build 4: `--skip` matches branch, expect skip-commit partial path

Pass `--skip 'master'` so `git.matchesBranch(skip)` is truthy. Expected sequence:

1. `onSkippingBuild(git)` callback fires *inside* `gatherGitInfo` — this is the "gross escape hatch" called out in code comments. It mutates `ctx.git` and dispatches the `skippingBuild` UI transition mid-task, before the GQL mutation.
2. `SkipBuildMutation` runs.
3. Returns `{ kind: 'partial', output: { phase: 'skip-commit', git, projectMetadata }, reason: 'skipped-for-commit' }`.
4. `applyGitInfoPartial` writes `ctx.git`, `ctx.projectMetadata`, sets exit code 0.
6. `createTask`'s `transitions.partial` resolves to `skippedForCommit(ctx)`.

Expecting that the intermediate `skippingBuild` UI transition fires *and* the final `skippedForCommit` transition fires.

```bash
CHROMATIC_INDEX_URL=https://index.staging-chromatic.com npx chromatic@16.7.1--canary.1314.25379321801.0 --project-token=chpt_916394ded3a5885 --no-interactive --skip 'master' 2>&1; echo "---exit=$?---"
```

Output:
```output

09:56:26.352 Chromatic CLI v16.7.1--canary.1314.25379321801.0
             https://www.chromatic.com/docs/cli

09:56:26.355 Authenticating with Chromatic [staging]
09:56:26.355     → Connecting to https://index.staging-chromatic.com
09:56:26.490 Authenticated with Chromatic [staging]
                 → Using project token '****************5885'
09:56:26.491 Retrieving git information
09:56:26.726 Skipping build
09:56:26.726     → Skipping build for commit 99f1d85
09:56:26.922 Skipping build
                 → Skipped build for commit 99f1d85 due to --skip
---exit=0---
```

### Results Summary

`skip-commit` partial path fires, both UI transitions in correct order.

Look at the two `Skipping build` lines:

| # | Line | Source |
|---|------|--------|
| 1 | `Skipping build for commit 99f1d85` | `transitionTo(skippingBuild)` invoked inside the `onSkippingBuild` escape-hatch callback, *during* `gatherGitInfo`, before the GQL mutation. |
| 2 | `Skipped build for commit 99f1d85 due to --skip` | `skippedForCommit(ctx)` resolved through `createTask`'s `transitions.partial` after the partial output is applied. |

Both transitions firing in this order confirms the escape hatch wiring works end-to-end.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>16.10.1--canary.1314.25686169334.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@16.10.1--canary.1314.25686169334.0
  # or 
  yarn add chromatic@16.10.1--canary.1314.25686169334.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
