### PR TITLE
Fix `getUncommittedHash` in Windows environments

### DIFF
--- a/node-src/git/execGit.ts
+++ b/node-src/git/execGit.ts
@@ -32,13 +32,16 @@ export async function execGitCommand(
 ) {
   try {
     log.debug(`execGitCommand: ${command}`);
-    const { all } = await runCommand(command, { ...defaultOptions, ...options });
+    const { all, stdout } = await runCommand(command, { ...defaultOptions, ...options });
+    // If the caller sets `all: false`, then `stdout` will be the output. Otherwise, `all` will
+    // contain interleaved stdout and stderr.
+    const output = all ?? stdout;
 
-    if (all === undefined) {
+    if (output === undefined) {
       throw new Error(`Unexpected missing git command output for command: '${command}'`);
     }
 
-    const result = all.toString();
+    const result = output.toString();
     log.debug(`execGitCommand result: '${result}'`);
     return result;
   } catch (error) {

--- a/node-src/git/git.ts
+++ b/node-src/git/git.ts
@@ -118,15 +118,37 @@ export async function getUncommittedHash(deps: Pick<Deps, 'log'>) {
   const listStagedFiles = 'git diff --name-only --no-relative --diff-filter=d --cached';
   const listUnstagedFiles = 'git diff --name-only --no-relative --diff-filter=d';
   const listUntrackedFiles = 'git ls-files --others --exclude-standard';
-  const listUncommittedFiles = [listStagedFiles, listUnstagedFiles, listUntrackedFiles].join(';');
 
-  const uncommittedHashWithPadding = await execGitCommand(
-    deps,
-    // Pass the combined list of filenames to hash-object to retrieve a list of hashes. Then pass
-    // the list of hashes to hash-object again to retrieve a single hash of all hashes. We use
-    // stdin to avoid the limit on command line arguments.
-    `(${listUncommittedFiles}) | git hash-object --stdin-paths | git hash-object --stdin`
-  );
+  // Use `all: false` so only stdout is captured and we can ignore stderr output that doesn't impact
+  // the result.
+  const stdoutOnly = { all: false };
+  const [stagedOutput, unstagedOutput, untrackedOutput] = await Promise.all([
+    execGitCommand(deps, listStagedFiles, stdoutOnly),
+    execGitCommand(deps, listUnstagedFiles, stdoutOnly),
+    execGitCommand(deps, listUntrackedFiles, stdoutOnly),
+  ]);
+
+  // Combine file listings into one path per line, stripping empty lines (including trailing
+  // newlines from each output).
+  const files = [stagedOutput, unstagedOutput, untrackedOutput]
+    .flatMap((output) => output?.split(newline) ?? [])
+    .filter(Boolean)
+    .join('\n');
+
+  if (!files) {
+    return '';
+  }
+
+  // Pass the combined list of filenames to hash-object to retrieve a list of hashes. Then pass
+  // the list of hashes to hash-object again to retrieve a single hash of all hashes. We use
+  // stdin to avoid the limit on command line arguments.
+  const fileHashes = await execGitCommand(deps, 'git hash-object --stdin-paths', {
+    input: files,
+  });
+
+  const uncommittedHashWithPadding = await execGitCommand(deps, 'git hash-object --stdin', {
+    input: fileHashes,
+  });
   const uncommittedHash = uncommittedHashWithPadding?.trim();
 
   // In case there are no uncommited changes (empty list), we always get this same hash.


### PR DESCRIPTION
In testing out a new feature in VTA, we discovered `getUncommittedHash` was not working properly in Windows environments. Turns out, it was because we were using a POSIX-specific command to get the hash of uncommitted changes, which doesn't work in Windows. This switches to a different command pipeline that is compatible in both environments.

I also discovered that `all: true` gets real messy when you just need the stdout and stderr has some information that doesn't impact the output so I added support for `all: false` in there.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>16.10.1--canary.1332.25926906664.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@16.10.1--canary.1332.25926906664.0
  # or 
  yarn add chromatic@16.10.1--canary.1332.25926906664.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
