### PR TITLE
Increase flaky test timeout

### DIFF
--- a/node-src/lib/turbosnap/getDependencies.test.ts
+++ b/node-src/lib/turbosnap/getDependencies.test.ts
@@ -57,24 +57,6 @@ describe('getDependencies', () => {
     }
   });
 
-  it.skip('should handle checked out manifest and lock files', async () => {
-    const tmpdir = fs.mkdtempSync(path.join(os.tmpdir(), 'chromatic'));
-
-    const dependencies = await getDependencies(ctx, {
-      rootPath: tmpdir,
-      manifestPath: await checkoutFile(ctx, 'HEAD', 'package.json', tmpdir),
-      lockfilePath: await checkoutFile(ctx, 'HEAD', 'yarn.lock', tmpdir),
-    });
-
-    const dependencyNames = dependencies.getDepPkgs().map((pkg) => pkg.name);
-    expect(dependencyNames).toEqual(
-      expect.arrayContaining([
-        ...Object.keys(packageJson.dependencies),
-        ...Object.keys(packageJson.devDependencies),
-      ])
-    );
-  });
-
   it('should handle historic files', async () => {
     // chromatic@6.12.0
     const commit = 'e61c2688597a6fda61a7057c866ebfabde955784';

--- a/node-src/lib/turbosnap/getDependencies.test.ts
+++ b/node-src/lib/turbosnap/getDependencies.test.ts
@@ -128,7 +128,7 @@ describe('getDependencies', () => {
         // ...
       ])
     );
-  });
+  }, 15_000); // Increase test timeout to account for I/O in CI
 
   it('should bail if the lock file is too large to parse', async () => {
     statSync.mockReturnValue({ size: MAX_LOCK_FILE_SIZE + 1000 });


### PR DESCRIPTION
We've been seeing a timeout flake in CI for this particular test which appears it could be I/O related. Let's see if bumping the timeout fixes the issue for now.

I also removed a skipped test since the "historic" test already covers it. 
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>16.10.2--canary.1326.25928570097.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@16.10.2--canary.1326.25928570097.0
  # or 
  yarn add chromatic@16.10.2--canary.1326.25928570097.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
