### PR TITLE
`react-native-build`: Don't overwrite artifacts without permission.

### DIFF
--- a/bin-src/reactNativeBuild.test.ts
+++ b/bin-src/reactNativeBuild.test.ts
@@ -1,3 +1,4 @@
+import { type PathLike } from 'fs';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('execa', () => ({
@@ -66,6 +67,14 @@ beforeEach(() => {
     write: vi.fn(),
     end: vi.fn((callback: () => void) => callback()),
   } as any);
+  // Default: output artifacts don't exist yet (clean build), but parent dirs and
+  // intermediate build outputs do exist (so validateOutputPath passes).
+  mockedExistsSync.mockImplementation((filePath: PathLike) => {
+    if (String(filePath).endsWith('storybook.apk') || String(filePath).endsWith('storybook.app')) {
+      return false;
+    }
+    return true;
+  });
 });
 
 describe('react-native-build', () => {
@@ -76,7 +85,6 @@ describe('react-native-build', () => {
       }
       return Promise.resolve({}) as any;
     });
-    mockedExistsSync.mockReturnValue(true);
 
     await main([]);
 
@@ -103,7 +111,6 @@ describe('react-native-build', () => {
       }
       return Promise.resolve({}) as any;
     });
-    mockedExistsSync.mockReturnValue(true);
 
     await main([]);
 
@@ -171,7 +178,6 @@ describe('react-native-build', () => {
       }
       return Promise.resolve({}) as any;
     });
-    mockedExistsSync.mockReturnValue(true);
 
     await main(['--output-dir', '/output']);
 
@@ -185,7 +191,6 @@ describe('react-native-build', () => {
       }
       return Promise.resolve({}) as any;
     });
-    mockedExistsSync.mockReturnValue(true);
 
     await main(['--output-dir', '/output']);
 
@@ -203,7 +208,6 @@ describe('react-native-build', () => {
       }
       return Promise.resolve({}) as any;
     });
-    mockedExistsSync.mockReturnValue(true);
 
     await main(['--output-dir', '/output']);
 
@@ -217,7 +221,6 @@ describe('react-native-build', () => {
       }
       return Promise.resolve({}) as any;
     });
-    mockedExistsSync.mockReturnValue(true);
 
     await main([]);
 
@@ -238,7 +241,6 @@ describe('react-native-build', () => {
       }
       return Promise.resolve({}) as any;
     });
-    mockedExistsSync.mockReturnValue(true);
 
     await expect(main([])).rejects.toThrow('process.exit');
     expect(mockedRmSync).toHaveBeenCalledWith('/tmp/chromatic-rn-build-test', {
@@ -261,7 +263,6 @@ describe('react-native-build', () => {
       }
       return Promise.resolve({}) as any;
     });
-    mockedExistsSync.mockReturnValue(true);
 
     await expect(main(['--output-dir', '/output'])).rejects.toThrow('process.exit');
     expect(mockedRmSync).not.toHaveBeenCalled();
@@ -277,7 +278,6 @@ describe('react-native-build', () => {
       }
       return Promise.resolve({}) as any;
     });
-    mockedExistsSync.mockReturnValue(true);
 
     await main([]);
 
@@ -296,7 +296,6 @@ describe('react-native-build', () => {
       }
       return Promise.resolve({}) as any;
     });
-    mockedExistsSync.mockReturnValue(true);
 
     await main([]);
 
@@ -324,5 +323,38 @@ describe('react-native-build', () => {
 
     await expect(main([])).rejects.toThrow('process.exit');
     expect(console.error).toHaveBeenCalledWith(expect.stringContaining('gradle failed'));
+  });
+
+  it('exits with error when output artifact exists and --overwrite is not passed', async () => {
+    mockedExeca.mockImplementation((command: any, args: any) => {
+      if (command === 'npx' && args?.[0] === 'expo' && args?.[1] === 'config') {
+        return { stdout: JSON.stringify({ platforms: ['android'], name: 'MyApp' }) } as any;
+      }
+      return Promise.resolve({}) as any;
+    });
+    mockedExistsSync.mockReturnValue(true);
+
+    await expect(main([])).rejects.toThrow('process.exit');
+    expect(console.error).toHaveBeenCalledWith(
+      expect.stringContaining('already exists. Use --overwrite')
+    );
+  });
+
+  it('proceeds with build when --overwrite is passed and artifact exists', async () => {
+    mockedExeca.mockImplementation((command: any, args: any) => {
+      if (command === 'npx' && args?.[0] === 'expo' && args?.[1] === 'config') {
+        return { stdout: JSON.stringify({ platforms: ['android'], name: 'MyApp' }) } as any;
+      }
+      return Promise.resolve({}) as any;
+    });
+    mockedExistsSync.mockReturnValue(true);
+
+    await main(['--overwrite']);
+
+    expect(mockedExeca).toHaveBeenCalledWith(
+      './gradlew',
+      expect.arrayContaining(['assembleRelease']),
+      expect.objectContaining({ cwd: expect.stringContaining('android') })
+    );
   });
 });

--- a/bin-src/reactNativeBuild.ts
+++ b/bin-src/reactNativeBuild.ts
@@ -1,5 +1,5 @@
 import chalk from 'chalk';
