### PR TITLE
Join individual bail subreasons into a single field

### DIFF
--- a/node-src/lib/turbosnap/classifyBailDetail.test.ts
+++ b/node-src/lib/turbosnap/classifyBailDetail.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { bailDetailKey, classifyBailDetail, detectLockfileKind } from './classifyBailDetail';
+import { classifyBailDetail, detectLockfileKind } from './classifyBailDetail';
 import {
   BaselineCheckoutFailedError,
   LockFileParseFailedError,
@@ -20,7 +20,7 @@ describe('classifyBailDetail', () => {
   it('classifies LockFileSizeExceededError with kind + size', () => {
     const err = new LockFileSizeExceededError('/tmp/checkout-abc/pnpm-lock.yaml', 12_000_000);
     expect(classifyBailDetail(err)).toEqual({
-      lockfileSizeExceeded: true,
+      bailSubreason: 'lockfileSizeExceeded',
       lockfileKind: 'pnpm-lock.yaml',
       lockfileSizeBytes: 12_000_000,
     });
@@ -30,7 +30,7 @@ describe('classifyBailDetail', () => {
     const err = new LockFileSizeExceededError('/tmp/weird-name', 12_000_000);
     const patch = classifyBailDetail(err);
     expect(patch).toEqual({
-      lockfileSizeExceeded: true,
+      bailSubreason: 'lockfileSizeExceeded',
       lockfileSizeBytes: 12_000_000,
     });
     expect(patch).not.toHaveProperty('lockfileKind');
@@ -41,34 +41,16 @@ describe('classifyBailDetail', () => {
       cause: new Error('no lock file parse for you'),
     });
     expect(classifyBailDetail(err)).toEqual({
-      lockfileParseFailed: true,
+      bailSubreason: 'lockfileParseFailed',
       lockfileKind: 'yarn.lock',
     });
   });
 
-  it('classifies BaselineCheckoutFailedError as { baselineCheckoutFailed: true }', () => {
+  it('classifies BaselineCheckoutFailedError as { bailSubreason: "baselineCheckoutFailed" }', () => {
     const err = new BaselineCheckoutFailedError('abc123:package.json', {
       cause: new Error('git show failed'),
     });
-    expect(classifyBailDetail(err)).toEqual({ baselineCheckoutFailed: true });
-  });
-});
-
-describe('bailDetailKey', () => {
-  it('returns undefined for an empty patch', () => {
-    expect(bailDetailKey({})).toBeUndefined();
-  });
-
-  it('returns "lockfileSizeExceeded" when the flag is set', () => {
-    expect(bailDetailKey({ lockfileSizeExceeded: true })).toBe('lockfileSizeExceeded');
-  });
-
-  it('returns "lockfileParseFailed" when the flag is set', () => {
-    expect(bailDetailKey({ lockfileParseFailed: true })).toBe('lockfileParseFailed');
-  });
-
-  it('returns "baselineCheckoutFailed" when the flag is set', () => {
-    expect(bailDetailKey({ baselineCheckoutFailed: true })).toBe('baselineCheckoutFailed');
+    expect(classifyBailDetail(err)).toEqual({ bailSubreason: 'baselineCheckoutFailed' });
   });
 });
 

--- a/node-src/lib/turbosnap/classifyBailDetail.ts
+++ b/node-src/lib/turbosnap/classifyBailDetail.ts
@@ -13,11 +13,6 @@ export type ChangedPackageFilesPatch = Partial<
   Extract<TurboSnapBailReason, { changedPackageFiles: string[] }>
 >;
 
-export type BailDetailKey =
-  | 'lockfileSizeExceeded'
-  | 'lockfileParseFailed'
-  | 'baselineCheckoutFailed';
-
 /**
  * Detect which supported lockfile kind a given path corresponds to.
  *
@@ -41,7 +36,7 @@ export function classifyBailDetail(err: unknown): ChangedPackageFilesPatch {
   if (err instanceof LockFileSizeExceededError) {
     const lockfileKind = detectLockfileKind(err.lockfilePath);
     return {
-      lockfileSizeExceeded: true,
+      bailSubreason: 'lockfileSizeExceeded',
       ...(lockfileKind && { lockfileKind }),
       lockfileSizeBytes: err.lockfileSizeBytes,
     };
@@ -49,27 +44,12 @@ export function classifyBailDetail(err: unknown): ChangedPackageFilesPatch {
   if (err instanceof LockFileParseFailedError) {
     const lockfileKind = detectLockfileKind(err.lockfilePath);
     return {
-      lockfileParseFailed: true,
+      bailSubreason: 'lockfileParseFailed',
       ...(lockfileKind && { lockfileKind }),
     };
   }
   if (err instanceof BaselineCheckoutFailedError) {
-    return { baselineCheckoutFailed: true };
+    return { bailSubreason: 'baselineCheckoutFailed' };
   }
   return {};
-}
-
-/**
- * Derive a short, primary key describing bail reason. Used for grouping related bail reasons in
- * Sentry. Returns `undefined` when no specific flag is set.
- *
- * @param patch The bail-detail patch to inspect.
- *
- * @returns A short string key identifying the patch's primary key.
- */
-export function bailDetailKey(patch: ChangedPackageFilesPatch): BailDetailKey | undefined {
-  if (patch.lockfileSizeExceeded) return 'lockfileSizeExceeded';
-  if (patch.lockfileParseFailed) return 'lockfileParseFailed';
-  if (patch.baselineCheckoutFailed) return 'baselineCheckoutFailed';
-  return;
 }

--- a/node-src/lib/turbosnap/getDependentStoryFiles.test.ts
+++ b/node-src/lib/turbosnap/getDependentStoryFiles.test.ts
@@ -968,7 +968,7 @@ describe('getDependentStoryFiles', () => {
     });
   });
 
-  it('bails with nodeModulesMissingInStats when the stats file has no node_modules entries', async () => {
+  it('bails with bailSubreason "nodeModulesMissingInStats" when the stats file has no node_modules entries', async () => {
     const changedFiles = ['package.json'];
     const changedDependencies = ['some-pkg'];
     const modules = [
@@ -998,11 +998,11 @@ describe('getDependentStoryFiles', () => {
     expect(result).toBeUndefined();
     expect(ctx.turboSnap.bailReason).toEqual({
       changedPackageFiles: ['package.json'],
-      nodeModulesMissingInStats: true,
+      bailSubreason: 'nodeModulesMissingInStats',
     });
   });
 
-  it('does not set nodeModulesMissingInStats when there are no changed dependencies', async () => {
+  it('does not set bailSubreason when there are no changed dependencies', async () => {
     const changedFiles = ['package.json'];
     const changedDependencies: string[] = [];
     const modules = [
@@ -1023,7 +1023,7 @@ describe('getDependentStoryFiles', () => {
       git: { ...rawContext.git, changedFiles: ['package.json'] },
     };
     await getDependentStoryFiles(ctx, { modules }, statsPath, changedFiles, changedDependencies);
-    expect(ctx.turboSnap.bailReason?.nodeModulesMissingInStats).toBeUndefined();
+    expect(ctx.turboSnap.bailReason?.bailSubreason).toBeUndefined();
   });
 });
 

--- a/node-src/lib/turbosnap/getDependentStoryFiles.ts
+++ b/node-src/lib/turbosnap/getDependentStoryFiles.ts
@@ -259,7 +259,7 @@ export async function getDependentStoryFiles(
         ...(ctx.git.changedFiles?.filter((file) => isPackageManifestFile(file)) || []),
         ...changedPackageLockFiles,
       ],
-      nodeModulesMissingInStats: true,
+      bailSubreason: 'nodeModulesMissingInStats',
     };
   }
 

--- a/node-src/lib/turbosnap/index.test.ts
+++ b/node-src/lib/turbosnap/index.test.ts
@@ -85,7 +85,7 @@ describe('traceChangedFiles', () => {
       error: new LockFileSizeExceededError('/tmp/checkout-abc/pnpm-lock.yaml', 12_000_000),
       expectedBailReason: {
         changedPackageFiles: ['./package.json'],
-        lockfileSizeExceeded: true,
+        bailSubreason: 'lockfileSizeExceeded',
         lockfileKind: 'pnpm-lock.yaml',
         lockfileSizeBytes: 12_000_000,
         sentryEventId: 'sentry-event-id',
@@ -100,7 +100,7 @@ describe('traceChangedFiles', () => {
       }),
       expectedBailReason: {
         changedPackageFiles: ['./package.json'],
-        lockfileParseFailed: true,
+        bailSubreason: 'lockfileParseFailed',
         lockfileKind: 'yarn.lock',
         sentryEventId: 'sentry-event-id',
       },
@@ -112,7 +112,7 @@ describe('traceChangedFiles', () => {
       error: new BaselineCheckoutFailedError('abc:package.json'),
       expectedBailReason: {
         changedPackageFiles: ['./package.json'],
-        baselineCheckoutFailed: true,
+        bailSubreason: 'baselineCheckoutFailed',
         sentryEventId: 'sentry-event-id',
       },
       expectedKey: 'baselineCheckoutFailed',

--- a/node-src/lib/turbosnap/index.ts
+++ b/node-src/lib/turbosnap/index.ts
@@ -6,7 +6,7 @@ import { Context } from '../../types';
 import missingStatsFile from '../../ui/messages/errors/missingStatsFile';
 import bailFile from '../../ui/messages/warnings/bailFile';
 import { checkStorybookBaseDirectory } from '../checkStorybookBaseDirectory';
-import { bailDetailKey, ChangedPackageFilesPatch, classifyBailDetail } from './classifyBailDetail';
+import { ChangedPackageFilesPatch, classifyBailDetail } from './classifyBailDetail';
 import { findChangedDependencies } from './findChangedDependencies';
 import { findChangedPackageFiles } from './findChangedPackageFiles';
 import { getDependentStoryFiles } from './getDependentStoryFiles';
@@ -58,12 +58,12 @@ export const traceChangedFiles = async (ctx: Context) => {
         // be times when findChangedDependencies fails but our fallback works. In those cases, we
         // don't want to capture an error since we were able to recover and didn't bail.
         if (pendingPatch && pendingError) {
-          const key = bailDetailKey(pendingPatch);
+          const { bailSubreason } = pendingPatch;
           pendingPatch.sentryEventId = Sentry.captureException(pendingError, {
-            tags: { bail_path: 'findChangedDependencies', bail_detail: key },
+            tags: { bail_path: 'findChangedDependencies', bail_detail: bailSubreason },
             // group known bail reasons under one issue per key; let Sentry's default grouping
             // handle unclassified errors so they don't all collapse into a single bucket
-            ...(key && { fingerprint: [key] }),
+            ...(bailSubreason && { fingerprint: [bailSubreason] }),
           });
         }
 

--- a/node-src/tasks/verify/publishBuild.test.ts
+++ b/node-src/tasks/verify/publishBuild.test.ts
@@ -48,9 +48,9 @@ describe('publishBuild', () => {
 
     const bailReason = {
       changedPackageFiles: ['./package.json'],
+      bailSubreason: 'lockfileSizeExceeded',
       lockfileKind: 'yarn.lock',
       lockfileSizeBytes: 12_000_000,
-      lockfileSizeExceeded: true,
       sentryEventId: 'sentry-event-id',
     };
 

--- a/node-src/types.ts
+++ b/node-src/types.ts
@@ -504,16 +504,19 @@ interface TurboSnapBailReasonBase {
   rebuild?: true;
 }
 
+export type TurboSnapBailSubreason =
+  | 'baselineCheckoutFailed'
+  | 'lockfileParseFailed'
+  | 'lockfileSizeExceeded'
+  | 'nodeModulesMissingInStats';
+
 export type TurboSnapBailReason =
   // All additional fields allowed for the changedPackageFiles bail reason
   | (TurboSnapBailReasonBase & {
       changedPackageFiles: string[];
-      baselineCheckoutFailed?: boolean;
+      bailSubreason?: TurboSnapBailSubreason;
       lockfileKind?: string;
-      lockfileParseFailed?: boolean;
       lockfileSizeBytes?: number;
-      lockfileSizeExceeded?: boolean;
-      nodeModulesMissingInStats?: boolean;
       sentryEventId?: string;
     })
   // All remaining bail reasons


### PR DESCRIPTION
## Summary

The original implementation used individual fields for TurboSnap bail subreasons. This made sense until we hit our analytics database which called that into question. Instead of hacking things in our analytics dashboards, we're going to fix the field now. This takes all those mutually exclusive fields and turns them into a single field.

Since this is still early, my idea for rollout is:

1. Merge backend change (which supports both formats)
2. Merge this change to send the new `bailSubreason` field
3. Deprecate the CLI version that sends the incorrect format
4. Wait some time
5. Cleanup the old fields from the backend

## QA

The goal is to trigger each flag under `changedPackageFiles`. I'm running this against my test project to ensure our backend can properly accept each one added in this PR.

_Note: All these extra fields live in the database and are not exposed by the API._

### Lockfile size exceeded

The easiest way to QA this is to run a build with `MAX_LOCK_FILE_SIZE=1`. Then any lockfile will trigger it.

- [x] Bail subreason: `lockfileSizeExceeded`
- [x] `lockfileSizeBytes`
- [x] `lockfileKind`

Production build that shows this error: https://www.chromatic.com/build?appId=67a3e1a61646506bc9485437&number=151

### Lockfile parse failed

This one is a little tricky to trigger. The way I did it is:

1. Make a dependency change that would cause a lockfile update
2. Do a `yarn install`
3. Do a manual build of the Storybook (otherwise, `yarn` will catch it) via `yarn build-storybook`
4. Break the YAML format by deleting a newline character or a `:` somewhere
5. Run a build via `npx` (again, otherwise `yarn` will catch it) and `-d storybook-static`

- [x] Bail subreason: `lockfileParseFailed`
- [x] `sentryEventId`

_Note: To find the Sentry event, you can open any event in the CLI Sentry project and replace the query param to `query=<sentryEventId>`._

Production build that shows this error: https://www.chromatic.com/build?appId=67a3e1a61646506bc9485437&number=153

### Baseline checkout failed

I had to force this one to break via this patch:

```
diff --git a/node-src/git/git.ts b/node-src/git/git.ts
index 1a8d6311..e11c150b 100644
--- a/node-src/git/git.ts
+++ b/node-src/git/git.ts
@@ -382,6 +382,7 @@ export async function checkoutFile(
 
     deps.log.debug(`Checking out file ${pathspec} at ${targetFileName}`);
     try {
+      throw 'git show failed I guess';
       await execGitCommand(deps, `git show ${pathspec} > ${targetFileName}`);
     } catch (error) {
       throw new BaselineCheckoutFailedError(pathspec, { cause: error });

```

- [x] Bail subreason: `baselineCheckoutFailed`
- [x] `sentryEventId`

Production build that shows this error: https://www.chromatic.com/build?appId=67a3e1a61646506bc9485437&number=154

### Node modules missing in stats

I had to force this one to break via this patch:

```
diff --git a/node-src/lib/turbosnap/getDependentStoryFiles.ts b/node-src/lib/turbosnap/getDependentStoryFiles.ts
index c6b8b2bc..50de8d99 100644
--- a/node-src/lib/turbosnap/getDependentStoryFiles.ts
+++ b/node-src/lib/turbosnap/getDependentStoryFiles.ts
@@ -143,7 +143,7 @@ export async function getDependentStoryFiles(
   stats.modules
     .filter((module_) => isUserModule(module_))
     // TODO: refactor this function
-    // eslint-disable-next-line complexity
+
     .map((module_) => {
       const normalizedName = normalize(module_.name);
       modulesByName.set(normalizedName, module_);
@@ -154,8 +154,8 @@ export async function getDependentStoryFiles(
         // Track all modules from any node_modules directory by their package name, so we can mark
         // all those files "changed" if a dependency (version) changes, while still being able to
         // "untrace" certain files (or globs) in those packages.
-        if (!nodeModules.has(packageName)) nodeModules.set(packageName, []);
-        nodeModules.get(packageName)?.push(normalizedName);
+        // if (!nodeModules.has(packageName)) nodeModules.set(packageName, []);
+        // nodeModules.get(packageName)?.push(normalizedName);
       }
 
       if (module_.modules) {

```

- [x] Bail subreason: `nodeModulesMissingInStats`

Production build that shows this error: https://www.chromatic.com/build?appId=67a3e1a61646506bc9485437&number=155

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>17.3.0--canary.1357.26778880423.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@17.3.0--canary.1357.26778880423.0
  # or 
  yarn add chromatic@17.3.0--canary.1357.26778880423.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
