### PR TITLE
Add test for external storybook config changes and TS

### DIFF
--- a/node-src/lib/turbosnap/getDependentStoryFiles.test.ts
+++ b/node-src/lib/turbosnap/getDependentStoryFiles.test.ts
@@ -528,8 +528,8 @@ describe('getDependentStoryFiles', () => {
     );
   });
 
-    it('does not bail on changed external Storybook config file', async () => {
-    const changedFiles = ['src/foo.stories.js', 'path/to/other-storybook-config/file.js'];
+  it('does not bail on changed external Storybook config file', async () => {
+    const changedFiles = ['src/foo.stories.js', 'path/to/other-storybook/.storybook/file.js'];
     const modules = [
       {
         id: './src/foo.stories.js',
@@ -539,10 +539,10 @@ describe('getDependentStoryFiles', () => {
       {
         id: CSF_GLOB,
         name: CSF_GLOB,
-        reasons: [{ moduleName: './path/to/storybook-config/generated-stories-entry.js' }],
+        reasons: [{ moduleName: './.storybook/generated-stories-entry.js' }],
       },
     ];
-    const ctx = getContext({ configDir: 'path/to/storybook-config' });
+    const ctx = getContext();
     const result = await getDependentStoryFiles(ctx, { modules }, statsPath, changedFiles);
     expect(ctx.turboSnap.bailReason).toBeUndefined();
     expect(result).toEqual({

--- a/node-src/lib/turbosnap/getDependentStoryFiles.test.ts
+++ b/node-src/lib/turbosnap/getDependentStoryFiles.test.ts
@@ -528,6 +528,28 @@ describe('getDependentStoryFiles', () => {
     );
   });
 
+    it('does not bail on changed external Storybook config file', async () => {
+    const changedFiles = ['src/foo.stories.js', 'path/to/other-storybook-config/file.js'];
+    const modules = [
+      {
+        id: './src/foo.stories.js',
+        name: './src/foo.stories.js',
+        reasons: [{ moduleName: CSF_GLOB }],
+      },
+      {
+        id: CSF_GLOB,
+        name: CSF_GLOB,
+        reasons: [{ moduleName: './path/to/storybook-config/generated-stories-entry.js' }],
+      },
+    ];
+    const ctx = getContext({ configDir: 'path/to/storybook-config' });
+    const result = await getDependentStoryFiles(ctx, { modules }, statsPath, changedFiles);
+    expect(ctx.turboSnap.bailReason).toBeUndefined();
+    expect(result).toEqual({
+      './src/foo.stories.js': ['src/foo.stories.js'],
+    });
+  });
+
   it('bails on changed preview.js file', async () => {
     const changedFiles = ['src/foo.stories.js', 'path/to/storybook-config/preview.js'];
     const modules = [


### PR DESCRIPTION
A test to demonstrate that in monorepos, changes to a second package's `main.js` will not trigger a TS bail.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>16.6.4--canary.1316.25331304252.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@16.6.4--canary.1316.25331304252.0
  # or 
  yarn add chromatic@16.6.4--canary.1316.25331304252.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
