### PR TITLE
Throw on shallow clone of 1

### DIFF
--- a/node-src/git/getCommitAndBranch.test.ts
+++ b/node-src/git/getCommitAndBranch.test.ts
@@ -12,6 +12,7 @@ vi.mock('./git');
 const getBranch = vi.mocked(git.getBranch);
 const getCommit = vi.mocked(git.getCommit);
 const hasPreviousCommit = vi.mocked(git.hasPreviousCommit);
+const isShallowRepository = vi.mocked(git.isShallowRepository);
 
 const log = new TestLogger();
 const ctx = { log } as unknown as Context;
@@ -54,13 +55,11 @@ beforeEach(() => {
     committerEmail: 'noreply@github.com',
   });
   hasPreviousCommit.mockResolvedValue(true);
+  isShallowRepository.mockResolvedValue(false);
 });
 
 afterEach(() => {
   vi.unstubAllEnvs();
-  envCi.mockReset();
-  getBranch.mockReset();
-  getCommit.mockReset();
 });
 
 const commitInfo = {
@@ -147,6 +146,12 @@ describe('getCommitAndBranch', () => {
   it('throws when there is only one commit, CI', async () => {
     envCi.mockReturnValue({ isCi: true });
     hasPreviousCommit.mockResolvedValue(false);
+    await expect(getCommitAndBranch(ctx)).rejects.toThrow('Found only one commit');
+  });
+
+  it('throws when the checkout is a shallow clone with only one commit', async () => {
+    hasPreviousCommit.mockResolvedValue(false);
+    isShallowRepository.mockResolvedValue(true);
     await expect(getCommitAndBranch(ctx)).rejects.toThrow('Found only one commit');
   });
 

--- a/node-src/git/getCommitAndBranch.ts
+++ b/node-src/git/getCommitAndBranch.ts
@@ -8,7 +8,7 @@ import missingTravisInfo from '../ui/messages/errors/missingTravisInfo';
 import customGitHubAction from '../ui/messages/info/customGitHubAction';
 import noCommitDetails from '../ui/messages/warnings/noCommitDetails';
 import travisInternalBuild from '../ui/messages/warnings/travisInternalBuild';
-import { getBranch, getCommit, hasPreviousCommit } from './git';
+import { getBranch, getCommit, hasPreviousCommit, isShallowRepository } from './git';
 
 const ORIGIN_PREFIX_REGEXP = /^origin\//;
 const notHead = (branch) => (branch && branch !== 'HEAD' ? branch : false);
@@ -90,6 +90,13 @@ export default async function getCommitAndBranch(
   const isGitHubPrBuild = GITHUB_EVENT_NAME === 'pull_request';
 
   if (!(await hasPreviousCommit(deps))) {
+    // Always throw if there's only 1 commit and it's a shallow clone to avoid confusion in
+    // baselines because this is likely NOT what the user intended and default behavior of their
+    // checkout step in CI.
+    if (await isShallowRepository(deps)) {
+      throw new Error(gitOneCommit(isGitHubAction));
+    }
+
     const message = gitOneCommit(isGitHubAction);
     if (isCi) {
       throw new Error(message);

--- a/node-src/git/git.test.ts
+++ b/node-src/git/git.test.ts
@@ -16,6 +16,7 @@ import {
   getUserEmail,
   getVersion,
   hasPreviousCommit,
+  isShallowRepository,
   NULL_BYTE,
 } from './git';
 
@@ -139,6 +140,18 @@ gpg: Can't check signature: No public key
 19b6c9c5b3d34d9fc55627fcaf8a85bd5d5e5b2a`.trim()
     );
     expect(await hasPreviousCommit(ctx)).toEqual(true);
+  });
+});
+
+describe('isShallowRepository', () => {
+  it('returns true for a shallow repository', async () => {
+    execGitCommand.mockResolvedValueOnce('true');
+    expect(await isShallowRepository(ctx)).toEqual(true);
+  });
+
+  it('returns false for a non-shallow repository', async () => {
+    execGitCommand.mockResolvedValueOnce('false');
+    expect(await isShallowRepository(ctx)).toEqual(false);
   });
 });
 

--- a/node-src/git/git.ts
+++ b/node-src/git/git.ts
@@ -150,6 +150,18 @@ export async function hasPreviousCommit(deps: Pick<Deps, 'log'>) {
 }
 
 /**
+ * Determine if the repository is shallow.
+ *
+ * @param deps Function dependencies.
+ *
+ * @returns True if the repository is shallow.
+ */
+export async function isShallowRepository(deps: Pick<Deps, 'log'>) {
+  const isShallowRepository = await execGitCommand(deps, 'git rev-parse --is-shallow-repository');
+  return isShallowRepository?.trim() === 'true';
+}
+
+/**
  * Check if a commit exists in the repository
  *
  * @param deps Function dependencies.


### PR DESCRIPTION
> [!CAUTION]
> This is a breaking change. If a user has been leaning on the default behavior and auto-upgrading to newer versions of the CLI, it will start failing their builds.

Some CI providers default checkout to a shallow clone of 1 which can break Chromatic baselines and cause unexpected behavior. Instead of logging this case to CI logs that can easily be missed, we're going to fail loudly when we have a shallow clone of only 1 commit.

Here's the result of the test in my test project:
<img width="1313" height="386" alt="image" src="https://github.com/user-attachments/assets/42412e25-6175-429c-acf1-20e358f2e71f" />

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>17.0.0--canary.1329.25811313516.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@17.0.0--canary.1329.25811313516.0
  # or 
  yarn add chromatic@17.0.0--canary.1329.25811313516.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
