### PR TITLE
Add context around file adds/moves in `BaselineCheckoutFailedError` bails

### DIFF
--- a/node-src/git/git.test.ts
+++ b/node-src/git/git.test.ts
@@ -13,6 +13,7 @@ import {
   findFilesFromRepositoryRoot,
   getBranch,
   getChangedFiles,
+  getChangedFilesWithStatus,
   getCommit,
   getCommittedFileCount,
   getNumberOfCommitters,
@@ -200,6 +201,63 @@ describe('getChangedFiles', () => {
 
     expect(err).toBeInstanceOf(GitCommandError);
     expect(err).toMatchObject({ cause });
+  });
+});
+
+describe('getChangedFilesWithStatus', () => {
+  it('parses single-path rows (added, modified, deleted) into status objects', async () => {
+    execGitCommand.mockResolvedValue(
+      ['A\tpackage.json', 'M\tsrc/index.ts', 'D\told.ts'].join('\n')
+    );
+
+    const result = await getChangedFilesWithStatus(ctx, 'abc123', 'HEAD');
+
+    expect(result).toEqual([
+      { status: 'added', path: 'package.json' },
+      { status: 'modified', path: 'src/index.ts' },
+      { status: 'deleted', path: 'old.ts' },
+    ]);
+    expect(execGitCommand).toHaveBeenCalledWith(
+      ctx,
+      'git diff --name-status --find-renames=20% abc123 HEAD'
+    );
+  });
+
+  it('parses a rename row into a renamed status carrying both paths', async () => {
+    execGitCommand.mockResolvedValue('R097\tlibs/old/package.json\tlibs/app/package.json\n');
+
+    const result = await getChangedFilesWithStatus(ctx, 'abc123', 'HEAD');
+
+    expect(result).toEqual([
+      { status: 'renamed', fromPath: 'libs/old/package.json', path: 'libs/app/package.json' },
+    ]);
+  });
+
+  it('maps an unrecognized status code to unknown', async () => {
+    execGitCommand.mockResolvedValue('X\tweird.txt\n');
+
+    const result = await getChangedFilesWithStatus(ctx, 'abc123', 'HEAD');
+
+    expect(result).toEqual([{ status: 'unknown', path: 'weird.txt' }]);
+  });
+
+  it('returns an empty array when there are no changes', async () => {
+    execGitCommand.mockResolvedValue('');
+
+    const result = await getChangedFilesWithStatus(ctx, 'abc123', 'HEAD');
+
+    expect(result).toEqual([]);
+  });
+
+  it('appends a quoted pathspec when one is provided', async () => {
+    execGitCommand.mockResolvedValue('');
+
+    await getChangedFilesWithStatus(ctx, 'abc123', 'HEAD', ':(glob,top)**/pnpm-lock.yaml');
+
+    expect(execGitCommand).toHaveBeenCalledWith(
+      ctx,
+      'git diff --name-status --find-renames=20% abc123 HEAD -- ":(glob,top)**/pnpm-lock.yaml"'
+    );
   });
 });
 

--- a/node-src/git/git.test.ts
+++ b/node-src/git/git.test.ts
@@ -219,7 +219,7 @@ describe('getChangedFilesWithStatus', () => {
     ]);
     expect(execGitCommand).toHaveBeenCalledWith(
       ctx,
-      'git diff --name-status --find-renames=20% abc123 HEAD'
+      'git --no-pager diff --name-status --no-relative --find-renames=20% abc123 HEAD'
     );
   });
 
@@ -256,7 +256,7 @@ describe('getChangedFilesWithStatus', () => {
 
     expect(execGitCommand).toHaveBeenCalledWith(
       ctx,
-      'git diff --name-status --find-renames=20% abc123 HEAD -- ":(glob,top)**/pnpm-lock.yaml"'
+      'git --no-pager diff --name-status --no-relative --find-renames=20% abc123 HEAD -- ":(glob,top)**/pnpm-lock.yaml"'
     );
   });
 });

--- a/node-src/git/git.ts
+++ b/node-src/git/git.ts
@@ -221,6 +221,73 @@ export async function getChangedFiles(deps: GitDeps, baseCommit: string, headCom
   }
 }
 
