### PR TITLE
Set `patch` label for Dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@ updates:
     schedule:
       interval: "weekly"
     labels:
-      # Semver-related labels (`major`, `minor`, `patch`) are added automatically.
+      - "patch"
       - "skip-release"
     exclude-paths:
       - "subdir/**"


### PR DESCRIPTION
Dependabot creates PRs wtih semver labels but it's based on the version bump of the dependency. A major bump in a dependency isn't a major bump for us so this forces those PRs to use `patch`.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>17.3.1--canary.1370.27027422564.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@17.3.1--canary.1370.27027422564.0
  # or 
  yarn add chromatic@17.3.1--canary.1370.27027422564.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
