### PR TITLE
fix: e2e build command ignores arguments when used with npm

### DIFF
--- a/node-src/lib/e2e.ts
+++ b/node-src/lib/e2e.ts
@@ -15,7 +15,7 @@ const quote = (argument: string) =>
 // We should probably PR this up to ni
 const parseNexec = ((agent, args) => {
   const map: Record<keyof typeof AGENTS, string> = {
-    npm: 'npm exec {0}',
+    npm: 'npm exec -- {0}',
     yarn: 'yarn {0}',
     'yarn@berry': 'yarn {0}',
     pnpm: 'pnpm exec {0}',

--- a/node-src/tasks/build/setBuildCommand.test.ts
+++ b/node-src/tasks/build/setBuildCommand.test.ts
@@ -188,4 +188,22 @@ describe('setBuildCommand', () => {
       );
     }
   );
+
+  it('forwards E2E build arguments through npm exec when running in the action', async () => {
+    getCliCommand.mockImplementation(async (runner, args) => runner('npm', args as string[]));
+
+    const ctx = {
+      ...baseContext,
+      sourceDir: './source-dir/',
+      options: { playwright: true, inAction: true },
+      git: {},
+      log: new TestLogger(),
+    } as any;
+
+    await setBuildCommand(ctx);
+
+    expect(ctx.buildCommand).toEqual(
+      'npm exec -- build-archive-storybook --output-dir=./source-dir/'
+    );
+  });
 });

--- a/node-src/tasks/prepare/validateFiles.test.ts
+++ b/node-src/tasks/prepare/validateFiles.test.ts
@@ -115,6 +115,41 @@ describe('validateFiles', () => {
         })
       );
     });