+/** The kind of change Git reported for a file in a `--name-status` diff. */
+export type ChangedFileStatus =
+  | 'added'
+  | 'deleted'
+  | 'modified'
+  | 'renamed'
+  | 'typeChanged'
+  | 'unknown';
+
+/** A single row of a `--name-status` diff, parsed into a usable shape. */
+export interface ChangedFileWithStatus {
+  /** The kind of change Git reported. */
+  status: ChangedFileStatus;
+  /** The file's current path (the new path for renames). */
+  path: string;
+  /** The original path for renames; otherwise undefined. */
+  fromPath?: string;
+}
+
+// Maps the leading character of a `--name-status` row to a readable status. Renames carry a
+// similarity score suffix (e.g. `R097`), so we only key off the first character.
+const NAME_STATUS_CODES: Record<string, ChangedFileStatus> = {
+  A: 'added',
+  D: 'deleted',
+  M: 'modified',
+  R: 'renamed',
+  T: 'typeChanged',
+};
+
+/**
+ * Get the name-status diff of a single commit or between two, with rename detection, parsed into
+ * one object per changed file.
+ *
+ * @param deps Function dependencies.
+ * @param baseCommit The base commit to diff from.
+ * @param headCommit The head commit to diff to (empty includes uncommitted changes).
+ * @param pathspec Optional pathspec limiting the diff (e.g. a `:(glob)` magic pathspec).
+ * See: https://git-scm.com/docs/gitglossary#Documentation/gitglossary.txt-pathspec for details on
+ * magic pathspecs.
+ *
+ * @returns One {@link ChangedFileWithStatus} per changed file.
+ */
+export async function getChangedFilesWithStatus(
+  deps: GitDeps,
+  baseCommit: string,
+  headCommit = '',
+  pathspec = ''
+): Promise<ChangedFileWithStatus[]> {
+  const pathspecArgument = pathspec ? ` -- "${pathspec}"` : '';
+  const output = await execGitCommand(
+    deps,
+    `git diff --name-status --find-renames=20% ${baseCommit} ${headCommit}${pathspecArgument}`
+  );
+
+  return output
+    .split(newline)
+    .filter(Boolean)
+    .map((line) => {
+      const [code, ...paths] = line.split('\t');
+      const status = NAME_STATUS_CODES[code[0]] ?? 'unknown';
+      // Rename rows carry the old path first, then the new path.
+      return status === 'renamed'
+        ? { status, fromPath: paths[0], path: paths.at(-1) as string }
+        : { status, path: paths[0] };
+    });
+}
+
 /**
  * Returns a boolean indicating whether the workspace is up-to-date (neither ahead nor behind) with
  * the remote. Returns true on error, assuming the workspace is up-to-date.

--- a/node-src/git/git.ts
+++ b/node-src/git/git.ts
@@ -272,7 +272,7 @@ export async function getChangedFilesWithStatus(
   const pathspecArgument = pathspec ? ` -- "${pathspec}"` : '';
   const output = await execGitCommand(
     deps,
-    `git diff --name-status --find-renames=20% ${baseCommit} ${headCommit}${pathspecArgument}`
+    `git --no-pager diff --name-status --no-relative --find-renames=20% ${baseCommit} ${headCommit}${pathspecArgument}`
   );
 
   return output

--- a/node-src/lib/turbosnap/captureBailException.ts
+++ b/node-src/lib/turbosnap/captureBailException.ts
@@ -11,15 +11,28 @@ import * as Sentry from '@sentry/node';
  * @param options Bail context.
  * @param options.bailSubreason The classified subreason, or `undefined` to use default Sentry grouping.
  * @param options.bailPath A stable identifier for the bail site (used as the `bail_path` tag).
+ * @param options.additionalTags Extra tags to attach, e.g. a refined root-cause classification.
  *
  * @returns The Sentry event ID for the captured exception.
  */
 export function captureBailException(
   error: unknown,
-  { bailSubreason, bailPath }: { bailSubreason: string | undefined; bailPath: string }
+  {
+    bailSubreason,
+    bailPath,
+    additionalTags,
+  }: {
+    bailSubreason: string | undefined;
+    bailPath: string;
+    additionalTags?: Record<string, string>;
+  }
 ): string {
   return Sentry.captureException(error, {
-    tags: { bail_path: bailPath, ...(bailSubreason && { bail_detail: bailSubreason }) },
+    tags: {
+      bail_path: bailPath,
+      ...(bailSubreason && { bail_detail: bailSubreason }),
+      ...additionalTags,
+    },
     ...(bailSubreason && { fingerprint: [bailSubreason] }),
   });
 }

--- a/node-src/lib/turbosnap/classifyBailRootCause.test.ts
+++ b/node-src/lib/turbosnap/classifyBailRootCause.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { getChangedFilesWithStatus as getChangedFilesWithStatusDep } from '../../git/git';
+import TestLogger from '../testLogger';
+import { classifyBaselineCheckoutFailure } from './classifyBailRootCause';
+import { BaselineCheckoutFailedError, LockFileParseFailedError } from './errors';
+
+vi.mock('../../git/git');
+const getChangedFilesWithStatus = vi.mocked(getChangedFilesWithStatusDep);
+
+const deps = { log: new TestLogger(), options: {} } as any;
+
+describe('classifyBaselineCheckoutFailure', () => {
+  it('returns undefined for a non-BaselineCheckoutFailedError', async () => {
+    const result = await classifyBaselineCheckoutFailure(
+      deps,
+      new LockFileParseFailedError('/tmp/checkout-abc/yarn.lock')
+    );
+
+    expect(result).toBeUndefined();
+    expect(getChangedFilesWithStatus).not.toHaveBeenCalled();
+  });
+
+  describe('BaselineCheckoutFailedError', () => {
+    it('classifies a file rename as "baselineManifestMoved"', async () => {
+      getChangedFilesWithStatus.mockResolvedValue([
+        { status: 'renamed', fromPath: 'libs/old/package.json', path: 'libs/app/package.json' },
+      ]);
+
+    const result = await classifyBaselineCheckoutFailure(
+      deps,
+      new BaselineCheckoutFailedError('abc123:libs/app/package.json')
+    );
+
+    expect(result).toBe('baselineManifestMoved');
+  });
+
+    it('classifies a file add as "baselineManifestAdded"', async () => {
+      getChangedFilesWithStatus.mockResolvedValue([
+        { status: 'added', path: 'libs/app/package.json' },
+      ]);
+
+    const result = await classifyBaselineCheckoutFailure(
+      deps,
+      new BaselineCheckoutFailedError('abc123:libs/app/package.json')
+    );
+
+    expect(result).toBe('baselineManifestAdded');
+  });
+
+    it('classifies a file rename as "baselineManifestMoved" over "baselineManifestAdded" when the diff has both rows', async () => {
+      getChangedFilesWithStatus.mockResolvedValue([
+        { status: 'added', path: 'libs/app/package.json' },
+        { status: 'renamed', fromPath: 'libs/old/package.json', path: 'libs/app/package.json' },
+      ]);
+
+    const result = await classifyBaselineCheckoutFailure(
+      deps,
+      new BaselineCheckoutFailedError('abc123:libs/app/package.json')
+    );
+
+    expect(result).toBe('baselineManifestMoved');
+  });
+
+    it('returns "unknownBaselineCheckoutFailure" when we cannot classify the change', async () => {
+      getChangedFilesWithStatus.mockResolvedValue([
+        { status: 'modified', path: 'some/other/package.json' },
+      ]);
+
+    const result = await classifyBaselineCheckoutFailure(
+      deps,
+      new BaselineCheckoutFailedError('abc123:libs/app/package.json')
+    );
+
+    expect(result).toBe('unknownBaselineCheckoutFailure');
+  });
+
+    it('returns "unknownBaselineCheckoutFailure" when a git command throws unexpectedly', async () => {
+      getChangedFilesWithStatus.mockRejectedValue(new Error('git diff blew up'));
+
+    const result = await classifyBaselineCheckoutFailure(
+      deps,
+      new BaselineCheckoutFailedError('abc123:libs/app/package.json')
+    );
+
+    expect(result).toBe('unknownBaselineCheckoutFailure');
+  });
+});

--- a/node-src/lib/turbosnap/classifyBailRootCause.test.ts
+++ b/node-src/lib/turbosnap/classifyBailRootCause.test.ts
@@ -85,5 +85,18 @@ describe('classifyTagsFromError', () => {
 
       expect(result).toEqual({ baseline_failure_kind: 'unknownBaselineCheckoutFailure' });
     });
+
+    it('splits the pathspec on the first colon so a filename containing colons still matches', async () => {
+      getChangedFilesWithStatus.mockResolvedValue([
+        { status: 'renamed', fromPath: 'libs/old/a:b.json', path: 'libs/app/a:b.json' },
+      ]);
+
+      const result = await classifyTagsFromError(
+        deps,
+        new BaselineCheckoutFailedError('abc123:libs/app/a:b.json')
+      );
+
+      expect(result).toEqual({ baseline_failure_kind: 'baselineManifestMoved' });
+    });
   });
 });