-import { mkdirSync, mkdtempSync, rmSync, type WriteStream } from 'fs';
+import { existsSync, mkdirSync, mkdtempSync, rmSync, type WriteStream } from 'fs';
 import meow from 'meow';
 import os from 'os';
 import path from 'path';
@@ -68,6 +68,7 @@ function parseFlags(argv: string[]) {
         Options
           --platform    Platform to build (android, ios). Can be specified multiple times. Defaults to all platforms in Expo config.
           --output-dir  Directory to write build artifacts and log file to.
+          --overwrite   Overwrite existing output directory if it exists.
         `,
     {
       argv,
@@ -80,6 +81,10 @@ function parseFlags(argv: string[]) {
         outputDir: {
           type: 'string',
         },
+        overwrite: {
+          type: 'boolean',
+          default: false,
+        },
       },
     }
   );
@@ -87,7 +92,7 @@ function parseFlags(argv: string[]) {
   const requestedPlatforms =
     flags.platform && flags.platform.length > 0 ? flags.platform : undefined;
 
-  return { requestedPlatforms, outputDir: flags.outputDir };
+  return { requestedPlatforms, outputDir: flags.outputDir, overwrite: flags.overwrite };
 }
 
 /**
@@ -146,6 +151,7 @@ Available platforms: ${configPlatforms.join(', ')}`);
  * @param platforms The platforms to build.
  * @param appName The app name from Expo config, required for iOS builds.
  * @param artifactDirectory The directory to place build artifacts in.
+ * @param overwrite Whether to overwrite existing build artifacts if they exist.
  * @param logStream The WriteStream to write build logs to.
  * @param androidBuildArchitectures Additional Android architectures to build for.
  *
@@ -155,6 +161,7 @@ async function buildPlatforms(
   platforms: string[],
   appName: string,
   artifactDirectory: string,
+  overwrite: boolean,
   logStream: WriteStream,
   androidBuildArchitectures?: string[]
 ) {
@@ -164,10 +171,20 @@ async function buildPlatforms(
     info(`Building for ${platformNames[platform]}`);
     if (platform === 'android') {
       const outputPath = path.join(artifactDirectory, 'storybook.apk');
+      if (!overwrite && existsSync(outputPath)) {
+        throw new Error(
+          `Output file ${outputPath} already exists. Use --overwrite to overwrite existing files.`
+        );
+      }
       const duration = await buildAndroid(outputPath, logStream, androidBuildArchitectures);
       artifacts.push({ platform: 'Android', path: outputPath, duration });
     } else if (platform === 'ios') {
       const outputPath = path.join(artifactDirectory, 'storybook.app');
+      if (!overwrite && existsSync(outputPath)) {
+        throw new Error(
+          `Output file ${outputPath} already exists. Use --overwrite to overwrite existing files.`
+        );
+      }
       const duration = await buildIos(appName, outputPath, logStream);
       artifacts.push({ platform: 'iOS', path: outputPath, duration });
     }
@@ -182,7 +199,7 @@ async function buildPlatforms(
  * @param argv A list of arguments passed.
  */
 export async function main(argv: string[]) {
-  const { requestedPlatforms, outputDir } = parseFlags(argv);
+  const { requestedPlatforms, outputDir, overwrite } = parseFlags(argv);
   const { androidBuildArchitectures } = await readReactNativeConfig();
 
   warn(
@@ -220,6 +237,7 @@ export async function main(argv: string[]) {
       platforms,
       config.name,
       artifactDirectory,
+      overwrite,
       logStream,
       androidBuildArchitectures
     );


### PR DESCRIPTION
`react-native-build` should error when the `.apk` or `.app` exists in the output directory, unless the `--overwrite` flag is provided.

```
$ ls -la storybook-static-rn
total 247592
drwxr-xr-x@  7 jmhobbs  staff       224 May  4 16:48 .
drwxr-xr-x@ 45 jmhobbs  staff      1440 Jun  1 16:24 ..
-rw-r--r--@  1 jmhobbs  staff      8640 May  4 10:07 manifest.json
-rw-r--r--@  1 jmhobbs  staff  93323942 May  4 10:05 storybook.apk
drwxr-xr-x@ 23 jmhobbs  staff       736 May  4 16:48 storybook.app

$ node ../cli/dist/bin.cjs react-native-build --output-dir storybook-static-rn/
⚠ Chromatic React Native Build is in alpha. Use with caution.
  → Please report any issues you encounter on the Chromatic CLI GitHub repository.
› Reading configuration from Expo
  → npx expo config --json
› Building for iOS
✖ Error
  → Output file storybook-static-rn/storybook.app already exists. Use --overwrite to overwrite existing files.
› Build failed, see log for details
  → storybook-static-rn/chromatic-react-native-build-1780410700412.log

$ node ../cli/dist/bin.cjs react-native-build --output-dir storybook-static-rn/ --overwrite
⚠ Chromatic React Native Build is in alpha. Use with caution.
  → Please report any issues you encounter on the Chromatic CLI GitHub repository.
› Reading configuration from Expo
  → npx expo config --json
› Building for iOS
...
```
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>17.3.1--canary.1364.27027424817.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@17.3.1--canary.1364.27027424817.0
  # or 
  yarn add chromatic@17.3.1--canary.1364.27027424817.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
