### PR TITLE
Migrate `gitInfo` to Clack

### DIFF
--- a/node-src/index.ts
+++ b/node-src/index.ts
@@ -33,6 +33,7 @@ import { rewriteErrorMessage } from './lib/utilities';
 import { writeChromaticDiagnostics } from './lib/writeChromaticDiagnostics';
 import { intro as clackIntro } from './renderer';
 import { renderAuth } from './renderer/auth';
+import { renderGitInfo } from './renderer/gitInfo';
 import getTasks from './tasks';
 import { Context, Flags, Options } from './types';
 import { endActivity } from './ui/components/activity';
@@ -288,6 +289,7 @@ async function runBuild(ctx: Context) {
         ctx.log.queue();
       }
       await renderAuth(ctx);
+      await renderGitInfo(ctx);
       await new Listr(getTasks(ctx), options).run(ctx);
       ctx.log.debug('Tasks completed');
     } catch (err) {

--- a/node-src/renderer/engine/clack/renderer.test.ts
+++ b/node-src/renderer/engine/clack/renderer.test.ts
@@ -1,5 +1,5 @@
 import { taskLog as clackTaskLog } from '@clack/prompts';
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it, test, vi } from 'vitest';
 
 import { Task } from '../../../types';
 import { clackTaskLogRenderer } from './renderer';
@@ -116,18 +116,39 @@ describe('clackTaskLogRenderer', () => {
       expect(formatted).toBe('Done');
     });
 
-    it('renders the title and the output', () => {
-      const formatted = formatVia('update', { title: 'Building', output: 'compiling' });
-
+    test.for(['succeed', 'fail'])('%s transition renders title and output', (transition) => {
+      const formatted = formatVia(transition as keyof typeof TRANSITION_METHOD, {
+        title: 'Building',
+        output: 'compiling',
+      });
       expect(formatted).toContain('Building');
       expect(formatted).toContain('compiling');
     });
 
-    it('wraps long output across multiple lines', () => {
+    it('update renders only output', () => {
+      const formatted = formatVia('update', { title: 'Building', output: 'compiling' });
+
+      expect(formatted).not.toContain('Building');
+      expect(formatted).toContain('compiling');
+    });
+
+    it('update renders title when there is no output', () => {
+      const formatted = formatVia('update', { title: 'Building' });
+      expect(formatted).toContain('Building');
+    });
+
+    it('wraps long terminal-state output across multiple lines', () => {
+      const longOutput = 'foo'.repeat(40);
+      const formatted = formatVia('succeed', { title: 'Building', output: longOutput });
+
+      expect(formatted.split('\n').length).toBeGreaterThan(2);
+    });
+
+    it('wraps long update output across multiple lines', () => {
       const longOutput = 'foo'.repeat(40);
       const formatted = formatVia('update', { title: 'Building', output: longOutput });
 
-      expect(formatted.split('\n').length).toBeGreaterThan(2);
+      expect(formatted.split('\n').length).toBeGreaterThan(1);
     });
   });
 });

