### PR TITLE
Force `es-toolkit` version to avoid bundle error in Yarn classic smoke test

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
   },
   "resolutions": {
     "any-observable": "^0.5.1",
+    "es-toolkit": "1.46.0",
     "lodash": "4.17.21",
     "@types/minimatch": "5.1.2"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -6358,7 +6358,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"es-toolkit@npm:^1.39.7":
+"es-toolkit@npm:1.46.0":
   version: 1.46.0
   resolution: "es-toolkit@npm:1.46.0"
   dependenciesMeta:


### PR DESCRIPTION
Our `yarn-classic` smoke test started failing this morning. Turns out, `es-toolkit` was upgraded by a transitive dependency. Forcing that version fixes the issue.

Error: `ReferenceError: Cannot access 'n' before initialization`

https://github.com/chromaui/chromatic-cli/actions/runs/26462130629/job/77912854163

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>17.0.2--canary.1347.26464721359.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@17.0.2--canary.1347.26464721359.0
  # or 
  yarn add chromatic@17.0.2--canary.1347.26464721359.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
