### PR TITLE
:wrench: Add a configuration parameter that controls git timeout.

### DIFF
--- a/node-src/context.ts
+++ b/node-src/context.ts
@@ -1,4 +1,5 @@
 import { InitialContext } from '.';
+import { DEFAULT_GIT_TIMEOUT_SECONDS } from './git/constants';
 import GraphQLClient from './io/graphqlClient';
 import HTTPClient from './io/httpClient';
 import { getConfiguration } from './lib/getConfiguration';
@@ -29,5 +30,14 @@ export async function setupContext(
     retries: 3,
   });
   ctx.configuration = await getConfiguration(configFile);
+  if (
+    ctx.configuration.gitTimeout &&
+    ctx.configuration.gitTimeout !== DEFAULT_GIT_TIMEOUT_SECONDS
+  ) {
+    ctx.log.debug(
+      `git timeout was set to ${ctx.configuration.gitTimeout}, which is different than the default ${DEFAULT_GIT_TIMEOUT_SECONDS} seconds`
+    );
+  }
+
   return ctx as Context;
 }

--- a/node-src/git/constants.ts
+++ b/node-src/git/constants.ts
@@ -1,0 +1,15 @@
+/**
+ * Constants related to git and git configuration.
+ */
+
+// The minimum number of seconds that a customer can set the git timeout to. This prevents customers from setting it
+// too low, which could cause issues with the build process.
+export const MINIMUM_GIT_TIMEOUT_SECONDS = 1;
+
+// The default number of seconds that the git timeout is set to. This is used when no timeout is specified by the
+// customer.
+export const DEFAULT_GIT_TIMEOUT_SECONDS = 20;
+
+// Default timeout for git commands that are not necessary for the build to succeed. Please note that, unlike the
+// previous constant, this timeout is in MILLISECONDS.
+export const DEFAULT_METADATA_GIT_TIMEOUT_MILLISECONDS = 5000;

--- a/node-src/git/execGit.test.ts
+++ b/node-src/git/execGit.test.ts
@@ -3,6 +3,7 @@ import { PassThrough, Transform } from 'node:stream';
 import { execa as execaDefault } from 'execa';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import * as shell from '../lib/shell/shell';
 import TestLogger from '../lib/testLogger';
 import gitNoCommits from '../ui/messages/errors/gitNoCommits';
 import gitNotInitialized from '../ui/messages/errors/gitNotInitialized';
