### PR TITLE
Add additional bail details to `changedPackageFiles`

### DIFF
--- a/node-src/git/git.test.ts
+++ b/node-src/git/git.test.ts
@@ -1,8 +1,10 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import TestLogger from '../lib/testLogger';
+import { BaselineCheckoutFailedError } from '../lib/turbosnap/errors';
 import * as execGit from './execGit';
 import {
+  checkoutFile,
   commitExists,
   findFilesFromRepositoryRoot,
   getBranch,
@@ -20,6 +22,9 @@ import {
 } from './git';
 
 vi.mock('./execGit');
+vi.mock('tmp-promise', () => ({
+  file: vi.fn().mockResolvedValue({ path: '/tmp/fake-target' }),
+}));
 
 const execGitCommand = vi.mocked(execGit.execGitCommand);
 const execGitCommandOneLine = vi.mocked(execGit.execGitCommandOneLine);
@@ -177,6 +182,18 @@ describe('findFilesFromRepositoryRoot', () => {
       'git ls-files --full-name -z "/root/package.json" "/root/**/package.json"'
     );
     expect(results).toEqual(filesFound);
+  });
+});
+
+describe('checkoutFile', () => {
+  it('wraps a failing `git show` in BaselineCheckoutFailedError with cause', async () => {
+    const cause = new Error('git show failed');
+    execGitCommand.mockRejectedValueOnce(cause);
+
+    const promise = checkoutFile(ctx, 'abc123', 'package.json', '/tmp/anywhere');
+
+    await expect(promise).rejects.toBeInstanceOf(BaselineCheckoutFailedError);
+    await expect(promise).rejects.toMatchObject({ cause });
   });
 });
 

--- a/node-src/git/git.ts
+++ b/node-src/git/git.ts
@@ -4,6 +4,7 @@ import pLimit from 'p-limit';
 import path from 'path';
 import { file as temporaryFile } from 'tmp-promise';
 
+import { BaselineCheckoutFailedError } from '../lib/turbosnap/errors';
 import { Deps } from '../types';
 import { execGitCommand, execGitCommandCountLines, execGitCommandOneLine } from './execGit';
 
@@ -380,7 +381,11 @@ export async function checkoutFile(
     });
 
     deps.log.debug(`Checking out file ${pathspec} at ${targetFileName}`);
-    await execGitCommand(deps, `git show ${pathspec} > ${targetFileName}`);
+    try {
+      await execGitCommand(deps, `git show ${pathspec} > ${targetFileName}`);
+    } catch (error) {
+      throw new BaselineCheckoutFailedError(pathspec, { cause: error });
+    }
 
     return targetFileName;
   });

--- a/node-src/lib/turbosnap/classifyBailDetail.test.ts
+++ b/node-src/lib/turbosnap/classifyBailDetail.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import { bailDetailKey, classifyBailDetail, detectLockfileKind } from './classifyBailDetail';
-import { LockFileSizeExceededError } from './errors';
+import { LockFileParseFailedError, LockFileSizeExceededError } from './errors';
 
 describe('classifyBailDetail', () => {
   it('returns {} for a generic Error', () => {
@@ -30,6 +30,16 @@ describe('classifyBailDetail', () => {
       lockfileSizeBytes: 12_000_000,
     });
   });
+
+  it('classifies LockFileParseFailedError with kind', () => {
+    const err = new LockFileParseFailedError('/tmp/checkout-abc/yarn.lock', {
+      cause: new Error('no lock file parse for you'),
+    });
+    expect(classifyBailDetail(err)).toEqual({
+      lockfileParseFailed: true,
+      lockfileKind: 'yarn.lock',
+    });
+  });
 });
 
 describe('bailDetailKey', () => {
@@ -39,6 +49,10 @@ describe('bailDetailKey', () => {
 
   it('returns "lockfileSizeExceeded" when the flag is set', () => {
     expect(bailDetailKey({ lockfileSizeExceeded: true })).toBe('lockfileSizeExceeded');
+  });
+
+  it('returns "lockfileParseFailed" when the flag is set', () => {
+    expect(bailDetailKey({ lockfileParseFailed: true })).toBe('lockfileParseFailed');
   });
 });
 

--- a/node-src/lib/turbosnap/classifyBailDetail.test.ts
+++ b/node-src/lib/turbosnap/classifyBailDetail.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+
+import { bailDetailKey, classifyBailDetail, detectLockfileKind } from './classifyBailDetail';
+
+describe('classifyBailDetail', () => {
+  it('returns {} for a generic Error', () => {
+    expect(classifyBailDetail(new Error('whatever'))).toEqual({});
+  });
+
+  it('returns {} for a non-Error value', () => {
+    expect(classifyBailDetail('string')).toEqual({});
+    expect(classifyBailDetail(undefined)).toEqual({});
+  });
+});
+
+describe('bailDetailKey', () => {
+  it('returns "unknown" for an empty patch', () => {
+    expect(bailDetailKey({})).toBe('unknown');
+  });
+});
+
+describe('detectLockfileKind', () => {
+  it('returns "yarn.lock" for a yarn lockfile path', () => {
+    expect(detectLockfileKind('/tmp/checkout-abc/yarn.lock')).toBe('yarn.lock');
+  });
+
+  it('returns "pnpm-lock.yaml" for a pnpm lockfile path', () => {
+    expect(detectLockfileKind('/tmp/checkout-abc/pnpm-lock.yaml')).toBe('pnpm-lock.yaml');
+  });
+
+  it('returns "package-lock.json" for an npm lockfile path', () => {
+    expect(detectLockfileKind('/tmp/checkout-abc/package-lock.json')).toBe('package-lock.json');
+  });
+
+  it('returns undefined for an unrecognized path', () => {
+    expect(detectLockfileKind('/tmp/checkout-abc/package.json')).toBeUndefined();
+    expect(detectLockfileKind('')).toBeUndefined();
+  });
+});

--- a/node-src/lib/turbosnap/classifyBailDetail.test.ts
+++ b/node-src/lib/turbosnap/classifyBailDetail.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, it } from 'vitest';
 
 import { bailDetailKey, classifyBailDetail, detectLockfileKind } from './classifyBailDetail';
-import { LockFileParseFailedError, LockFileSizeExceededError } from './errors';
+import {
+  BaselineCheckoutFailedError,
+  LockFileParseFailedError,
+  LockFileSizeExceededError,
+} from './errors';
 
 describe('classifyBailDetail', () => {
   it('returns {} for a generic Error', () => {
@@ -40,6 +44,13 @@ describe('classifyBailDetail', () => {
       lockfileKind: 'yarn.lock',
     });
   });
+
+  it('classifies BaselineCheckoutFailedError as { baselineCheckoutFailed: true }', () => {
+    const err = new BaselineCheckoutFailedError('abc123:package.json', {
+      cause: new Error('git show failed'),
+    });
+    expect(classifyBailDetail(err)).toEqual({ baselineCheckoutFailed: true });
+  });
 });
 
 describe('bailDetailKey', () => {
@@ -53,6 +64,10 @@ describe('bailDetailKey', () => {
 
   it('returns "lockfileParseFailed" when the flag is set', () => {
     expect(bailDetailKey({ lockfileParseFailed: true })).toBe('lockfileParseFailed');
+  });
+
+  it('returns "baselineCheckoutFailed" when the flag is set', () => {
+    expect(bailDetailKey({ baselineCheckoutFailed: true })).toBe('baselineCheckoutFailed');
   });
 });
 

--- a/node-src/lib/turbosnap/classifyBailDetail.test.ts
+++ b/node-src/lib/turbosnap/classifyBailDetail.test.ts
@@ -89,4 +89,9 @@ describe('detectLockfileKind', () => {
     expect(detectLockfileKind('/tmp/checkout-abc/package.json')).toBeUndefined();
     expect(detectLockfileKind('')).toBeUndefined();
   });
+
+  it('does not match a path whose basename only happens to end with a lockfile name', () => {
+    expect(detectLockfileKind('/tmp/checkout-abc/my.yarn.lock')).toBeUndefined();
+    expect(detectLockfileKind('/tmp/checkout-abc/old-package-lock.json')).toBeUndefined();
+  });
 });

--- a/node-src/lib/turbosnap/classifyBailDetail.test.ts
+++ b/node-src/lib/turbosnap/classifyBailDetail.test.ts
@@ -26,13 +26,14 @@ describe('classifyBailDetail', () => {
     });
   });
 