+
+    it('retries using multiline outputDir from build-storybook.log', async () => {
+      readdirSyncMock.mockReturnValueOnce([]);
+      readdirSyncMock.mockReturnValueOnce(['iframe.html', 'index.html'] as any);
+      statSyncMock.mockReturnValue({ isDirectory: () => false, size: 42 } as any);
+      readFileSyncMock.mockReturnValue(`\u001B[32m◇\u001B[39m  Output directory:
+\u001B[90m│\u001B[39m  /var/storybook-static
+\u001B[90m│\u001B[39m
+\u001B[90m└\u001B[39m  Storybook build completed successfully
+`);
+
+      const ctx = {
+        env: environment,
+        log,
+        http,
+        sourceDir: '/static/',
+        buildLogFile: 'build-storybook.log',
+        options: {},
+        packageJson: {},
+      } as any;
+      await validateFiles(ctx);
+
+      expect(log.warn).toHaveBeenCalledWith(expect.stringContaining('Unexpected build directory'));
+      expect(ctx.sourceDir).toBe('/var/storybook-static');
+      expect(ctx.fileInfo).toEqual(
+        expect.objectContaining({
+          lengths: [
+            { contentLength: 42, knownAs: 'iframe.html', pathname: 'iframe.html' },
+            { contentLength: 42, knownAs: 'index.html', pathname: 'index.html' },
+          ],
+          paths: ['iframe.html', 'index.html'],
+          total: 84,
+        })
+      );
+    });
   });
 
   describe('with isReactNativeApp', () => {

--- a/node-src/tasks/prepare/validateFiles.ts
+++ b/node-src/tasks/prepare/validateFiles.ts
@@ -67,7 +67,8 @@ function getOutputDirectory(buildLog: string) {
     if (sameLineOutput) return sameLineOutput;
 
     for (let index_ = index + 1; index_ < lines.length; index_ += 1) {
-      const candidate = lines[index_].replace(/^[\s│└┌├┬┴─]+/, '').trim();
+      // Remove Box Drawing glyphs (U+2500–U+257F)
+      const candidate = lines[index_].replace(/^[\s\u2500-\u257F]+/u, '').trim();
       if (!candidate) continue;
       return candidate;
     }

--- a/node-src/tasks/prepare/validateFiles.ts
+++ b/node-src/tasks/prepare/validateFiles.ts
@@ -55,13 +55,24 @@ function getPathSpecsInDirectory(ctx: Context, rootDirectory: string, dirname = 
  * @returns The output directory path if found, undefined otherwise
  */
 function getOutputDirectory(buildLog: string) {
-  const outputString = 'Output directory: ';
-  const outputIndex = buildLog.lastIndexOf(outputString);
-  if (outputIndex === -1) return undefined;
-  const remainingLog = buildLog.slice(outputIndex + outputString.length);
-  const newlineIndex = remainingLog.indexOf('\n');
-  const outputDirectory = newlineIndex === -1 ? remainingLog : remainingLog.slice(0, newlineIndex);
-  return outputDirectory.trim();
+  const cleanLog = buildLog.replaceAll(/\u001B\[[0-?]*[ -/]*[@-~]/g, '');
+  const lines = cleanLog.split('\n');
+
+  for (let i = lines.length - 1; i >= 0; i -= 1) {
+    const outputIndex = lines[i].lastIndexOf('Output directory:');
+    if (outputIndex === -1) continue;
+
+    const sameLineOutput = lines[i].slice(outputIndex + 'Output directory:'.length).trim();
+    if (sameLineOutput) return sameLineOutput;
+
+    for (let j = i + 1; j < lines.length; j += 1) {
+      const candidate = lines[j].replace(/^[\s│└┌├┬┴─]+/, '').trim();
+      if (!candidate) continue;
+      return candidate;
+    }
+  }
+
+  return undefined;
 }
 
 /**

--- a/node-src/tasks/prepare/validateFiles.ts
+++ b/node-src/tasks/prepare/validateFiles.ts
@@ -59,15 +59,15 @@ function getOutputDirectory(buildLog: string) {
   const cleanLog = stripVTControlCharacters(buildLog);
   const lines = cleanLog.split('\n');
 
-  for (let i = lines.length - 1; i >= 0; i -= 1) {
-    const outputIndex = lines[i].lastIndexOf('Output directory:');
+  for (let index = lines.length - 1; index >= 0; index -= 1) {
+    const outputIndex = lines[index].lastIndexOf('Output directory:');
     if (outputIndex === -1) continue;
 
-    const sameLineOutput = lines[i].slice(outputIndex + 'Output directory:'.length).trim();
+    const sameLineOutput = lines[index].slice(outputIndex + 'Output directory:'.length).trim();
     if (sameLineOutput) return sameLineOutput;
 
-    for (let j = i + 1; j < lines.length; j += 1) {
-      const candidate = lines[j].replace(/^[\s│└┌├┬┴─]+/, '').trim();
+    for (let index_ = index + 1; index_ < lines.length; index_ += 1) {
+      const candidate = lines[index_].replace(/^[\s│└┌├┬┴─]+/, '').trim();
       if (!candidate) continue;
       return candidate;
     }

--- a/node-src/tasks/prepare/validateFiles.ts
+++ b/node-src/tasks/prepare/validateFiles.ts
@@ -1,5 +1,6 @@
 import { readdirSync, readFileSync, statSync } from 'fs';
 import path from 'path';
+import { stripVTControlCharacters } from 'util';
 
 import { posix } from '../../lib/posix';
 import { Context } from '../../types';
@@ -55,7 +56,7 @@ function getPathSpecsInDirectory(ctx: Context, rootDirectory: string, dirname = 
  * @returns The output directory path if found, undefined otherwise
  */
 function getOutputDirectory(buildLog: string) {
-  const cleanLog = buildLog.replaceAll(/\u001B\[[0-?]*[ -/]*[@-~]/g, '');
+  const cleanLog = stripVTControlCharacters(buildLog);
   const lines = cleanLog.split('\n');
 
   for (let i = lines.length - 1; i >= 0; i -= 1) {


### PR DESCRIPTION
#1312 with permissions to run actions properly, with merge conflict resolved
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>17.4.2--canary.1385.27358949313.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@17.4.2--canary.1385.27358949313.0
  # or 
  yarn add chromatic@17.4.2--canary.1385.27358949313.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