@@ -21,7 +22,7 @@ vi.mock('execa', async (importOriginal) => {
 });
 
 beforeEach(() => {
-  vi.clearAllMocks();
+  vi.restoreAllMocks();
 });
 
 describe('execGitCommand', () => {
@@ -69,6 +70,36 @@ describe('execGitCommand', () => {
     execa.mockRejectedValue(new Error('something random'));
     await expect(execGitCommand(ctx, 'some command')).rejects.toThrow('something random');
   });
+
+  it('uses a default timeout of 20 seconds when none is specified', async () => {
+    const runCommand = vi
+      .spyOn(shell, 'runCommand')
+      .mockReturnValue(Promise.resolve({ all: Buffer.from('output') }) as any);
+
+    await execGitCommand(ctx, 'some command');
+
+    expect(runCommand).toHaveBeenCalledWith(
+      'some command',
+      expect.objectContaining({ timeout: 20_000 })
+    );
+  });
+
+  it('overrides the default timeout when a custom one is provided', async () => {
+    const runCommand = vi
+      .spyOn(shell, 'runCommand')
+      .mockReturnValue(Promise.resolve({ all: Buffer.from('output') }) as any);
+
+    await execGitCommand(ctx, 'some command', { timeout: 60_000 });
+
+    expect(runCommand).toHaveBeenCalledWith(
+      'some command',
+      expect.objectContaining({ timeout: 60_000 })
+    );
+    expect(runCommand).not.toHaveBeenCalledWith(
+      'some command',
+      expect.objectContaining({ timeout: 20_000 })
+    );
+  });
 });
 
 function createExecaStreamer() {
@@ -113,7 +144,7 @@ describe('execGitCommandOneLine', () => {
     expect(await promise).toEqual('First line');
   });
 
-  it('Return an error if the command has no ouput', async () => {
+  it('Return an error if the command has no output', async () => {
     const streamer = createExecaStreamer();
     execa.mockReturnValue(streamer as any);
 

--- a/node-src/git/execGit.ts
+++ b/node-src/git/execGit.ts
@@ -7,32 +7,47 @@ import { Deps } from '../types';
 import gitNoCommits from '../ui/messages/errors/gitNoCommits';
 import gitNotInitialized from '../ui/messages/errors/gitNotInitialized';
 import gitNotInstalled from '../ui/messages/errors/gitNotInstalled';
+import { DEFAULT_GIT_TIMEOUT_SECONDS } from './constants';
+
+export type GitDeps = Pick<Deps, 'log'> & { options?: { gitTimeout?: number } };
 
 const defaultOptions: Options = {
   env: { LANG: 'C', LC_ALL: 'C' }, // make sure we're speaking English
-  timeout: 20_000, // 20 seconds
   all: true, // interleave stdout and stderr
   shell: true, // we'll deal with escaping ourselves (for now)
 };
 
 /**
+ * Retrieve the git timeout in milliseconds.
+ *
+ * @param depOptions The options object for the Git command (this contains the `gitTimeout` property if it's set).
+ *
+ @returns the git timeout in milliseconds, defaulting to `DEFAULT_GIT_TIMEOUT_SECONDS` if not set.
+ */
+function getGitTimeout(depOptions: GitDeps['options']): number {
+  return depOptions?.gitTimeout ?? DEFAULT_GIT_TIMEOUT_SECONDS * 1000;
+}
+
+/**
  * Execute a Git command in the local terminal.
  *
- * @param context Standard context object.
- * @param context.log Standard context logger.
+ * @param deps Standard context object.
+ * @param deps.log Standard context logger.
+ * @param deps.options Options object for the Git command.
  * @param command The command to execute.
  * @param options Execa options
  *
  * @returns The result of the command from the terminal.
  */
 export async function execGitCommand(
-  { log }: Pick<Deps, 'log'>,
+  { log, options: depOptions }: GitDeps,
   command: string,
   options?: Options
 ) {
   try {
     log.debug(`execGitCommand: ${command}`);
-    const { all, stdout } = await runCommand(command, { ...defaultOptions, ...options });
+    const timeout = getGitTimeout(depOptions);
+    const { all, stdout } = await runCommand(command, { timeout, ...defaultOptions, ...options });
     // If the caller sets `all: false`, then `stdout` will be the output. Otherwise, `all` will
     // contain interleaved stdout and stderr.
     const output = all ?? stdout;
@@ -68,20 +83,23 @@ export async function execGitCommand(
 /**
  * Execute a Git command in the local terminal and just get the first line.
  *
- * @param context Standard context object.
- * @param context.log Standard context logger.
+ * @param deps Standard context object.
+ * @param deps.log Standard context logger.
+ * @param deps.options Options object for the Git command.
  * @param command The command to execute.
  * @param options Execa options
  *
  * @returns The first line of the command from the terminal.
  */
 export async function execGitCommandOneLine(
-  { log }: Pick<Deps, 'log'>,
+  { log, options: depOptions }: GitDeps,
   command: string,
   options?: Options
 ) {
   log.debug(`execGitCommandOneLine: ${command}`);
+  const timeout = getGitTimeout(depOptions);
   const process = runCommand(command, {
+    timeout,
     ...defaultOptions,
     buffer: false,
     ...options,
@@ -114,20 +132,23 @@ export async function execGitCommandOneLine(
 /**
  * Execute a Git command in the local terminal and count the lines in the result
  *
- * @param context Standard context object.
- * @param context.log Standard context logger.
+ * @param deps Standard context object.
+ * @param deps.log Standard context logger.
+ * @param deps.options Options object for the Git command.
  * @param command The command to execute.
  * @param options Execa options
  *
  * @returns The number of lines the command returned
  */
 export async function execGitCommandCountLines(
-  { log }: Pick<Deps, 'log'>,
+  { log, options: depOptions }: GitDeps,
   command: string,
   options?: Options
 ) {
   log.debug(`execGitCommandCountLines: ${command}`);
+  const timeout = getGitTimeout(depOptions);
   const process = runCommand(command, {
+    timeout,
     ...defaultOptions,
     buffer: false,
     ...options,

--- a/node-src/git/getCommitAndBranch.ts
+++ b/node-src/git/getCommitAndBranch.ts
@@ -1,6 +1,5 @@
 import envCi from 'env-ci';
 
-import { Deps } from '../types';
 import forksUnsupported from '../ui/messages/errors/forksUnsupported';
 import gitOneCommit from '../ui/messages/errors/gitOneCommit';
 import missingGitHubInfo from '../ui/messages/errors/missingGitHubInfo';
@@ -8,6 +7,7 @@ import missingTravisInfo from '../ui/messages/errors/missingTravisInfo';
 import customGitHubAction from '../ui/messages/info/customGitHubAction';
 import noCommitDetails from '../ui/messages/warnings/noCommitDetails';
 import travisInternalBuild from '../ui/messages/warnings/travisInternalBuild';
+import { GitDeps } from './execGit';
 import { getBranch, getCommit, hasPreviousCommit } from './git';
 
 const ORIGIN_PREFIX_REGEXP = /^origin\//;
@@ -44,7 +44,7 @@ function getBranchDetailsFromEnvironmentCI(log) {
 // TODO: refactor this function
 // eslint-disable-next-line complexity, max-statements
 export default async function getCommitAndBranch(
-  deps: Pick<Deps, 'log'>,
+  deps: GitDeps,
   {
     branchName,
     patchBaseRef,

--- a/node-src/git/getParentCommits.ts
+++ b/node-src/git/getParentCommits.ts
@@ -2,7 +2,7 @@ import gql from 'fake-tag';
 
 import { localBuildsSpecifier } from '../lib/localBuildsSpecifier';
 import { Deps, Git } from '../types';
-import { execGitCommand } from './execGit';
+import { execGitCommand, GitDeps } from './execGit';
 import { commitExists } from './git';
 
 export const FETCH_N_INITIAL_BUILD_COMMITS = 20;
@@ -89,7 +89,7 @@ function commitsForCLI(commits: string[]) {
 // `commitsWithBuilds`.
 //
 async function nextCommits(
-  deps: Pick<Deps, 'log'>,
+  deps: Pick<Deps, 'options' | 'log'>,
   limit: number,
   {
     firstCommittedAtSeconds,
@@ -144,11 +144,15 @@ async function step(
   log.debug(`step: commitsWithBuilds: ${commitsWithBuilds}`);
   log.debug(`step: commitsWithoutBuilds: ${commitsWithoutBuilds}`);
 
-  const { candidateCommits, visitedCommitsWithoutBuilds } = await nextCommits({ log }, limit, {
-    firstCommittedAtSeconds,
-    commitsWithBuilds,
-    commitsWithoutBuilds,
-  });
+  const { candidateCommits, visitedCommitsWithoutBuilds } = await nextCommits(
+    { options, log },
+    limit,
+    {
+      firstCommittedAtSeconds,
+      commitsWithBuilds,
+      commitsWithoutBuilds,
+    }
+  );
 
   log.debug(
     `step: candidateCommits: ${candidateCommits}, visitedCommitsWithoutBuilds: ${visitedCommitsWithoutBuilds}`
@@ -181,7 +185,7 @@ async function step(
 
 // Which of the listed commits are "maximally descendent":
 // ie c in commits such that there are no descendents of c in commits.
-async function maximallyDescendentCommits(deps: Pick<Deps, 'log'>, commits: string[]) {
+async function maximallyDescendentCommits(deps: GitDeps, commits: string[]) {
   if (commits.length === 0) {
     return commits;
   }

--- a/node-src/git/git.test.ts
+++ b/node-src/git/git.test.ts
@@ -10,7 +10,7 @@ import {
   getBranch,
   getCommit,
   getCommittedFileCount,
-  getNumberOfComitters,
+  getNumberOfCommitters,
   getRepositoryCreationDate,
   getSlug,
   getStorybookCreationDate,
@@ -238,7 +238,7 @@ describe('getStorybookCreationDate', () => {
 describe('getNumberOfComitters', () => {
   it('parses the count successfully', async () => {
     execGitCommandCountLines.mockResolvedValue(17);
-    expect(await getNumberOfComitters(ctx)).toEqual(17);
+    expect(await getNumberOfCommitters(ctx)).toEqual(17);
   });
 });
 

--- a/node-src/git/git.ts
+++ b/node-src/git/git.ts
@@ -5,8 +5,13 @@ import path from 'path';
 import { file as temporaryFile } from 'tmp-promise';
 
 import { BaselineCheckoutFailedError } from '../lib/turbosnap/errors';
-import { Deps } from '../types';
-import { execGitCommand, execGitCommandCountLines, execGitCommandOneLine } from './execGit';
+import { DEFAULT_METADATA_GIT_TIMEOUT_MILLISECONDS } from './constants';
+import {
+  execGitCommand,
+  execGitCommandCountLines,
+  execGitCommandOneLine,
+  GitDeps,
+} from './execGit';
 
 const newline = /\r\n|\r|\n/; // Git may return \n even on Windows, so we can't use EOL
 export const NULL_BYTE = '\0'; // Separator used when running `git ls-files` with `-z`
@@ -18,7 +23,7 @@ export const NULL_BYTE = '\0'; // Separator used when running `git ls-files` wit
  *
  * @returns The Git version.
  */
-export async function getVersion(deps: Pick<Deps, 'log'>) {
+export async function getVersion(deps: GitDeps) {
   const result = await execGitCommand(deps, `git --version`);
   return result?.replace('git version ', '').replace(/\s*\(.*\)/, '');
 }
@@ -30,7 +35,7 @@ export async function getVersion(deps: Pick<Deps, 'log'>) {
  *
  * @returns The user's email.
  */
-export async function getUserEmail(deps: Pick<Deps, 'log'>) {
+export async function getUserEmail(deps: GitDeps) {
   return execGitCommand(deps, `git config user.email`);
 }
 
@@ -43,7 +48,7 @@ export async function getUserEmail(deps: Pick<Deps, 'log'>) {
  *
  * @returns The slug of the remote URL.
  */
-export async function getSlug(deps: Pick<Deps, 'log'>) {
+export async function getSlug(deps: GitDeps) {
   const result = await execGitCommand(deps, `git config --get remote.origin.url`);
   const downcasedResult = result?.toLowerCase() || '';
   const [, slug] = downcasedResult.match(/([^/:]+\/[^/]+?)(\.git)?$/) || [];
@@ -62,7 +67,7 @@ export async function getSlug(deps: Pick<Deps, 'log'>) {
  *
  * @returns Commit details from Git.
  */
-export async function getCommit(deps: Pick<Deps, 'log'>, revision = '') {
+export async function getCommit(deps: GitDeps, revision = '') {
   const result = await execGitCommand(
     deps,
     // Technically this yields the author info, not committer info
@@ -85,7 +90,7 @@ export async function getCommit(deps: Pick<Deps, 'log'>, revision = '') {
  *
  * @returns The branch name from Git.
  */
-export async function getBranch(deps: Pick<Deps, 'log'>) {
+export async function getBranch(deps: GitDeps) {
   try {
     // Git v2.22 and above
     // Yields an empty string when in detached HEAD state
@@ -115,7 +120,7 @@ export async function getBranch(deps: Pick<Deps, 'log'>) {
  *
  * @returns The uncommited hash, if available.
  */
-export async function getUncommittedHash(deps: Pick<Deps, 'log'>) {
+export async function getUncommittedHash(deps: GitDeps) {
   const listStagedFiles = 'git diff --name-only --no-relative --diff-filter=d --cached';
   const listUnstagedFiles = 'git diff --name-only --no-relative --diff-filter=d';
   const listUntrackedFiles = 'git ls-files --others --exclude-standard';
@@ -164,7 +169,7 @@ export async function getUncommittedHash(deps: Pick<Deps, 'log'>) {
  *
  * @returns True if the current commit has at least one parent.
  */
-export async function hasPreviousCommit(deps: Pick<Deps, 'log'>) {
+export async function hasPreviousCommit(deps: GitDeps) {
   const result = await execGitCommand(deps, `git --no-pager log -n 1 --skip=1 --format="%H"`);
 
   // Ignore lines that don't match the expected format (e.g. gpg signature info)
@@ -180,7 +185,7 @@ export async function hasPreviousCommit(deps: Pick<Deps, 'log'>) {
  *
  * @returns True if the commit exists.
  */
-export async function commitExists(deps: Pick<Deps, 'log'>, commit: string) {
+export async function commitExists(deps: GitDeps, commit: string) {
   try {
     await execGitCommand(deps, `git cat-file -e "${commit}^{commit}"`);
     return true;
@@ -198,11 +203,7 @@ export async function commitExists(deps: Pick<Deps, 'log'>, commit: string) {
  *
  * @returns The list of changed files of a single commit or between two commits.
  */
-export async function getChangedFiles(
-  deps: Pick<Deps, 'log'>,
-  baseCommit: string,
-  headCommit = ''
-) {
+export async function getChangedFiles(deps: GitDeps, baseCommit: string, headCommit = '') {
   // Note that an empty headCommit will include uncommitted (staged or unstaged) changes.
   const files = await execGitCommand(
     deps,
@@ -219,7 +220,7 @@ export async function getChangedFiles(
  *
  * @returns True if the workspace is up-to-date.
  */
-export async function isUpToDate(deps: Pick<Deps, 'log'>) {
+export async function isUpToDate(deps: GitDeps) {
   const { log } = deps;
 
   try {
@@ -257,7 +258,7 @@ export async function isUpToDate(deps: Pick<Deps, 'log'>) {
  *
  * @returns True if the workspace has no changes.
  */
-export async function isClean(deps: Pick<Deps, 'log'>) {
+export async function isClean(deps: GitDeps) {
   const status = await execGitCommand(deps, 'git status --porcelain');
   return status === '';
 }
@@ -270,7 +271,7 @@ export async function isClean(deps: Pick<Deps, 'log'>) {
  *
  * @returns A message indicating how far behind the branch is from the remote.
  */
-export async function getUpdateMessage(deps: Pick<Deps, 'log'>) {
+export async function getUpdateMessage(deps: GitDeps) {
   const status = await execGitCommand(deps, 'git status');
   return status
     ?.split(/(\r\n|\r|\n){2}/)[0] // drop the 'nothing to commit' part
@@ -313,11 +314,7 @@ export async function getUpdateMessage(deps: Pick<Deps, 'log'>) {
  *
  * @returns The best common ancestor commit between the two provided.
  */
-export async function findMergeBase(
-  deps: Pick<Deps, 'log'>,
-  headReference: string,
-  baseReference: string
-) {
+export async function findMergeBase(deps: GitDeps, headReference: string, baseReference: string) {
   const result = await execGitCommand(
     deps,
     `git merge-base --all ${headReference} ${baseReference}`
@@ -349,7 +346,7 @@ export async function findMergeBase(
  *
  * @returns The result of the Git checkout call in the terminal.
  */
-export async function checkout(deps: Pick<Deps, 'log'>, reference: string) {
+export async function checkout(deps: GitDeps, reference: string) {
   return execGitCommand(deps, `git checkout ${reference}`);
 }
 
@@ -367,7 +364,7 @@ const limitConcurrency = pLimit(10);
  * @returns The temporary file path of the checked out file.
  */
 export async function checkoutFile(
-  deps: Pick<Deps, 'log'>,
+  deps: GitDeps,
   reference: string,
   fileName: string,
   tmpdir: string
@@ -398,7 +395,7 @@ export async function checkoutFile(
  *
  * @returns The result of the `git checkout` command in the terminal.
  */
-export async function checkoutPrevious(deps: Pick<Deps, 'log'>) {
+export async function checkoutPrevious(deps: GitDeps) {
   return execGitCommand(deps, `git checkout -`);
 }
 
@@ -409,7 +406,7 @@ export async function checkoutPrevious(deps: Pick<Deps, 'log'>) {
  *
  * @returns The result of the `git reset` command in the terminal.
  */
-export async function discardChanges(deps: Pick<Deps, 'log'>) {
+export async function discardChanges(deps: GitDeps) {
   return execGitCommand(deps, `git reset --hard`);
 }
 
@@ -420,7 +417,7 @@ export async function discardChanges(deps: Pick<Deps, 'log'>) {
  *
  * @returns The root directory of the Git repository.
  */
-export async function getRepositoryRoot(deps: Pick<Deps, 'log'>) {
+export async function getRepositoryRoot(deps: GitDeps) {
   return execGitCommand(deps, `git rev-parse --show-toplevel`);
 }
 
@@ -434,7 +431,7 @@ export async function getRepositoryRoot(deps: Pick<Deps, 'log'>) {
  * @returns A list of files matching the pattern.
  */
 export async function findFilesFromRepositoryRoot(
-  deps: Pick<Deps, 'log'>,
+  deps: GitDeps,
   repoRoot: string,
   ...patterns: string[]
 ) {
@@ -457,15 +454,21 @@ export async function findFilesFromRepositoryRoot(
  *
  * @param deps Function dependencies.
  *
- * @returns Date The date the repository was created
+ *  NOTE: This function is not necessary for the build. It provides metadata to the build, and will return `undefined`
+ *       if the command fails or times out.
+ *
+ * @returns Date The date the repository was created, or `undefined` if the command fails or times out.
  */
-export async function getRepositoryCreationDate(deps: Pick<Deps, 'log'>) {
+export async function getRepositoryCreationDate(deps: GitDeps) {
   try {
     const dateString = await execGitCommandOneLine(
       deps,
       `git log --reverse --format=%cd --date=iso`,
       {
-        timeout: 5000,
+        timeout: Math.min(
+          deps?.options?.gitTimeout ?? DEFAULT_METADATA_GIT_TIMEOUT_MILLISECONDS,
+          DEFAULT_METADATA_GIT_TIMEOUT_MILLISECONDS
+        ),
       }
     );
 
@@ -482,21 +485,25 @@ export async function getRepositoryCreationDate(deps: Pick<Deps, 'log'>) {
  * @param deps.options Object standard context options
  * @param deps.options.storybookConfigDir Configured Storybook config dir, if set
  *
- * @returns Date The date the storybook was added
+ *  NOTE: This function is not necessary for the build. It provides metadata to the build, and will return `undefined`
+ *       if the command fails or times out.
+ *
+ * @returns Date The date the storybook was added, or `undefined` if the command fails or times out.
  */
 export async function getStorybookCreationDate(
-  deps: Pick<Deps, 'log'> & {
-    options: {
-      storybookConfigDir?: Deps['options']['storybookConfigDir'];
-    };
-  }
+  deps: GitDeps & { options?: { storybookConfigDir?: string } }
 ) {
   try {
-    const configDirectory = deps.options.storybookConfigDir ?? '.storybook';
+    const configDirectory = deps.options?.storybookConfigDir ?? '.storybook';
     const dateString = await execGitCommandOneLine(
       deps,
       `git log --follow --reverse --format=%cd --date=iso -- ${configDirectory}`,
-      { timeout: 5000 }
+      {
+        timeout: Math.min(
+          deps?.options?.gitTimeout ?? DEFAULT_METADATA_GIT_TIMEOUT_MILLISECONDS,
+          DEFAULT_METADATA_GIT_TIMEOUT_MILLISECONDS
+        ),
+      }
     );
     return new Date(dateString);
   } catch {
@@ -509,12 +516,20 @@ export async function getStorybookCreationDate(
  *
  * @param deps Function dependencies.
  *
- * @returns number The number of committers
+ *  NOTE: This function is not necessary for the build. It provides metadata to the build, and will return `undefined`
+ *       if the command fails or times out.
+ *
+ * @returns number The number of committers, or `undefined` if the command fails or times out.
  */
-export async function getNumberOfComitters(deps: Pick<Deps, 'log'>) {
+export async function getNumberOfCommitters(deps: GitDeps) {
   try {
+    // Note that this timeout is explicitly less than the default because this command is not necessary and was
+    // previously causing builds to fail collecting metadata.
     return await execGitCommandCountLines(deps, `git shortlog -sn --all --since="6 months ago"`, {
-      timeout: 5000,
+      timeout: Math.min(
+        deps?.options?.gitTimeout ?? DEFAULT_METADATA_GIT_TIMEOUT_MILLISECONDS,
+        DEFAULT_METADATA_GIT_TIMEOUT_MILLISECONDS
+      ),
     });
   } catch {
     return undefined;
@@ -528,10 +543,13 @@ export async function getNumberOfComitters(deps: Pick<Deps, 'log'>) {
  * @param nameMatches The names to match - will be matched with upper and lowercase first letter
  * @param extensions The filetypes to match
  *
- * @returns The number of files matching the above
+ * NOTE: This function is not necessary for the build. It provides metadata to the build, and will return `undefined`
+ *       if the command fails or times out.
+ *
+ * @returns The number of files matching the above, or `undefined` if the command fails
  */
 export async function getCommittedFileCount(
-  deps: Pick<Deps, 'log'>,
+  deps: GitDeps,
   nameMatches: string[],
   extensions: string[]
 ) {
@@ -544,9 +562,13 @@ export async function getCommittedFileCount(
     const globs = bothCasesNameMatches.flatMap((match) =>
       extensions.map((extension) => `"*${match}*.${extension}"`)
     );
-
+    // Note that this timeout is explicitly less than the default because this command is not necessary and was
+    // previously causing builds to fail collecting metadata.
     return await execGitCommandCountLines(deps, `git ls-files -- ${globs.join(' ')}`, {
-      timeout: 5000,
+      timeout: Math.min(
+        deps?.options?.gitTimeout ?? DEFAULT_METADATA_GIT_TIMEOUT_MILLISECONDS,
+        DEFAULT_METADATA_GIT_TIMEOUT_MILLISECONDS
+      ),
     });
   } catch {
     return undefined;

--- a/node-src/lib/getConfiguration.test.ts
+++ b/node-src/lib/getConfiguration.test.ts
@@ -390,4 +390,22 @@ describe('reactNative config', () => {
     const config = await getConfiguration();
     expect(config.reactNative).toBeUndefined();
   });
+
+  it('accepts a configuration containing a gitTimeout', async () => {
+    mockedReadFile.mockReturnValue(
+      JSON.stringify({
+        gitTimeout: 30,
+      })
+    );
+
+    const config = await getConfiguration();
+    expect(config.gitTimeout).toBe(30);
+  });
+
+  it('leaves gitTimeout undefined when not specified in config', async () => {
+    mockedReadFile.mockReturnValue(JSON.stringify({ projectId: 'project-id' }));
+
+    const config = await getConfiguration();
+    expect(config.gitTimeout).toBeUndefined();
+  });
 });

--- a/node-src/lib/getConfiguration.ts
+++ b/node-src/lib/getConfiguration.ts
@@ -2,6 +2,7 @@ import { existsSync, readFileSync } from 'fs';
 import JSON5 from 'json5';
 import { z, ZodError } from 'zod';
 
+import { MINIMUM_GIT_TIMEOUT_SECONDS } from '../git/constants';
 import { invalidConfigurationFile } from '../ui/messages/errors/invalidConfigurationFile';
 import { missingConfigurationFile } from '../ui/messages/errors/missingConfigurationFile';
 import { unparseableConfigurationFile } from '../ui/messages/errors/unparseableConfigurationFile';
@@ -28,6 +29,7 @@ const configurationSchema = z
     exitZeroOnChanges: z.union([z.string(), z.boolean()]),
     exitOnceUploaded: z.union([z.string(), z.boolean()]),
     ignoreLastBuildOnBranch: z.string(),
+    gitTimeout: z.number().min(MINIMUM_GIT_TIMEOUT_SECONDS).optional(),
 
     buildScriptName: z.string(),
     buildCommand: z.string(),
@@ -76,7 +78,7 @@ function resolveConfigFileName(configFile?: string): string {
  * @param configFile The path to a custom config file (outside of the normal chromatic.config.json
  * file)
  *
- * @returns A parsed configration object from the local config file.
+ * @returns A parsed configuration object from the local config file.
  */
 export async function getConfiguration(
   configFile?: string

--- a/node-src/lib/shell/treeKill.test.ts
+++ b/node-src/lib/shell/treeKill.test.ts
@@ -16,7 +16,7 @@ function pidIsAlive(pid: number) {
  * Spawns a Node parent process that itself spawns a `sleep 60` child.
  * Returns handles to both so we can assert on their lifecycle independently.
  *
- * @returns
+ * @returns Handles to the parent process and its child's PID.
  */
 function spawnTree(): Promise<{ parent: ChildProcess; childPid: number }> {
   return new Promise((resolve, reject) => {

--- a/node-src/tasks/gitInfo.test.ts
+++ b/node-src/tasks/gitInfo.test.ts
@@ -49,7 +49,7 @@ const getUserEmail = vi.mocked(git.getUserEmail);
 const getRepositoryCreationDate = vi.mocked(git.getRepositoryCreationDate);
 const getRepositoryRoot = vi.mocked(git.getRepositoryRoot);
 const getStorybookCreationDate = vi.mocked(git.getStorybookCreationDate);
-const getNumberOfComitters = vi.mocked(git.getNumberOfComitters);
+const getNumberOfCommitters = vi.mocked(git.getNumberOfCommitters);
 const getCommittedFileCount = vi.mocked(git.getCommittedFileCount);
 const getUncommittedHash = vi.mocked(git.getUncommittedHash);
 const getBaselineBuilds = vi.mocked(getBaselineBuildsUnmocked);
@@ -103,7 +103,7 @@ beforeEach(() => {
   getRepositoryCreationDate.mockResolvedValue(new Date('2024-11-01'));
   getRepositoryRoot.mockResolvedValue('/path/to/project');
   getStorybookCreationDate.mockResolvedValue(new Date('2025-11-01'));
-  getNumberOfComitters.mockResolvedValue(17);
+  getNumberOfCommitters.mockResolvedValue(17);
   getCommittedFileCount.mockResolvedValue(100);
   getHasRouter.mockReturnValue(true);
 

--- a/node-src/tasks/gitInfo.ts
+++ b/node-src/tasks/gitInfo.ts
@@ -6,7 +6,7 @@ import getCommitAndBranch from '../git/getCommitAndBranch';
 import { getParentCommits } from '../git/getParentCommits';
 import {
   getCommittedFileCount,
-  getNumberOfComitters,
+  getNumberOfCommitters,
   getRepositoryCreationDate,
   getRepositoryRoot,
   getSlug,
@@ -157,23 +157,23 @@ export async function gatherGitInfo(
     onSkippingBuild,
   } = input;
 
-  const version = await getVersion({ log });
+  const version = await getVersion({ log, options });
   const commitAndBranchInfo = await getCommitAndBranch(
-    { log },
+    { log, options },
     { branchName, patchBaseRef, ci: fromCI }
   );
 
   const git: Git = {
     version,
-    gitUserEmail: await getUserEmail({ log }).catch((err) => {
+    gitUserEmail: await getUserEmail({ log, options }).catch((err) => {
       log.debug('Failed to retrieve Git user email', err);
       return undefined;
     }),
-    uncommittedHash: await getUncommittedHash({ log }).catch((err) => {
+    uncommittedHash: await getUncommittedHash({ log, options }).catch((err) => {
       log.warn('Failed to retrieve uncommitted files hash', err);
       return undefined;
     }),
-    rootPath: await getRepositoryRoot({ log }),
+    rootPath: await getRepositoryRoot({ log, options }),
     ...commitAndBranchInfo,
   };
 
@@ -181,11 +181,11 @@ export async function gatherGitInfo(
   try {
     projectMetadata = {
       hasRouter: getHasRouter(packageJson),
-      creationDate: await getRepositoryCreationDate({ log }),
+      creationDate: await getRepositoryCreationDate({ log, options }),
       storybookCreationDate: await getStorybookCreationDate({ log, options }),
-      numberOfCommitters: await getNumberOfComitters({ log }),
+      numberOfCommitters: await getNumberOfCommitters({ log, options }),
       numberOfAppFiles: await getCommittedFileCount(
-        { log },
+        { log, options },
         ['page', 'screen'],
         ['js', 'jsx', 'ts', 'tsx']
       ),
@@ -200,7 +200,7 @@ export async function gatherGitInfo(
 
   if (!git.slug) {
     try {
-      git.slug = await getSlug({ log });
+      git.slug = await getSlug({ log, options });
     } catch (err) {
       log.debug('Failed to retrieve Git repository slug', err);
     }


### PR DESCRIPTION
This adds a configuration parameter that controls the time for a git timeout, in seconds. This is translated through to the git shell command as milliseconds (if set), and defaults to the original 20_000 if unset.

Fixes CAP-4554.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>17.4.0--canary.1371.27027417409.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@17.4.0--canary.1371.27027417409.0
  # or 
  yarn add chromatic@17.4.0--canary.1371.27027417409.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
