### PR TITLE
Fix getUncommittedHash on Windows

### DIFF
--- a/node-src/git/git.test.ts
+++ b/node-src/git/git.test.ts
@@ -101,8 +101,69 @@ describe('getBranch', () => {
 
 describe('getUncommittedHash', () => {
   it('returns the uncommitted hash', async () => {
-    execGitCommand.mockResolvedValue('1234567890');
+    execGitCommand
+      .mockResolvedValueOnce('src/a.ts\n') // staged
+      .mockResolvedValueOnce('src/b.ts\n') // unstaged
+      .mockResolvedValueOnce('src/c.ts\n') // untracked
+      .mockResolvedValueOnce('hash-a\nhash-b\nhash-c\n') // hash-object --stdin-paths
+      .mockResolvedValueOnce('1234567890\n'); // hash-object --stdin
+
     expect(await getUncommittedHash(ctx)).toEqual('1234567890');
+
+    expect(execGitCommand).toHaveBeenNthCalledWith(
+      1,
+      ctx,
+      'git diff --name-only --no-relative --diff-filter=d --cached'
+    );
+    expect(execGitCommand).toHaveBeenNthCalledWith(
+      2,
+      ctx,
+      'git diff --name-only --no-relative --diff-filter=d'
+    );
+    expect(execGitCommand).toHaveBeenNthCalledWith(
+      3,
+      ctx,
+      'git ls-files --others --exclude-standard'
+    );
+    expect(execGitCommand).toHaveBeenNthCalledWith(4, ctx, 'git hash-object --stdin-paths', {
+      input: 'src/a.ts\nsrc/b.ts\nsrc/c.ts\n',
+    });
+    expect(execGitCommand).toHaveBeenNthCalledWith(5, ctx, 'git hash-object --stdin', {
+      input: 'hash-a\nhash-b\nhash-c\n',
+    });
+  });
+
+  it('returns empty string when there are no uncommitted files', async () => {
+    execGitCommand.mockResolvedValueOnce('').mockResolvedValueOnce('').mockResolvedValueOnce('');
+
+    expect(await getUncommittedHash(ctx)).toEqual('');
+    // Should short-circuit without invoking hash-object.
+    expect(execGitCommand).toHaveBeenCalledTimes(3);
+  });
+
+  it('returns empty string for the well-known empty-blob hash', async () => {
+    execGitCommand
+      .mockResolvedValueOnce('src/a.ts\n')
+      .mockResolvedValueOnce('')
+      .mockResolvedValueOnce('')
+      .mockResolvedValueOnce('hash-a\n')
+      .mockResolvedValueOnce('e69de29bb2d1d6434b8b29ae775ad8c2e48c5391\n');
+
+    expect(await getUncommittedHash(ctx)).toEqual('');
+  });
+
+  it('handles Windows CRLF line endings in file lists', async () => {
+    execGitCommand
+      .mockResolvedValueOnce('src/a.ts\r\nsrc/b.ts\r\n')
+      .mockResolvedValueOnce('')
+      .mockResolvedValueOnce('')
+      .mockResolvedValueOnce('hash-a\nhash-b\n')
+      .mockResolvedValueOnce('deadbeef\n');
+
+    expect(await getUncommittedHash(ctx)).toEqual('deadbeef');
+    expect(execGitCommand).toHaveBeenNthCalledWith(4, ctx, 'git hash-object --stdin-paths', {
+      input: 'src/a.ts\nsrc/b.ts\n',
+    });
   });
 });
 

--- a/node-src/git/git.ts
+++ b/node-src/git/git.ts
@@ -108,30 +108,44 @@ export async function getBranch(deps: Pick<Deps, 'log'>) {
 /**
  * Retrieve the hash of all uncommitted files, which includes staged, unstaged, and untracked files,
  * excluding deleted files (which can't be hashed) and ignored files. There is no one single Git
- * command to reliably get this information, so we use a combination of commands grouped together.
+ * command to reliably get this information, so we run three list commands and feed the combined
+ * file list into `git hash-object` via stdin. Stdin is used (instead of shell pipes) so the
+ * implementation works on Windows `cmd.exe` as well as POSIX shells.
  *
  * @param deps Function dependencies.
  *
  * @returns The uncommited hash, if available.
  */
 export async function getUncommittedHash(deps: Pick<Deps, 'log'>) {
-  const listStagedFiles = 'git diff --name-only --no-relative --diff-filter=d --cached';
-  const listUnstagedFiles = 'git diff --name-only --no-relative --diff-filter=d';
-  const listUntrackedFiles = 'git ls-files --others --exclude-standard';
-  const listUncommittedFiles = [listStagedFiles, listUnstagedFiles, listUntrackedFiles].join(';');
+  const [stagedFiles, unstagedFiles, untrackedFiles] = await Promise.all([
+    execGitCommand(deps, 'git diff --name-only --no-relative --diff-filter=d --cached'),
+    execGitCommand(deps, 'git diff --name-only --no-relative --diff-filter=d'),
+    execGitCommand(deps, 'git ls-files --others --exclude-standard'),
+  ]);
 
-  const uncommittedHashWithPadding = await execGitCommand(
-    deps,
-    // Pass the combined list of filenames to hash-object to retrieve a list of hashes. Then pass
-    // the list of hashes to hash-object again to retrieve a single hash of all hashes. We use
-    // stdin to avoid the limit on command line arguments.
-    `(${listUncommittedFiles}) | git hash-object --stdin-paths | git hash-object --stdin`
-  );
-  const uncommittedHash = uncommittedHashWithPadding?.trim();
+  const files = [stagedFiles, unstagedFiles, untrackedFiles]
+    .filter(Boolean)
+    .flatMap((output) => (output as string).split(/\r?\n/))
+    .map((line) => line.trim())
+    .filter(Boolean);
+
+  if (files.length === 0) return '';
+
+  // Pipe file paths to `git hash-object --stdin-paths` via stdin to retrieve a list of hashes,
+  // then pipe that list to `git hash-object --stdin` to retrieve a single hash of all hashes.
+  const fileHashes = await execGitCommand(deps, 'git hash-object --stdin-paths', {
+    input: `${files.join('\n')}\n`,
+  });
+  if (!fileHashes?.trim()) return '';
+
+  const finalHash = await execGitCommand(deps, 'git hash-object --stdin', {
+    input: fileHashes,
+  });
+  const uncommittedHash = finalHash?.trim();
 
   // In case there are no uncommited changes (empty list), we always get this same hash.
   const noChangesHash = 'e69de29bb2d1d6434b8b29ae775ad8c2e48c5391';
-  return uncommittedHash === noChangesHash ? '' : uncommittedHash;
+  return !uncommittedHash || uncommittedHash === noChangesHash ? '' : uncommittedHash;
 }
 
 /**


### PR DESCRIPTION
## Summary

- `getUncommittedHash` joined three `git` commands with `;` inside `(...)` and piped the result to `git hash-object` twice. That pipeline only works under POSIX shells. On Windows it runs through `cmd.exe`, which treats `;` as a literal and folds the rest of the line into the first `git diff` invocation, so the hash always came back as the empty-blob SHA and was reduced to `''`.
- Replace the single shell-piped command with three independent `git` invocations, concatenate the file lists in JavaScript, then feed them to `git hash-object --stdin-paths` and `git hash-object --stdin` via execa's `input` option. Same output on POSIX shells, now works identically on Windows.
- Downstream impact: consumers like the Storybook visual tests addon use `uncommittedHash` to detect local changes (see `ShareSection`'s `checkOutdated`). With the broken pipeline on Windows the hash never changed, so the "Republish" prompt never appeared after a code edit.

## Test plan

- [x] `yarn vitest run node-src/git/git.test.ts` — 26 tests pass, including new cases for empty list, well-known empty-blob hash, and CRLF line endings.
- [x] `yarn lint node-src/git/git.ts node-src/git/git.test.ts` — clean.
- [x] `npx tsc --noEmit` — clean.
- [ ] Manual verification on Windows: edit a tracked file, confirm `getUncommittedHash` now returns a non-empty hash that changes with further edits.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>16.10.1--canary.1328.25739265808.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@16.10.1--canary.1328.25739265808.0
  # or 
  yarn add chromatic@16.10.1--canary.1328.25739265808.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
