### PR TITLE
Increase Sentry message length

### DIFF
--- a/node-src/errorMonitoring.ts
+++ b/node-src/errorMonitoring.ts
@@ -65,4 +65,8 @@ Sentry.init({
   },
   beforeSend: filterErrorEvent,
   beforeBreadcrumb: filterBreadcrumb,
+  // Increase max message length to prevent truncation of long error messages
+  // Default is 250
+  // Max is 8192
+  maxValueLength: 500,
 });


### PR DESCRIPTION
We're getting some Sentry errors that are truncated to the default 250 characters and leaving off some important context. This bumps that so we get a little more context.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>17.3.1--canary.1380.27027419094.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@17.3.1--canary.1380.27027419094.0
  # or 
  yarn add chromatic@17.3.1--canary.1380.27027419094.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