--- a/node-src/renderer/engine/clack/renderer.ts
+++ b/node-src/renderer/engine/clack/renderer.ts
@@ -26,7 +26,7 @@ export function clackTaskLogRenderer(output?: Writable): TaskRenderer {
       if (state.output) taskLog.message(wrapTextForClack(state.output));
     },
     update: (state: Task) => {
-      taskLog.message(taskMessageFormatter(state));
+      taskLog.message(wrapTextForClack(state.output || state.title));
     },
     succeed: (state: Task) => {
       taskLog.success(taskMessageFormatter(state));

--- a/node-src/renderer/engine/index.ts
+++ b/node-src/renderer/engine/index.ts
@@ -174,11 +174,19 @@ function failureState<TInput, TOutput, TPartial>(
   error: Error,
   pendingTitle: string
 ): Task {
-  const configuredFailureState = config.transitions.failure?.(ctx, error);
-  if (configuredFailureState) {
-    return configuredFailureState;
-  }
+  return config.transitions.failure?.(ctx, error) ?? fallbackFailureState(pendingTitle, error);
+}
 
+/**
+ * The failure state `runTask` derives when a task supplies no explicit `failure` transition.
+ * Exported so Storybook frames can render the exact state the runtime would produce.
+ *
+ * @param pendingTitle The title of the task's `pending` transition.
+ * @param error The thrown error whose message becomes the failure body.
+ *
+ * @returns The `Task` state describing the failure for the renderer.
+ */
+export function fallbackFailureState(pendingTitle: string, error: Error): Task {
   return {
     status: 'error',
     title: `${pendingTitle} failed`,

--- a/node-src/renderer/gitInfo.ts
+++ b/node-src/renderer/gitInfo.ts
@@ -1,0 +1,37 @@
+import {
+  applyGitInfoOutput,
+  applyGitInfoPartial,
+  extractGitInfoInput,
+  gatherGitInfo,
+} from '../tasks/gitInfo';
+import { Context } from '../types';
+import { pending, skippedForCommit, skippedRebuild, success } from '../ui/tasks/gitInfo';
+import { runTask } from './engine';
+import { clackTaskLogRenderer } from './engine/clack/renderer';
+import { getRenderer } from './engine/getRenderer';
+
+/**
+ * Render the gitInfo task.
+ *
+ * @param ctx The CLI context.
+ */
+export async function renderGitInfo(ctx: Context): Promise<void> {
+  await runTask(
+    ctx,
+    {
+      name: 'gitInfo',
+      title: 'Retrieve git information',
+      transitions: {
+        pending,
+        success,
+        partial: (ctx, partial) =>
+          partial.phase === 'skip-commit' ? skippedForCommit(ctx) : skippedRebuild(),
+      },
+      extractInput: extractGitInfoInput,
+      run: gatherGitInfo,
+      applyOutput: applyGitInfoOutput,
+      applyPartial: applyGitInfoPartial,
+    },
+    getRenderer(ctx, clackTaskLogRenderer)
+  );
+}

--- a/node-src/renderer/storybook/captureTask.ts
+++ b/node-src/renderer/storybook/captureTask.ts
@@ -18,10 +18,13 @@ const CAPTURE_WIDTH = 80;
  * task leaves the frame open.
  *
  * @param state The `Task` state to render (`pending`, `success`, or `error`).
+ * @param startingState The `Task` to render as the initial state. `success` and `error` tasks
+ * overwrite the starting state, but the `update` task inherits the starting state's title.
+ * Defaults to a generic "Starting task..." state.
  *
  * @returns The settled ANSI frame.
  */
-export function captureTask(state: Task): string {
+export function captureTask(state: Task, startingState?: Task): string {
   const { sink, read } = createSink();
 
   // Clack drops transient `.message()` output in non-TTY mode, gated on `process.env.CI === 'true'`.
@@ -33,7 +36,7 @@ export function captureTask(state: Task): string {
   process.stdout.columns = CAPTURE_WIDTH;
   try {
     intro({ pkg } as Pick<Context, 'pkg'>, sink);
-    drive(clackTaskLogRenderer(sink), state);
+    drive(clackTaskLogRenderer(sink), state, startingState);
   } finally {
     process.stdout.columns = previousColumns;
     // `process.env.CI = undefined` would coerce to the string "undefined" (truthy), so unset
@@ -45,7 +48,18 @@ export function captureTask(state: Task): string {
   return settle(read());
 }
 
-function drive(renderer: ReturnType<typeof clackTaskLogRenderer>, state: Task): void {
+function drive(
+  renderer: ReturnType<typeof clackTaskLogRenderer>,
+  state: Task,
+  startingState?: Task
+): void {
+  if (!startingState) {
+    startingState = {
+      status: 'pending',
+      title: 'Generic starting state',
+      output: 'Starting task...',
+    };
+  }
   // clack's taskLog requires starting before rendering success/error hooks, so we call `start`
   // first on success/error hooks
   switch (state.status) {
@@ -53,13 +67,18 @@ function drive(renderer: ReturnType<typeof clackTaskLogRenderer>, state: Task): 
       renderer.start(state);
       return;
     }
+    case 'updating': {
+      renderer.start(startingState);
+      renderer.update(state);
+      return;
+    }
     case 'success': {
-      renderer.start({ title: state.title });
+      renderer.start(startingState);
       renderer.succeed(state);
       return;
     }
     case 'error': {
-      renderer.start({ title: state.title });
+      renderer.start(startingState);
       renderer.fail(state);
       return;
     }

--- a/node-src/tasks/gitInfo.test.ts
+++ b/node-src/tasks/gitInfo.test.ts
@@ -78,6 +78,7 @@ const buildDeps = (overrides: Partial<GitInfoDeps> = {}): GitInfoDeps => ({
   options: {} as any,
   runtime: {} as any,
   packageJson: {},
+  report: vi.fn(),
   ...overrides,
 });
 
@@ -87,7 +88,6 @@ const buildInput = (overrides: Partial<GitInfoInput> = {}): GitInfoInput => ({
   isLocalBuild: false,
   skip: false,
   onlyChanged: false,
-  onSkippingBuild: vi.fn(),
   ...overrides,
 });
 
@@ -241,14 +241,17 @@ describe('gatherGitInfo', () => {
 
   it('returns skip-commit partial when skip matches branch and mutation succeeds', async () => {
     client.runQuery.mockResolvedValue(true);
-    const onSkippingBuild = vi.fn();
-    const result = await gatherGitInfo(buildDeps(), buildInput({ skip: true, onSkippingBuild }));
+    const report = vi.fn();
+    const result = await gatherGitInfo(buildDeps({ report }), buildInput({ skip: true }));
 
     expectKind(result, 'partial');
     expectPhase(result.output, 'skip-commit');
     expect(result.output.git.commit).toBe(commitInfo.commit);
     expect(result.output.projectMetadata).toMatchObject({ hasRouter: true });
-    expect(onSkippingBuild).toHaveBeenCalledWith(result.output.git);
+    expect(report).toHaveBeenCalledWith({
+      title: 'Skipping build',
+      output: `Skipping build for commit ${result.output.git.commit.slice(0, 7)}`,
+    });
   });
 
   it('throws when skip matches branch but mutation returns falsy', async () => {
@@ -395,9 +398,8 @@ describe('extractGitInfoInput', () => {
         untraced: ['bar'],
       },
     } as any;
-    const listrTask: any = {};
 
-    const input = extractGitInfoInput(ctx, listrTask);
+    const input = extractGitInfoInput(ctx);
 
     expect(input).toMatchObject({
       branchName: 'branch',
@@ -413,17 +415,5 @@ describe('extractGitInfoInput', () => {
       externals: ['foo'],
       untraced: ['bar'],
     });
-  });
-
-  it('onSkippingBuild writes git to ctx and transitions the listr task title', () => {
-    const ctx = { options: {}, log } as any;
-    const listrTask: any = { title: 'initial' };
-
-    const input = extractGitInfoInput(ctx, listrTask);
-    const git = { commit: 'abc', branch: 'main' } as any;
-    input.onSkippingBuild(git);
-
-    expect(ctx.git).toBe(git);
-    expect(listrTask.title).not.toBe('initial');
   });
 });

--- a/node-src/tasks/gitInfo.ts
+++ b/node-src/tasks/gitInfo.ts
@@ -1,5 +1,3 @@
-import type Listr from 'listr';
-
 import { getBaselineBuilds } from '../git/getBaselineBuilds';
 import { getChangedFilesWithReplacement } from '../git/getChangedFilesWithReplacement';
 import getCommitAndBranch from '../git/getCommitAndBranch';
@@ -18,7 +16,6 @@ import {
 import { getHasRouter } from '../lib/getHasRouter';
 import matchesBranch from '../lib/matchesBranch';
 import { exitCodes, setExitCode } from '../lib/setExitCode';
-import { createTask, transitionTo } from '../lib/tasks';
 import { isPackageMetadataFile, matchesFile } from '../lib/utilities';
 import {
   BaselineBuild,
@@ -36,17 +33,12 @@ import externalsChanged from '../ui/messages/warnings/externalsChanged';
 import invalidChangedFiles from '../ui/messages/warnings/invalidChangedFiles';
 import isRebuild from '../ui/messages/warnings/isRebuild';
 import undefinedBranchOwner from '../ui/messages/warnings/undefinedBranchOwner';
-import {
-  initial,
-  pending,
-  skipFailed,
-  skippedForCommit,
-  skippedRebuild,
-  skippingBuild,
-  success,
-} from '../ui/tasks/gitInfo';
+import { skipFailed, skippingBuild } from '../ui/tasks/gitInfo';
 
-export type GitInfoDeps = Pick<Deps, 'log' | 'client' | 'options' | 'runtime' | 'packageJson'>;
+export type GitInfoDeps = Pick<
+  Deps,
+  'log' | 'client' | 'options' | 'runtime' | 'packageJson' | 'report'
+>;
 
 export interface GitInfoInput {
   branchName?: string;
@@ -61,7 +53,6 @@ export interface GitInfoInput {
   onlyChanged: boolean | string;
   externals?: string[];
   untraced?: string[];
-  onSkippingBuild: (git: Git) => void;
 }
 
 type LastBuild = NonNullable<Context['rebuildForBuild']>;
@@ -140,7 +131,7 @@ export async function gatherGitInfo(
   deps: GitInfoDeps,
   input: GitInfoInput
 ): Promise<TaskResult<GitInfoOutput, GitInfoPartial>> {
-  const { log, client, options, runtime, packageJson } = deps;
+  const { log, client, options, runtime, packageJson, report } = deps;
   const {
     branchName,
     ownerName,
@@ -154,7 +145,6 @@ export async function gatherGitInfo(
     onlyChanged,
     externals,
     untraced,
-    onSkippingBuild,
   } = input;
 
   const version = await getVersion({ log });
@@ -220,7 +210,8 @@ export async function gatherGitInfo(
   git.matchesBranch = (glob: string | boolean) => matchesBranch(branch, glob);
 
   if (git.matchesBranch(skip)) {
-    onSkippingBuild(git);
+    const { title, output } = skippingBuild(git);
+    report({ title, output });
     // The SkipBuildMutation ensures the commit is tagged properly.
     if (await client.runQuery(SkipBuildMutation, { commit, branch, slug })) {
       return {
@@ -419,10 +410,7 @@ export async function gatherGitInfo(
   };
 }
 
-export const extractGitInfoInput = (
-  ctx: Context,
-  listrTask: Listr.ListrTaskWrapper<Context>
-): GitInfoInput => ({
+export const extractGitInfoInput = (ctx: Context): GitInfoInput => ({
   branchName: ctx.options.branchName,
   ownerName: ctx.options.ownerName,
   repositorySlug: ctx.options.repositorySlug,
@@ -435,14 +423,6 @@ export const extractGitInfoInput = (
   onlyChanged: ctx.options.onlyChanged,
   externals: ctx.options.externals,
   untraced: ctx.options.untraced,
-  onSkippingBuild: (git) => {
-    // Kind of a gross escape hatch here. The `skippingBuild` UI function needs `git` on the context to construct its message,
-    // so we have to mutate context in this callback. Can't put this in applyGitInfoPartial because it's an intermediate UI
-    // transition: it's called before running the GQL mutation that skips the build. Having one escape hatch here seemed better
-    // than abstracting it away at this stage, but if this keeps coming up, we should find a better pattern for this.
-    ctx.git = git;
-    transitionTo(skippingBuild)(ctx, listrTask);
-  },
 });
 
 export const applyGitInfoOutput = (ctx: Context, output: GitInfoOutput) => {
@@ -469,27 +449,3 @@ export const applyGitInfoPartial = (ctx: Context, partial: GitInfoPartial) => {
     if (partial.setForceRebuild) ctx.runtime.forceRebuild = true;
   }
 };
-
-/**
- * Sets up the Listr task for gathering information from Git.
- *
- * @param _ The context set when executing the CLI.
- *
- * @returns A Listr task.
- */
-export default function main(_: Context) {
-  return createTask({
-    name: 'gitInfo',
-    title: initial.title,
-    transitions: {
-      pending,
-      success,
-      partial: (ctx, partial) =>
-        partial.phase === 'skip-commit' ? skippedForCommit(ctx) : skippedRebuild(),
-    },
-    extractInput: extractGitInfoInput,
-    applyOutput: applyGitInfoOutput,
-    applyPartial: applyGitInfoPartial,
-    run: gatherGitInfo,
-  });
-}

--- a/node-src/tasks/index.ts
+++ b/node-src/tasks/index.ts
@@ -2,7 +2,6 @@ import Listr from 'listr';
 
 import { Context } from '../types';
 import build from './build';
-import gitInfo from './gitInfo';
 import initialize from './initialize';
 import prepare from './prepare';
 import prepareWorkspace from './prepareWorkspace';
@@ -16,16 +15,7 @@ import verify from './verify';
 
 export const runShare = [build, prepare, uploadShare];
 
-export const runUploadBuild = [
-  gitInfo,
-  storybookInfo,
-  initialize,
-  build,
-  prepare,
-  upload,
-  verify,
-  snapshot,
-];
+export const runUploadBuild = [storybookInfo, initialize, build, prepare, upload, verify, snapshot];
 
 export const runPatchBuild = [prepareWorkspace, ...runUploadBuild, restoreWorkspace];
 

--- a/node-src/ui/tasks/gitInfo.frames.ts
+++ b/node-src/ui/tasks/gitInfo.frames.ts
@@ -1,0 +1,37 @@
+import { captureTask } from '../../renderer/storybook/captureTask';
+import {
+  pending,
+  skipFailed,
+  skippedForCommit,
+  skippedRebuild,
+  skippingBuild,
+  success,
+} from './gitInfo';
+
+// Node-side scenarios for the gitInfo task. The `?clack` Vite plugin runs this module in Node,
+// renders each export through the real Clack renderer, and hands the resulting ANSI strings to the
+// browser story (`gitInfo.stories.ts`).
+
+const git = { commit: 'a32af7e265aa08e4a16d', branch: 'feat/new-ui', parentCommits: ['a', 'b'] };
+const options = {};
+
+export const Pending = () => captureTask(pending());
+
+export const Success = () => captureTask(success({ git, options } as any));
+
+export const FromFork = () =>
+  captureTask(success({ git, options: { ownerName: 'chromaui' } } as any));
+
+export const NoBaselines = () =>
+  captureTask(success({ git: { ...git, parentCommits: [] }, options } as any));
+
+export const TurboSnapDisabled = () =>
+  captureTask(success({ git, options, turboSnap: { bailReason: {} } } as any));
+
+export const Skipping = () => captureTask(skippingBuild(git as any), pending());
+
+export const Skipped = () => captureTask(skippedForCommit({ git } as any));
+
+export const SkippedRebuild = () => captureTask(skippedRebuild());
+
+export const SkipFailed = () => captureTask(skipFailed());

--- a/node-src/ui/tasks/gitInfo.frames.ts
+++ b/node-src/ui/tasks/gitInfo.frames.ts
@@ -1,3 +1,4 @@
+import { fallbackFailureState } from '../../renderer/engine';
 import { captureTask } from '../../renderer/storybook/captureTask';
 import {
   pending,
@@ -34,4 +35,7 @@ export const Skipped = () => captureTask(skippedForCommit({ git } as any));
 
 export const SkippedRebuild = () => captureTask(skippedRebuild());
 
-export const SkipFailed = () => captureTask(skipFailed());
+// gitInfo registers no `failure` transition, so a skip failure renders the engine's fallback
+// failure state, built from the pending title and the error gatherGitInfo throws.
+export const SkipFailed = () =>
+  captureTask(fallbackFailureState(pending().title, new Error(skipFailed().output)));

--- a/node-src/ui/tasks/gitInfo.stories.ts
+++ b/node-src/ui/tasks/gitInfo.stories.ts
@@ -1,30 +1,15 @@
-import task from '../components/task';
-import {
-  initial,
-  pending,
-  skipFailed,
-  skippedForCommit,
-  skippedRebuild,
-  skippingBuild,
-  success,
-} from './gitInfo';
+import frames from './gitInfo.frames?clack';
 
 export default {
   title: 'CLI/Tasks/GitInfo',
-  decorators: [(storyFunction) => task(storyFunction())],
 };
 
-const git = { commit: 'a32af7e265aa08e4a16d', branch: 'feat/new-ui', parentCommits: ['a', 'b'] };
-const options = {};
-
-export const Initial = () => initial;
-export const Pending = () => pending();
-export const Success = () => success({ git, options } as any);
-export const FromFork = () => success({ git, options: { ownerName: 'chromaui' } } as any);
-export const NoBaselines = () => success({ git: { ...git, parentCommits: [] }, options } as any);
-export const TurboSnapDisabled = () =>
-  success({ git, options, turboSnap: { bailReason: {} } } as any);
-export const Skipping = () => skippingBuild({ git } as any);
-export const Skipped = () => skippedForCommit({ git } as any);
-export const SkippedRebuild = () => skippedRebuild();
-export const SkipFailed = () => skipFailed();
+export const Pending = () => frames.Pending;
+export const Success = () => frames.Success;
+export const FromFork = () => frames.FromFork;
+export const NoBaselines = () => frames.NoBaselines;
+export const TurboSnapDisabled = () => frames.TurboSnapDisabled;
+export const Skipping = () => frames.Skipping;
+export const Skipped = () => frames.Skipped;
+export const SkippedRebuild = () => frames.SkippedRebuild;
+export const SkipFailed = () => frames.SkipFailed;

--- a/node-src/ui/tasks/gitInfo.ts
+++ b/node-src/ui/tasks/gitInfo.ts
@@ -30,10 +30,10 @@ export const pending = () => ({
   title: 'Retrieving git information',
 });
 
-export const skippingBuild = (ctx: Context) => ({
+export const skippingBuild = (git: Context['git']) => ({
   status: 'pending',
   title: 'Skipping build',
-  output: `Skipping build for commit ${ctx.git.commit.slice(0, 7)}`,
+  output: `Skipping build for commit ${git.commit.slice(0, 7)}`,
 });
 
 export const skippedForCommit = (ctx: Context) => ({

--- a/node-src/ui/tasks/gitInfo.ts
+++ b/node-src/ui/tasks/gitInfo.ts
@@ -31,7 +31,7 @@ export const pending = () => ({
 });
 
 export const skippingBuild = (git: Context['git']) => ({
-  status: 'pending',
+  status: 'updating',
   title: 'Skipping build',
   output: `Skipping build for commit ${git.commit.slice(0, 7)}`,
 });

--- a/node-src/ui/workflows/uploadBuild.stories.ts
+++ b/node-src/ui/workflows/uploadBuild.stories.ts
@@ -6,7 +6,11 @@ import { Intro } from '../messages/info/intro.stories';
 import { StorybookPublished } from '../messages/info/storybookPublished.stories';
 import { authenticated, authenticating, initial } from '../tasks/auth';
 import * as build from '../tasks/build.stories';
-import * as gitInfo from '../tasks/gitInfo.stories';
+import {
+  initial as gitInfoInitial,
+  pending as gitInfoPending,
+  success as gitInfoSuccess,
+} from '../tasks/gitInfo';
 import * as initialize from '../tasks/initialize.stories';
 import * as snapshot from '../tasks/snapshot.stories';
 import * as storybookInfo from '../tasks/storybookInfo.stories';
@@ -21,6 +25,15 @@ const auth = {
   Initial: () => initial,
   Authenticating: () => authenticating({ env: environment } as any),
   Authenticated: () => authenticated({ env: environment, options } as any),
+};
+
+// gitInfo.stories now returns rendered ANSI strings (Clack capture), which the old task() path
+// can't consume, so rebuild the states the workflow needs from the raw task source.
+const git = { commit: 'a32af7e265aa08e4a16d', branch: 'feat/new-ui', parentCommits: ['a', 'b'] };
+const gitInfo = {
+  Initial: () => gitInfoInitial,
+  Pending: () => gitInfoPending(),
+  Success: () => gitInfoSuccess({ git, options } as any),
 };
 
 export default {

--- a/node-src/ui/workflows/uploadBuildE2E.stories.ts
+++ b/node-src/ui/workflows/uploadBuildE2E.stories.ts
@@ -6,7 +6,11 @@ import { Intro } from '../messages/info/intro.stories';
 import { StorybookPublished } from '../messages/info/storybookPublishedE2E.stories';
 import { authenticated, authenticating, initial } from '../tasks/auth';
 import * as build from '../tasks/buildE2E.stories';
-import * as gitInfo from '../tasks/gitInfo.stories';
+import {
+  initial as gitInfoInitial,
+  pending as gitInfoPending,
+  success as gitInfoSuccess,
+} from '../tasks/gitInfo';
 import * as initialize from '../tasks/initialize.stories';
 import * as snapshot from '../tasks/snapshotE2E.stories';
 import * as storybookInfo from '../tasks/storybookInfoE2E.stories';
@@ -22,6 +26,15 @@ const auth = {
   Initial: () => initial,
   Authenticating: () => authenticating({ env: environment } as any),
   Authenticated: () => authenticated({ env: environment, options } as any),
+};
+
+// gitInfo.stories now returns rendered ANSI strings (Clack capture), which the old task() path
+// can't consume, so rebuild the states the workflow needs from the raw task source.
+const git = { commit: 'a32af7e265aa08e4a16d', branch: 'feat/new-ui', parentCommits: ['a', 'b'] };
+const gitInfo = {
+  Initial: () => gitInfoInitial,
+  Pending: () => gitInfoPending(),
+  Success: () => gitInfoSuccess({ git, options } as any),
 };
 
 export default {


### PR DESCRIPTION
# Description

This PR migrates the `gitInfo` task from Listr to Clack. Along the way, I found a couple oversights with how renderer `update` calls are handled. These were surfaced because this is the first task to actually use the `update` hook. I bundled the fixes to these in this PR so that it was easier to see them in action. Hopefully that doesn't make things too hard to read. I've split these functionality changes into their own commits. Here's the breakdown:

## Rendering `gitInfo` with Clack

The first commit migrates the `gitInfo` task to the `runTask` helper that renders through Clack. This includes the boilerplate stuff of defining the `renderGitInfo` helper (basically the same as the `renderAuth` helper that came before) and plugging in all the pieces. The bigger change here is around the mid-task UI updates that `gitInfo` needs when skipping a build. Previously, we had a gross `onSkippingBuild` callback that we wired up in `extractGitInfoInput`. The new pattern relies on the `deps.report` callback added in #1388, which is much cleaner. The building of that reporter happens in `renderer/engine/index.ts`. The `gitInfo` task itself knows nothing about it and just calls the reporter with the correct UI state object, which gets passed through to the renderer's `update` call. So all the plumbing and testing around `onSkippingBuild` is removed in this commit.

## Fixing Storybook rendering for `update` the renderer hook

The second commit fixes an omission in the pipeline for rendering Clack in Storybook. This logic branches on the UI state object's `status` field, but I originally overlooked the fact that mid-task UI updates (like `gitInfo`'s `skippingBuild` use `status === 'pending'`. This is also used by the starting UI state objects. So I needed to add support for an `updating` status, which calls the renderer's `update` hook. This added an additional wrinkle, because Clack doesn't allow changing a task log's title except for terminal hooks (succeed/fail), so the UI state after calling `update` is dependent on the state object used to `start` the task log. To support this flow, I added an optional `startingState` parameter to `captureTask`. When provided, we use this state object for the `renderer.start` call, before we call `renderer.update`.

## Fixing redundancy in how `clackTaskLogRenderer` renders the `update` hook

The third commit slightly modifies the text we display when we call `clackTaskLogRenderer.update`. Previously, we called it with `state.title + '\n' + state.output`. This resulted in a task log that looked something like:
```
<bold>Retrieving git info</bold>      <- inherited state.title from start call
Skipping build                        <- state.title
Skipping build for commit 'abc'       <- state.output
```
Obviously, this is a bit redundant. I updated it to only render the `state.output`, falling back to `state.title` if `state.output` is falsy, so we get:
```
<bold>Retrieving git info</bold>
Skipping build for commit 'abc'
```
Once this project is done, we should look into refactoring these `Task` UI state objects, as `TaskRenderer` consumes them in a different way than Listr does. But that's out of scope here.

## Migrating `gitInfo` stories to Clack-based renderer

The fourth commit updates the `gitInfo` stories to use the new Clack rendering pipeline. This includes 1) a boilerplate port in the pattern established in #1386, 2) adding a `startingState` argument to the `Skipping` story, and 3) updating `skippingBuild.status` to the new `'updating'` value that drives the correct rendering path in the Storybook rendering pipeline. I audited the codebase to confirm that this field is not consumed anywhere except the Storybook rendering logic. (This is a good code smell for the previously mentioned refactor, but again, out of scope for now.)

## Updating the `SkipFailed` story

When `gatherGitInfo` fails to skip a build, it throws an error with `skipFailed().output` as its error message. This error is then fed into a function that generates an error UI state object for the renderer. The `skipFailed` object itself is not used. I had to tweak the `SkipFailed` story slightly to use this runtime-derived fallback error state so that the story matches what the user actually sees. There is the risk of drift here, if the task changes what error it throws, but I feel like it's acceptable, as that risk has always been present with these stories, and tying the storybook to the task-running code would be a very large lift that would arguably be against the spirit of Storybook anyway.

>[!NOTE]
> There are also some deliberate UI messaging changes and discussion around some other updates we might make. See the UI review on Chromatic for discussion around these.

# Manual QA

I set up a [staging project](https://www.staging-chromatic.com/builds?appId=6a29a44e846d014918beb9f2) with a fresh repo.

**Build 1:** regular happy path
<img width="1588" height="1232" alt="CleanShot 2026-06-10 at 13 57 52@2x" src="https://github.com/user-attachments/assets/9432e519-ced0-4baa-8078-945e0c375487" />

Log file head:
```
13:55:24.016 Chromatic CLI v17.4.1--canary.1389.27295086586.0
             https://www.chromatic.com/docs/cli 
13:55:24.032 Authenticating with Chromatic [staging] 
13:55:24.032     → Connecting to https://index.staging-chromatic.com
13:55:24.405 Authenticated with Chromatic [staging]
13:55:24.405     → Using project token '****************8273'
13:55:24.406 Retrieving git information
13:55:25.051 Retrieved git information
13:55:25.051     → Commit '1524e3b' on branch 'master'; no ancestor found
13:55:25.053 Collecting Storybook metadata
```

**Build 2:** rebuild noop

Ran the same command again on the same commit. Git info skips due to a rebuild of a fully passed/accepted build. Note the Listr tasks all skip as well, showing the `ctx.skip` propagation works.
<img width="1642" height="756" alt="CleanShot 2026-06-10 at 14 00 47@2x" src="https://github.com/user-attachments/assets/c757416a-2796-451c-b13b-c9452eca777a" />

Log file head:
```
13:59:39.641 Chromatic CLI v17.4.1--canary.1389.27295086586.0
             https://www.chromatic.com/docs/cli 
13:59:39.661 Authenticating with Chromatic [staging] 
13:59:39.662     → Connecting to https://index.staging-chromatic.com
13:59:40.181 Authenticated with Chromatic [staging]
13:59:40.182     → Using project token '****************8273'
13:59:40.183 Retrieving git information
13:59:41.052 ℹ Skipping rebuild of an already fully passed/accepted build
             A build for the same commit as the last build on the branch is considered a rebuild.
             If the last build is passed or accepted, the rebuild is skipped because it shouldn't change anything.
```

**Build 3:** explicit skip with `--skip 'master'`
<img width="838" height="582" alt="CleanShot 2026-06-10 at 14 02 18@2x" src="https://github.com/user-attachments/assets/61a2e890-3f38-4611-b9b7-e7264f652a2f" />

Log file head:
```
14:01:51.169 Chromatic CLI v17.4.1--canary.1389.27295086586.0
             https://www.chromatic.com/docs/cli 
14:01:51.191 Authenticating with Chromatic [staging] 
14:01:51.191     → Connecting to https://index.staging-chromatic.com
14:01:51.525 Authenticated with Chromatic [staging]
14:01:51.525     → Using project token '****************8273'
14:01:51.526 Retrieving git information
14:01:51.653     → Skipping build for commit 1524e3b
14:01:51.803 Skipping build
14:01:51.804     → Skipped build for commit 1524e3b due to --skip
```
Note that this is the only skip path that does the mid-task UI update with the `skippingBuild` UI state object. That's why you see the `Skipping build for commit` line in the log file here.

I ran the same command with a local CLI build that adds a sleep after the UI transition so you can see it in action.
<img width="800" height="639" alt="CleanShot 2026-06-10 at 14 08 36" src="https://github.com/user-attachments/assets/2215fb46-2944-4ba4-a191-68aa9b451de5" />

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>17.4.2--canary.1389.27434918549.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@17.4.2--canary.1389.27434918549.0
  # or 
  yarn add chromatic@17.4.2--canary.1389.27434918549.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
