### PR TITLE
Update Codecov to fix GPG issue

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -36,6 +36,6 @@ jobs:
       - run: yarn test
 
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Codecov started failing with a GPG verification issue. This was updated in the later versions of their Action. 

Issue for reference: [https://github.com/codecov/codecov-action/issues/1956](https://github.com/codecov/codecov-action/issues/1956)
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>17.4.1--canary.1387.27219813902.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@17.4.1--canary.1387.27219813902.0
  # or 
  yarn add chromatic@17.4.1--canary.1387.27219813902.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
