### PR TITLE
Update Dependabot to skip test fixture dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      # Semver-related labels (`major`, `minor`, `patch`) are added automatically.
+      - "skip-release"
+    exclude-paths:
+      - "subdir/**"
+      - "node-src/__mocks__/**"


### PR DESCRIPTION
Our Dependabot appears to be creating PRs against our test fixture dependencies that aren't installed anywhere. This trims those out to only apply update to the root `yarn.lock` which are the real dependencies of the repository.

Example: https://github.com/chromaui/chromatic-cli/pull/1362

`subdir` is a test fixture.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>17.3.1--canary.1363.27027430128.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@17.3.1--canary.1363.27027430128.0
  # or 
  yarn add chromatic@17.3.1--canary.1363.27027430128.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
