### PR TITLE
:robot: Propagate node configuration in order to fix CI smoketests.

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -14,6 +14,7 @@ const config: StorybookConfig = {
   viteFinal: async (config) => {
     config.resolve = {
       ...config.resolve,
+      conditions: ['node'],
       alias: {
         ...config.resolve?.alias,
         os: fileURLToPath(import.meta.resolve('os-browserify/browser')),

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -14,6 +14,7 @@ export default defineConfig((options) => [
     clean: true,
     platform: 'node',
     target: 'node20', // Lowest supported Node version
+    conditions: ['node'],
     env: {
       SENTRY_ENVIRONMENT: process.env.CI ? 'production' : 'development',
       SENTRY_RELEASE: process.env.SENTRY_RELEASE || 'development',
@@ -34,6 +35,7 @@ export default defineConfig((options) => [
     clean: true,
     platform: 'node',
     target: 'node20', // Lowest supported Node version
+    conditions: ['node'],
     external: ['semver'],
     env: {
       SENTRY_ENVIRONMENT: process.env.CI ? 'production' : 'development',


### PR DESCRIPTION
We use `unicorn-magic` as a transitive dependency. However, it has two different build configurations: `node` and `default`. Even though we specify `platform: node`, this isn't getting transferred down to our dependency configurations, and thus it causes an error with unknown imports when run in CI.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>17.2.1--canary.1372.26902877224.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@17.2.1--canary.1372.26902877224.0
  # or 
  yarn add chromatic@17.2.1--canary.1372.26902877224.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