-  it('classifies LockFileSizeExceededError with undefined lockfileKind for an unrecognized path', () => {
+  it('classifies LockFileSizeExceededError without lockfileKind for an unrecognized path', () => {
     const err = new LockFileSizeExceededError('/tmp/weird-name', 12_000_000);
-    expect(classifyBailDetail(err)).toEqual({
+    const patch = classifyBailDetail(err);
+    expect(patch).toEqual({
       lockfileSizeExceeded: true,
-      lockfileKind: undefined,
       lockfileSizeBytes: 12_000_000,
     });
+    expect(patch).not.toHaveProperty('lockfileKind');
   });
 
   it('classifies LockFileParseFailedError with kind', () => {

--- a/node-src/lib/turbosnap/classifyBailDetail.test.ts
+++ b/node-src/lib/turbosnap/classifyBailDetail.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import { bailDetailKey, classifyBailDetail, detectLockfileKind } from './classifyBailDetail';
+import { LockFileSizeExceededError } from './errors';
 
 describe('classifyBailDetail', () => {
   it('returns {} for a generic Error', () => {
@@ -11,11 +12,33 @@ describe('classifyBailDetail', () => {
     expect(classifyBailDetail('string')).toEqual({});
     expect(classifyBailDetail(undefined)).toEqual({});
   });
+
+  it('classifies LockFileSizeExceededError with kind + size', () => {
+    const err = new LockFileSizeExceededError('/tmp/checkout-abc/pnpm-lock.yaml', 12_000_000);
+    expect(classifyBailDetail(err)).toEqual({
+      lockfileSizeExceeded: true,
+      lockfileKind: 'pnpm-lock.yaml',
+      lockfileSizeBytes: 12_000_000,
+    });
+  });
+
+  it('classifies LockFileSizeExceededError with undefined lockfileKind for an unrecognized path', () => {
+    const err = new LockFileSizeExceededError('/tmp/weird-name', 12_000_000);
+    expect(classifyBailDetail(err)).toEqual({
+      lockfileSizeExceeded: true,
+      lockfileKind: undefined,
+      lockfileSizeBytes: 12_000_000,
+    });
+  });
 });
 
 describe('bailDetailKey', () => {
   it('returns "unknown" for an empty patch', () => {
     expect(bailDetailKey({})).toBe('unknown');
+  });
+
+  it('returns "lockfileSizeExceeded" when the flag is set', () => {
+    expect(bailDetailKey({ lockfileSizeExceeded: true })).toBe('lockfileSizeExceeded');
   });
 });
 

--- a/node-src/lib/turbosnap/classifyBailDetail.test.ts
+++ b/node-src/lib/turbosnap/classifyBailDetail.test.ts
@@ -55,8 +55,8 @@ describe('classifyBailDetail', () => {
 });
 
 describe('bailDetailKey', () => {
-  it('returns "unknown" for an empty patch', () => {
-    expect(bailDetailKey({})).toBe('unknown');
+  it('returns undefined for an empty patch', () => {
+    expect(bailDetailKey({})).toBeUndefined();
   });
 
   it('returns "lockfileSizeExceeded" when the flag is set', () => {

--- a/node-src/lib/turbosnap/classifyBailDetail.ts
+++ b/node-src/lib/turbosnap/classifyBailDetail.ts
@@ -6,6 +6,12 @@ export type ChangedPackageFilesPatch = Partial<
   Extract<TurboSnapBailReason, { changedPackageFiles: string[] }>
 >;
 
+export type BailDetailKey =
+  | 'lockfileSizeExceeded'
+  | 'lockfileParseFailed'
+  | 'baselineCheckoutFailed'
+  | 'unknown';
+
 /**
  * Detect which supported lockfile kind a given path corresponds to.
  *
@@ -36,7 +42,7 @@ export function classifyBailDetail(_err: unknown): ChangedPackageFilesPatch {
  *
  * @returns A short string key identifying the patch's primary key.
  */
-export function bailDetailKey(patch: ChangedPackageFilesPatch): string {
+export function bailDetailKey(patch: ChangedPackageFilesPatch): BailDetailKey {
   if (patch.lockfileSizeExceeded) return 'lockfileSizeExceeded';
   if (patch.lockfileParseFailed) return 'lockfileParseFailed';
   if (patch.baselineCheckoutFailed) return 'baselineCheckoutFailed';

--- a/node-src/lib/turbosnap/classifyBailDetail.ts
+++ b/node-src/lib/turbosnap/classifyBailDetail.ts
@@ -1,4 +1,5 @@
 import { TurboSnapBailReason } from '../../types';
+import { LockFileSizeExceededError } from './errors';
 import { SUPPORTED_LOCK_FILES } from './findChangedDependencies';
 
 // Extract all bail detail fields related to changedPackageFiles
@@ -26,11 +27,18 @@ export function detectLockfileKind(path: string): string | undefined {
 /**
  * Map an unknown thrown error into a partial `TurboSnapBailReason` patch.
  *
- * @param _err The thrown value to classify.
+ * @param err The thrown value to classify.
  *
  * @returns A partial patch object to merge into the bail reason.
  */
-export function classifyBailDetail(_err: unknown): ChangedPackageFilesPatch {
+export function classifyBailDetail(err: unknown): ChangedPackageFilesPatch {
+  if (err instanceof LockFileSizeExceededError) {
+    return {
+      lockfileSizeExceeded: true,
+      lockfileKind: detectLockfileKind(err.lockfilePath),
+      lockfileSizeBytes: err.lockfileSizeBytes,
+    };
+  }
   return {};
 }
 

--- a/node-src/lib/turbosnap/classifyBailDetail.ts
+++ b/node-src/lib/turbosnap/classifyBailDetail.ts
@@ -1,0 +1,44 @@
+import { TurboSnapBailReason } from '../../types';
+import { SUPPORTED_LOCK_FILES } from './findChangedDependencies';
+
+// Extract all bail detail fields related to changedPackageFiles
+export type ChangedPackageFilesPatch = Partial<
+  Extract<TurboSnapBailReason, { changedPackageFiles: string[] }>
+>;
+
+/**
+ * Detect which supported lockfile kind a given path corresponds to.
+ *
+ * @param path The filesystem path to inspect.
+ *
+ * @returns The matching lockfile filename, or `undefined` if none match.
+ */
+export function detectLockfileKind(path: string): string | undefined {
+  return SUPPORTED_LOCK_FILES.find((lockfile) => path.endsWith(lockfile));
+}
+
+/**
+ * Map an unknown thrown error into a partial `TurboSnapBailReason` patch.
+ *
+ * @param _err The thrown value to classify.
+ *
+ * @returns A partial patch object to merge into the bail reason.
+ */
+export function classifyBailDetail(_err: unknown): ChangedPackageFilesPatch {
+  return {};
+}
+
+/**
+ * Derive a short, primary key describing bail reason. Used for grouping related bail reasons in
+ * Sentry. Returns `'unknown'` when no specific flag is set.
+ *
+ * @param patch The bail-detail patch to inspect.
+ *
+ * @returns A short string key identifying the patch's primary key.
+ */
+export function bailDetailKey(patch: ChangedPackageFilesPatch): string {
+  if (patch.lockfileSizeExceeded) return 'lockfileSizeExceeded';
+  if (patch.lockfileParseFailed) return 'lockfileParseFailed';
+  if (patch.baselineCheckoutFailed) return 'baselineCheckoutFailed';
+  return 'unknown';
+}

--- a/node-src/lib/turbosnap/classifyBailDetail.ts
+++ b/node-src/lib/turbosnap/classifyBailDetail.ts
@@ -1,5 +1,9 @@
 import { TurboSnapBailReason } from '../../types';
-import { LockFileParseFailedError, LockFileSizeExceededError } from './errors';
+import {
+  BaselineCheckoutFailedError,
+  LockFileParseFailedError,
+  LockFileSizeExceededError,
+} from './errors';
 import { SUPPORTED_LOCK_FILES } from './findChangedDependencies';
 
 // Extract all bail detail fields related to changedPackageFiles
@@ -44,6 +48,9 @@ export function classifyBailDetail(err: unknown): ChangedPackageFilesPatch {
       lockfileParseFailed: true,
       lockfileKind: detectLockfileKind(err.lockfilePath),
     };
+  }
+  if (err instanceof BaselineCheckoutFailedError) {
+    return { baselineCheckoutFailed: true };
   }
   return {};
 }

--- a/node-src/lib/turbosnap/classifyBailDetail.ts
+++ b/node-src/lib/turbosnap/classifyBailDetail.ts
@@ -1,5 +1,5 @@
 import { TurboSnapBailReason } from '../../types';
-import { LockFileSizeExceededError } from './errors';
+import { LockFileParseFailedError, LockFileSizeExceededError } from './errors';
 import { SUPPORTED_LOCK_FILES } from './findChangedDependencies';
 
 // Extract all bail detail fields related to changedPackageFiles
@@ -37,6 +37,12 @@ export function classifyBailDetail(err: unknown): ChangedPackageFilesPatch {
       lockfileSizeExceeded: true,
       lockfileKind: detectLockfileKind(err.lockfilePath),
       lockfileSizeBytes: err.lockfileSizeBytes,
+    };
+  }
+  if (err instanceof LockFileParseFailedError) {
+    return {
+      lockfileParseFailed: true,
+      lockfileKind: detectLockfileKind(err.lockfilePath),
     };
   }
   return {};

--- a/node-src/lib/turbosnap/classifyBailDetail.ts
+++ b/node-src/lib/turbosnap/classifyBailDetail.ts
@@ -37,16 +37,18 @@ export function detectLockfileKind(path: string): string | undefined {
  */
 export function classifyBailDetail(err: unknown): ChangedPackageFilesPatch {
   if (err instanceof LockFileSizeExceededError) {
+    const lockfileKind = detectLockfileKind(err.lockfilePath);
     return {
       lockfileSizeExceeded: true,
-      lockfileKind: detectLockfileKind(err.lockfilePath),
+      ...(lockfileKind && { lockfileKind }),
       lockfileSizeBytes: err.lockfileSizeBytes,
     };
   }
   if (err instanceof LockFileParseFailedError) {
+    const lockfileKind = detectLockfileKind(err.lockfilePath);
     return {
       lockfileParseFailed: true,
-      lockfileKind: detectLockfileKind(err.lockfilePath),
+      ...(lockfileKind && { lockfileKind }),
     };
   }
   if (err instanceof BaselineCheckoutFailedError) {

--- a/node-src/lib/turbosnap/classifyBailDetail.ts
+++ b/node-src/lib/turbosnap/classifyBailDetail.ts
@@ -1,3 +1,5 @@
+import path from 'path';
+
 import { TurboSnapBailReason } from '../../types';
 import {
   BaselineCheckoutFailedError,
@@ -20,12 +22,13 @@ export type BailDetailKey =
 /**
  * Detect which supported lockfile kind a given path corresponds to.
  *
- * @param path The filesystem path to inspect.
+ * @param filePath The filesystem path to inspect.
  *
  * @returns The matching lockfile filename, or `undefined` if none match.
  */
-export function detectLockfileKind(path: string): string | undefined {
-  return SUPPORTED_LOCK_FILES.find((lockfile) => path.endsWith(lockfile));
+export function detectLockfileKind(filePath: string): string | undefined {
+  const basename = path.basename(filePath);
+  return SUPPORTED_LOCK_FILES.find((lockfile) => basename === lockfile);
 }
 
 /**

--- a/node-src/lib/turbosnap/classifyBailDetail.ts
+++ b/node-src/lib/turbosnap/classifyBailDetail.ts
@@ -16,8 +16,7 @@ export type ChangedPackageFilesPatch = Partial<
 export type BailDetailKey =
   | 'lockfileSizeExceeded'
   | 'lockfileParseFailed'
-  | 'baselineCheckoutFailed'
-  | 'unknown';
+  | 'baselineCheckoutFailed';
 
 /**
  * Detect which supported lockfile kind a given path corresponds to.
@@ -62,15 +61,15 @@ export function classifyBailDetail(err: unknown): ChangedPackageFilesPatch {
 
 /**
  * Derive a short, primary key describing bail reason. Used for grouping related bail reasons in
- * Sentry. Returns `'unknown'` when no specific flag is set.
+ * Sentry. Returns `undefined` when no specific flag is set.
  *
  * @param patch The bail-detail patch to inspect.
  *
  * @returns A short string key identifying the patch's primary key.
  */
-export function bailDetailKey(patch: ChangedPackageFilesPatch): BailDetailKey {
+export function bailDetailKey(patch: ChangedPackageFilesPatch): BailDetailKey | undefined {
   if (patch.lockfileSizeExceeded) return 'lockfileSizeExceeded';
   if (patch.lockfileParseFailed) return 'lockfileParseFailed';
   if (patch.baselineCheckoutFailed) return 'baselineCheckoutFailed';
-  return 'unknown';
+  return;
 }

--- a/node-src/lib/turbosnap/errors.ts
+++ b/node-src/lib/turbosnap/errors.ts
@@ -19,8 +19,20 @@ export class LockFileParseFailedError extends Error {
     public lockfilePath: string,
     options?: { cause?: unknown }
   ) {
-    super('Failed to parse dependency graph');
+    super('Failed to parse dependency graph', options);
     this.name = 'LockFileParseFailedError';
-    if (options?.cause !== undefined) this.cause = options.cause;
+  }
+}
+
+/**
+ * Error thrown when checking out a baseline file via `git show` fails.
+ */
+export class BaselineCheckoutFailedError extends Error {
+  constructor(
+    public pathspec: string,
+    options?: { cause?: unknown }
+  ) {
+    super(`Failed to check out baseline file: ${pathspec}`, options);
+    this.name = 'BaselineCheckoutFailedError';
   }
 }

--- a/node-src/lib/turbosnap/errors.ts
+++ b/node-src/lib/turbosnap/errors.ts
@@ -1,0 +1,10 @@
+/** Thrown when a lockfile exceeds the configured maximum size and parsing is skipped. */
+export class LockFileSizeExceededError extends Error {
+  constructor(
+    public lockfilePath: string,
+    public lockfileSizeBytes: number
+  ) {
+    super('Lock file too large to parse');
+    this.name = 'LockFileSizeExceededError';
+  }
+}

--- a/node-src/lib/turbosnap/errors.ts
+++ b/node-src/lib/turbosnap/errors.ts
@@ -8,3 +8,15 @@ export class LockFileSizeExceededError extends Error {
     this.name = 'LockFileSizeExceededError';
   }
 }
+
+/** Thrown when the lockfile parser fails to produce a dependency graph. */
+export class LockFileParseFailedError extends Error {
+  constructor(
+    public lockfilePath: string,
+    options?: { cause?: unknown }
+  ) {
+    super('Failed to parse dependency graph');
+    this.name = 'LockFileParseFailedError';
+    if (options?.cause !== undefined) this.cause = options.cause;
+  }
+}

--- a/node-src/lib/turbosnap/errors.ts
+++ b/node-src/lib/turbosnap/errors.ts
@@ -1,4 +1,6 @@
-/** Thrown when a lockfile exceeds the configured maximum size and parsing is skipped. */
+/**
+ * Error thrown when a lockfile exceeds the configured maximum size and parsing is skipped.
+ */
 export class LockFileSizeExceededError extends Error {
   constructor(
     public lockfilePath: string,
@@ -9,7 +11,9 @@ export class LockFileSizeExceededError extends Error {
   }
 }
 
-/** Thrown when the lockfile parser fails to produce a dependency graph. */
+/**
+ * Error thrown when the lockfile parser fails to produce a dependency graph.
+ */
 export class LockFileParseFailedError extends Error {
   constructor(
     public lockfilePath: string,

--- a/node-src/lib/turbosnap/getDependencies.test.ts
+++ b/node-src/lib/turbosnap/getDependencies.test.ts
@@ -8,6 +8,7 @@ import { describe, expect, it, Mock, vi } from 'vitest';
 import packageJson from '../../__mocks__/dependencyChanges/plain/package.json';
 import { checkoutFile } from '../../git/git';
 import TestLogger from '../testLogger';
+import { LockFileSizeExceededError } from './errors';
 import { SUPPORTED_LOCK_FILES } from './findChangedDependencies';
 import { getDependencies, MAX_LOCK_FILE_SIZE } from './getDependencies';
 
@@ -121,7 +122,7 @@ describe('getDependencies', () => {
         manifestPath: 'package.json',
         lockfilePath: 'yarn.lock',
       })
-    ).rejects.toThrowError();
+    ).rejects.toBeInstanceOf(LockFileSizeExceededError);
   });
 
   it('should use MAX_LOCK_FILE_SIZE environment variable, if set', async () => {

--- a/node-src/lib/turbosnap/getDependencies.test.ts
+++ b/node-src/lib/turbosnap/getDependencies.test.ts
@@ -8,7 +8,7 @@ import { describe, expect, it, Mock, vi } from 'vitest';
 import packageJson from '../../__mocks__/dependencyChanges/plain/package.json';
 import { checkoutFile } from '../../git/git';
 import TestLogger from '../testLogger';
-import { LockFileSizeExceededError } from './errors';
+import { LockFileParseFailedError, LockFileSizeExceededError } from './errors';
 import { SUPPORTED_LOCK_FILES } from './findChangedDependencies';
 import { getDependencies, MAX_LOCK_FILE_SIZE } from './getDependencies';
 
@@ -166,5 +166,19 @@ describe('getDependencies', () => {
         lockfilePath: 'yarn.lock',
       })
     ).rejects.toThrowError();
+  });
+
+  it('wraps inspect rejection in LockFileParseFailedError with cause', async () => {
+    const cause = new Error('inspect blew up');
+    inspect.mockRejectedValueOnce(cause);
+
+    const promise = getDependencies(ctx, {
+      rootPath: path.join(__dirname, '../../__mocks__/dependencyChanges/plain'),
+      manifestPath: 'package.json',
+      lockfilePath: 'yarn.lock',
+    });
+
+    await expect(promise).rejects.toBeInstanceOf(LockFileParseFailedError);
+    await expect(promise).rejects.toMatchObject({ cause });
   });
 });

--- a/node-src/lib/turbosnap/getDependencies.ts
+++ b/node-src/lib/turbosnap/getDependencies.ts
@@ -3,7 +3,7 @@ import path from 'path';
 import { inspect } from 'snyk-nodejs-plugin';
 
 import { Context } from '../../types';
-import { LockFileSizeExceededError } from './errors';
+import { LockFileParseFailedError, LockFileSizeExceededError } from './errors';
 
 export const MAX_LOCK_FILE_SIZE = 10_485_760; // 10 MB
 
@@ -33,13 +33,10 @@ export const getDependencies = async (
   ensureLockFileSize(ctx, absoluteLockfilePath);
 
   try {
-    const headGraph = await inspect(path.dirname(absoluteManifestPath), absoluteLockfilePath, {
-      dev: true, // Include dev dependencies
-      strictOutOfSync: false, // Don't throw an error if the lock file is out of sync
-    });
+    const headGraph = await inspectLockfile(absoluteManifestPath, absoluteLockfilePath);
 
     if (headGraph.scannedProjects.length !== 1 || !headGraph.scannedProjects[0].depGraph) {
-      throw new Error('Failed to parse dependency graph');
+      throw new LockFileParseFailedError(absoluteLockfilePath);
     }
 
     return headGraph.scannedProjects[0].depGraph;
@@ -48,6 +45,17 @@ export const getDependencies = async (
     throw err;
   }
 };
+
+async function inspectLockfile(absoluteManifestPath: string, absoluteLockfilePath: string) {
+  try {
+    return await inspect(path.dirname(absoluteManifestPath), absoluteLockfilePath, {
+      dev: true, // Include dev dependencies
+      strictOutOfSync: false, // Don't throw an error if the lock file is out of sync
+    });
+  } catch (error) {
+    throw new LockFileParseFailedError(absoluteLockfilePath, { cause: error });
+  }
+}
 
 function ensureLockFileSize(ctx: Context, fullPath: string) {
   const maxLockFileSize =

--- a/node-src/lib/turbosnap/getDependencies.ts
+++ b/node-src/lib/turbosnap/getDependencies.ts
@@ -3,6 +3,7 @@ import path from 'path';
 import { inspect } from 'snyk-nodejs-plugin';
 
 import { Context } from '../../types';
+import { LockFileSizeExceededError } from './errors';
 
 export const MAX_LOCK_FILE_SIZE = 10_485_760; // 10 MB
 
@@ -55,6 +56,6 @@ function ensureLockFileSize(ctx: Context, fullPath: string) {
   const stats = statSync(fullPath);
   if (stats.size > maxLockFileSize) {
     ctx.log.warn({ fullPath }, 'Lock file too large to parse, skipping');
-    throw new Error('Lock file too large to parse');
+    throw new LockFileSizeExceededError(fullPath, stats.size);
   }
 }

--- a/node-src/lib/turbosnap/getDependentStoryFiles.test.ts
+++ b/node-src/lib/turbosnap/getDependentStoryFiles.test.ts
@@ -1001,6 +1001,30 @@ describe('getDependentStoryFiles', () => {
       nodeModulesMissingInStats: true,
     });
   });
+
+  it('does not set nodeModulesMissingInStats when there are no changed dependencies', async () => {
+    const changedFiles = ['package.json'];
+    const changedDependencies: string[] = [];
+    const modules = [
+      {
+        id: './src/foo.stories.js',
+        name: './src/foo.stories.js',
+        reasons: [{ moduleName: CSF_GLOB }],
+      },
+      {
+        id: CSF_GLOB,
+        name: CSF_GLOB,
+        reasons: [{ moduleName: './.storybook/generated-stories-entry.js' }],
+      },
+    ];
+    const rawContext = getContext();
+    const ctx = {
+      ...rawContext,
+      git: { ...rawContext.git, changedFiles: ['package.json'] },
+    };
+    await getDependentStoryFiles(ctx, { modules }, statsPath, changedFiles, changedDependencies);
+    expect(ctx.turboSnap.bailReason?.nodeModulesMissingInStats).toBeUndefined();
+  });
 });
 
 describe('normalizePath', () => {

--- a/node-src/lib/turbosnap/getDependentStoryFiles.test.ts
+++ b/node-src/lib/turbosnap/getDependentStoryFiles.test.ts
@@ -967,6 +967,40 @@ describe('getDependentStoryFiles', () => {
       './src/foo.stories.js': ['src/foo.stories.js'],
     });
   });
+
+  it('bails with nodeModulesMissingInStats when the stats file has no node_modules entries', async () => {
+    const changedFiles = ['package.json'];
+    const changedDependencies = ['some-pkg'];
+    const modules = [
+      {
+        id: './src/foo.stories.js',
+        name: './src/foo.stories.js',
+        reasons: [{ moduleName: CSF_GLOB }],
+      },
+      {
+        id: CSF_GLOB,
+        name: CSF_GLOB,
+        reasons: [{ moduleName: './.storybook/generated-stories-entry.js' }],
+      },
+    ];
+    const rawContext = getContext();
+    const ctx = {
+      ...rawContext,
+      git: { ...rawContext.git, changedFiles: ['package.json'] },
+    };
+    const result = await getDependentStoryFiles(
+      ctx,
+      { modules },
+      statsPath,
+      changedFiles,
+      changedDependencies
+    );
+    expect(result).toBeUndefined();
+    expect(ctx.turboSnap.bailReason).toEqual({
+      changedPackageFiles: ['package.json'],
+      nodeModulesMissingInStats: true,
+    });
+  });
 });
 
 describe('normalizePath', () => {

--- a/node-src/lib/turbosnap/getDependentStoryFiles.ts
+++ b/node-src/lib/turbosnap/getDependentStoryFiles.ts
@@ -259,6 +259,7 @@ export async function getDependentStoryFiles(
         ...(ctx.git.changedFiles?.filter((file) => isPackageManifestFile(file)) || []),
         ...changedPackageLockFiles,
       ],
+      nodeModulesMissingInStats: true,
     };
   }
 

--- a/node-src/lib/turbosnap/index.test.ts
+++ b/node-src/lib/turbosnap/index.test.ts
@@ -1,15 +1,30 @@
+import * as Sentry from '@sentry/node';
 import { access } from 'fs';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { exitCodes } from '../setExitCode';
 import TestLogger from '../testLogger';
 import { traceChangedFiles } from '.';
+import {
+  BaselineCheckoutFailedError,
+  LockFileParseFailedError,
+  LockFileSizeExceededError,
+} from './errors';
 import { findChangedDependencies as findChangedDependenciesDep } from './findChangedDependencies';
 import { findChangedPackageFiles as findChangedPackageFilesDep } from './findChangedPackageFiles';
 import { getDependentStoryFiles as getDependentStoryFilesDep } from './getDependentStoryFiles';
 
+vi.mock('@sentry/node', () => ({
+  captureException: vi.fn(() => 'sentry-event-id'),
+}));
 vi.mock('fs');
-vi.mock('./findChangedDependencies');
+vi.mock('./findChangedDependencies', async (importOriginal) => {
+  const originalModule = await importOriginal<typeof import('./findChangedDependencies')>();
+  return {
+    ...originalModule,
+    findChangedDependencies: vi.fn(),
+  };
+});
 vi.mock('./findChangedPackageFiles');
 vi.mock('./getDependentStoryFiles');
 vi.mock('../../tasks/readStatsFile', () => ({
@@ -28,6 +43,7 @@ const getDependentStoryFiles = vi.mocked(getDependentStoryFilesDep);
 const findChangedPackageFiles = vi.mocked(findChangedPackageFilesDep);
 const findChangedDependencies = vi.mocked(findChangedDependenciesDep);
 const accessMock = vi.mocked(access);
+const captureException = vi.mocked(Sentry.captureException);
 
 const environment = { CHROMATIC_RETRIES: 2, CHROMATIC_OUTPUT_INTERVAL: 0 };
 const log = new TestLogger();
@@ -63,27 +79,84 @@ describe('traceChangedFiles', () => {
     expect(findChangedPackageFiles).not.toHaveBeenCalled();
   });
 
-  it('bails on package.json changes if it fails to retrieve lockfile changes (fallback scenario)', async () => {
-    findChangedDependencies.mockRejectedValue(new Error('no lockfile'));
-    findChangedPackageFiles.mockResolvedValue(['./package.json']);
+  const findChangedDependenciesFailureCases = [
+    {
+      name: 'lockfileSizeExceeded',
+      error: new LockFileSizeExceededError('/tmp/checkout-abc/pnpm-lock.yaml', 12_000_000),
+      expectedBailReason: {
+        changedPackageFiles: ['./package.json'],
+        lockfileSizeExceeded: true,
+        lockfileKind: 'pnpm-lock.yaml',
+        lockfileSizeBytes: 12_000_000,
+        sentryEventId: 'sentry-event-id',
+      },
+      expectedKey: 'lockfileSizeExceeded',
+    },
+    {
+      name: 'lockfileParseFailed',
+      error: new LockFileParseFailedError('/tmp/checkout-abc/yarn.lock', {
+        cause: new Error('inner'),
+      }),
+      expectedBailReason: {
+        changedPackageFiles: ['./package.json'],
+        lockfileParseFailed: true,
+        lockfileKind: 'yarn.lock',
+        sentryEventId: 'sentry-event-id',
+      },
+      expectedKey: 'lockfileParseFailed',
+    },
+    {
+      name: 'baselineCheckoutFailed',
+      error: new BaselineCheckoutFailedError('abc:package.json'),
+      expectedBailReason: {
+        changedPackageFiles: ['./package.json'],
+        baselineCheckoutFailed: true,
+        sentryEventId: 'sentry-event-id',
+      },
+      expectedKey: 'baselineCheckoutFailed',
+    },
+    {
+      name: 'unknown',
+      error: new Error('something else'),
+      expectedBailReason: {
+        changedPackageFiles: ['./package.json'],
+        sentryEventId: 'sentry-event-id',
+      },
+      expectedKey: 'unknown',
+    },
+  ];
 
-    const packageMetadataChanges = [{ changedFiles: ['./package.json'], commit: 'abcdef' }];
-    const ctx = {
-      env: environment,
-      log,
-      http,
-      options: {},
-      sourceDir: '/static/',
-      fileInfo: { statsPath: '/static/preview-stats.json' },
-      git: { changedFiles: ['./example.js', './package.json'], packageMetadataChanges },
-      turboSnap: {},
-    } as any;
-    await traceChangedFiles(ctx);
+  for (const {
+    name,
+    error,
+    expectedBailReason,
+    expectedKey,
+  } of findChangedDependenciesFailureCases) {
+    it(`bails on package.json changes and tags bailReason as ${name}`, async () => {
+      findChangedDependencies.mockRejectedValue(error);
+      findChangedPackageFiles.mockResolvedValue(['./package.json']);
 
-    expect(ctx.turboSnap.bailReason).toEqual({ changedPackageFiles: ['./package.json'] });
-    expect(findChangedPackageFiles).toHaveBeenCalledWith(ctx, packageMetadataChanges);
-    expect(getDependentStoryFiles).not.toHaveBeenCalled();
-  });
+      const packageMetadataChanges = [{ changedFiles: ['./package.json'], commit: 'abcdef' }];
+      const ctx = {
+        env: environment,
+        log,
+        http,
+        options: {},
+        sourceDir: '/static/',
+        fileInfo: { statsPath: '/static/preview-stats.json' },
+        git: { changedFiles: ['./example.js', './package.json'], packageMetadataChanges },
+        turboSnap: {},
+      } as any;
+      await traceChangedFiles(ctx);
+
+      expect(ctx.turboSnap.bailReason).toEqual(expectedBailReason);
+      expect(captureException).toHaveBeenCalledTimes(1);
+      expect(captureException).toHaveBeenCalledWith(error, {
+        tags: { bail_path: 'findChangedDependencies', bail_detail: expectedKey },
+        fingerprint: [expectedKey],
+      });
+    });
+  }
 
   it('stores dependency changes', async () => {
     findChangedDependencies.mockResolvedValue(['moment']);
@@ -150,6 +223,33 @@ describe('traceChangedFiles', () => {
     expect(ctx.turboSnap.bailReason).toBeUndefined();
     expect(onlyStoryFiles).toStrictEqual(deps);
     expect(findChangedPackageFiles).toHaveBeenCalledWith(ctx, packageMetadataChanges);
+  });
+
+  it('does not set bailReason when findChangedDependencies fails but findChangedPackageFiles is empty', async () => {
+    const error = new LockFileSizeExceededError('/tmp/x', 999);
+    findChangedDependencies.mockRejectedValue(error);
+    findChangedPackageFiles.mockResolvedValue([]);
+    getDependentStoryFiles.mockResolvedValue({});
+
+    const packageMetadataChanges = [{ changedFiles: ['./package.json'], commit: 'abcdef' }];
+    const ctx = {
+      env: environment,
+      log,
+      http,
+      options: {},
+      sourceDir: '/static/',
+      fileInfo: { statsPath: '/static/preview-stats.json' },
+      git: { changedFiles: ['./example.js', './package.json'], packageMetadataChanges },
+      turboSnap: {},
+    } as any;
+    await traceChangedFiles(ctx);
+
+    expect(ctx.turboSnap.bailReason).toBeUndefined();
+    expect(captureException).toHaveBeenCalledTimes(1);
+    expect(captureException).toHaveBeenCalledWith(error, {
+      tags: { bail_path: 'findChangedDependencies', bail_detail: 'lockfileSizeExceeded' },
+      fingerprint: ['lockfileSizeExceeded'],
+    });
   });
 
   it('throws if stats file is not found', async () => {

--- a/node-src/lib/turbosnap/index.test.ts
+++ b/node-src/lib/turbosnap/index.test.ts
@@ -125,7 +125,7 @@ describe('traceChangedFiles', () => {
         changedPackageFiles: ['./package.json'],
         sentryEventId: 'sentry-event-id',
       },
-      expectedKey: 'unknown',
+      expectedKey: undefined,
       expectFingerprint: false,
     },
   ];

--- a/node-src/lib/turbosnap/index.test.ts
+++ b/node-src/lib/turbosnap/index.test.ts
@@ -225,7 +225,7 @@ describe('traceChangedFiles', () => {
     expect(findChangedPackageFiles).toHaveBeenCalledWith(ctx, packageMetadataChanges);
   });
 
-  it('does not set bailReason when findChangedDependencies fails but findChangedPackageFiles is empty', async () => {
+  it('does not set bailReason or capture to Sentry when findChangedDependencies fails but findChangedPackageFiles is empty', async () => {
     const error = new LockFileSizeExceededError('/tmp/x', 999);
     findChangedDependencies.mockRejectedValue(error);
     findChangedPackageFiles.mockResolvedValue([]);
@@ -245,11 +245,7 @@ describe('traceChangedFiles', () => {
     await traceChangedFiles(ctx);
 
     expect(ctx.turboSnap.bailReason).toBeUndefined();
-    expect(captureException).toHaveBeenCalledTimes(1);
-    expect(captureException).toHaveBeenCalledWith(error, {
-      tags: { bail_path: 'findChangedDependencies', bail_detail: 'lockfileSizeExceeded' },
-      fingerprint: ['lockfileSizeExceeded'],
-    });
+    expect(captureException).not.toHaveBeenCalled();
   });
 
   it('throws if stats file is not found', async () => {

--- a/node-src/lib/turbosnap/index.test.ts
+++ b/node-src/lib/turbosnap/index.test.ts
@@ -91,6 +91,7 @@ describe('traceChangedFiles', () => {
         sentryEventId: 'sentry-event-id',
       },
       expectedKey: 'lockfileSizeExceeded',
+      expectFingerprint: true,
     },
     {
       name: 'lockfileParseFailed',
@@ -104,6 +105,7 @@ describe('traceChangedFiles', () => {
         sentryEventId: 'sentry-event-id',
       },
       expectedKey: 'lockfileParseFailed',
+      expectFingerprint: true,
     },
     {
       name: 'baselineCheckoutFailed',
@@ -114,6 +116,7 @@ describe('traceChangedFiles', () => {
         sentryEventId: 'sentry-event-id',
       },
       expectedKey: 'baselineCheckoutFailed',
+      expectFingerprint: true,
     },
     {
       name: 'unknown',
@@ -123,6 +126,7 @@ describe('traceChangedFiles', () => {
         sentryEventId: 'sentry-event-id',
       },
       expectedKey: 'unknown',
+      expectFingerprint: false,
     },
   ];
 
@@ -131,6 +135,7 @@ describe('traceChangedFiles', () => {
     error,
     expectedBailReason,
     expectedKey,
+    expectFingerprint,
   } of findChangedDependenciesFailureCases) {
     it(`bails on package.json changes and tags bailReason as ${name}`, async () => {
       findChangedDependencies.mockRejectedValue(error);
@@ -153,7 +158,7 @@ describe('traceChangedFiles', () => {
       expect(captureException).toHaveBeenCalledTimes(1);
       expect(captureException).toHaveBeenCalledWith(error, {
         tags: { bail_path: 'findChangedDependencies', bail_detail: expectedKey },
-        fingerprint: [expectedKey],
+        ...(expectFingerprint && { fingerprint: [expectedKey] }),
       });
     });
   }

--- a/node-src/lib/turbosnap/index.ts
+++ b/node-src/lib/turbosnap/index.ts
@@ -1,3 +1,4 @@
+import * as Sentry from '@sentry/node';
 import semver from 'semver';
 
 import { readStatsFile } from '../../tasks/readStatsFile';
@@ -5,6 +6,7 @@ import { Context } from '../../types';
 import missingStatsFile from '../../ui/messages/errors/missingStatsFile';
 import bailFile from '../../ui/messages/warnings/bailFile';
 import { checkStorybookBaseDirectory } from '../checkStorybookBaseDirectory';
+import { bailDetailKey, ChangedPackageFilesPatch, classifyBailDetail } from './classifyBailDetail';
 import { findChangedDependencies } from './findChangedDependencies';
 import { findChangedPackageFiles } from './findChangedPackageFiles';
 import { getDependentStoryFiles } from './getDependentStoryFiles';
@@ -28,8 +30,17 @@ export const traceChangedFiles = async (ctx: Context) => {
 
   // eslint-disable-next-line @typescript-eslint/no-invalid-void-type
   let changedDependencyNames: void | string[] = [];
+  let pendingPatch: ChangedPackageFilesPatch | undefined;
   if (packageMetadataChanges?.length) {
     changedDependencyNames = await findChangedDependencies(ctx).catch((err) => {
+      const patch = classifyBailDetail(err);
+      const key = bailDetailKey(patch);
+      const sentryEventId = Sentry.captureException(err, {
+        tags: { bail_path: 'findChangedDependencies', bail_detail: key },
+        fingerprint: [key], // group all errors with the same bail primary key
+      });
+      pendingPatch = { ...patch, sentryEventId };
+
       const { name, message, stack, code } = err;
       ctx.log.debug({ name, message, stack, code });
     });
@@ -47,7 +58,7 @@ export const traceChangedFiles = async (ctx: Context) => {
 
       const changedPackageFiles = await findChangedPackageFiles(ctx, packageMetadataChanges);
       if (changedPackageFiles.length > 0) {
-        ctx.turboSnap.bailReason = { changedPackageFiles };
+        ctx.turboSnap.bailReason = { changedPackageFiles, ...pendingPatch };
         ctx.log.warn(bailFile({ turboSnap: ctx.turboSnap }));
         return;
       }

--- a/node-src/lib/turbosnap/index.ts
+++ b/node-src/lib/turbosnap/index.ts
@@ -61,7 +61,9 @@ export const traceChangedFiles = async (ctx: Context) => {
           const key = bailDetailKey(pendingPatch);
           pendingPatch.sentryEventId = Sentry.captureException(pendingError, {
             tags: { bail_path: 'findChangedDependencies', bail_detail: key },
-            fingerprint: [key], // group all errors with the same bail primary key
+            // group known bail reasons under one issue per key; let Sentry's default grouping
+            // handle unclassified errors so they don't all collapse into a single bucket
+            ...(key === 'unknown' ? {} : { fingerprint: [key] }),
           });
         }
 

--- a/node-src/lib/turbosnap/index.ts
+++ b/node-src/lib/turbosnap/index.ts
@@ -63,7 +63,7 @@ export const traceChangedFiles = async (ctx: Context) => {
             tags: { bail_path: 'findChangedDependencies', bail_detail: key },
             // group known bail reasons under one issue per key; let Sentry's default grouping
             // handle unclassified errors so they don't all collapse into a single bucket
-            ...(key === 'unknown' ? {} : { fingerprint: [key] }),
+            ...(key && { fingerprint: [key] }),
           });
         }
 

--- a/node-src/lib/turbosnap/index.ts
+++ b/node-src/lib/turbosnap/index.ts
@@ -30,16 +30,12 @@ export const traceChangedFiles = async (ctx: Context) => {
 
   // eslint-disable-next-line @typescript-eslint/no-invalid-void-type
   let changedDependencyNames: void | string[] = [];
+  let pendingError: unknown;
   let pendingPatch: ChangedPackageFilesPatch | undefined;
   if (packageMetadataChanges?.length) {
     changedDependencyNames = await findChangedDependencies(ctx).catch((err) => {
-      const patch = classifyBailDetail(err);
-      const key = bailDetailKey(patch);
-      const sentryEventId = Sentry.captureException(err, {
-        tags: { bail_path: 'findChangedDependencies', bail_detail: key },
-        fingerprint: [key], // group all errors with the same bail primary key
-      });
-      pendingPatch = { ...patch, sentryEventId };
+      pendingError = err;
+      pendingPatch = classifyBailDetail(err);
 
       const { name, message, stack, code } = err;
       ctx.log.debug({ name, message, stack, code });
@@ -58,7 +54,21 @@ export const traceChangedFiles = async (ctx: Context) => {
 
       const changedPackageFiles = await findChangedPackageFiles(ctx, packageMetadataChanges);
       if (changedPackageFiles.length > 0) {
-        ctx.turboSnap.bailReason = { changedPackageFiles, ...pendingPatch };
+        // Capture original error from findChangedDependencies at the actual bail site. There could
+        // be times when findChangedDependencies fails but our fallback works. In those cases, we
+        // don't want to capture an error since we were able to recover and didn't bail.
+        if (pendingPatch && pendingError) {
+          const key = bailDetailKey(pendingPatch);
+          pendingPatch.sentryEventId = Sentry.captureException(pendingError, {
+            tags: { bail_path: 'findChangedDependencies', bail_detail: key },
+            fingerprint: [key], // group all errors with the same bail primary key
+          });
+        }
+
+        ctx.turboSnap.bailReason = {
+          changedPackageFiles,
+          ...pendingPatch,
+        };
         ctx.log.warn(bailFile({ turboSnap: ctx.turboSnap }));
         return;
       }

--- a/node-src/tasks/verify/publishBuild.test.ts
+++ b/node-src/tasks/verify/publishBuild.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 
 import TestLogger from '../../lib/testLogger';
-import type { TurboSnapBailDetail } from '../../types';
 import { publishBuild } from './publishBuild';
 
 const environment = {
@@ -41,16 +40,17 @@ describe('publishBuild', () => {
     expect(ctx.announcedBuild).toEqual({ ...announcedBuild, ...publishedBuild });
   });
 
-  it('sends turboSnapBailDetail in the publishBuild input when ctx.turboSnap.bailDetail is defined', async () => {
+  it('forwards turboSnapBailReason with merged detail fields in the publishBuild input', async () => {
     const announcedBuild = { number: 1, status: 'ANNOUNCED', reportToken: 'report-token' };
     const publishedBuild = { status: 'PUBLISHED' };
     const client = { runQuery: vi.fn() };
     client.runQuery.mockReturnValue({ publishBuild: publishedBuild });
 
-    const bailDetail: TurboSnapBailDetail = {
-      reason: 'lockfileSizeExceeded',
+    const bailReason = {
+      changedPackageFiles: ['./package.json'],
       lockfileKind: 'yarn.lock',
       lockfileSizeBytes: 12_000_000,
+      lockfileSizeExceeded: true,
       sentryEventId: 'sentry-event-id',
     };
 
@@ -65,10 +65,7 @@ describe('publishBuild', () => {
       buildLogFile: 'build-storybook.log',
       options: {},
       packageJson: {},
-      turboSnap: {
-        bailReason: { changedPackageFiles: ['./package.json'] },
-        bailDetail,
-      },
+      turboSnap: { bailReason },
     } as any;
     await publishBuild(ctx);
 
@@ -76,37 +73,11 @@ describe('publishBuild', () => {
       expect.stringMatching(/PublishBuildMutation/),
       {
         input: {
-          turboSnapBailReason: { changedPackageFiles: ['./package.json'] },
-          turboSnapBailDetail: bailDetail,
+          turboSnapBailReason: bailReason,
           turboSnapStatus: 'BAILED',
         },
       },
       { headers: { Authorization: `Bearer report-token` }, retries: 3 }
     );
-  });
-
-  it('omits turboSnapBailDetail when ctx.turboSnap.bailDetail is undefined', async () => {
-    const announcedBuild = { number: 1, status: 'ANNOUNCED', reportToken: 'report-token' };
-    const publishedBuild = { status: 'PUBLISHED' };
-    const client = { runQuery: vi.fn() };
-    client.runQuery.mockReturnValue({ publishBuild: publishedBuild });
-
-    const ctx = {
-      env: environment,
-      log,
-      http,
-      client,
-      announcedBuild,
-      git: {},
-      sourceDir: '/static/',
-      buildLogFile: 'build-storybook.log',
-      options: {},
-      packageJson: {},
-      turboSnap: { bailReason: { changedPackageFiles: ['./package.json'] } },
-    } as any;
-    await publishBuild(ctx);
-
-    const input = client.runQuery.mock.calls[0][1].input;
-    expect(input).not.toHaveProperty('turboSnapBailDetail');
   });
 });

--- a/node-src/tasks/verify/publishBuild.test.ts
+++ b/node-src/tasks/verify/publishBuild.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 
 import TestLogger from '../../lib/testLogger';
+import type { TurboSnapBailDetail } from '../../types';
 import { publishBuild } from './publishBuild';
 
 const environment = {
@@ -38,5 +39,74 @@ describe('publishBuild', () => {
       { headers: { Authorization: `Bearer report-token` }, retries: 3 }
     );
     expect(ctx.announcedBuild).toEqual({ ...announcedBuild, ...publishedBuild });
+  });
+
+  it('sends turboSnapBailDetail in the publishBuild input when ctx.turboSnap.bailDetail is defined', async () => {
+    const announcedBuild = { number: 1, status: 'ANNOUNCED', reportToken: 'report-token' };
+    const publishedBuild = { status: 'PUBLISHED' };
+    const client = { runQuery: vi.fn() };
+    client.runQuery.mockReturnValue({ publishBuild: publishedBuild });
+
+    const bailDetail: TurboSnapBailDetail = {
+      reason: 'lockfileSizeExceeded',
+      lockfileKind: 'yarn.lock',
+      lockfileSizeBytes: 12_000_000,
+      sentryEventId: 'sentry-event-id',
+    };
+
+    const ctx = {
+      env: environment,
+      log,
+      http,
+      client,
+      announcedBuild,
+      git: {},
+      sourceDir: '/static/',
+      buildLogFile: 'build-storybook.log',
+      options: {},
+      packageJson: {},
+      turboSnap: {
+        bailReason: { changedPackageFiles: ['./package.json'] },
+        bailDetail,
+      },
+    } as any;
+    await publishBuild(ctx);
+
+    expect(client.runQuery).toHaveBeenCalledWith(
+      expect.stringMatching(/PublishBuildMutation/),
+      {
+        input: {
+          turboSnapBailReason: { changedPackageFiles: ['./package.json'] },
+          turboSnapBailDetail: bailDetail,
+          turboSnapStatus: 'BAILED',
+        },
+      },
+      { headers: { Authorization: `Bearer report-token` }, retries: 3 }
+    );
+  });
+
+  it('omits turboSnapBailDetail when ctx.turboSnap.bailDetail is undefined', async () => {
+    const announcedBuild = { number: 1, status: 'ANNOUNCED', reportToken: 'report-token' };
+    const publishedBuild = { status: 'PUBLISHED' };
+    const client = { runQuery: vi.fn() };
+    client.runQuery.mockReturnValue({ publishBuild: publishedBuild });
+
+    const ctx = {
+      env: environment,
+      log,
+      http,
+      client,
+      announcedBuild,
+      git: {},
+      sourceDir: '/static/',
+      buildLogFile: 'build-storybook.log',
+      options: {},
+      packageJson: {},
+      turboSnap: { bailReason: { changedPackageFiles: ['./package.json'] } },
+    } as any;
+    await publishBuild(ctx);
+
+    const input = client.runQuery.mock.calls[0][1].input;
+    expect(input).not.toHaveProperty('turboSnapBailDetail');
   });
 });

--- a/node-src/tasks/verify/publishBuild.ts
+++ b/node-src/tasks/verify/publishBuild.ts
@@ -26,9 +26,11 @@ export const publishBuild = async (ctx: Context) => {
   const { onlyStoryNames, onlyStoryFiles = ctx.onlyStoryFiles } = ctx.options;
 
   let turboSnapBailReason;
+  let turboSnapBailDetail;
   let turboSnapStatus = 'UNUSED';
   if (turboSnap) {
     turboSnapBailReason = turboSnap.bailReason;
+    turboSnapBailDetail = turboSnap.bailDetail;
     turboSnapStatus = turboSnap.bailReason ? 'BAILED' : 'APPLIED';
   }
 
@@ -43,6 +45,7 @@ export const publishBuild = async (ctx: Context) => {
         // GraphQL does not support union input types (yet), so we send an object
         // @see https://github.com/graphql/graphql-spec/issues/488
         ...(turboSnapBailReason && { turboSnapBailReason }),
+        ...(turboSnapBailDetail && { turboSnapBailDetail }),
         turboSnapStatus,
       },
     },

--- a/node-src/tasks/verify/publishBuild.ts
+++ b/node-src/tasks/verify/publishBuild.ts
@@ -26,11 +26,9 @@ export const publishBuild = async (ctx: Context) => {
   const { onlyStoryNames, onlyStoryFiles = ctx.onlyStoryFiles } = ctx.options;
 
   let turboSnapBailReason;
-  let turboSnapBailDetail;
   let turboSnapStatus = 'UNUSED';
   if (turboSnap) {
     turboSnapBailReason = turboSnap.bailReason;
-    turboSnapBailDetail = turboSnap.bailDetail;
     turboSnapStatus = turboSnap.bailReason ? 'BAILED' : 'APPLIED';
   }
 
@@ -45,7 +43,6 @@ export const publishBuild = async (ctx: Context) => {
         // GraphQL does not support union input types (yet), so we send an object
         // @see https://github.com/graphql/graphql-spec/issues/488
         ...(turboSnapBailReason && { turboSnapBailReason }),
-        ...(turboSnapBailDetail && { turboSnapBailDetail }),
         turboSnapStatus,
       },
     },

--- a/node-src/types.ts
+++ b/node-src/types.ts
@@ -513,7 +513,7 @@ export type TurboSnapBailReason =
       lockfileParseFailed?: boolean;
       lockfileSizeBytes?: number;
       lockfileSizeExceeded?: boolean;
-      noNodeModulesInStats?: boolean;
+      nodeModulesMissingInStats?: boolean;
       sentryEventId?: string;
     })
   // All remaining bail reasons

--- a/node-src/types.ts
+++ b/node-src/types.ts
@@ -494,6 +494,18 @@ export interface TargetInfo {
   formFields: Record<string, string>;
 }
 
+export type TurboSnapBailDetail =
+  | {
+      reason: 'lockfileSizeExceeded';
+      lockfileKind?: string;
+      lockfileSizeBytes: number;
+      sentryEventId?: string;
+    }
+  | { reason: 'snykParseFailed'; lockfileKind?: string; sentryEventId?: string }
+  | { reason: 'baselineCheckoutFailed'; sentryEventId?: string }
+  | { reason: 'noNodeModulesInStats' }
+  | { reason: 'unknown'; sentryEventId?: string };
+
 export interface TurboSnap {
   unavailable?: boolean;
   rootPath?: string;
@@ -517,6 +529,7 @@ export interface TurboSnap {
     noAncestorBuild?: true;
     rebuild?: true;
   };
+  bailDetail?: TurboSnapBailDetail;
 }
 
 export { type Configuration } from './lib/getConfiguration';

--- a/node-src/types.ts
+++ b/node-src/types.ts
@@ -494,17 +494,30 @@ export interface TargetInfo {
   formFields: Record<string, string>;
 }
 
-export type TurboSnapBailDetail =
-  | {
-      reason: 'lockfileSizeExceeded';
+interface TurboSnapBailReasonBase {
+  changedStorybookFiles?: string[];
+  changedStaticFiles?: string[];
+  changedExternalFiles?: string[];
+  invalidChangedFiles?: true;
+  missingStatsFile?: true;
+  noAncestorBuild?: true;
+  rebuild?: true;
+}
+
+export type TurboSnapBailReason =
+  // All additional fields allowed for the changedPackageFiles bail reason
+  | (TurboSnapBailReasonBase & {
+      changedPackageFiles: string[];
+      baselineCheckoutFailed?: boolean;
       lockfileKind?: string;
-      lockfileSizeBytes: number;
+      lockfileParseFailed?: boolean;
+      lockfileSizeBytes?: number;
+      lockfileSizeExceeded?: boolean;
+      noNodeModulesInStats?: boolean;
       sentryEventId?: string;
-    }
-  | { reason: 'snykParseFailed'; lockfileKind?: string; sentryEventId?: string }
-  | { reason: 'baselineCheckoutFailed'; sentryEventId?: string }
-  | { reason: 'noNodeModulesInStats' }
-  | { reason: 'unknown'; sentryEventId?: string };
+    })
+  // All remaining bail reasons
+  | (TurboSnapBailReasonBase & { changedPackageFiles?: never });
 
 export interface TurboSnap {
   unavailable?: boolean;
@@ -519,17 +532,7 @@ export interface TurboSnap {
   changedDependencyNames?: Set<string>;
   changedManifestFiles?: Set<string>;
   affectedModuleIds?: Set<string | number>;
-  bailReason?: {
-    changedPackageFiles?: string[];
-    changedStorybookFiles?: string[];
-    changedStaticFiles?: string[];
-    changedExternalFiles?: string[];
-    invalidChangedFiles?: true;
-    missingStatsFile?: true;
-    noAncestorBuild?: true;
-    rebuild?: true;
-  };
-  bailDetail?: TurboSnapBailDetail;
+  bailReason?: TurboSnapBailReason;
 }
 
 export { type Configuration } from './lib/getConfiguration';


### PR DESCRIPTION
## Summary

Populates additional bail detail fields on `ctx.turboSnap.bailReason` so telemetry can disambiguate the two TurboSnap code paths that previously collapsed into the same `changedPackageFiles` bucket.

- `lockfileSizeExceeded` (+ `lockfileKind`, `lockfileSizeBytes`)
- `lockfileParseFailed` (+ `lockfileKind`)
- `baselineCheckoutFailed`

Each bail reason that includes an exception being thrown is sent to Sentry so we can improve that section of the codebase over time. It includes a `fingerprint` to group these bail reasons together. 

## QA

The goal is to trigger each flag under `changedPackageFiles`. I'm running this against my test project to ensure our backend can properly accept each one added in this PR.

_Note: All these extra fields live in the database and are not exposed by the API._

### Lockfile size exceeded

The easiest way to QA this is to run a build with `MAX_LOCK_FILE_SIZE=1`. Then any lockfile will trigger it.

Production build with this CLI version: https://www.chromatic.com/build?appId=67a3e1a61646506bc9485437&number=129

- [x] `lockfileSizeBytes`
- [x] `lockfileSizeExceeded`
- [x] `lockfileKind`

### Lockfile parse failed

This one is a little tricky to trigger. The way I did it is:

1. Make a dependency change that would cause a lockfile update
2. Do a `yarn install`
3. Do a manual build of the Storybook (otherwise, `yarn` will catch it) via `yarn build-storybook`
4. Break the YAML format by deleting a newline character or a `:` somewhere
5. Run a build via `npx` (again, otherwise `yarn` will catch it) and `-d storybook-static`

Production build with this CLI version: https://www.chromatic.com/build?appId=67a3e1a61646506bc9485437&number=132

- [x] `lockfileParseFailed`
- [x] `sentryEventId`

_Note: To find the Sentry event, you can open any event in the CLI Sentry project and replace the query param to `query=<sentryEventId>`._

### Baseline checkout failed

I had to force this one to break via this patch:

```
diff --git a/node-src/git/git.ts b/node-src/git/git.ts
index 1a8d6311..e11c150b 100644
--- a/node-src/git/git.ts
+++ b/node-src/git/git.ts
@@ -382,6 +382,7 @@ export async function checkoutFile(
 
     deps.log.debug(`Checking out file ${pathspec} at ${targetFileName}`);
     try {
+      throw 'git show failed I guess';
       await execGitCommand(deps, `git show ${pathspec} > ${targetFileName}`);
     } catch (error) {
       throw new BaselineCheckoutFailedError(pathspec, { cause: error });

```

Production build with this CLI version: https://www.chromatic.com/build?appId=67a3e1a61646506bc9485437&number=133

- [x] `baselineCheckoutFailed`
- [x] `sentryEventId`

### Node modules missing in stats

I had to force this one to break via this patch:

```
diff --git a/node-src/lib/turbosnap/getDependentStoryFiles.ts b/node-src/lib/turbosnap/getDependentStoryFiles.ts
index c6b8b2bc..50de8d99 100644
--- a/node-src/lib/turbosnap/getDependentStoryFiles.ts
+++ b/node-src/lib/turbosnap/getDependentStoryFiles.ts
@@ -143,7 +143,7 @@ export async function getDependentStoryFiles(
   stats.modules
     .filter((module_) => isUserModule(module_))
     // TODO: refactor this function
-    // eslint-disable-next-line complexity
+
     .map((module_) => {
       const normalizedName = normalize(module_.name);
       modulesByName.set(normalizedName, module_);
@@ -154,8 +154,8 @@ export async function getDependentStoryFiles(
         // Track all modules from any node_modules directory by their package name, so we can mark
         // all those files "changed" if a dependency (version) changes, while still being able to
         // "untrace" certain files (or globs) in those packages.
-        if (!nodeModules.has(packageName)) nodeModules.set(packageName, []);
-        nodeModules.get(packageName)?.push(normalizedName);
+        // if (!nodeModules.has(packageName)) nodeModules.set(packageName, []);
+        // nodeModules.get(packageName)?.push(normalizedName);
       }
 
       if (module_.modules) {

```

Production build with this CLI version: https://www.chromatic.com/build?appId=67a3e1a61646506bc9485437&number=136

- [x] `nodeModulesMissingInStats`

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>17.2.0--canary.1344.26525383535.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@17.2.0--canary.1344.26525383535.0
  # or 
  yarn add chromatic@17.2.0--canary.1344.26525383535.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
