### PR TITLE
Fix `release` workflow failures from concurrent PR updates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,12 @@ on:
       - package.json
       - storybook-addon.*
 
+# Opening a PR and attaching labels can trigger multiple action runs at the same time. Instead, we
+# group them together by the pull request ref so only 1 runs at a time.
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   id-token: write
   contents: write


### PR DESCRIPTION
I noticed our `release` CI step fails pretty often. Turns out, GitHub can kick off multiple Action runs when you create a PR and they all fight when talking to NPM.

Let's say you open a PR and set labels at the same time. You'll get 3 `release` Action runs and the race is on.

Instead, we can set concurrency on that Action per-PR so it only runs 1 at a time to avoid that problem.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>17.2.1--canary.1382.26982337362.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@17.2.1--canary.1382.26982337362.0
  # or 
  yarn add chromatic@17.2.1--canary.1382.26982337362.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
