### PR TITLE
Fan out `auth` and `intro` output to Clack and file logging

### DIFF
--- a/node-src/index.ts
+++ b/node-src/index.ts
@@ -31,7 +31,7 @@ import { exitCodes, setExitCode } from './lib/setExitCode';
 import { uploadMetadataFiles } from './lib/uploadMetadataFiles';
 import { rewriteErrorMessage } from './lib/utilities';
 import { writeChromaticDiagnostics } from './lib/writeChromaticDiagnostics';
-import { intro } from './renderer';
+import { intro as clackIntro } from './renderer';
 import { renderAuth } from './renderer/auth';
 import getTasks from './tasks';
 import { Context, Flags, Options } from './types';
@@ -44,6 +44,7 @@ import missingStories from './ui/messages/errors/missingStories';
 import noPackageJson from './ui/messages/errors/noPackageJson';
 import runtimeError from './ui/messages/errors/runtimeError';
 import taskError from './ui/messages/errors/taskError';
+import intro from './ui/messages/info/intro';
 import skipNoProjectToken from './ui/messages/warnings/skipNoProjectToken';
 
 // Make keys of `T` outside of `R` optional.
@@ -167,8 +168,6 @@ export async function run({
  * @returns A promise that resolves when all steps are completed.
  */
 export async function runAll(initialContext: InitialContext) {
-  intro(initialContext);
-
   const onError = (err: Error | Error[]) => {
     initialContext.log.info('');
     initialContext.log.error(fatalError(initialContext, [err].flat()));
@@ -187,6 +186,12 @@ export async function runAll(initialContext: InitialContext) {
     );
 
     const partialOptions = getPartialOptions(initialContext);
+    if (partialOptions.interactive) {
+      clackIntro(initialContext);
+      initialContext.log.file(intro(initialContext)); // noop if file logging not enabled
+    } else {
+      initialContext.log.info(intro(initialContext));
+    }
 
     if (await shouldSkipWithoutProjectToken(initialContext, partialOptions)) {
       initialContext.log.warn(skipNoProjectToken());

--- a/node-src/renderer/auth.ts
+++ b/node-src/renderer/auth.ts
@@ -3,6 +3,7 @@ import { Context } from '../types';
 import { authenticated, authenticating } from '../ui/tasks/auth';
 import { runTask } from './engine';
 import { clackTaskLogRenderer } from './engine/clack/renderer';
+import { getRenderer } from './engine/getRenderer';
 
 /**
  * Render the auth task.
@@ -20,6 +21,6 @@ export async function renderAuth(ctx: Context): Promise<void> {
       run: runAuth,
       applyOutput: applyAuthOutput,
     },
-    clackTaskLogRenderer()
+    getRenderer(ctx, clackTaskLogRenderer)
   );
 }

--- a/node-src/renderer/engine/getRenderer.test.ts
+++ b/node-src/renderer/engine/getRenderer.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { Context, Task } from '../../types';
+import { getRenderer } from './getRenderer';
+import { TaskRenderer } from './index';
+
+/**
+ * Build a minimal `ctx` for `getRenderer`, capturing the lines written to each log channel.
+ *
+ * @param interactive Whether the run is interactive.
+ *
+ * @returns The `ctx` slice plus the `file` and `info` channel sinks.
+ */
+function buildContext(interactive: boolean) {
+  const file: unknown[][] = [];
+  const info: unknown[][] = [];
+  const ctx = {
+    options: { interactive },
+    log: {
+      file: (...args: unknown[]) => file.push(args),
+      info: (...args: unknown[]) => info.push(args),
+    },
+  } as unknown as Pick<Context, 'options' | 'log'>;
+  return { ctx, file, info };
+}
+
+/**
+ * Build a `TaskRenderer` whose four hooks are spies.
+ *
+ * @returns A `TaskRenderer` with `vi.fn()` hooks.
+ */
+function spyRenderer(): TaskRenderer {
+  return { start: vi.fn(), update: vi.fn(), succeed: vi.fn(), fail: vi.fn() };
+}
+
+const task: Task = { status: 'pending', title: 'Authenticating', output: 'working...' };
+
+describe('getRenderer', () => {
+  it('drives the interactive renderer on interactive runs', () => {
+    const { ctx } = buildContext(true);
+    const interactive = spyRenderer();
+
+    const renderer = getRenderer(ctx, () => interactive);
+    renderer.start(task);
+
+    expect(interactive.start).toHaveBeenCalledWith(task);
+  });
+
+  it('does not construct the interactive renderer on non-interactive runs', () => {
+    const { ctx } = buildContext(false);
+    const makeInteractiveRenderer = vi.fn(spyRenderer);
+
+    getRenderer(ctx, makeInteractiveRenderer);
+
+    expect(makeInteractiveRenderer).not.toHaveBeenCalled();
+  });
+
+  it('writes to the info channel on non-interactive runs', () => {
+    const { ctx, info, file } = buildContext(false);
+
+    const renderer = getRenderer(ctx, spyRenderer);
+    renderer.start(task);
+
+    expect(info).toEqual([['Authenticating'], ['    → working...']]);
+    expect(file).toEqual([]); // reminder: the logger handles fanout to file, not the renderer
+  });
+
+  it('mirrors to the file channel alongside the interactive renderer on interactive runs', () => {
+    const { ctx, file, info } = buildContext(true);
+    const interactive = spyRenderer();
+
+    const renderer = getRenderer(ctx, () => interactive);
+    renderer.start(task);
+
+    expect(interactive.start).toHaveBeenCalledWith(task);
+    expect(file).toEqual([['Authenticating'], ['    → working...']]);
+    expect(info).toEqual([]);
+  });
+
+  it('reports a throwing interactive renderer to the file channel rather than crashing', () => {
+    const { ctx, file } = buildContext(true);
+    const interactive: TaskRenderer = {
+      ...spyRenderer(),
+      start: () => {
+        throw new Error('boom');
+      },
+    };
+
+    const renderer = getRenderer(ctx, () => interactive);
+
+    expect(() => renderer.start(task)).not.toThrow();
+    expect(file.some(([message]) => message === 'renderer start hook threw')).toBe(true);
+  });
+});

--- a/node-src/renderer/engine/getRenderer.ts
+++ b/node-src/renderer/engine/getRenderer.ts
@@ -1,0 +1,33 @@
+import { Context } from '../../types';
+import { broadcastRenderer } from './broadcast';
+import { TaskRenderer } from './index';
+import { logRenderer } from './logRenderer/renderer';
+
+/**
+ * Assemble the composed `TaskRenderer` for a task.
+ *
+ * Interactive runs render through the task's interactive renderer plus a file-only
+ * `logRenderer`. Non-interactive runs render through a single `logRenderer` writing to `ctx.log.info`.
+ * The logger itself handles branching the logs to the log file when enabled.
+ *
+ * The result is always wrapped in `broadcastRenderer` so a renderer hook throwing is logged to the
+ * log file rather than crashing the task.
+ *
+ * @param ctx The CLI context, narrowed to options and log.
+ * @param makeInteractiveRenderer Factory for the task's interactive renderer.
+ *
+ * @returns A single composed `TaskRenderer`.
+ */
+export function getRenderer(
+  ctx: Pick<Context, 'options' | 'log'>,
+  makeInteractiveRenderer: () => TaskRenderer
+): TaskRenderer {
+  const reportError = (error: unknown, hook: keyof TaskRenderer) =>
+    ctx.log.file(`renderer ${hook} hook threw`, error);
+
+  const renderers = ctx.options.interactive
+    ? [makeInteractiveRenderer(), logRenderer(ctx.log.file)]
+    : [logRenderer(ctx.log.info)];
+
+  return broadcastRenderer(renderers, reportError);
+}


### PR DESCRIPTION
# Description

This PR implements small helper to determine what `TaskRenderer`s each task should use. The task itself owns what interactive renderer it needs (since, e.g., the `upload` task wants a progress bar, while most other tasks just want the regular task log renderer). The helper is responsible for determining whether interactive or non-interactive rendering is needed and handling file logging. The results are composed into a single `TaskRenderer` instance using `broadcastRenderer`.

# Manual QA

Build 1: interactive, no file logging -> Clack-based stdout, no file
<img width="1470" height="886" alt="CleanShot 2026-06-05 at 13 48 15@2x" src="https://github.com/user-attachments/assets/1a2c921d-8305-45bd-a986-135ffe402bb7" />

Build 2: non-interactive, no file logging -> log.info stdout, no file
<img width="1958" height="1438" alt="CleanShot 2026-06-05 at 13 50 44@2x" src="https://github.com/user-attachments/assets/f94fdbb6-1c24-4320-b327-499fff927da6" />

Build 3: interactive, file logging -> Clack-based stdout, file logs
<img width="1764" height="882" alt="CleanShot 2026-06-05 at 14 18 23@2x" src="https://github.com/user-attachments/assets/23e16afb-fd93-4101-9850-635afde502db" />

`head` of the log file:
```
14:18:05.728 Chromatic CLI v17.1.0
             https://www.chromatic.com/docs/cli 
14:18:05.731 Authenticating with Chromatic [staging] 
14:18:05.731     → Connecting to https://index.staging-chromatic.com
14:18:06.114 Authenticated with Chromatic [staging]
14:18:06.114     → Using project token '****************1c89'
14:18:06.116 Retrieving git information
14:18:07.231 Retrieved git information
                 → Commit '763e9d9' on branch 'HEAD'; found 1 parent build
14:18:07.232 Collecting Storybook metadata
```

Build 4: non-interactive, file logging -> log.info stdout, file logs
<img width="1964" height="1428" alt="CleanShot 2026-06-05 at 13 53 05@2x" src="https://github.com/user-attachments/assets/9dcb34ce-16f1-48ff-bb9a-b2d532c1bfc0" />

`head` of the log file:
```
13:52:47.985 Chromatic CLI v17.1.0
             https://www.chromatic.com/docs/cli 
13:52:48.000 Authenticating with Chromatic [staging] 
13:52:48.000     → Connecting to https://index.staging-chromatic.com
13:52:48.365 Authenticated with Chromatic [staging]
13:52:48.365     → Using project token '****************1c89'
13:52:48.367 Retrieving git information
13:52:49.320 Retrieved git information
                 → Commit '763e9d9' on branch 'HEAD'; found 1 parent build
13:52:49.321 Collecting Storybook metadata
```
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>18.0.1--canary.1384.28528497436.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@18.0.1--canary.1384.28528497436.0
  # or 
  yarn add chromatic@18.0.1--canary.1384.28528497436.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
