### PR TITLE
Delay check of `build-storybook` script validation

### DIFF
--- a/node-src/index.test.ts
+++ b/node-src/index.test.ts
@@ -94,6 +94,10 @@ vi.mock('node-fetch', () => ({
         return { data: { cliToken: 'token' } };
       }
 
+      if (query?.match('CLIAppInfo')) {
+        return { data: { app: { features: { isReactNativeApp: false } } } };
+      }
+
       if (query?.match('AnnounceBuildMutation')) {
         announcedBuild = variables.input;
         return {

--- a/node-src/lib/getOptions.ts
+++ b/node-src/lib/getOptions.ts
@@ -11,7 +11,6 @@ import invalidPatchBuild from '../ui/messages/errors/invalidPatchBuild';
 import invalidReportPath from '../ui/messages/errors/invalidReportPath';
 import invalidRepositorySlug from '../ui/messages/errors/invalidRepositorySlug';
 import invalidSingularOptions from '../ui/messages/errors/invalidSingularOptions';
-import missingBuildScriptName from '../ui/messages/errors/missingBuildScriptName';
 import missingProjectToken from '../ui/messages/errors/missingProjectToken';
 import deprecatedOption from '../ui/messages/warnings/deprecatedOption';
 import { isE2EBuild } from './e2eUtils';
@@ -357,9 +356,11 @@ export default function getOptions(
     }
   }
 
-  if (scripts && buildScriptName && scripts[buildScriptName]) {
-    return { ...options, buildScriptName };
-  }
-
-  throw new Error(missingBuildScriptName(buildScriptName));
+  // The missingBuildScriptName throw that previously lived here has moved to
+  // storybookInfo.ts, where it is gated on !isReactNativeApp. It could not remain
+  // here because isReactNativeApp is only known after auth runs — too late for
+  // option parsing. The finding/defaulting logic above stays here because
+  // getStorybookMetadata reads options.buildScriptName during the storybookInfo task
+  // and needs the value resolved before that task runs.
+  return { ...options, buildScriptName };
 }

--- a/node-src/tasks/auth.test.ts
+++ b/node-src/tasks/auth.test.ts
@@ -5,25 +5,34 @@ import { AuthDeps, AuthInput, runAuth } from './auth';
 const buildDeps = (overrides: Partial<AuthDeps> = {}): AuthDeps => ({
   client: { runQuery: vi.fn(), setAuthorization: vi.fn() } as any,
   env: { CHROMATIC_INDEX_URL: 'https://index.chromatic.com' } as any,
+  log: { warn: vi.fn(), info: vi.fn(), debug: vi.fn(), error: vi.fn() } as any,
   ...overrides,
+});
+
+const appInfoResult = (isReactNativeApp: boolean) => ({
+  app: { features: { isReactNativeApp } },
 });
 
 describe('runAuth', () => {
   it('updates the GraphQL client with an app token from the index', async () => {
     const client = { runQuery: vi.fn(), setAuthorization: vi.fn() };
-    client.runQuery.mockResolvedValue({ appToken: 'app-token' });
+    client.runQuery
+      .mockResolvedValueOnce({ appToken: 'app-token' })
+      .mockResolvedValueOnce(appInfoResult(false));
     const deps = buildDeps({ client: client as any });
 
     const input: AuthInput = { mode: 'app', projectToken: 'test' };
     const result = await runAuth(deps, input);
 
     expect(client.setAuthorization).toHaveBeenCalledWith('app-token');
-    expect(result).toEqual({ kind: 'continue', output: undefined });
+    expect(result).toEqual({ kind: 'continue', output: { isReactNativeApp: false } });
   });
 
   it('supports projectId + userToken (cli mode)', async () => {
     const client = { runQuery: vi.fn(), setAuthorization: vi.fn() };
-    client.runQuery.mockResolvedValue({ cliToken: 'cli-token' });
+    client.runQuery
+      .mockResolvedValueOnce({ cliToken: 'cli-token' })
+      .mockResolvedValueOnce(appInfoResult(false));
     const deps = buildDeps({ client: client as any });
 
     const input: AuthInput = {
@@ -35,7 +44,33 @@ describe('runAuth', () => {
     const result = await runAuth(deps, input);
 
     expect(client.setAuthorization).toHaveBeenCalledWith('cli-token');
-    expect(result).toEqual({ kind: 'continue', output: undefined });
+    expect(result).toEqual({ kind: 'continue', output: { isReactNativeApp: false } });
+  });
+
+  it('returns isReactNativeApp: true when the pre-flight query says so', async () => {
+    const client = { runQuery: vi.fn(), setAuthorization: vi.fn() };
+    client.runQuery
+      .mockResolvedValueOnce({ appToken: 'app-token' })
+      .mockResolvedValueOnce(appInfoResult(true));
+    const deps = buildDeps({ client: client as any });
+
+    const input: AuthInput = { mode: 'app', projectToken: 'test' };
+    const result = await runAuth(deps, input);
+
+    expect(result).toEqual({ kind: 'continue', output: { isReactNativeApp: true } });
+  });
+
+  it('defaults isReactNativeApp to false when the pre-flight query fails', async () => {
+    const client = { runQuery: vi.fn(), setAuthorization: vi.fn() };
+    client.runQuery
+      .mockResolvedValueOnce({ appToken: 'app-token' })
+      .mockRejectedValueOnce(new Error('network error'));
+    const deps = buildDeps({ client: client as any });
+
+    const input: AuthInput = { mode: 'app', projectToken: 'test' };
+    const result = await runAuth(deps, input);
+
+    expect(result).toEqual({ kind: 'continue', output: { isReactNativeApp: false } });
   });
 
   it('throws invalidProjectId on "Must login" / "No Access"', async () => {

--- a/node-src/tasks/auth.ts
+++ b/node-src/tasks/auth.ts
@@ -18,11 +18,30 @@ const CreateAppTokenMutation = `
   }
 `;
 
-export type AuthDeps = Pick<Deps, 'client' | 'env'>;
+// Pre-flight query to determine app type before the pipeline reaches storybookInfo.
+// This is placed here to avoid adding a new task to the pipeline, which was an accepted
+// tradeoff. Ideally this would live in a dedicated appInfo task between auth and
+// storybookInfo. The result is a best-effort early signal; announceBuild remains the
+// authoritative source for isReactNativeApp.
+const AppInfoQuery = `
+  query CLIAppInfo {
+    app {
+      features {
+        isReactNativeApp
+      }
+    }
+  }
+`;
+
+export type AuthDeps = Pick<Deps, 'client' | 'env' | 'log'>;
 
 export type AuthInput =
   | { mode: 'cli'; projectId: string; userToken: string; projectToken: string }
   | { mode: 'app'; projectToken: string };
+
+export interface AuthOutput {
+  isReactNativeApp: boolean;
+}
 
 /**
  * Retrieves an authentication token based on the specified mode.
@@ -67,7 +86,8 @@ const getToken = async (deps: AuthDeps, input: AuthInput): Promise<string> => {
   }
 };
 
-export const runAuth: TaskFunction<AuthInput, void, AuthDeps> = async (deps, input) => {
+/* eslint-disable-next-line complexity */
+export const runAuth: TaskFunction<AuthInput, AuthOutput, AuthDeps> = async (deps, input) => {
   try {
     const token = await getToken(deps, input);
     deps.client.setAuthorization(token);
@@ -81,7 +101,26 @@ export const runAuth: TaskFunction<AuthInput, void, AuthDeps> = async (deps, inp
     }
     throw errors;
   }
-  return { kind: 'continue', output: undefined };
+
+  // Pre-flight: fetch app type so storybookInfo can skip the build-storybook script
+  // check for react-native projects. Skip if projectToken is absent (e.g. cli mode
+  // without a project token). On any failure, soft-fail and assume a web storybook —
+  // announceBuild will make the authoritative determination.
+  let isReactNativeApp = false;
+  try {
+    const { app } = await deps.client.runQuery<{
+      app: { features: { isReactNativeApp: boolean } };
+    }>(AppInfoQuery, {});
+    isReactNativeApp = app?.features?.isReactNativeApp ?? false;
+  } catch {
+    deps.log.warn('Failed to fetch app info; assuming web storybook for build script check.');
+  }
+
+  return { kind: 'continue', output: { isReactNativeApp } };
+};
+
+export const applyAuthOutput = (ctx: Context, output: AuthOutput) => {
+  ctx.isReactNativeApp = output.isReactNativeApp;
 };
 
 /**
@@ -106,6 +145,7 @@ export default function main(_: Context) {
       }
       return { mode: 'app', projectToken };
     },
+    applyOutput: applyAuthOutput,
     run: runAuth,
   });
 }

--- a/node-src/tasks/storybookInfo.test.ts
+++ b/node-src/tasks/storybookInfo.test.ts
@@ -18,9 +18,9 @@ const mockedSentrySetContext = vi.mocked(Sentry.setContext);
 const buildDeps = (overrides: Partial<StorybookInfoDeps> = {}): StorybookInfoDeps =>
   ({
     log: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
-    options: {},
+    options: { buildScriptName: 'build-storybook' },
     env: {},
-    packageJson: {},
+    packageJson: { scripts: { 'build-storybook': 'build-storybook' } },
     ...overrides,
   }) as StorybookInfoDeps;
 
@@ -30,7 +30,10 @@ describe('setStorybookInfo', () => {
     getStorybookInfo.mockResolvedValue(storybook);
     mockedGetStorybookBaseDirectory.mockReturnValue('');
 
-    const result = await setStorybookInfo(buildDeps(), { gitRootPath: '/some/git/root' });
+    const result = await setStorybookInfo(buildDeps(), {
+      gitRootPath: '/some/git/root',
+      isReactNativeApp: false,
+    });
 
     expect(result).toEqual({
       kind: 'continue',
@@ -42,9 +45,12 @@ describe('setStorybookInfo', () => {
     getStorybookInfo.mockResolvedValue({ version: '1.0.0', addons: [] });
     mockedGetStorybookBaseDirectory.mockReturnValue('packages/storybook');
 
-    await setStorybookInfo(buildDeps({ options: { storybookBaseDir: 'override' } as any }), {
-      gitRootPath: '/repo/root',
-    });
+    await setStorybookInfo(
+      buildDeps({
+        options: { buildScriptName: 'build-storybook', storybookBaseDir: 'override' } as any,
+      }),
+      { gitRootPath: '/repo/root', isReactNativeApp: false }
+    );
 
     expect(mockedGetStorybookBaseDirectory).toHaveBeenCalledWith({
       storybookBaseDir: 'override',
@@ -56,12 +62,39 @@ describe('setStorybookInfo', () => {
     getStorybookInfo.mockResolvedValue({});
     mockedGetStorybookBaseDirectory.mockReturnValue('.');
 
-    const result = await setStorybookInfo(buildDeps(), { gitRootPath: '/repo/root' });
+    const result = await setStorybookInfo(buildDeps(), {
+      gitRootPath: '/repo/root',
+      isReactNativeApp: false,
+    });
 
     expect(result).toEqual({
       kind: 'continue',
       output: { storybook: { baseDir: '.' } },
     });
+  });
+
+  it('skips the build script check for react-native apps', async () => {
+    getStorybookInfo.mockResolvedValue({});
+    mockedGetStorybookBaseDirectory.mockReturnValue('.');
+
+    await expect(
+      setStorybookInfo(buildDeps({ options: {} as any, packageJson: {} }), {
+        gitRootPath: '/repo/root',
+        isReactNativeApp: true,
+      })
+    ).resolves.not.toThrow();
+  });
+
+  it('throws missingBuildScriptName when the build script is absent and app is not react-native', async () => {
+    await expect(
+      setStorybookInfo(
+        buildDeps({
+          options: { buildScriptName: 'build-storybook' } as any,
+          packageJson: { scripts: {} },
+        }),
+        { gitRootPath: '/repo/root', isReactNativeApp: false }
+      )
+    ).rejects.toThrow(/build-storybook/);
   });
 });
 

--- a/node-src/tasks/storybookInfo.ts
+++ b/node-src/tasks/storybookInfo.ts
@@ -1,15 +1,18 @@
 import * as Sentry from '@sentry/node';
 
+import { isE2EBuild } from '../lib/e2eUtils';
 import { getStorybookBaseDirectory } from '../lib/getStorybookBaseDirectory';
 import getStorybookInfo from '../lib/getStorybookInfo';
 import { createTask } from '../lib/tasks';
 import { Context, Deps, Storybook, TaskFunction } from '../types';
+import missingBuildScriptName from '../ui/messages/errors/missingBuildScriptName';
 import { initial, pending, success } from '../ui/tasks/storybookInfo';
 
 export type StorybookInfoDeps = Pick<Deps, 'log' | 'options' | 'env' | 'packageJson'>;
 
 export interface StorybookInfoInput {
   gitRootPath?: string;
+  isReactNativeApp: boolean;
 }
 
 export interface StorybookInfoOutput {
@@ -21,6 +24,27 @@ export const setStorybookInfo: TaskFunction<
   StorybookInfoOutput,
   StorybookInfoDeps
 > = async (deps, input) => {
+  // Validate the build script for web storybooks. The throw that was previously in
+  // getOptions.ts has moved here because it must be gated on isReactNativeApp, which
+  // is only known after auth runs. The script-finding/defaulting logic remains in
+  // getOptions.ts because getStorybookMetadata reads options.buildScriptName during
+  // this task and needs the value resolved in advance.
+  // Skip validation when a build script is not needed: react-native apps use their
+  // own build process, a pre-built storybook dir was provided, a custom build command
+  // was specified, or an E2E runner is in use.
+  if (
+    !input.isReactNativeApp &&
+    !deps.options.storybookBuildDir &&
+    !deps.options.buildCommand &&
+    !isE2EBuild(deps.options)
+  ) {
+    const { buildScriptName } = deps.options;
+    const scripts = (deps.packageJson.scripts ?? {}) as Record<string, string>;
+    if (!buildScriptName || !scripts[buildScriptName]) {
+      throw new Error(missingBuildScriptName(buildScriptName ?? ''));
+    }
+  }
+
   const storybook: Storybook = {
     ...((await getStorybookInfo(deps)) as Storybook),
     baseDir: getStorybookBaseDirectory({
@@ -56,6 +80,7 @@ export default function main(ctx: Context) {
     extractInput: (ctx): StorybookInfoInput => ({
       // git.rootPath is truly optional here, so we don't need to verify that it's present
       gitRootPath: ctx.git?.rootPath,
+      isReactNativeApp: ctx.isReactNativeApp ?? false,
     }),
     applyOutput: applyStorybookInfoOutput,
     run: setStorybookInfo,


### PR DESCRIPTION
The `build-storybook` script requirement does not apply to React Native only projects, so we need to work around that. This adds a pre-flight request to get app details and see if it is a React Native app.

The request was added to `auth` to avoid another task in the UI, and validation has moved from `getOptions` to `storybookInfo` to delay it until the proper context is available, but still run it before `announceBuild`
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>17.0.1--canary.1327.26314486957.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@17.0.1--canary.1327.26314486957.0
  # or 
  yarn add chromatic@17.0.1--canary.1327.26314486957.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
