### PR TITLE
Move `xcodebuild` to shared executor

### DIFF
--- a/node-src/lib/react-native/build.ts
+++ b/node-src/lib/react-native/build.ts
@@ -5,12 +5,25 @@ import path from 'path';
 
 import { sanitizedName } from './expoConfig';
 
-async function exec(
+/**
+ * Execute a command with the needed context for a React Native Storybook build.
+ *
+ * @param command The command to execute.
+ * @param args The arguments to pass to the command.
+ * @param options Additional options for command execution, such as environment variables and working directory.
+ * @param options.env Environment variables to add for the command execution.
+ * @param options.cwd The working directory to execute the command in.
+ * @param logStream The WriteStream to write command output to.
+ *
+ * @returns A promise that resolves when the command execution is complete.
+ */
+export async function execWithBuildEnvironment(
   command: string,
   args: string[],
   options: { env?: Record<string, string>; cwd?: string } = {},
   logStream: WriteStream
 ) {
+  logStream.write(`\n[chromatic] build: "${command} ${args.join(' ')}"\n`);
   return execa(command, args, {
     ...options,
     stdout: logStream,
@@ -68,12 +81,17 @@ export async function buildAndroid(outputPath: string, logStream: WriteStream) {
   const start = new Date();
 
   logStream.write('\n[chromatic] Android build: npx expo prebuild --platform android\n');
-  await exec('npx', ['expo', 'prebuild', '--platform', 'android'], {}, logStream);
+  await execWithBuildEnvironment(
+    'npx',
+    ['expo', 'prebuild', '--platform', 'android'],
+    {},
+    logStream
+  );
 
   logStream.write(
     '\n[chromatic] Android build: ./gradlew assembleRelease -PreactNativeArchitectures=x86_64\n'
   );
-  await exec(
+  await execWithBuildEnvironment(
     './gradlew',
     ['assembleRelease', '-PreactNativeArchitectures=x86_64'],
     { cwd: path.resolve('android') },
@@ -112,7 +130,7 @@ export async function buildIos(name: string, outputPath: string, logStream: Writ
   const cleanName = sanitizedName(name);
 
   logStream.write('\n[chromatic] iOS build: npx expo prebuild --platform ios\n');
-  await exec('npx', ['expo', 'prebuild', '--platform', 'ios'], {}, logStream);
+  await execWithBuildEnvironment('npx', ['expo', 'prebuild', '--platform', 'ios'], {}, logStream);
 
   const derivedDataPath = mkdtempSync(path.join(os.tmpdir(), 'chromatic-rn-ios-'));
 
@@ -145,11 +163,14 @@ export async function buildIos(name: string, outputPath: string, logStream: Writ
   logStream.write(`\n[chromatic] iOS build: xcodebuild ${xcodebuildArguments.join(' ')}\n`);
 
   try {
-    await execa('xcodebuild', xcodebuildArguments, {
-      cwd: path.resolve('ios'),
-      stdout: logStream,
-      stderr: logStream,
-    });
+    await execWithBuildEnvironment(
+      'xcodebuild',
+      xcodebuildArguments,
+      {
+        cwd: path.resolve('ios'),
+      },
+      logStream
+    );
     if (!existsSync(appPath)) {
       throw new Error(`Expected .app bundle not found at ${appPath}`);
     }

--- a/node-src/tasks/buildReactNative.test.ts
+++ b/node-src/tasks/buildReactNative.test.ts
@@ -42,10 +42,14 @@ vi.mock('fs', async (importOriginal) => {
     createReadStream: vi.fn(() => Readable.from([mockLogLines])),
   };
 });
-vi.mock('../lib/react-native/build', () => ({
-  buildAndroid: vi.fn(() => Promise.resolve(1)),
-  buildIos: vi.fn(() => Promise.resolve(1)),
-}));
+vi.mock('../lib/react-native/build', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../lib/react-native/build')>();
+  return {
+    ...actual,
+    buildAndroid: vi.fn(() => Promise.resolve(1)),
+    buildIos: vi.fn(() => Promise.resolve(1)),
+  };
+});
 vi.mock('../lib/react-native/expoConfig', () => ({
   readExpoConfig: vi.fn(() => Promise.resolve({ platforms: ['ios', 'android'], name: 'MyApp' })),
 }));
@@ -145,7 +149,9 @@ describe('buildArtifacts', () => {
     expect(execa).toHaveBeenCalledWith(
       cmd,
       args,
-      expect.objectContaining({ env: { CHROMATIC_ARTIFACT_DIRECTORY: '/path/to/build' } })
+      expect.objectContaining({
+        env: expect.objectContaining({ CHROMATIC_ARTIFACT_DIRECTORY: '/path/to/build' }),
+      })
     );
   });
 
@@ -164,7 +170,9 @@ describe('buildArtifacts', () => {
     expect(execa).toHaveBeenCalledWith(
       cmd,
       args,
-      expect.objectContaining({ env: { CHROMATIC_ARTIFACT_DIRECTORY: '/path/to/build' } })
+      expect.objectContaining({
+        env: expect.objectContaining({ CHROMATIC_ARTIFACT_DIRECTORY: '/path/to/build' }),
+      })
     );
   });
 

--- a/node-src/tasks/buildReactNative.ts
+++ b/node-src/tasks/buildReactNative.ts
@@ -3,11 +3,10 @@ import path from 'path';
 import { createInterface } from 'readline';
 
 import { openLogFileStream } from '../lib/logFile';
-import { buildAndroid, buildIos } from '../lib/react-native/build';
+import { buildAndroid, buildIos, execWithBuildEnvironment } from '../lib/react-native/build';
 import { readExpoConfig } from '../lib/react-native/expoConfig';
 import { generateManifest } from '../lib/react-native/generateManifest';
 import { exitCodes, setExitCode } from '../lib/setExitCode';
-import { runCommand } from '../lib/shell/shell';
 import { transitionTo } from '../lib/tasks';
 import { Context, Task } from '../types';
 import { reactNativeBuildFailed } from '../ui/messages/errors/buildFailed';
@@ -33,23 +32,15 @@ async function readLastLines(filePath: string, lineCount: number): Promise<strin
   });
 }
 
-const runPlatformCommand = async (
-  ctx: Context,
-  platform: 'android' | 'ios',
-  command: string,
-  logStream: WriteStream
-) => {
+const runPlatformCommand = async (ctx: Context, command: string, logStream: WriteStream) => {
   ctx.log.debug('Running React Native build command:', command);
-  const label = platform === 'android' ? 'Android' : 'iOS';
-  logStream.write(`\n[chromatic] ${label} build: ${command}\n`);
   try {
-    await runCommand(command, {
-      stdout: logStream,
-      stderr: logStream,
-      env: {
-        CHROMATIC_ARTIFACT_DIRECTORY: ctx.sourceDir,
-      },
-    });
+    await execWithBuildEnvironment(
+      command,
+      [],
+      { env: { CHROMATIC_ARTIFACT_DIRECTORY: ctx.sourceDir } },
+      logStream
+    );
   } catch (err) {
     throw new Error(`React Native build command failed: ${command}\n${err.message}`);
   }
@@ -83,7 +74,7 @@ export const buildArtifacts = async (ctx: Context, task: Task) => {
       const { androidBuildCommand } = ctx.options.reactNative ?? {};
       ctx.log.debug({ androidBuildCommand }, 'Running Android build');
       await (androidBuildCommand
-        ? runPlatformCommand(ctx, 'android', androidBuildCommand, logStream)
+        ? runPlatformCommand(ctx, androidBuildCommand, logStream)
         : buildAndroid(path.join(ctx.sourceDir, 'storybook.apk'), logStream));
     }
 
@@ -92,7 +83,7 @@ export const buildArtifacts = async (ctx: Context, task: Task) => {
       const { iosBuildCommand } = ctx.options.reactNative ?? {};
       ctx.log.debug({ iosBuildCommand }, 'Running iOS build');
       if (iosBuildCommand) {
-        await runPlatformCommand(ctx, 'ios', iosBuildCommand, logStream);
+        await runPlatformCommand(ctx, iosBuildCommand, logStream);
       } else {
         const config = await readExpoConfig();
         await buildIos(config.name, path.join(ctx.sourceDir, 'storybook.app'), logStream);


### PR DESCRIPTION
We need the environment variables on that call as well.

Also moves the custom build commands to that exec so they have access to the correct variables, and cleans up command logs in the build logfile to one spot.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>16.8.1--canary.1318.25383995389.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@16.8.1--canary.1318.25383995389.0
  # or 
  yarn add chromatic@16.8.1--canary.1318.25383995389.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