--- a/node-src/lib/turbosnap/classifyBailRootCause.test.ts
+++ b/node-src/lib/turbosnap/classifyBailRootCause.test.ts
@@ -2,19 +2,19 @@ import { describe, expect, it, vi } from 'vitest';
 
 import { getChangedFilesWithStatus as getChangedFilesWithStatusDep } from '../../git/git';
 import TestLogger from '../testLogger';
-import { classifyBaselineCheckoutFailure } from './classifyBailRootCause';
-import { BaselineCheckoutFailedError, LockFileParseFailedError } from './errors';
+import { classifyTagsFromError } from './classifyBailRootCause';
+import { BaselineCheckoutFailedError } from './errors';
 
 vi.mock('../../git/git');
 const getChangedFilesWithStatus = vi.mocked(getChangedFilesWithStatusDep);
 
 const deps = { log: new TestLogger(), options: {} } as any;
 
-describe('classifyBaselineCheckoutFailure', () => {
-  it('returns undefined for a non-BaselineCheckoutFailedError', async () => {
-    const result = await classifyBaselineCheckoutFailure(
+describe('classifyTagsFromError', () => {
+  it('returns undefined for an error that is not classified yet', async () => {
+    const result = await classifyTagsFromError(
       deps,
-      new LockFileParseFailedError('/tmp/checkout-abc/yarn.lock')
+      new Error("some random error which won't have special handling")
     );
 
     expect(result).toBeUndefined();
@@ -27,26 +27,26 @@ describe('classifyBaselineCheckoutFailure', () => {
         { status: 'renamed', fromPath: 'libs/old/package.json', path: 'libs/app/package.json' },
       ]);
 
-    const result = await classifyBaselineCheckoutFailure(
-      deps,
-      new BaselineCheckoutFailedError('abc123:libs/app/package.json')
-    );
+      const result = await classifyTagsFromError(
+        deps,
+        new BaselineCheckoutFailedError('abc123:libs/app/package.json')
+      );
 
-    expect(result).toBe('baselineManifestMoved');
-  });
+      expect(result).toEqual({ baseline_failure_kind: 'baselineManifestMoved' });
+    });
 
     it('classifies a file add as "baselineManifestAdded"', async () => {
       getChangedFilesWithStatus.mockResolvedValue([
         { status: 'added', path: 'libs/app/package.json' },
       ]);
 
-    const result = await classifyBaselineCheckoutFailure(
-      deps,
-      new BaselineCheckoutFailedError('abc123:libs/app/package.json')
-    );
+      const result = await classifyTagsFromError(
+        deps,
+        new BaselineCheckoutFailedError('abc123:libs/app/package.json')
+      );
 
-    expect(result).toBe('baselineManifestAdded');
-  });
+      expect(result).toEqual({ baseline_failure_kind: 'baselineManifestAdded' });
+    });
 
     it('classifies a file rename as "baselineManifestMoved" over "baselineManifestAdded" when the diff has both rows', async () => {
       getChangedFilesWithStatus.mockResolvedValue([
@@ -54,35 +54,36 @@ describe('classifyBaselineCheckoutFailure', () => {
         { status: 'renamed', fromPath: 'libs/old/package.json', path: 'libs/app/package.json' },
       ]);
 
-    const result = await classifyBaselineCheckoutFailure(
-      deps,
-      new BaselineCheckoutFailedError('abc123:libs/app/package.json')
-    );
+      const result = await classifyTagsFromError(
+        deps,
+        new BaselineCheckoutFailedError('abc123:libs/app/package.json')
+      );
 
-    expect(result).toBe('baselineManifestMoved');
-  });
+      expect(result).toEqual({ baseline_failure_kind: 'baselineManifestMoved' });
+    });
 
     it('returns "unknownBaselineCheckoutFailure" when we cannot classify the change', async () => {
       getChangedFilesWithStatus.mockResolvedValue([
         { status: 'modified', path: 'some/other/package.json' },
       ]);
 
-    const result = await classifyBaselineCheckoutFailure(
-      deps,
-      new BaselineCheckoutFailedError('abc123:libs/app/package.json')
-    );
+      const result = await classifyTagsFromError(
+        deps,
+        new BaselineCheckoutFailedError('abc123:libs/app/package.json')
+      );
 
-    expect(result).toBe('unknownBaselineCheckoutFailure');
-  });
+      expect(result).toEqual({ baseline_failure_kind: 'unknownBaselineCheckoutFailure' });
+    });
 
     it('returns "unknownBaselineCheckoutFailure" when a git command throws unexpectedly', async () => {
       getChangedFilesWithStatus.mockRejectedValue(new Error('git diff blew up'));
 
-    const result = await classifyBaselineCheckoutFailure(
-      deps,
-      new BaselineCheckoutFailedError('abc123:libs/app/package.json')
-    );
+      const result = await classifyTagsFromError(
+        deps,
+        new BaselineCheckoutFailedError('abc123:libs/app/package.json')
+      );
 
-    expect(result).toBe('unknownBaselineCheckoutFailure');
+      expect(result).toEqual({ baseline_failure_kind: 'unknownBaselineCheckoutFailure' });
+    });
   });
 });

--- a/node-src/lib/turbosnap/classifyBailRootCause.test.ts
+++ b/node-src/lib/turbosnap/classifyBailRootCause.test.ts
@@ -1,12 +1,16 @@
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { getChangedFilesWithStatus as getChangedFilesWithStatusDep } from '../../git/git';
+import {
+  commitExists as commitExistsDep,
+  getChangedFilesWithStatus as getChangedFilesWithStatusDep,
+} from '../../git/git';
 import TestLogger from '../testLogger';
 import { classifyTagsFromError } from './classifyBailRootCause';
 import { BaselineCheckoutFailedError } from './errors';
 
 vi.mock('../../git/git');
 const getChangedFilesWithStatus = vi.mocked(getChangedFilesWithStatusDep);
