### PR TITLE
Migrate `storybookInfo` to Clack

### DIFF
--- a/node-src/index.ts
+++ b/node-src/index.ts
@@ -34,6 +34,7 @@ import { writeChromaticDiagnostics } from './lib/writeChromaticDiagnostics';
 import { intro as clackIntro } from './renderer';
 import { renderAuth } from './renderer/auth';
 import { renderGitInfo } from './renderer/gitInfo';
+import { renderStorybookInfo } from './renderer/storybookInfo';
 import getTasks from './tasks';
 import { Context, Flags, Options } from './types';
 import { endActivity } from './ui/components/activity';
@@ -290,6 +291,7 @@ async function runBuild(ctx: Context) {
       }
       await renderAuth(ctx);
       await renderGitInfo(ctx);
+      await renderStorybookInfo(ctx);
       await new Listr(getTasks(ctx), options).run(ctx);
       ctx.log.debug('Tasks completed');
     } catch (err) {

--- a/node-src/renderer/engine/clack/renderer.test.ts
+++ b/node-src/renderer/engine/clack/renderer.test.ts
@@ -1,5 +1,5 @@
 import { taskLog as clackTaskLog } from '@clack/prompts';
-import { describe, expect, it, test, vi } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import { Task } from '../../../types';
 import { clackTaskLogRenderer } from './renderer';
@@ -116,13 +116,22 @@ describe('clackTaskLogRenderer', () => {
       expect(formatted).toBe('Done');
     });
 
-    test.for(['succeed', 'fail'])('%s transition renders title and output', (transition) => {
-      const formatted = formatVia(transition as keyof typeof TRANSITION_METHOD, {
+    it('succeed transition renders title and output', () => {
+      const formatted = formatVia('succeed', {
         title: 'Building',
         output: 'compiling',
       });
       expect(formatted).toContain('Building');
       expect(formatted).toContain('compiling');
+    });
+
+    it('fail transition renders only title ', () => {
+      const formatted = formatVia('fail', {
+        title: 'Building',
+        output: 'compiling',
+      });
+      expect(formatted).toContain('Building');
+      expect(formatted).not.toContain('compiling');
     });
 
     it('update renders only output', () => {

--- a/node-src/renderer/engine/clack/renderer.ts
+++ b/node-src/renderer/engine/clack/renderer.ts
@@ -32,7 +32,7 @@ export function clackTaskLogRenderer(output?: Writable): TaskRenderer {
       taskLog.success(taskMessageFormatter(state));
     },
     fail: (state: Task) => {
-      taskLog.error(taskMessageFormatter(state), { showLog: false });
+      taskLog.error(wrapTextForClack(state.title), { showLog: false });
     },
   };
 }

--- a/node-src/renderer/engine/index.test.ts
+++ b/node-src/renderer/engine/index.test.ts
@@ -21,9 +21,10 @@ function recordingRenderer() {
 }
 
 // Minimal Context. `run` ignores its deps in these tests, so most fields can stay empty; we only
-// need `options` to exist (the engine reads experimental_* hooks off it) and `now` for the timer.
+// need `options` to exist (the engine reads experimental_* hooks off it), `log` (the skip guard
+// logs), and `now` for the timer.
 function fakeContext(overrides: Partial<Context> = {}): Context {
-  return { options: {}, ...overrides } as Context;
+  return { options: {}, log: { debug: vi.fn() }, ...overrides } as unknown as Context;
 }
 
 const transitions = {
@@ -130,6 +131,27 @@ describe('runTask', () => {
     // start still fires — the engine can't know it'll skip until after run() returns.
     expect(calls.map((c) => c.hook)).toEqual(['start', 'succeed']);
     expect(ctx.skip).toBe(true);
+  });
+
+  it('renders nothing and skips the task when an upstream task set ctx.skip', async () => {
+    const ctx = fakeContext({ skip: true });
+    const { renderer, calls } = recordingRenderer();
+    const run = vi.fn(async () => ({ kind: 'continue' as const, output: {} }));
+
+    await runTask(
+      ctx,
+      {
+        name: 'storybookInfo',
+        title: 'Collect metadata',
+        transitions,
+        extractInput: () => ({}),
+        run,
+      },
+      renderer
+    );
+
+    expect(run).not.toHaveBeenCalled();
+    expect(calls).toEqual([]);
   });
 
   it('falls back to a generic failure headline when no failure transition is provided', async () => {

--- a/node-src/renderer/engine/index.ts
+++ b/node-src/renderer/engine/index.ts
@@ -62,6 +62,12 @@ export async function runTask<TInput, TOutput, TPartial = never>(
   config: TaskConfig<TInput, TOutput, TPartial>,
   renderer: TaskRenderer
 ): Promise<void> {
+  // An upstream task decided to short-circuit the pipeline, so downstream tasks bail
+  if (ctx.skip) {
+    ctx.log.debug(`Skipping task '${config.name}' due to upstream skip`);
+    return;
+  }
+
   ctx.task = config.name;
   ctx.title = config.title;
   ctx.startedAt = Number.isInteger(ctx.now) ? (ctx.now as number) : Date.now();

--- a/node-src/renderer/storybookInfo.ts
+++ b/node-src/renderer/storybookInfo.ts
@@ -1,0 +1,32 @@
+import {
+  applyStorybookInfoOutput,
+  extractStorybookInfoInput,
+  setStorybookInfo,
+} from '../tasks/storybookInfo';
+import { Context } from '../types';
+import { initial, pending, success } from '../ui/tasks/storybookInfo';
+import { runTask } from './engine';
+import { clackTaskLogRenderer } from './engine/clack/renderer';
+import { getRenderer } from './engine/getRenderer';
+
+/**
+ * Render the storybookInfo task.
+ *
+ * @param ctx The CLI context.
+ */
+export async function renderStorybookInfo(ctx: Context): Promise<void> {
+  await runTask(
+    ctx,
+    {
+      name: 'storybookInfo',
+      // The title varies by build type (Storybook vs E2E test suite), so unlike other tasks it's
+      // derived from ctx rather than hardcoded.
+      title: initial(ctx).title,
+      transitions: { pending, success },
+      extractInput: extractStorybookInfoInput,
+      run: setStorybookInfo,
+      applyOutput: applyStorybookInfoOutput,
+    },
+    getRenderer(ctx, clackTaskLogRenderer)
+  );
+}

--- a/node-src/tasks/index.ts
+++ b/node-src/tasks/index.ts
@@ -8,14 +8,13 @@ import prepareWorkspace from './prepareWorkspace';
 import report from './report';
 import restoreWorkspace from './restoreWorkspace';
 import snapshot from './snapshot';
-import storybookInfo from './storybookInfo';
 import upload from './upload';
 import uploadShare from './uploadShare';
 import verify from './verify';
 
 export const runShare = [build, prepare, uploadShare];
 
-export const runUploadBuild = [storybookInfo, initialize, build, prepare, upload, verify, snapshot];
+export const runUploadBuild = [initialize, build, prepare, upload, verify, snapshot];
 
 export const runPatchBuild = [prepareWorkspace, ...runUploadBuild, restoreWorkspace];
 

--- a/node-src/tasks/storybookInfo.ts
+++ b/node-src/tasks/storybookInfo.ts
@@ -3,10 +3,8 @@ import * as Sentry from '@sentry/node';
 import { isE2EBuild } from '../lib/e2eUtils';
 import { getStorybookBaseDirectory } from '../lib/getStorybookBaseDirectory';
 import getStorybookInfo from '../lib/getStorybookInfo';
-import { createTask } from '../lib/tasks';
 import { Context, Deps, Storybook, TaskFunction } from '../types';
 import missingBuildScriptName from '../ui/messages/errors/missingBuildScriptName';
-import { initial, pending, success } from '../ui/tasks/storybookInfo';
 
 export type StorybookInfoDeps = Pick<Deps, 'log' | 'options' | 'env' | 'packageJson'>;
 
@@ -14,6 +12,12 @@ export interface StorybookInfoInput {
   gitRootPath?: string;
   isReactNativeApp: boolean;
 }
+
+export const extractStorybookInfoInput = (ctx: Context): StorybookInfoInput => ({
+  // git.rootPath is truly optional here, so we don't need to verify that it's present
+  gitRootPath: ctx.git?.rootPath,
+  isReactNativeApp: ctx.isReactNativeApp ?? false,
+});
 
 export interface StorybookInfoOutput {
   storybook: Storybook;
@@ -63,26 +67,3 @@ export const applyStorybookInfoOutput = (ctx: Context, { storybook }: StorybookI
   }
   Sentry.setContext('storybook', { ...storybook });
 };
-
-/**
- * Sets up the Listr task for gathering Storybook information.
- *
- * @param ctx The context set when executing the CLI.
- *
- * @returns A Listr task.
- */
-export default function main(ctx: Context) {
-  return createTask({
-    name: 'storybookInfo',
-    title: initial(ctx).title,
-    skip: (ctx: Context) => ctx.skip,
-    transitions: { pending, success },
-    extractInput: (ctx): StorybookInfoInput => ({
-      // git.rootPath is truly optional here, so we don't need to verify that it's present
-      gitRootPath: ctx.git?.rootPath,
-      isReactNativeApp: ctx.isReactNativeApp ?? false,
-    }),
-    applyOutput: applyStorybookInfoOutput,
-    run: setStorybookInfo,
-  });
-}

--- a/node-src/ui/tasks/storybookInfo.frames.ts
+++ b/node-src/ui/tasks/storybookInfo.frames.ts
@@ -1,0 +1,12 @@
+import { captureTask } from '../../renderer/storybook/captureTask';
+import { pending, success } from './storybookInfo';
+
+// Node-side scenarios for the storybookInfo task. The `?clack` Vite plugin runs this module in
+// Node, renders each export through the real Clack renderer, and hands the resulting ANSI strings
+// to the browser story (`storybookInfo.stories.ts`).
+
+const ctx = { options: {} };
+
+export const Pending = () => captureTask(pending(ctx as any));
+
+export const Success = () => captureTask(success(ctx as any));

--- a/node-src/ui/tasks/storybookInfo.frames.ts
+++ b/node-src/ui/tasks/storybookInfo.frames.ts
@@ -1,4 +1,6 @@
+import { fallbackFailureState } from '../../renderer/engine';
 import { captureTask } from '../../renderer/storybook/captureTask';
+import missingBuildScriptName from '../messages/errors/missingBuildScriptName';
 import { pending, success } from './storybookInfo';
 
 // Node-side scenarios for the storybookInfo task. The `?clack` Vite plugin runs this module in
@@ -10,3 +12,11 @@ const ctx = { options: {} };
 export const Pending = () => captureTask(pending(ctx as any));
 
 export const Success = () => captureTask(success(ctx as any));
+
+export const Failed = () =>
+  captureTask(
+    fallbackFailureState(
+      pending(ctx as any).title,
+      new Error(missingBuildScriptName('build-storybook'))
+    )
+  );

--- a/node-src/ui/tasks/storybookInfo.stories.ts
+++ b/node-src/ui/tasks/storybookInfo.stories.ts
@@ -1,21 +1,8 @@
-import task from '../components/task';
-import { initial, pending, success } from './storybookInfo';
+import frames from './storybookInfo.frames?clack';
 
 export default {
   title: 'CLI/Tasks/StorybookInfo',
-  decorators: [(storyFunction: any) => task(storyFunction())],
 };
 
-const storybook = {
-  version: '5.3.0',
-  builder: { name: 'webpack4', packageVersion: '5.3.0' },
-  addons: [],
-};
-
-const ctx = { options: {} } as any;
-
-export const Initial = () => initial(ctx);
-
-export const Pending = () => pending(ctx);
-
-export const Success = () => success({ ...ctx, storybook } as any);
+export const Pending = () => frames.Pending;
+export const Success = () => frames.Success;

--- a/node-src/ui/tasks/storybookInfo.stories.ts
+++ b/node-src/ui/tasks/storybookInfo.stories.ts
@@ -6,3 +6,4 @@ export default {
 
 export const Pending = () => frames.Pending;
 export const Success = () => frames.Success;
+export const Failed = () => frames.Failed;

--- a/node-src/ui/tasks/storybookInfoE2E.frames.ts
+++ b/node-src/ui/tasks/storybookInfoE2E.frames.ts
@@ -1,0 +1,11 @@
+import { captureTask } from '../../renderer/storybook/captureTask';
+import { pending, success } from './storybookInfo';
+
+// Node-side scenarios for the storybookInfo task in an E2E project, where the task reports on the
+// "test suite" rather than "Storybook". See `storybookInfo.frames.ts`.
+
+const ctx = { options: { playwright: true } };
+
+export const Pending = () => captureTask(pending(ctx as any));
+
+export const Success = () => captureTask(success(ctx as any));

--- a/node-src/ui/tasks/storybookInfoE2E.frames.ts
+++ b/node-src/ui/tasks/storybookInfoE2E.frames.ts
@@ -1,3 +1,4 @@
+import { fallbackFailureState } from '../../renderer/engine';
 import { captureTask } from '../../renderer/storybook/captureTask';
 import { pending, success } from './storybookInfo';
 
@@ -9,3 +10,11 @@ const ctx = { options: { playwright: true } };
 export const Pending = () => captureTask(pending(ctx as any));
 
 export const Success = () => captureTask(success(ctx as any));
+
+export const Failed = () =>
+  captureTask(
+    fallbackFailureState(
+      pending(ctx as any).title,
+      new Error('Unexpected error collecting metadata')
+    )
+  );

--- a/node-src/ui/tasks/storybookInfoE2E.stories.ts
+++ b/node-src/ui/tasks/storybookInfoE2E.stories.ts
@@ -1,15 +1,8 @@
-import task from '../components/task';
-import { initial, pending, success } from './storybookInfo';
+import frames from './storybookInfoE2E.frames?clack';
 
 export default {
   title: 'CLI/Tasks/StorybookInfo/E2E',
-  decorators: [(storyFunction: any) => task(storyFunction())],
 };
 
-const ctx = { options: { playwright: true } } as any;
-
-export const Initial = () => initial(ctx);
-
-export const Pending = () => pending(ctx);
-
-export const Success = () => success(ctx);
+export const Pending = () => frames.Pending;
+export const Success = () => frames.Success;

--- a/node-src/ui/tasks/storybookInfoE2E.stories.ts
+++ b/node-src/ui/tasks/storybookInfoE2E.stories.ts
@@ -6,3 +6,4 @@ export default {
 
 export const Pending = () => frames.Pending;
 export const Success = () => frames.Success;
+export const Failed = () => frames.Failed;

--- a/node-src/ui/workflows/uploadBuild.stories.ts
+++ b/node-src/ui/workflows/uploadBuild.stories.ts
@@ -13,7 +13,11 @@ import {
 } from '../tasks/gitInfo';
 import * as initialize from '../tasks/initialize.stories';
 import * as snapshot from '../tasks/snapshot.stories';
-import * as storybookInfo from '../tasks/storybookInfo.stories';
+import {
+  initial as storybookInfoInitial,
+  pending as storybookInfoPending,
+  success as storybookInfoSuccess,
+} from '../tasks/storybookInfo';
 import * as upload from '../tasks/upload.stories';
 import * as verify from '../tasks/verify.stories';
 
@@ -34,6 +38,15 @@ const gitInfo = {
   Initial: () => gitInfoInitial,
   Pending: () => gitInfoPending(),
   Success: () => gitInfoSuccess({ git, options } as any),
+};
+
+// storybookInfo.stories now returns rendered ANSI strings (Clack capture), which the old task()
+// path can't consume, so rebuild the states the workflow needs from the raw task source.
+const storybookInfoContext = { options: {} } as any;
+const storybookInfo = {
+  Initial: () => storybookInfoInitial(storybookInfoContext),
+  Pending: () => storybookInfoPending(storybookInfoContext),
+  Success: () => storybookInfoSuccess(storybookInfoContext),
 };
 
 export default {

--- a/node-src/ui/workflows/uploadBuildE2E.stories.ts
+++ b/node-src/ui/workflows/uploadBuildE2E.stories.ts
@@ -13,7 +13,11 @@ import {
 } from '../tasks/gitInfo';
 import * as initialize from '../tasks/initialize.stories';
 import * as snapshot from '../tasks/snapshotE2E.stories';
-import * as storybookInfo from '../tasks/storybookInfoE2E.stories';
+import {
+  initial as storybookInfoInitial,
+  pending as storybookInfoPending,
+  success as storybookInfoSuccess,
+} from '../tasks/storybookInfo';
 import * as upload from '../tasks/uploadE2E.stories';
 import * as verify from '../tasks/verifyE2E.stories';
 
@@ -35,6 +39,14 @@ const gitInfo = {
   Initial: () => gitInfoInitial,
   Pending: () => gitInfoPending(),
   Success: () => gitInfoSuccess({ git, options } as any),
+};
+
+// storybookInfo.stories now returns rendered ANSI strings (Clack capture), which the old task()
+// path can't consume, so rebuild the states the workflow needs from the raw task source.
+const storybookInfo = {
+  Initial: () => storybookInfoInitial(ctx),
+  Pending: () => storybookInfoPending(ctx),
+  Success: () => storybookInfoSuccess(ctx),
 };
 
 export default {


### PR DESCRIPTION
# Description

This PR migrates the `storybookInfo` task to Clack and updates the relevant stories. In addition to the boilerplate part of the migration, there are three other changes:
1. Added logic to `runTask` to bail early when `ctx.skip` is set (which can be set upstream by `gitInfo`).
2. Added failure state stories for the `storybookInfo` task. Our current storybook only tests pending/success.
3. Updated the Clack renderer to only render the UI state title in failure modes. The full error details are rendered below the task list, so this removes some duplication. I decided to do this within the Clack renderer, rather than the renderer-agnostic error format helper, because other renderers might make different decisions regarding what to do with the detailed error info.

# Manual QA

Staging app used for QA: 

**Build 1:** happy path

Note the build number is 2. I forgot to use `--log-file` for the first build.
<img width="1746" height="1120" alt="CleanShot 2026-06-11 at 12 57 25@2x" src="https://github.com/user-attachments/assets/2e899407-2e6f-4874-b1b6-385013a5b076" />

Log file head:
```
12:56:16.604 Chromatic CLI v17.4.2--canary.1392.27360106835.0
             https://www.chromatic.com/docs/cli 
12:56:16.607 Authenticating with Chromatic [staging] 
12:56:16.607     → Connecting to https://index.staging-chromatic.com
12:56:16.942 Authenticated with Chromatic [staging]
12:56:16.942     → Using project token '****************be59'
12:56:16.943 Retrieving git information
12:56:17.583 Retrieved git information
12:56:17.583     → Commit '26c89fc' on branch 'master'; found 1 parent build
12:56:17.583 Collecting Storybook metadata
12:56:17.615 Collected Storybook metadata
12:56:17.616     → Build metadata gathered
12:56:17.617 Initializing build
12:56:18.064 Initialized build
                 → Build 2 initialized
```

**Build 2:** skipping a rebuild

Ran again on the same commit without `--force-rebuild`. `gitInfo` set skip, so `storybookInfo` doesn't render at all.
<img width="1628" height="714" alt="CleanShot 2026-06-11 at 13 00 02@2x" src="https://github.com/user-attachments/assets/8aeacb4e-bbdd-4993-91b9-535b68076802" />

Note this UI is kind of strange, as the remaining Listr tasks still render in a skipped state, but the Storybook info task is just missing. This UI will be cleaner when the migration is complete, as the `Skipping build` line will be terminal.

Log file head:
```
12:59:07.990 Chromatic CLI v17.4.2--canary.1392.27360106835.0
             https://www.chromatic.com/docs/cli 
12:59:07.993 Authenticating with Chromatic [staging] 
12:59:07.993     → Connecting to https://index.staging-chromatic.com
12:59:08.372 Authenticated with Chromatic [staging]
12:59:08.372     → Using project token '****************be59'
12:59:08.372 Retrieving git information
12:59:09.093 ℹ Skipping rebuild of an already fully passed/accepted build
             A build for the same commit as the last build on the branch is considered a rebuild.
             If the last build is passed or accepted, the rebuild is skipped because it shouldn't change anything.
             You can override this using the --force-rebuild flag.
12:59:09.095 Skipping build
12:59:09.095     → Skipping rebuild of an already fully passed/accepted build
```

**Build 3:** non-interactive renderer
<img width="1458" height="690" alt="CleanShot 2026-06-11 at 13 02 24@2x" src="https://github.com/user-attachments/assets/474152b4-cd9f-4179-85c2-e8e53115618d" />

**Build 4:** failure state

I deleted the `build-storybook` script from my `package.json`, which causes this task to fail.
<img width="2084" height="2356" alt="CleanShot 2026-06-12 at 09 24 11@2x" src="https://github.com/user-attachments/assets/675472e2-a3fa-4374-98b8-b25e2e16144e" />

Full log file:
```
09:23:21.645 Chromatic CLI v17.4.2--canary.1392.27418016999.0
             https://www.chromatic.com/docs/cli 
09:23:21.660 Authenticating with Chromatic [staging] 
09:23:21.660     → Connecting to https://index.staging-chromatic.com
09:23:22.061 Authenticated with Chromatic [staging]
09:23:22.061     → Using project token '****************be59'
09:23:22.061 Retrieving git information
09:23:22.941 Retrieved git information
09:23:22.942     → Commit '1c19d37' on branch 'master'; found 1 parent build
09:23:22.942 Collecting Storybook metadata
09:23:22.943 Collecting Storybook metadata failed
09:23:22.943     → ✖ Build script not found
             The CLI didn't find a script called "build-storybook" in your package.json.
             Make sure you set the --build-script-name option to the value of the script name that builds your Storybook.

09:23:22.955 ✖ Failed to collect Storybook metadata
             ✖ Build script not found
             The CLI didn't find a script called "build-storybook" in your package.json.
             Make sure you set the --build-script-name option to the value of the script name that builds your Storybook.
             → View the full stacktrace below
             
             If you need help, please chat with us at https://www.chromatic.com/docs/cli for the fastest response.
             You can also email the team at support@chromatic.com if chat is not an option.
             
             Please provide us with the above CLI output and the following info:
             {
               "timestamp": "2026-06-12T13:23:22.952Z",
               "sessionId": "18b77c88-d0bd-4bda-b3fe-a0ac756a16ca",
               "gitVersion": "2.47.1",
               "gitBranch": "master",
               "gitSlug": "test-user/chromatic-qa-fake",
               "fromCI": false,
               "nodePlatform": "darwin",
               "nodeVersion": "22.22.3",
               "packageName": "chromatic",
               "packageVersion": "17.4.2--canary.1392.27418016999.0",
               "flags": {
                 "forceRebuild": "",
                 "logFile": "",
                 "outputDir": [],
                 "storybookBuildDir": [],
                 "externals": [],
                 "onlyStoryFiles": [],
                 "onlyStoryNames": [],
                 "untraced": [],
                 "fileHashing": true,
                 "interactive": true
               },
               "configuration": {},
               "exitCode": 0,
               "exitCodeKey": "OK",
               "errorType": "Error",
               "errorMessage": "✖ Failed to collect Storybook metadata"
             }
             
             Error: ✖ Build script not found
             The CLI didn't find a script called "build-storybook" in your package.json.
             Make sure you set the --build-script-name option to the value of the script name that builds your Storybook.
                 at Object.KO [as run] (/Users/justin/.npm/_npx/cc5b2d6285b43a5d/node_modules/chromatic/dist/node-src-iLwpJ9SQ.cjs:1267:281)
                 at WD (/Users/justin/.npm/_npx/cc5b2d6285b43a5d/node_modules/chromatic/dist/node-src-iLwpJ9SQ.cjs:1133:3014)
                 at $O (/Users/justin/.npm/_npx/cc5b2d6285b43a5d/node_modules/chromatic/dist/node-src-iLwpJ9SQ.cjs:1267:888)
                 at NN (/Users/justin/.npm/_npx/cc5b2d6285b43a5d/node_modules/chromatic/dist/node-src-iLwpJ9SQ.cjs:1641:4046)
                 at process.processTicksAndRejections (node:internal/process/task_queues:103:5)
                 at async Promise.all (index 0)
                 at async AN (/Users/justin/.npm/_npx/cc5b2d6285b43a5d/node_modules/chromatic/dist/node-src-iLwpJ9SQ.cjs:1641:3343)
                 at async Object.kN (/Users/justin/.npm/_npx/cc5b2d6285b43a5d/node_modules/chromatic/dist/node-src-iLwpJ9SQ.cjs:1641:1933)
                 at async vct (/Users/justin/.npm/_npx/cc5b2d6285b43a5d/node_modules/chromatic/dist/main-WJssRim1.cjs:13:11707)
```

Note that the log file _does_ include the detailed error output in the task failure log, because only the Clack renderer (not the log renderer) was updated to remove it.


<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>17.4.2--canary.1392.27548118284.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@17.4.2--canary.1392.27548118284.0
  # or 
  yarn add chromatic@17.4.2--canary.1392.27548118284.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
