### PR TITLE
Fix TurboSnap mis-categorizing static assets as Storybook config changes

### DIFF
--- a/node-src/lib/getStorybookMetadata.test.ts
+++ b/node-src/lib/getStorybookMetadata.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { findStaticDirectories } from './getStorybookMetadata';
+
+const makeConfig = (returnValue: any) => ({
+  getSafeFieldValue: vi.fn().mockReturnValue(returnValue),
+});
+
+describe('findStaticDirs', () => {
+  it('returns string entries resolved relative to configDirectory', () => {
+    const config = makeConfig(['./static', '../public']);
+    expect(findStaticDirectories(config, true, '.storybook')).toEqual({
+      staticDir: ['.storybook/static', 'public'],
+    });
+  });
+
+  it('extracts `from` from object entries and resolves relative to configDirectory', () => {
+    const config = makeConfig([
+      { from: './static', to: '/' },
+      { from: '../public', to: '/public' },
+    ]);
+    expect(findStaticDirectories(config, true, '.storybook')).toEqual({
+      staticDir: ['.storybook/static', 'public'],
+    });
+  });
+
+  it('handles mixed string and object entries', () => {
+    const config = makeConfig(['./static', { from: '../public', to: '/' }]);
+    expect(findStaticDirectories(config, true, '.storybook')).toEqual({
+      staticDir: ['.storybook/static', 'public'],
+    });
+  });
+
+  it('leaves absolute paths unchanged', () => {
+    const config = makeConfig(['/absolute/path']);
+    expect(findStaticDirectories(config, true, '.storybook')).toEqual({
+      staticDir: ['/absolute/path'],
+    });
+  });
+
+  it('uses nested configDirectory when provided', () => {
+    const config = makeConfig(['./static']);
+    expect(findStaticDirectories(config, true, 'packages/ui/.storybook')).toEqual({
+      staticDir: ['packages/ui/.storybook/static'],
+    });
+  });
+
+  it('returns {} for empty array', () => {
+    const config = makeConfig([]);
+    expect(findStaticDirectories(config, true)).toEqual({});
+  });
+
+  it('returns {} when v7 is false', () => {
+    const config = makeConfig(['./static']);
+    expect(findStaticDirectories(config, false)).toEqual({});
+  });
+
+  it('returns {} when mainConfig is null', () => {
+    expect(findStaticDirectories(null, true)).toEqual({});
+  });
+
+  it('returns {} when staticDirs is not present on config', () => {
+    const config = makeConfig(undefined);
+    expect(findStaticDirectories(config, true)).toEqual({});
+  });
+
+  it('returns {} when staticDirs is a non-array value', () => {
+    const config = makeConfig('./static');
+    expect(findStaticDirectories(config, true)).toEqual({});
+  });
+
+  it('returns {} when all entries have no valid path', () => {
+    const config = makeConfig([null, undefined, { to: '/' }]);
+    expect(findStaticDirectories(config, true)).toEqual({});
+  });
+});

--- a/node-src/lib/getStorybookMetadata.ts
+++ b/node-src/lib/getStorybookMetadata.ts
@@ -10,6 +10,7 @@ import type { StorybookInfoDeps } from '../tasks/storybookInfo';
 import { Storybook } from '../types';
 import packageDoesNotExist from '../ui/messages/errors/noViewLayerPackage';
 import { builders } from './builders';
+import { posix } from './posix';
 import { raceFulfilled, timeout } from './promises';
 import { viewLayers } from './viewLayers';
 
@@ -186,6 +187,30 @@ const findReferences = async (mainConfig, v7) => {
   return references ? { refs: references } : {};
 };
 
+export const findStaticDirectories = (
+  mainConfig: any,
+  v7: boolean,
+  configDirectory = '.storybook'
+): { staticDir?: string[] } => {
+  if (!mainConfig || !v7) return {};
+
+  const staticDirectories = mainConfig.getSafeFieldValue(['staticDirs']);
+  if (!Array.isArray(staticDirectories) || staticDirectories.length === 0) return {};
+
+  // staticDirs entries can be plain strings or { from, to } DirectoryMapping objects
+  const directories = staticDirectories
+    .map((entry: string | { from: string }) => (typeof entry === 'string' ? entry : entry?.from))
+    .filter(Boolean) as string[];
+
+  // Convert directories to posix for cross-platform consistency
+  const safeConfigDirectory = posix(configDirectory);
+  const resolvedDirectories = directories.map((directory) =>
+    path.posix.isAbsolute(directory) ? directory : path.posix.join(safeConfigDirectory, directory)
+  );
+
+  return resolvedDirectories.length > 0 ? { staticDir: resolvedDirectories } : {};
+};
+
 export const findStorybookConfigFile = async (
   storybookConfigDirectory: string | undefined,
   pattern: RegExp
@@ -196,8 +221,10 @@ export const findStorybookConfigFile = async (
   return configFile && path.join(configDirectory, configFile);
 };
 
+// TODO: refactor this function
 export const getStorybookMetadata = async (
   deps: StorybookInfoDeps
+  // eslint-disable-next-line complexity
 ): Promise<Partial<Storybook>> => {
   const configDirectory = deps.options.storybookConfigDir ?? '.storybook';
 
@@ -234,16 +261,20 @@ export const getStorybookMetadata = async (
     findStorybookVersion(deps),
     findBuilder(mainConfig, v7),
     findReferences(mainConfig, v7),
+    findStaticDirectories(mainConfig, v7, configDirectory),
   ]);
 
   deps.log.debug(info);
-  let metadata = {};
+  let metadata: Record<string, any> = {};
   for (const sbItem of info) {
     if (sbItem.status === 'fulfilled') {
-      metadata = {
-        ...metadata,
-        ...(sbItem?.value as any),
-      };
+      const { staticDir: staticDirectories, ...rest } = sbItem?.value as any;
+      metadata = { ...metadata, ...rest };
+
+      // Merge static directories from multiple sources and remove duplicates
+      if (staticDirectories?.length) {
+        metadata.staticDir = [...new Set([...(metadata.staticDir ?? []), ...staticDirectories])];
+      }
     }
   }
   return metadata;

--- a/node-src/lib/turbosnap/getDependentStoryFiles.test.ts
+++ b/node-src/lib/turbosnap/getDependentStoryFiles.test.ts
@@ -1,4 +1,4 @@
-/* eslint-disable max-lines */
+/* eslint-disable max-lines, max-statements */
 import chalk from 'chalk';
 import { afterEach, describe, expect, it } from 'vitest';
 
@@ -656,6 +656,62 @@ describe('getDependentStoryFiles', () => {
       expect.stringContaining(chalk`Found a static file change in {bold path/to/statics/image.png}`)
     );
   });