+const commitExists = vi.mocked(commitExistsDep);
 
 const deps = { log: new TestLogger(), options: {} } as any;
 
@@ -22,6 +26,22 @@ describe('classifyTagsFromError', () => {
   });
 
   describe('BaselineCheckoutFailedError', () => {
+    beforeEach(() => {
+      commitExists.mockResolvedValue(true);
+    });
+
+    it('classifies a missing baseline commit as "baselineCommitMissing" without diffing', async () => {
+      commitExists.mockResolvedValue(false);
+
+      const result = await classifyTagsFromError(
+        deps,
+        new BaselineCheckoutFailedError('abc123:libs/app/package.json')
+      );
+
+      expect(result).toEqual({ baseline_failure_kind: 'baselineCommitMissing' });
+      expect(getChangedFilesWithStatus).not.toHaveBeenCalled();
+    });
+
     it('classifies a file rename as "baselineManifestMoved"', async () => {
       getChangedFilesWithStatus.mockResolvedValue([
         { status: 'renamed', fromPath: 'libs/old/package.json', path: 'libs/app/package.json' },

--- a/node-src/lib/turbosnap/classifyBailRootCause.test.ts
+++ b/node-src/lib/turbosnap/classifyBailRootCause.test.ts
@@ -53,6 +53,7 @@ describe('classifyTagsFromError', () => {
       );
 
       expect(result).toEqual({ baseline_failure_kind: 'baselineManifestMoved' });
+      expectBaselineDiffWasRun('abc123', 'package.json');
     });
 
     it('classifies a file add as "baselineManifestAdded"', async () => {
@@ -117,6 +118,23 @@ describe('classifyTagsFromError', () => {
       );
 
       expect(result).toEqual({ baseline_failure_kind: 'baselineManifestMoved' });
+      // The basename is extracted after splitting on the first colon, so the glob keeps the colon.
+      expectBaselineDiffWasRun('abc123', 'a:b.json');
     });
   });
 });
+
+// Assert we're running the exact git command. We don't normally add these to tests since it mimics
+// the implementation. However, we opted to add this one because it's more stable than running it
+// against a real repo.
+//
+// If you change the git command and the tests fail, be sure to think about the test behavior here before updating.
+function expectBaselineDiffWasRun(reference: string, basename: string) {
+  expect(commitExists).toHaveBeenCalledWith(deps, reference);
+  expect(getChangedFilesWithStatus).toHaveBeenCalledWith(
+    deps,
+    reference,
+    'HEAD',
+    `:(glob,top)**/${basename}`
+  );
+}

--- a/node-src/lib/turbosnap/classifyBailRootCause.ts
+++ b/node-src/lib/turbosnap/classifyBailRootCause.ts
@@ -2,7 +2,7 @@ import * as Sentry from '@sentry/node';
 import path from 'path';
 
 import { GitDeps } from '../../git/execGit';
-import { ChangedFileWithStatus, getChangedFilesWithStatus } from '../../git/git';
+import { ChangedFileWithStatus, commitExists, getChangedFilesWithStatus } from '../../git/git';
 import { BaselineCheckoutFailedError } from './errors';
 
 /**
@@ -33,6 +33,7 @@ export async function classifyTagsFromError(
 export type BaselineCheckoutFailureKind =
   | 'baselineManifestMoved'
   | 'baselineManifestAdded'
+  | 'baselineCommitMissing'
   | 'unknownBaselineCheckoutFailure';
 
 /**
@@ -50,6 +51,11 @@ async function classifyBaselineCheckoutFailureTags(
   const { reference, fileName } = parsePathspec(error.pathspec);
 
   try {
+    // In a shallow clone or rebase/squash merge the baseline commit may not be present locally.
+    if (!(await commitExists(deps, reference))) {
+      return { baseline_failure_kind: 'baselineCommitMissing' };
+    }
+
     // Determine how the file changed between the baseline and HEAD (such as if it was added, moved,
     // renamed, etc).
     const basename = path.basename(fileName);

--- a/node-src/lib/turbosnap/classifyBailRootCause.ts
+++ b/node-src/lib/turbosnap/classifyBailRootCause.ts
@@ -1,0 +1,104 @@
+import * as Sentry from '@sentry/node';
+import path from 'path';
+
+import { GitDeps } from '../../git/execGit';
+import { ChangedFileWithStatus, getChangedFilesWithStatus } from '../../git/git';
+import { BaselineCheckoutFailedError } from './errors';
+
+/**
+ * Refined root-cause kinds for a BaselineCheckoutFailedError.
+ *
+ * These exist for Sentry ONLY and are not sent to the backend.
+ */
+export type BaselineCheckoutFailureKind =
+  | 'baselineManifestMoved'
+  | 'baselineManifestAdded'
+  | 'unknownBaselineCheckoutFailure';
+
+/**
+ * Check git to determine the root cause of a BaselineCheckoutFailedError.
+ *
+ * @param deps Function dependencies.
+ * @param error The error captured at the bail site.
+ *
+ * @returns The refined failure kind or `undefined` when `error` is not a
+ * `BaselineCheckoutFailedError`.
+ */
+export async function classifyBaselineCheckoutFailure(
+  deps: GitDeps,
+  error: unknown
+): Promise<BaselineCheckoutFailureKind | undefined> {
+  if (!(error instanceof BaselineCheckoutFailedError)) {
+    return undefined;
+  }
+
+  const { reference, fileName } = parsePathspec(error.pathspec);
+
+  try {
+    // Determine how the file changed between the baseline and HEAD (such as if it was added, moved,
+    // renamed, etc).
+    const basename = path.basename(fileName);
+    const changes = await getChangedFilesWithStatus(
+      deps,
+      reference,
+      'HEAD',
+      // See https://git-scm.com/docs/gitglossary#Documentation/gitglossary.txt-pathspec for details
+      //
+      // `glob` allows us to pass in a glob pattern
+      // `top` anchors the response to the root of the repository (so we can catch cross-directory changes)
+      `:(glob,top)**/${basename}`
+    );
+    return classifyRenameDiff(changes, fileName);
+  } catch (err) {
+    // We capture the exception higher in the stack so we can simply attach the error context here.
+    Sentry.addBreadcrumb({
+      level: 'error',
+      category: 'classifyBaselineCheckoutFailure',
+      message: 'Error classifying baseline checkout failure',
+      data: {
+        error: err,
+      },
+    });
+
+    return 'unknownBaselineCheckoutFailure';
+  }
+}
+
+/**
+ * Determine if the file was moved or added or something else.
+ *
+ * @param changes The parsed changed files from the diff.
+ * @param fileName The failed file path to match against.
+ *
+ * @returns The matching manifest failure kind.
+ */
+function classifyRenameDiff(
+  changes: ChangedFileWithStatus[],
+  fileName: string
+): BaselineCheckoutFailureKind {
+  // Check renames first so a moved manifest is never mislabeled as added.
+  if (changes.some((change) => change.status === 'renamed' && change.path === fileName)) {
+    return 'baselineManifestMoved';
+  }
+  if (changes.some((change) => change.status === 'added' && change.path === fileName)) {
+    return 'baselineManifestAdded';
+  }
+  return 'unknownBaselineCheckoutFailure';
+}
+
+/**
+ * Split a pathspec of the form `<reference>:<fileName>` into its parts.
+ *
+ * @param pathspec The pathspec carried by a `BaselineCheckoutFailedError`.
+ *
+ * @returns The baseline reference (SHA) and the file path.
+ */
+function parsePathspec(pathspec: string): { reference: string; fileName: string } {
+  // Find the first colon which separates the reference from the file path. We can't just split on
+  // colon and return the first and second parts since files can contain colons.
+  const separatorIndex = pathspec.indexOf(':');
+  return {
+    reference: pathspec.slice(0, separatorIndex),
+    fileName: pathspec.slice(separatorIndex + 1),
+  };
+}

--- a/node-src/lib/turbosnap/classifyBailRootCause.ts
+++ b/node-src/lib/turbosnap/classifyBailRootCause.ts
@@ -6,6 +6,26 @@ import { ChangedFileWithStatus, getChangedFilesWithStatus } from '../../git/git'
 import { BaselineCheckoutFailedError } from './errors';
 
 /**
+ * Classify an error captured at the TurboSnap bail site into additional Sentry tags describing its
+ * root cause.
+ *
+ * @param deps Function dependencies.
+ * @param error The error captured at the bail site.
+ *
+ * @returns A map of Sentry tags, or `undefined` when the error type is not recognized.
+ */
+export async function classifyTagsFromError(
+  deps: GitDeps,
+  error: unknown
+): Promise<Record<string, string> | undefined> {
+  if (error instanceof BaselineCheckoutFailedError) {
+    return classifyBaselineCheckoutFailureTags(deps, error);
+  }
+
+  return undefined;
+}
+
+/**
  * Refined root-cause kinds for a BaselineCheckoutFailedError.
  *
  * These exist for Sentry ONLY and are not sent to the backend.
@@ -24,10 +44,10 @@ export type BaselineCheckoutFailureKind =
  * @returns The refined failure kind or `undefined` when `error` is not a
  * `BaselineCheckoutFailedError`.
  */
-export async function classifyBaselineCheckoutFailure(
+async function classifyBaselineCheckoutFailureTags(
   deps: GitDeps,
   error: unknown
-): Promise<BaselineCheckoutFailureKind | undefined> {
+): Promise<Record<'baseline_failure_kind', BaselineCheckoutFailureKind> | undefined> {
   if (!(error instanceof BaselineCheckoutFailedError)) {
     return undefined;
   }
@@ -48,7 +68,7 @@ export async function classifyBaselineCheckoutFailure(
       // `top` anchors the response to the root of the repository (so we can catch cross-directory changes)
       `:(glob,top)**/${basename}`
     );
-    return classifyRenameDiff(changes, fileName);
+    return { baseline_failure_kind: classifyRenameDiff(changes, fileName) };
   } catch (err) {
     // We capture the exception higher in the stack so we can simply attach the error context here.
     Sentry.addBreadcrumb({
@@ -60,7 +80,7 @@ export async function classifyBaselineCheckoutFailure(
       },
     });
 
-    return 'unknownBaselineCheckoutFailure';
+    return { baseline_failure_kind: 'unknownBaselineCheckoutFailure' };
   }
 }
 

--- a/node-src/lib/turbosnap/classifyBailRootCause.ts
+++ b/node-src/lib/turbosnap/classifyBailRootCause.ts
@@ -68,7 +68,7 @@ async function classifyBaselineCheckoutFailureTags(
       // `top` anchors the response to the root of the repository (so we can catch cross-directory changes)
       `:(glob,top)**/${basename}`
     );
-    return { baseline_failure_kind: classifyRenameDiff(changes, fileName) };
+    return { baseline_failure_kind: classifyManifestChange(changes, fileName) };
   } catch (err) {
     // We capture the exception higher in the stack so we can simply attach the error context here.
     Sentry.addBreadcrumb({
@@ -92,7 +92,7 @@ async function classifyBaselineCheckoutFailureTags(
  *
  * @returns The matching manifest failure kind.
  */
-function classifyRenameDiff(
+function classifyManifestChange(
   changes: ChangedFileWithStatus[],
   fileName: string
 ): BaselineCheckoutFailureKind {

--- a/node-src/lib/turbosnap/classifyBailRootCause.ts
+++ b/node-src/lib/turbosnap/classifyBailRootCause.ts
@@ -70,9 +70,7 @@ async function classifyBaselineCheckoutFailureTags(
       level: 'error',
       category: 'classifyBaselineCheckoutFailure',
       message: 'Error classifying baseline checkout failure',
-      data: {
-        error: err,
-      },
+      data: { name: err.name, message: err.message, stack: err.stack },
     });
 
     return { baseline_failure_kind: 'unknownBaselineCheckoutFailure' };

--- a/node-src/lib/turbosnap/classifyBailRootCause.ts
+++ b/node-src/lib/turbosnap/classifyBailRootCause.ts
@@ -41,17 +41,12 @@ export type BaselineCheckoutFailureKind =
  * @param deps Function dependencies.
  * @param error The error captured at the bail site.
  *
- * @returns The refined failure kind or `undefined` when `error` is not a
- * `BaselineCheckoutFailedError`.
+ * @returns The refined failure kind.
  */
 async function classifyBaselineCheckoutFailureTags(
   deps: GitDeps,
-  error: unknown
-): Promise<Record<'baseline_failure_kind', BaselineCheckoutFailureKind> | undefined> {
-  if (!(error instanceof BaselineCheckoutFailedError)) {
-    return undefined;
-  }
-
+  error: BaselineCheckoutFailedError
+): Promise<Record<'baseline_failure_kind', BaselineCheckoutFailureKind>> {
   const { reference, fileName } = parsePathspec(error.pathspec);
 
   try {

--- a/node-src/lib/turbosnap/index.test.ts
+++ b/node-src/lib/turbosnap/index.test.ts
@@ -169,12 +169,10 @@ describe('traceChangedFiles', () => {
       expect(captureException).toHaveBeenCalledWith(error, {
         tags: {
           bail_path: 'findChangedDependencies',
-          bail_detail: expectedKey,
+          ...(expectedKey && { bail_detail: expectedKey }),
           ...(expectedFailureKind && { baseline_failure_kind: expectedFailureKind }),
         },
-        ...(expectFingerprint && {
-          fingerprint: [expectedKey],
-        }),
+        ...(expectFingerprint && { fingerprint: [expectedKey] }),
       });
     });
   }

--- a/node-src/lib/turbosnap/index.test.ts
+++ b/node-src/lib/turbosnap/index.test.ts
@@ -5,7 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { exitCodes } from '../setExitCode';
 import TestLogger from '../testLogger';
 import { traceChangedFiles } from '.';
-import { classifyBaselineCheckoutFailure as classifyBaselineCheckoutFailureDep } from './classifyBailRootCause';
+import { classifyTagsFromError as classifyTagsFromErrorDep } from './classifyBailRootCause';
 import {
   BaselineCheckoutFailedError,
   LockFileParseFailedError,
@@ -44,7 +44,7 @@ vi.mock('../../tasks/readStatsFile', () => ({
 const getDependentStoryFiles = vi.mocked(getDependentStoryFilesDep);
 const findChangedPackageFiles = vi.mocked(findChangedPackageFilesDep);
 const findChangedDependencies = vi.mocked(findChangedDependenciesDep);
-const classifyBaselineCheckoutFailure = vi.mocked(classifyBaselineCheckoutFailureDep);
+const classifyTagsFromError = vi.mocked(classifyTagsFromErrorDep);
 const accessMock = vi.mocked(access);
 const captureException = vi.mocked(Sentry.captureException);
 
@@ -145,8 +145,10 @@ describe('traceChangedFiles', () => {
     it(`bails on package.json changes and tags bailReason as ${name}`, async () => {
       findChangedDependencies.mockRejectedValue(error);
       findChangedPackageFiles.mockResolvedValue(['./package.json']);
-      classifyBaselineCheckoutFailure.mockImplementation(async (_deps, err) =>
-        err instanceof BaselineCheckoutFailedError ? 'baselineManifestMoved' : undefined
+      classifyTagsFromError.mockImplementation(async (_deps, err) =>
+        err instanceof BaselineCheckoutFailedError
+          ? { baseline_failure_kind: 'baselineManifestMoved' }
+          : undefined
       );
 
       const packageMetadataChanges = [{ changedFiles: ['./package.json'], commit: 'abcdef' }];
@@ -171,7 +173,7 @@ describe('traceChangedFiles', () => {
           ...(expectedFailureKind && { baseline_failure_kind: expectedFailureKind }),
         },
         ...(expectFingerprint && {
-          fingerprint: expectedFailureKind ? [expectedKey, expectedFailureKind] : [expectedKey],
+          fingerprint: [expectedKey],
         }),
       });
     });

--- a/node-src/lib/turbosnap/index.test.ts
+++ b/node-src/lib/turbosnap/index.test.ts
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { exitCodes } from '../setExitCode';
 import TestLogger from '../testLogger';
 import { traceChangedFiles } from '.';
+import { classifyBaselineCheckoutFailure as classifyBaselineCheckoutFailureDep } from './classifyBailRootCause';
 import {
   BaselineCheckoutFailedError,
   LockFileParseFailedError,
@@ -27,6 +28,7 @@ vi.mock('./findChangedDependencies', async (importOriginal) => {
 });
 vi.mock('./findChangedPackageFiles');
 vi.mock('./getDependentStoryFiles');
+vi.mock('./classifyBailRootCause');
 vi.mock('../../tasks/readStatsFile', () => ({
   readStatsFile: () =>
     Promise.resolve({
@@ -42,6 +44,7 @@ vi.mock('../../tasks/readStatsFile', () => ({
 const getDependentStoryFiles = vi.mocked(getDependentStoryFilesDep);
 const findChangedPackageFiles = vi.mocked(findChangedPackageFilesDep);
 const findChangedDependencies = vi.mocked(findChangedDependenciesDep);
+const classifyBaselineCheckoutFailure = vi.mocked(classifyBaselineCheckoutFailureDep);
 const accessMock = vi.mocked(access);
 const captureException = vi.mocked(Sentry.captureException);
 
@@ -116,6 +119,7 @@ describe('traceChangedFiles', () => {
         sentryEventId: 'sentry-event-id',
       },
       expectedKey: 'baselineCheckoutFailed',
+      expectedFailureKind: 'baselineManifestMoved',
       expectFingerprint: true,
     },
     {
@@ -135,11 +139,15 @@ describe('traceChangedFiles', () => {
     error,
     expectedBailReason,
     expectedKey,
+    expectedFailureKind,
     expectFingerprint,
   } of findChangedDependenciesFailureCases) {
     it(`bails on package.json changes and tags bailReason as ${name}`, async () => {
       findChangedDependencies.mockRejectedValue(error);
       findChangedPackageFiles.mockResolvedValue(['./package.json']);
+      classifyBaselineCheckoutFailure.mockImplementation(async (_deps, err) =>
+        err instanceof BaselineCheckoutFailedError ? 'baselineManifestMoved' : undefined
+      );
 
       const packageMetadataChanges = [{ changedFiles: ['./package.json'], commit: 'abcdef' }];
       const ctx = {
@@ -159,9 +167,12 @@ describe('traceChangedFiles', () => {
       expect(captureException).toHaveBeenCalledWith(error, {
         tags: {
           bail_path: 'findChangedDependencies',
-          ...(expectedKey && { bail_detail: expectedKey }),
+          bail_detail: expectedKey,
+          ...(expectedFailureKind && { baseline_failure_kind: expectedFailureKind }),
         },
-        ...(expectFingerprint && { fingerprint: [expectedKey] }),
+        ...(expectFingerprint && {
+          fingerprint: expectedFailureKind ? [expectedKey, expectedFailureKind] : [expectedKey],
+        }),
       });
     });
   }

--- a/node-src/lib/turbosnap/index.ts
+++ b/node-src/lib/turbosnap/index.ts
@@ -7,8 +7,7 @@ import missingStatsFile from '../../ui/messages/errors/missingStatsFile';
 import bailFile from '../../ui/messages/warnings/bailFile';
 import { checkStorybookBaseDirectory } from '../checkStorybookBaseDirectory';
 import { classifyChangedPackageFilesDetail } from './classifyBailDetail';
-import { classifyBaselineCheckoutFailure } from './classifyBailRootCause';
-import { BaselineCheckoutFailedError } from './errors';
+import { classifyTagsFromError } from './classifyBailRootCause';
 import { findChangedDependencies } from './findChangedDependencies';
 import { findChangedPackageFiles } from './findChangedPackageFiles';
 import { getDependentStoryFiles } from './getDependentStoryFiles';
@@ -61,23 +60,17 @@ export const traceChangedFiles = async (ctx: Context) => {
         // don't want to capture an error since we were able to recover and didn't bail.
         if (pendingPatch && pendingError) {
           const { bailSubreason } = pendingPatch;
-          // TODO: make this better
-          const baselineFailureKind =
-            pendingError instanceof BaselineCheckoutFailedError
-              ? await classifyBaselineCheckoutFailure(ctx, pendingError)
-              : undefined;
+          const additionalTags = await classifyTagsFromError(ctx, pendingError);
           pendingPatch.sentryEventId = Sentry.captureException(pendingError, {
             tags: {
               bail_path: 'findChangedDependencies',
               bail_detail: bailSubreason,
-              ...(baselineFailureKind && { baseline_failure_kind: baselineFailureKind }),
+              ...additionalTags,
             },
             // group known bail reasons under one issue per key; let Sentry's default grouping
             // handle unclassified errors so they don't all collapse into a single bucket
             ...(bailSubreason && {
-              fingerprint: baselineFailureKind
-                ? [bailSubreason, baselineFailureKind]
-                : [bailSubreason],
+              fingerprint: [bailSubreason],
             }),
           });
         }

--- a/node-src/lib/turbosnap/index.ts
+++ b/node-src/lib/turbosnap/index.ts
@@ -1,3 +1,4 @@
+import * as Sentry from '@sentry/node';
 import semver from 'semver';
 
 import { readStatsFile } from '../../tasks/readStatsFile';
@@ -5,13 +6,14 @@ import { ChangedPackageFilesBailReason, Context } from '../../types';
 import missingStatsFile from '../../ui/messages/errors/missingStatsFile';
 import bailFile from '../../ui/messages/warnings/bailFile';
 import { checkStorybookBaseDirectory } from '../checkStorybookBaseDirectory';
-import { captureBailException } from './captureBailException';
 import { classifyChangedPackageFilesDetail } from './classifyBailDetail';
+import { classifyBaselineCheckoutFailure } from './classifyBailRootCause';
+import { BaselineCheckoutFailedError } from './errors';
 import { findChangedDependencies } from './findChangedDependencies';
 import { findChangedPackageFiles } from './findChangedPackageFiles';
 import { getDependentStoryFiles } from './getDependentStoryFiles';
 
-// eslint-disable-next-line complexity
+// eslint-disable-next-line complexity, max-statements
 export const traceChangedFiles = async (ctx: Context) => {
   if (!ctx.turboSnap || ctx.turboSnap.unavailable) return;
   if (!ctx.git.changedFiles) return;
@@ -58,9 +60,25 @@ export const traceChangedFiles = async (ctx: Context) => {
         // be times when findChangedDependencies fails but our fallback works. In those cases, we
         // don't want to capture an error since we were able to recover and didn't bail.
         if (pendingPatch && pendingError) {
-          pendingPatch.sentryEventId = captureBailException(pendingError, {
-            bailSubreason: pendingPatch.bailSubreason,
-            bailPath: 'findChangedDependencies',
+          const { bailSubreason } = pendingPatch;
+          // TODO: make this better
+          const baselineFailureKind =
+            pendingError instanceof BaselineCheckoutFailedError
+              ? await classifyBaselineCheckoutFailure(ctx, pendingError)
+              : undefined;
+          pendingPatch.sentryEventId = Sentry.captureException(pendingError, {
+            tags: {
+              bail_path: 'findChangedDependencies',
+              bail_detail: bailSubreason,
+              ...(baselineFailureKind && { baseline_failure_kind: baselineFailureKind }),
+            },
+            // group known bail reasons under one issue per key; let Sentry's default grouping
+            // handle unclassified errors so they don't all collapse into a single bucket
+            ...(bailSubreason && {
+              fingerprint: baselineFailureKind
+                ? [bailSubreason, baselineFailureKind]
+                : [bailSubreason],
+            }),
           });
         }
 

--- a/node-src/lib/turbosnap/index.ts
+++ b/node-src/lib/turbosnap/index.ts
@@ -1,4 +1,3 @@
-import * as Sentry from '@sentry/node';
 import semver from 'semver';
 
 import { readStatsFile } from '../../tasks/readStatsFile';
@@ -6,13 +5,14 @@ import { ChangedPackageFilesBailReason, Context } from '../../types';
 import missingStatsFile from '../../ui/messages/errors/missingStatsFile';
 import bailFile from '../../ui/messages/warnings/bailFile';
 import { checkStorybookBaseDirectory } from '../checkStorybookBaseDirectory';
+import { captureBailException } from './captureBailException';
 import { classifyChangedPackageFilesDetail } from './classifyBailDetail';
 import { classifyTagsFromError } from './classifyBailRootCause';
 import { findChangedDependencies } from './findChangedDependencies';
 import { findChangedPackageFiles } from './findChangedPackageFiles';
 import { getDependentStoryFiles } from './getDependentStoryFiles';
 
-// eslint-disable-next-line complexity, max-statements
+// eslint-disable-next-line complexity
 export const traceChangedFiles = async (ctx: Context) => {
   if (!ctx.turboSnap || ctx.turboSnap.unavailable) return;
   if (!ctx.git.changedFiles) return;
@@ -59,19 +59,10 @@ export const traceChangedFiles = async (ctx: Context) => {
         // be times when findChangedDependencies fails but our fallback works. In those cases, we
         // don't want to capture an error since we were able to recover and didn't bail.
         if (pendingPatch && pendingError) {
-          const { bailSubreason } = pendingPatch;
-          const additionalTags = await classifyTagsFromError(ctx, pendingError);
-          pendingPatch.sentryEventId = Sentry.captureException(pendingError, {
-            tags: {
-              bail_path: 'findChangedDependencies',
-              bail_detail: bailSubreason,
-              ...additionalTags,
-            },
-            // group known bail reasons under one issue per key; let Sentry's default grouping
-            // handle unclassified errors so they don't all collapse into a single bucket
-            ...(bailSubreason && {
-              fingerprint: [bailSubreason],
-            }),
+          pendingPatch.sentryEventId = captureBailException(pendingError, {
+            bailSubreason: pendingPatch.bailSubreason,
+            bailPath: 'findChangedDependencies',
+            additionalTags: await classifyTagsFromError(ctx, pendingError),
           });
         }
 


### PR DESCRIPTION
This PR adds additional tags to our Sentry exceptions to add more context to our `BaselineCheckoutFailedError` error in TurboSnap. To do that, we try to determine if a field was added or moved since the baseline because checking out either will fail earlier in the TurboSnap diff process. Ideally, we would use this information to follow the file around instead of bailing but we'll start with data collection first.

I was using my sample monorepo project to test out each scenario. I'll attempt to describe how I QAed each below. It uses `Nx` with `Yarn`.

> [!NOTE]
> This addition does NOT get sent to the backend. It's merely adding Sentry details.

To force these exceptions to go to Sentry, I patched the CLI to enable it:

```
diff --git a/node-src/errorMonitoring.ts b/node-src/errorMonitoring.ts
index f673ddac..987b1b4f 100644
--- a/node-src/errorMonitoring.ts
+++ b/node-src/errorMonitoring.ts
@@ -51,10 +51,8 @@ Sentry.init({
   release: process.env.SENTRY_RELEASE || process.env.npm_package_version,
   dist: process.env.SENTRY_DIST,
   sampleRate: 1,
-  environment: process.env.SENTRY_ENVIRONMENT,
-  enabled:
-    process.env.DISABLE_ERROR_MONITORING !== 'true' &&
-    process.env.SENTRY_ENVIRONMENT !== 'development',
+  environment: 'development',
+  enabled: true,
   enableTracing: false,
   integrations: [],
   initialScope: {
```

## `baselineManifestAdded`

I added a new package to my monorepo and commited it. Then ran a build with TurboSnap enabled (`--only-changed`). Doing this, yielded the expected bail:

```
execGitCommand: git cat-file -e "ac63e5eb474358e6a3b1e9ee9a2a5ea5b436448a^{commit}"
execGitCommand result: ''
execGitCommand: git diff --name-status --find-renames=20% ac63e5eb474358e6a3b1e9ee9a2a5ea5b436448a HEAD -- ":(glob,top)**/package.json"
execGitCommand result: 'A  packages/lambda/package.json'
⚠ TurboSnap disabled due to file change
Found a package file change in packages/lambda/package.json or its module sibling yarn.lock
A full build is required because this file cannot be linked to any specific stories.
ℹ Read more at https://www.chromatic.com/docs/turbosnap#how-it-works
```

Then in Sentry:
<img width="509" height="285" alt="Screenshot 2026-06-10 at 2 58 26 PM" src="https://github.com/user-attachments/assets/dd2773bd-06c4-43cf-9801-9d5856d20788" />

## `baselineManifestMoved`

Following [baselineManifestAdded](#baselineManifestAdded), I moved the `lambda` package to `lambda2` then ran another build. Doing this, yielded the expected bail:

```
execGitCommand: git cat-file -e "8619400ab8ee0aaac20a6b1c39c5edd2b971cc50^{commit}"
execGitCommand result: ''
execGitCommand: git diff --name-status --find-renames=20% 8619400ab8ee0aaac20a6b1c39c5edd2b971cc50 HEAD -- ":(glob,top)**/package.json"
execGitCommand result: 'R100       packages/lambda/package.json    packages/lambda2/package.json'
⚠ TurboSnap disabled due to file change
Found a package file change in packages/lambda2/package.json or its module sibling yarn.lock
A full build is required because this file cannot be linked to any specific stories.
ℹ Read more at https://www.chromatic.com/docs/turbosnap#how-it-works
```

Then in Sentry:
<img width="511" height="285" alt="Screenshot 2026-06-10 at 2 58 59 PM" src="https://github.com/user-attachments/assets/61efe58c-d958-4e34-a95c-c634be708635" />

## `unknownBaselineCheckoutFailure`

For this one, I forced the error by patching the CLI:

```
diff --git a/node-src/lib/turbosnap/classifyBailRootCause.ts b/node-src/lib/turbosnap/classifyBailRootCause.ts
index ab345544..2d9a4fc8 100644
--- a/node-src/lib/turbosnap/classifyBailRootCause.ts
+++ b/node-src/lib/turbosnap/classifyBailRootCause.ts
@@ -51,6 +51,7 @@ async function classifyBaselineCheckoutFailureTags(
   if (!(error instanceof BaselineCheckoutFailedError)) {
     return undefined;
   }
+  return { baseline_failure_kind: 'unknownBaselineCheckoutFailure' };
 
   const { reference, fileName } = parsePathspec(error.pathspec);
 
```

Then I built the CLI, added a new package in my monorepo, then ran another TurboSnap build. Then I got the following bail reason:

```
⚠ TurboSnap disabled due to file change
Found a package file change in packages/lambda/package.json or its module sibling yarn.lock
A full build is required because this file cannot be linked to any specific stories.
ℹ Read more at https://www.chromatic.com/docs/turbosnap#how-it-works
```

Then in Sentry:
<img width="511" height="289" alt="Screenshot 2026-06-10 at 3 23 51 PM" src="https://github.com/user-attachments/assets/cbfcf5dc-1e45-47f5-91e7-82a90dd93dd6" />

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>17.6.0--canary.1391.27703306584.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@17.6.0--canary.1391.27703306584.0
  # or 
  yarn add chromatic@17.6.0--canary.1391.27703306584.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
