### PR TITLE
Drop `slash` dependency for internal helper

### DIFF
--- a/node-src/tasks/prepare/validateFiles.ts
+++ b/node-src/tasks/prepare/validateFiles.ts
@@ -1,7 +1,7 @@
 import { readdirSync, readFileSync, statSync } from 'fs';
 import path from 'path';
-import slash from 'slash';
 
+import { posix } from '../../lib/posix';
 import { Context } from '../../types';
 import deviatingOutputDirectory from '../../ui/messages/warnings/deviatingOutputDirectory';
 import { invalid, invalidReactNative } from '../../ui/tasks/prepare';
@@ -76,7 +76,7 @@ function getOutputDirectory(buildLog: string) {
 function getFileInfo(ctx: Context, sourceDirectory: string) {
   const lengths = getPathSpecsInDirectory(ctx, sourceDirectory).map((o) => ({
     ...o,
-    knownAs: slash(o.pathname),
+    knownAs: posix(o.pathname),
   }));
   const total = lengths.map(({ contentLength }) => contentLength).reduce((a, b) => a + b, 0);
   const paths: string[] = [];

--- a/package.json
+++ b/package.json
@@ -203,7 +203,6 @@
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "read-package-up": "^11.0.0",
-    "slash": "^3.0.0",
     "snyk-nodejs-lockfile-parser": "^1.58.18",
     "snyk-nodejs-plugin": "^1.4.3",
     "sort-package-json": "1.50.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5137,7 +5137,6 @@ __metadata:
     react-dom: "npm:^17.0.2"
     read-package-up: "npm:^11.0.0"
     semver: "npm:^7.3.5"
-    slash: "npm:^3.0.0"
     snyk-nodejs-lockfile-parser: "npm:^1.58.18"
     snyk-nodejs-plugin: "npm:^1.4.3"
     sort-package-json: "npm:1.50.0"


### PR DESCRIPTION
Related to https://github.com/chromaui/chromatic-cli/pull/1368

We got a dependabot PR for bumping `slash`. Looking around, we actually already have an internal helper that already does what `slash` does. Instead of upgrading, we can just drop it entirely.

> [!NOTE]
> This may not close the dependabot PR because it might be a transitive dependency.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>17.2.1--canary.1374.26915613665.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@17.2.1--canary.1374.26915613665.0
  # or 
  yarn add chromatic@17.2.1--canary.1374.26915613665.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
