### PR TITLE
Add config option for building multiple Android architectures

### DIFF
--- a/bin-src/reactNativeBuild.test.ts
+++ b/bin-src/reactNativeBuild.test.ts
@@ -4,6 +4,10 @@ vi.mock('execa', () => ({
   execa: vi.fn(),
 }));
 
+vi.mock('../node-src/lib/getConfiguration', () => ({
+  getConfiguration: vi.fn(),
+}));
+
 vi.mock('../node-src/lib/logFile', () => ({
   openLogFileStream: vi.fn(),
 }));
@@ -36,6 +40,7 @@ vi.mock('fs', async () => {
 import { execa } from 'execa';
 import fs from 'fs';
 
+import { getConfiguration } from '../node-src/lib/getConfiguration';
 import { openLogFileStream } from '../node-src/lib/logFile';
 import { main } from './reactNativeBuild';
 
@@ -44,6 +49,7 @@ const mockedExistsSync = vi.mocked(fs.existsSync);
 const mockedMkdtempSync = vi.mocked(fs.mkdtempSync);
 const mockedMkdirSync = vi.mocked(fs.mkdirSync);
 const mockedRmSync = vi.mocked(fs.rmSync);
+const mockedGetConfiguration = vi.mocked(getConfiguration);
 const mockedOpenLogFileStream = vi.mocked(openLogFileStream);
 
 beforeEach(() => {
@@ -54,6 +60,7 @@ beforeEach(() => {
     throw new Error('process.exit');
   });
 
+  mockedGetConfiguration.mockResolvedValue({});
   mockedMkdtempSync.mockReturnValue('/tmp/chromatic-rn-build-test' as any);
   mockedOpenLogFileStream.mockResolvedValue({
     write: vi.fn(),
@@ -258,6 +265,46 @@ describe('react-native-build', () => {
 
     await expect(main(['--output-dir', '/output'])).rejects.toThrow('process.exit');
     expect(mockedRmSync).not.toHaveBeenCalled();
+  });
+
+  it('passes androidBuildArchitectures from config to buildAndroid', async () => {
+    mockedGetConfiguration.mockResolvedValue({
+      reactNative: { androidBuildArchitectures: ['arm64-v8a'] },
+    });
+    mockedExeca.mockImplementation((command: any, args: any) => {
+      if (command === 'npx' && args?.[0] === 'expo' && args?.[1] === 'config') {
+        return { stdout: JSON.stringify({ platforms: ['android'], name: 'MyApp' }) } as any;
+      }
+      return Promise.resolve({}) as any;
+    });
+    mockedExistsSync.mockReturnValue(true);
+
+    await main([]);
+
+    expect(mockedExeca).toHaveBeenCalledWith(
+      './gradlew',
+      ['assembleRelease', '-PreactNativeArchitectures=x86_64,arm64-v8a'],
+      expect.objectContaining({ cwd: expect.stringContaining('android') })
+    );
+  });
+
+  it('falls back gracefully when config file read fails', async () => {
+    mockedGetConfiguration.mockRejectedValue(new Error('invalid config'));
+    mockedExeca.mockImplementation((command: any, args: any) => {
+      if (command === 'npx' && args?.[0] === 'expo' && args?.[1] === 'config') {
+        return { stdout: JSON.stringify({ platforms: ['android'], name: 'MyApp' }) } as any;
+      }
+      return Promise.resolve({}) as any;
+    });
+    mockedExistsSync.mockReturnValue(true);
+
+    await main([]);
+
+    expect(mockedExeca).toHaveBeenCalledWith(
+      './gradlew',
+      ['assembleRelease', '-PreactNativeArchitectures=x86_64'],
+      expect.objectContaining({ cwd: expect.stringContaining('android') })
+    );
   });
 
   it('exits when android build fails', async () => {

--- a/bin-src/reactNativeBuild.ts
+++ b/bin-src/reactNativeBuild.ts
@@ -4,6 +4,7 @@ import meow from 'meow';
 import os from 'os';
 import path from 'path';
 
+import { Configuration, getConfiguration } from '../node-src/lib/getConfiguration';
 import { openLogFileStream } from '../node-src/lib/logFile';
 import { buildAndroid, buildIos } from '../node-src/lib/react-native/build';
 import { ExpoConfig, readExpoConfig } from '../node-src/lib/react-native/expoConfig';
@@ -90,6 +91,16 @@ function parseFlags(argv: string[]) {
 }
 
 /**
+ * Read the Chromatic configuration file and extract React Native settings.
+ *
+ * @returns The React Native configuration block, or an empty object if the config file is missing or invalid.
+ */
+async function readReactNativeConfig() {
+  const configuration = await getConfiguration().catch((): Configuration => ({}));
+  return configuration.reactNative ?? {};
+}
+
+/**
  * Resolve the platforms to build by intersecting the Expo config with the requested platforms.
  *
  * @param config The Expo config.
@@ -136,6 +147,7 @@ Available platforms: ${configPlatforms.join(', ')}`);
  * @param appName The app name from Expo config, required for iOS builds.
  * @param artifactDirectory The directory to place build artifacts in.
  * @param logStream The WriteStream to write build logs to.
+ * @param androidBuildArchitectures Additional Android architectures to build for.
  *
  * @returns The list of build artifacts.
  */
@@ -143,7 +155,8 @@ async function buildPlatforms(
   platforms: string[],
   appName: string,
   artifactDirectory: string,
-  logStream: WriteStream
+  logStream: WriteStream,
+  androidBuildArchitectures?: string[]
 ) {
   const artifacts: { platform: string; path: string; duration: number }[] = [];
 
@@ -151,7 +164,7 @@ async function buildPlatforms(
     info(`Building for ${platformNames[platform]}`);
     if (platform === 'android') {
       const outputPath = path.join(artifactDirectory, 'storybook.apk');
-      const duration = await buildAndroid(outputPath, logStream);
+      const duration = await buildAndroid(outputPath, logStream, androidBuildArchitectures);
       artifacts.push({ platform: 'Android', path: outputPath, duration });
     } else if (platform === 'ios') {
       const outputPath = path.join(artifactDirectory, 'storybook.app');
@@ -170,6 +183,7 @@ async function buildPlatforms(
  */
 export async function main(argv: string[]) {
   const { requestedPlatforms, outputDir } = parseFlags(argv);
+  const { androidBuildArchitectures } = await readReactNativeConfig();
 
   warn(
     'Chromatic React Native Build is in alpha. Use with caution.',
@@ -202,7 +216,13 @@ export async function main(argv: string[]) {
 
   let artifacts: { platform: string; path: string; duration: number }[];
   try {
-    artifacts = await buildPlatforms(platforms, config.name, artifactDirectory, logStream);
+    artifacts = await buildPlatforms(
+      platforms,
+      config.name,
+      artifactDirectory,
+      logStream,
+      androidBuildArchitectures
+    );
     await new Promise<void>((resolve) => logStream.end(resolve));
   } catch (err) {
     await new Promise<void>((resolve) => logStream.end(resolve));

--- a/node-src/lib/getConfiguration.ts
+++ b/node-src/lib/getConfiguration.ts
@@ -49,6 +49,7 @@ const configurationSchema = z
       .object({
         iosBuildCommand: z.string(),
         androidBuildCommand: z.string(),
+        androidBuildArchitectures: z.array(z.string()),
       })
       .partial(),
   })

--- a/node-src/lib/react-native/build.test.ts
+++ b/node-src/lib/react-native/build.test.ts
@@ -64,6 +64,36 @@ describe('buildAndroid', () => {
     );
   });
 
+  it('includes additional architectures in the gradlew command', async () => {
+    const logStream = makeLogStream();
+    await buildAndroid('/tmp/out/storybook.apk', logStream, ['arm64-v8a']);
+    expect(execa).toHaveBeenCalledWith(
+      './gradlew',
+      ['assembleRelease', '-PreactNativeArchitectures=x86_64,arm64-v8a'],
+      expect.objectContaining({ cwd: expect.stringContaining('android') })
+    );
+  });
+
+  it('deduplicates x86_64 when provided in additional architectures', async () => {
+    const logStream = makeLogStream();
+    await buildAndroid('/tmp/out/storybook.apk', logStream, ['x86_64', 'arm64-v8a']);
+    expect(execa).toHaveBeenCalledWith(
+      './gradlew',
+      ['assembleRelease', '-PreactNativeArchitectures=x86_64,arm64-v8a'],
+      expect.objectContaining({ cwd: expect.stringContaining('android') })
+    );
+  });
+
+  it('always includes x86_64 even with empty additional architectures', async () => {
+    const logStream = makeLogStream();
+    await buildAndroid('/tmp/out/storybook.apk', logStream, []);
+    expect(execa).toHaveBeenCalledWith(
+      './gradlew',
+      ['assembleRelease', '-PreactNativeArchitectures=x86_64'],
+      expect.objectContaining({ cwd: expect.stringContaining('android') })
+    );
+  });
+
   it('writes command headers to the log stream', async () => {
     const logStream = makeLogStream();
     await buildAndroid('/tmp/out/storybook.apk', logStream);

--- a/node-src/lib/react-native/build.ts
+++ b/node-src/lib/react-native/build.ts
@@ -72,10 +72,15 @@ function validateOutputPath(outputPath: string) {
  *
  * @param outputPath The full file path where the built APK should be placed.
  * @param logStream The WriteStream to write build logs to.
+ * @param additionalArchitectures Additional Android architectures to include alongside x86_64.
  *
  * @returns The build duration in seconds.
  */
-export async function buildAndroid(outputPath: string, logStream: WriteStream) {
+export async function buildAndroid(
+  outputPath: string,
+  logStream: WriteStream,
+  additionalArchitectures: string[] = []
+) {
   validateOutputPath(outputPath);
 
   const start = new Date();
@@ -88,12 +93,13 @@ export async function buildAndroid(outputPath: string, logStream: WriteStream) {
     logStream
   );
 
-  logStream.write(
-    '\n[chromatic] Android build: ./gradlew assembleRelease -PreactNativeArchitectures=x86_64\n'
-  );
+  const architectures = [...new Set(['x86_64', ...additionalArchitectures])].join(',');
+  const architecturesFlag = `-PreactNativeArchitectures=${architectures}`;
+
+  logStream.write(`\n[chromatic] Android build: ./gradlew assembleRelease ${architecturesFlag}\n`);
   await execWithBuildEnvironment(
     './gradlew',
-    ['assembleRelease', '-PreactNativeArchitectures=x86_64'],
+    ['assembleRelease', architecturesFlag],
     { cwd: path.resolve('android') },
     logStream
   );

--- a/node-src/tasks/buildReactNative.test.ts
+++ b/node-src/tasks/buildReactNative.test.ts
@@ -119,7 +119,25 @@ describe('buildArtifacts', () => {
       sourceDir: '/path/to/build',
     } as any;
     await buildArtifacts(ctx, task);
-    expect(buildAndroid).toHaveBeenCalledWith('/path/to/build/storybook.apk', mockLogStream);
+    expect(buildAndroid).toHaveBeenCalledWith(
+      '/path/to/build/storybook.apk',
+      mockLogStream,
+      undefined
+    );
+  });
+
+  it('passes androidBuildArchitectures to buildAndroid', async () => {
+    const ctx = {
+      ...baseContext,
+      announcedBuild: { browsers: ['android'] },
+      log: new TestLogger(),
+      options: { reactNative: { androidBuildArchitectures: ['arm64-v8a'] } },
+      sourceDir: '/path/to/build',
+    } as any;
+    await buildArtifacts(ctx, task);
+    expect(buildAndroid).toHaveBeenCalledWith('/path/to/build/storybook.apk', mockLogStream, [
+      'arm64-v8a',
+    ]);
   });
 
   it('reads expo config and calls buildIos with output path when ios is in browsers', async () => {
@@ -155,6 +173,27 @@ describe('buildArtifacts', () => {
     );
   });
 
+  it('ignores androidBuildArchitectures when androidBuildCommand is set and logs debug message', async () => {
+    const log = new TestLogger();
+    const ctx = {
+      ...baseContext,
+      announcedBuild: { browsers: ['android'] },
+      log,
+      options: {
+        reactNative: {
+          androidBuildCommand: 'my-android-build',
+          androidBuildArchitectures: ['arm64-v8a'],
+        },
+      },
+      sourceDir: '/path/to/build',
+    } as any;
+    await buildArtifacts(ctx, task);
+    expect(buildAndroid).not.toHaveBeenCalled();
+    expect(log.debug).toHaveBeenCalledWith(
+      'androidBuildArchitectures is ignored when androidBuildCommand is set'
+    );
+  });
+
   it('uses iosBuildCommand when set and does not call buildIos or readExpoConfig', async () => {
     const ctx = {
       ...baseContext,
@@ -185,7 +224,11 @@ describe('buildArtifacts', () => {
       sourceDir: '/path/to/build',
     } as any;
     await buildArtifacts(ctx, task);
-    expect(buildAndroid).toHaveBeenCalledWith('/path/to/build/storybook.apk', mockLogStream);
+    expect(buildAndroid).toHaveBeenCalledWith(
+      '/path/to/build/storybook.apk',
+      mockLogStream,
+      undefined
+    );
     expect(readExpoConfig).toHaveBeenCalled();
     expect(buildIos).toHaveBeenCalledWith('MyApp', '/path/to/build/storybook.app', mockLogStream);
   });

--- a/node-src/tasks/buildReactNative.ts
+++ b/node-src/tasks/buildReactNative.ts
@@ -52,6 +52,36 @@ const resolvePlatforms = (ctx: Context) => {
   );
 };
 
+const buildAndroidArtifact = async (ctx: Context, task: Task, logStream: WriteStream) => {
+  transitionTo(pendingAndroid)(ctx, task);
+  const { androidBuildCommand, androidBuildArchitectures } = ctx.options.reactNative ?? {};
+  ctx.log.debug({ androidBuildCommand }, 'Running Android build');
+  if (androidBuildCommand) {
+    if (androidBuildArchitectures?.length) {
+      ctx.log.debug('androidBuildArchitectures is ignored when androidBuildCommand is set');
+    }
+    await runPlatformCommand(ctx, androidBuildCommand, logStream);
+  } else {
+    await buildAndroid(
+      path.join(ctx.sourceDir, 'storybook.apk'),
+      logStream,
+      androidBuildArchitectures
+    );
+  }
+};
+
+const buildIosArtifact = async (ctx: Context, task: Task, logStream: WriteStream) => {
+  transitionTo(pendingIOS)(ctx, task);
+  const { iosBuildCommand } = ctx.options.reactNative ?? {};
+  ctx.log.debug({ iosBuildCommand }, 'Running iOS build');
+  if (iosBuildCommand) {
+    await runPlatformCommand(ctx, iosBuildCommand, logStream);
+  } else {
+    const config = await readExpoConfig();
+    await buildIos(config.name, path.join(ctx.sourceDir, 'storybook.app'), logStream);
+  }
+};
+
 export const buildArtifacts = async (ctx: Context, task: Task) => {
   const platforms = resolvePlatforms(ctx);
   const needsAndroid = platforms.includes('android');
@@ -69,27 +99,8 @@ export const buildArtifacts = async (ctx: Context, task: Task) => {
   const logStream = await openLogFileStream(ctx.reactNativeBuildLogFile);
 
   try {
-    if (needsAndroid) {
-      transitionTo(pendingAndroid)(ctx, task);
-      const { androidBuildCommand } = ctx.options.reactNative ?? {};
-      ctx.log.debug({ androidBuildCommand }, 'Running Android build');
-      await (androidBuildCommand
-        ? runPlatformCommand(ctx, androidBuildCommand, logStream)
-        : buildAndroid(path.join(ctx.sourceDir, 'storybook.apk'), logStream));
-    }
-
-    if (needsIos) {
-      transitionTo(pendingIOS)(ctx, task);
-      const { iosBuildCommand } = ctx.options.reactNative ?? {};
-      ctx.log.debug({ iosBuildCommand }, 'Running iOS build');
-      if (iosBuildCommand) {
-        await runPlatformCommand(ctx, iosBuildCommand, logStream);
-      } else {
-        const config = await readExpoConfig();
-        await buildIos(config.name, path.join(ctx.sourceDir, 'storybook.app'), logStream);
-      }
-    }
-
+    if (needsAndroid) await buildAndroidArtifact(ctx, task, logStream);
+    if (needsIos) await buildIosArtifact(ctx, task, logStream);
     await new Promise<void>((resolve) => logStream.end(resolve));
   } catch (buildError) {
     setExitCode(ctx, exitCodes.NPM_BUILD_STORYBOOK_FAILED, true);


### PR DESCRIPTION
By default, Chromatic only builds `x86_64` as that is all we need, but for testing customers may want to build additional native architectures.

This adds a config value, `reactNative.androidBuildArchitectures`, which accepts an array of strings that are additional Android architectures to be built.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>16.10.1--canary.1321.25686171106.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@16.10.1--canary.1321.25686171106.0
  # or 
  yarn add chromatic@16.10.1--canary.1321.25686171106.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