+
+  // A static asset nested under the Storybook config dir (e.g. an MSW
+  // auto-generated `mockServiceWorker.js`) must be categorized by its
+  // staticDir membership, not by its `.storybook/` prefix.
+  it('bails on changed static file nested inside Storybook config dir', async () => {
+    const changedFiles = ['src/foo.stories.js', '.storybook/static/foo.js'];
+    const modules = [
+      {
+        id: './src/foo.stories.js',
+        name: './src/foo.stories.js',
+        reasons: [{ moduleName: CSF_GLOB }],
+      },
+      {
+        id: CSF_GLOB,
+        name: CSF_GLOB,
+        reasons: [{ moduleName: './.storybook/generated-stories-entry.js' }],
+      },
+    ];
+    const ctx = getContext({ staticDir: ['.storybook/static'] });
+    const result = await getDependentStoryFiles(ctx, { modules }, statsPath, changedFiles);
+    expect(result).toBeUndefined();
+    expect(ctx.turboSnap.bailReason).toEqual({
+      changedStaticFiles: ['.storybook/static/foo.js'],
+    });
+    expect(ctx.log.warn).toHaveBeenCalledWith(
+      expect.stringContaining(chalk`Found a static file change in {bold .storybook/static/foo.js}`)
+    );
+  });
+
+  it('falls back to Storybook config bail for files inside .storybook when no staticDirs configured', async () => {
+    const changedFiles = ['src/foo.stories.js', '.storybook/static/foo.js'];
+    const modules = [
+      {
+        id: './src/foo.stories.js',
+        name: './src/foo.stories.js',
+        reasons: [{ moduleName: CSF_GLOB }],
+      },
+      {
+        id: CSF_GLOB,
+        name: CSF_GLOB,
+        reasons: [{ moduleName: './.storybook/generated-stories-entry.js' }],
+      },
+    ];
+    const ctx = getContext();
+    const result = await getDependentStoryFiles(ctx, { modules }, statsPath, changedFiles);
+    expect(result).toBeUndefined();
+    expect(ctx.turboSnap.bailReason).toEqual({
+      changedStorybookFiles: ['.storybook/static/foo.js'],
+    });
+    expect(ctx.log.warn).toHaveBeenCalledWith(
+      expect.stringContaining(
+        chalk`Found a Storybook config change in {bold .storybook/static/foo.js}`
+      )
+    );
+  });
+
   it('ignores untraced files and dependencies with a glob pattern match', async () => {
     const changedFiles = ['src/stories/Button.jsx', 'src/stories/Page.jsx'];
     const modules = [

--- a/node-src/lib/turbosnap/getDependentStoryFiles.ts
+++ b/node-src/lib/turbosnap/getDependentStoryFiles.ts
@@ -265,12 +265,16 @@ export async function getDependentStoryFiles(
   function shouldBail(moduleName: string) {
     if (!ctx.turboSnap) ctx.turboSnap = {};
 
-    if (isStorybookFile(moduleName)) {
-      ctx.turboSnap.bailReason = { changedStorybookFiles: files(moduleName) };
-      return true;
-    }
+    // Check staticDirs before the Storybook config dir so static assets
+    // nested under `.storybook/` (e.g. an MSW-generated mockServiceWorker.js
+    // inside a configured staticDir) aren't mis-categorized as config changes.
     if (isStaticFile(moduleName)) {
       ctx.turboSnap.bailReason = { changedStaticFiles: files(moduleName) };
+      return true;
+    }
+
+    if (isStorybookFile(moduleName)) {
+      ctx.turboSnap.bailReason = { changedStorybookFiles: files(moduleName) };
       return true;
     }
     return false;


### PR DESCRIPTION
In doing some investigation into our SteadySnap bail reasons, it appears we're not catching static file changes nested under `.storybook/` as static file changes, but instead categorizing them as Storybook config changes because the file change path contains `.storybook/`.

This fixes that by
1. Swapping the order of those functions
2. Parsing the `staticDirs` field from the Storybook config ([docs](https://storybook.js.org/docs/api/main-config/main-config-static-dirs))
    - Surprisingly enough, we were only parsing `-s` in the build command which isn't a thing in newer Storybook versions

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>17.0.2--canary.1340.26464723943.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@17.0.2--canary.1340.26464723943.0
  # or 
  yarn add chromatic@17.0.2--canary.1340.26464723943.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
