### PR TITLE
POC for turboskipping a build

### DIFF
--- a/node-src/tasks/verify/publishBuild.ts
+++ b/node-src/tasks/verify/publishBuild.ts
@@ -1,6 +1,6 @@
 import { exitCodes, setExitCode } from '../../lib/setExitCode';
 import { Context } from '../../types';
-import { publishFailed, publishSkipped } from '../../ui/tasks/verify';
+import { publishFailed } from '../../ui/tasks/verify';
 
 const PublishBuildMutation = `
   mutation PublishBuildMutation($id: ID!, $input: PublishBuildInput!) {

--- a/node-src/tasks/verify/publishBuild.ts
+++ b/node-src/tasks/verify/publishBuild.ts
@@ -1,6 +1,6 @@
 import { exitCodes, setExitCode } from '../../lib/setExitCode';
 import { Context } from '../../types';
-import { publishFailed } from '../../ui/tasks/verify';
+import { publishFailed, publishSkipped } from '../../ui/tasks/verify';
 
 const PublishBuildMutation = `
   mutation PublishBuildMutation($id: ID!, $input: PublishBuildInput!) {
@@ -56,5 +56,9 @@ export const publishBuild = async (ctx: Context) => {
   if (publishedBuild.status === 'FAILED') {
     setExitCode(ctx, exitCodes.BUILD_FAILED, false);
     throw new Error(publishFailed(ctx).output);
+  }
+
+  if (publishedBuild.status === 'SKIPPED') {
+    ctx.skip = true;
   }
 };

--- a/node-src/tasks/verify/verifyBuild.ts
+++ b/node-src/tasks/verify/verifyBuild.ts
@@ -122,6 +122,10 @@ export const verifyBuild = async (ctx: Context, task: Task) => {
   // It's not possible to set both --only-changed and --only-story-files and/or --only-story-names
   // onlyStoryFiles may be passed directly, or calculated via --only-changed
   if (onlyStoryFiles) {
+    if (onlyStoryFiles.length === 0) {
+      transitionTo(success, true)(ctx, task);
+      return;
+    }
     transitionTo(runOnlyFiles)(ctx, task);
   }
   if (onlyStoryNames) {

--- a/node-src/ui/tasks/verify.ts
+++ b/node-src/ui/tasks/verify.ts
@@ -27,6 +27,12 @@ export const publishFailed = (ctx: Context) => ({
   output: 'Failed to publish build',
 });
 
+export const publishSkipped = (ctx: Context) => ({
+  status: 'error',
+  title: `Verifying your ${buildType(ctx)}`,
+  output: 'Build skipped, not publishing',
+});
+
 export const runOnlyFiles = (ctx: Context) => ({
   status: 'pending',
   title: 'Starting partial build',


### PR DESCRIPTION
Super-basic CLI changes needed to get turboskipping POC to work on the backend. Mainly this just skips further CLI steps after publishing the build.


<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>17.2.1--canary.1375.26916509418.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@17.2.1--canary.1375.26916509418.0
  # or 
  yarn add chromatic@17.2.1--canary.1375.26916509418.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
