### PR TITLE
Implement logRenderer

### DIFF
--- a/node-src/lib/log.ts
+++ b/node-src/lib/log.ts
@@ -72,7 +72,7 @@ const createPrefixer =
   };
 
 type LogType = 'error' | 'warn' | 'info' | 'debug';
-type LogFunction = (...args: any[]) => void;
+export type LogFunction = (...args: any[]) => void;
 export interface Logger {
   error: LogFunction;
   warn: LogFunction;

--- a/node-src/renderer/engine/logRenderer/renderer.test.ts
+++ b/node-src/renderer/engine/logRenderer/renderer.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from 'vitest';
+
+import { logRenderer } from './renderer';
+
+/**
+ * Collects the lines passed to the injected `logFunction` so tests can assert on the exact
+ * log output the renderer would produce.
+ *
+ * @returns A `logFunction` sink plus the `lines` array it records into.
+ */
+function recordingLogFunction() {
+  const lines: string[] = [];
+  return { logFunction: (message: string) => lines.push(message), lines };
+}
+
+describe('logRenderer', () => {
+  it('emits the title then the output line on start', () => {
+    const { logFunction, lines } = recordingLogFunction();
+    const renderer = logRenderer(logFunction);
+
+    renderer.start({
+      status: 'pending',
+      title: 'Authenticating',
+      output: 'Connecting to Chromatic',
+    });
+
+    expect(lines).toEqual(['Authenticating', '    → Connecting to Chromatic']);
+  });
+
+  it('emits only the output line on update, not the title', () => {
+    const { logFunction, lines } = recordingLogFunction();
+    const renderer = logRenderer(logFunction);
+
+    renderer.update({ status: 'pending', title: 'Authenticating', output: 'Still working' });
+
+    expect(lines).toEqual(['    → Still working']);
+  });
+
+  it('emits the title then the output line on succeed', () => {
+    const { logFunction, lines } = recordingLogFunction();
+    const renderer = logRenderer(logFunction);
+
+    renderer.succeed({ status: 'success', title: 'Authenticated', output: 'Using token ****1234' });
+
+    expect(lines).toEqual(['Authenticated', '    → Using token ****1234']);
+  });
+
+  it('emits the title then the output line on fail', () => {
+    const { logFunction, lines } = recordingLogFunction();
+    const renderer = logRenderer(logFunction);
+
+    renderer.fail({ status: 'error', title: 'Authentication failed', output: 'invalid token' });
+
+    expect(lines).toEqual(['Authentication failed', '    → invalid token']);
+  });
+
+  it('emits only the title when there is no output', () => {
+    const { logFunction, lines } = recordingLogFunction();
+    const renderer = logRenderer(logFunction);
+
+    renderer.start({ status: 'pending', title: 'Authenticating' });
+
+    expect(lines).toEqual(['Authenticating']);
+  });
+
+  it('emits nothing on update when there is no output', () => {
+    const { logFunction, lines } = recordingLogFunction();
+    const renderer = logRenderer(logFunction);
+
+    renderer.update({ status: 'pending', title: 'Authenticating' });
+
+    expect(lines).toEqual([]);
+  });
+
+  it('dedupes consecutive identical output across hooks', () => {
+    const { logFunction, lines } = recordingLogFunction();
+    const renderer = logRenderer(logFunction);
+
+    // Note the first call is start, then two updates. But output is identical, so still deduped.
+    renderer.start({ status: 'pending', title: 'Uploading', output: 'Sending files' });
+    renderer.update({ status: 'pending', title: 'Uploading', output: 'Sending files' });
+    renderer.update({ status: 'pending', title: 'Uploading', output: 'Sending files' });
+
+    expect(lines).toEqual(['Uploading', '    → Sending files']);
+  });
+
+  it('re-emits output when it changes and again when it reverts', () => {
+    const { logFunction, lines } = recordingLogFunction();
+    const renderer = logRenderer(logFunction);
+
+    renderer.update({ status: 'pending', title: 'Uploading', output: 'A' });
+    renderer.update({ status: 'pending', title: 'Uploading', output: 'B' });
+    renderer.update({ status: 'pending', title: 'Uploading', output: 'A' });
+
+    expect(lines).toEqual(['    → A', '    → B', '    → A']);
+  });
+
+  it('passes multi-line output through as a single arrow-prefixed string', () => {
+    const { logFunction, lines } = recordingLogFunction();
+    const renderer = logRenderer(logFunction);
+
+    renderer.fail({ status: 'error', title: 'Failed', output: 'line one\nline two' });
+
+    expect(lines).toEqual(['Failed', '    → line one\nline two']);
+  });
+});

--- a/node-src/renderer/engine/logRenderer/renderer.ts
+++ b/node-src/renderer/engine/logRenderer/renderer.ts
@@ -1,0 +1,38 @@
+import { LogFunction } from '@cli/log';
+
+import { Task } from '../../../types';
+import { TaskRenderer } from '../index';
+
+/**
+ * Create a `TaskRenderer` that mirrors task UI state to a log via the injected `logFunction`
+ * (e.g. `ctx.log.info`, which also writes to the log file).
+ *
+ * `start`, `succeed`, and `fail` write the task title followed by its output line; `update` writes
+ * only the output line. Consecutive identical output is deduped to reduce spam, especially from
+ * a hot `update` loop.
+ *
+ * @param logFunction The log function (e.g. `ctx.log.info`) to append lines to.
+ *
+ * @returns A `TaskRenderer` that writes task title and output lines via the log function.
+ */
+export function logRenderer(logFunction: LogFunction): TaskRenderer {
+  let lastData: string | undefined;
+
+  const emitOutput = (state: Task) => {
+    if (!state.output || state.output === lastData) return;
+    lastData = state.output;
+    logFunction(`    → ${state.output}`);
+  };
+
+  const emitTitleAndOutput = (state: Task) => {
+    logFunction(state.title);
+    emitOutput(state);
+  };
+
+  return {
+    start: emitTitleAndOutput,
+    update: emitOutput,
+    succeed: emitTitleAndOutput,
+    fail: emitTitleAndOutput,
+  };
+}


### PR DESCRIPTION
# Description

This PR implements `logRenderer`, an implementation of the `TaskRenderer` interface for rendering tasks in the new `runTask` orchestration layer used by the Clack refactor. This renderer is responsible for 1) stdout logging when `ctx.interactive === false`, and 2) file logging when that feature is enabled.

This renderer naturally serves double duty for these two tasks by taking a `LogFunction` (typically `ctx.log.info`). Our logger, in `node-src/lib/log.ts`, is set up to pipe logs to a file when file logging is enabled, so `ctx.log.info` already does double duty for stdout and file logging.

# Manual QA

This isn't wired up currently, but I did some testing with a few patches. First, I applied this patch, which uses `logRenderer` with `ctx.log.info` as the auth task rendering engine:
```patch
diff --git a/node-src/renderer/auth.ts b/node-src/renderer/auth.ts
index de09a539..987772a0 100644
--- a/node-src/renderer/auth.ts
+++ b/node-src/renderer/auth.ts
@@ -2,7 +2,7 @@ import { applyAuthOutput, extractInput, runAuth } from '../tasks/auth';
 import { Context } from '../types';
 import { authenticated, authenticating } from '../ui/tasks/auth';
 import { runTask } from './engine';
-import { clackTaskLogRenderer } from './engine/clack/renderer';
+import { logRenderer } from './engine/logRenderer/renderer';
 
 /**
  * Render the auth task.
@@ -20,6 +20,6 @@ export async function renderAuth(ctx: Context): Promise<void> {
       run: runAuth,
       applyOutput: applyAuthOutput,
     },
-    clackTaskLogRenderer()
+    logRenderer(ctx.log.info)
   );
 }
```

Then I ran a build.
<img width="1768" height="1056" alt="CleanShot 2026-06-05 at 09 14 51@2x" src="https://github.com/user-attachments/assets/55ab39c7-cea3-4cbe-b214-1cec6af04828" />

This output is a little odd, but expected. When `ctx.interactive === true`, `ctx.log.info` calls are queued up and then flushed when the task pipeline finishes. So we get intro renders in Clack (intro is not migrated in this PR) -> auth task output, running through `logRenderer`'s` ctx.log.info`, gets queued up -> the rest of the Listr tasks run and print to stdout -> `ctx.log.info` gets flushed to stdout.

Next, I ran a build with `--no-interactive`.
<img width="1966" height="1468" alt="CleanShot 2026-06-05 at 10 16 20@2x" src="https://github.com/user-attachments/assets/1793f3c7-1cfe-4fec-ab19-37fe26c07db0" />

This output is more typical. Since `ctx.interactive === false`, the log isn't queued, and the auth output shows up right away.

I then ran two more builds (with and without `--no-interactive`) with `--log-file`. In both cases, the stdout was the same as the above, and file logging worked as expected. Here's the head of one of the log files:
```
10:18:34.028 ⚠ Unsupported Node.js version
             You are running Node.js v20.14.0, but Chromatic supports >=22.0.0.
             Chromatic may not work as expected. Please upgrade Node.js to a supported version based on Node's release schedule:
             https://github.com/nodejs/release#release-schedule 
10:18:34.052 Authenticating with Chromatic [staging] 
10:18:34.053     → Connecting to https://index.staging-chromatic.com
10:18:34.449 Authenticated with Chromatic [staging]
10:18:34.450     → Using project token '****************1c89'
10:18:34.453 Retrieving git information
10:18:35.804 Retrieved git information
```

Next, I applied this patch, which uses `ctx.log.file` as the logging function instead of `ctx.log.info`. 
```patch
diff --git a/node-src/renderer/auth.ts b/node-src/renderer/auth.ts
index de09a539..3ed297f2 100644
--- a/node-src/renderer/auth.ts
+++ b/node-src/renderer/auth.ts
@@ -2,7 +2,7 @@ import { applyAuthOutput, extractInput, runAuth } from '../tasks/auth';
 import { Context } from '../types';
 import { authenticated, authenticating } from '../ui/tasks/auth';
 import { runTask } from './engine';
-import { clackTaskLogRenderer } from './engine/clack/renderer';
+import { logRenderer } from './engine/logRenderer/renderer';
 
 /**
  * Render the auth task.
@@ -20,6 +20,6 @@ export async function renderAuth(ctx: Context): Promise<void> {
       run: runAuth,
       applyOutput: applyAuthOutput,
     },
-    clackTaskLogRenderer()
+    logRenderer(ctx.log.file)
   );
 }
```

With this as the renderer, we would expect 1) no stdout output for the auth task, regardless of the state of `ctx.interactive`, 2) file log output when `--log-file` is set, and 3) no file log output when `--log-file` is not set (because the logger itself makes `ctx.log.file` a noop when `--log-file` is not set). And that's what happened.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>18.0.1--canary.1378.28528500505.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@18.0.1--canary.1378.28528500505.0
  # or 
  yarn add chromatic@18.0.1--canary.1378.28528500505.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
