### PR TITLE
Migrate `initialize` to Clack renderer

### DIFF
--- a/node-src/index.ts
+++ b/node-src/index.ts
@@ -34,6 +34,7 @@ import { writeChromaticDiagnostics } from './lib/writeChromaticDiagnostics';
 import { intro as clackIntro } from './renderer';
 import { renderAuth } from './renderer/auth';
 import { renderGitInfo } from './renderer/gitInfo';
+import { renderInitialize } from './renderer/initialize';
 import { renderStorybookInfo } from './renderer/storybookInfo';
 import getTasks from './tasks';
 import { Context, Flags, Options } from './types';
@@ -292,6 +293,7 @@ async function runBuild(ctx: Context) {
       await renderAuth(ctx);
       await renderGitInfo(ctx);
       await renderStorybookInfo(ctx);
+      await renderInitialize(ctx);
       await new Listr(getTasks(ctx), options).run(ctx);
       ctx.log.debug('Tasks completed');
     } catch (err) {

--- a/node-src/renderer/initialize.ts
+++ b/node-src/renderer/initialize.ts
@@ -1,0 +1,26 @@
+import { applyInitializeOutput, extractInitializeInput, initialize } from '../tasks/initialize';
+import { Context } from '../types';
+import { initial, pending, success } from '../ui/tasks/initialize';
+import { runTask } from './engine';
+import { clackTaskLogRenderer } from './engine/clack/renderer';
+import { getRenderer } from './engine/getRenderer';
+
+/**
+ * Render the initialize task.
+ *
+ * @param ctx The CLI context.
+ */
+export async function renderInitialize(ctx: Context): Promise<void> {
+  await runTask(
+    ctx,
+    {
+      name: 'initialize',
+      title: initial.title,
+      transitions: { pending, success },
+      extractInput: extractInitializeInput,
+      run: initialize,
+      applyOutput: applyInitializeOutput,
+    },
+    getRenderer(ctx, clackTaskLogRenderer)
+  );
+}

--- a/node-src/tasks/index.ts
+++ b/node-src/tasks/index.ts
@@ -2,7 +2,6 @@ import Listr from 'listr';
 
 import { Context } from '../types';
 import build from './build';
-import initialize from './initialize';
 import prepare from './prepare';
 import prepareWorkspace from './prepareWorkspace';
 import report from './report';
@@ -14,7 +13,7 @@ import verify from './verify';
 
 export const runShare = [build, prepare, uploadShare];
 
-export const runUploadBuild = [initialize, build, prepare, upload, verify, snapshot];
+export const runUploadBuild = [build, prepare, upload, verify, snapshot];
 
 export const runPatchBuild = [prepareWorkspace, ...runUploadBuild, restoreWorkspace];
 

--- a/node-src/tasks/initialize/index.ts
+++ b/node-src/tasks/initialize/index.ts
@@ -1,11 +1,9 @@
 import { createAnalyticsClient } from '@cli/analytics';
 import { validateStorybookReactNativeVersion } from '@cli/react-native/validateStorybookVersion';
-import { createTask } from '@cli/tasks';
 
 import { AnnouncedBuild, Context, Deps, RuntimeMetadata, TaskResult } from '../../types';
 import turboSnapNotAvailableForReactNative from '../../ui/messages/errors/turboSnapNotAvailableForReactNative';
 import noAncestorBuild from '../../ui/messages/warnings/noAncestorBuild';
-import { initial, pending, success } from '../../ui/tasks/initialize';
 import { announceBuild, AnnounceBuildInput } from './announceBuild';
 import { gatherEnvironment } from './gatherEnvironment';
 import { getRuntimeMetadata } from './getRuntimeMetadata';
@@ -85,25 +83,3 @@ export const applyInitializeOutput = async (ctx: Context, output: InitializeOutp
     ctx.log.warn(noAncestorBuild(ctx));
   }
 };
-
-/**
- * Sets up the Listr task for announcing a new build on Chromatic.
- *
- * @param _ The context set when executing the CLI.
- *
- * @returns A Listr task.
- */
-export default function main(_: Context) {
-  return createTask({
-    name: 'initialize',
-    title: initial.title,
-    skip: (ctx: Context) => ctx.skip,
-    transitions: {
-      pending,
-      success,
-    },
-    extractInput: extractInitializeInput,
-    applyOutput: applyInitializeOutput,
-    run: initialize,
-  });
-}

--- a/node-src/ui/tasks/initialize.frames.ts
+++ b/node-src/ui/tasks/initialize.frames.ts
@@ -1,0 +1,12 @@
+import { captureTask } from '../../renderer/storybook/captureTask';
+import { pending, success } from './initialize';
+
+// Node-side scenarios for the initialize task. The `?clack` Vite plugin runs this module in Node,
+// renders each export through the real Clack renderer, and hands the resulting ANSI strings to the
+// browser story (`initialize.stories.ts`).
+
+const announcedBuild = { number: 42 };
+
+export const Pending = () => captureTask(pending());
+
+export const Success = () => captureTask(success({ announcedBuild } as any));

--- a/node-src/ui/tasks/initialize.stories.ts
+++ b/node-src/ui/tasks/initialize.stories.ts
@@ -1,17 +1,8 @@
-import task from '../components/task';
-import { initial, pending, success } from './initialize';
+import frames from './initialize.frames?clack';
 
 export default {
   title: 'CLI/Tasks/Initialize',
-  decorators: [(storyFunction: any) => task(storyFunction())],
 };
 
-const announcedBuild = {
-  number: 42,
-};
-
-export const Initial = () => initial;
-
-export const Pending = () => pending();
-
-export const Success = () => success({ announcedBuild } as any);
+export const Pending = () => frames.Pending;
+export const Success = () => frames.Success;

--- a/node-src/ui/workflows/uploadBuild.stories.ts
+++ b/node-src/ui/workflows/uploadBuild.stories.ts
@@ -11,7 +11,11 @@ import {
   pending as gitInfoPending,
   success as gitInfoSuccess,
 } from '../tasks/gitInfo';
-import * as initialize from '../tasks/initialize.stories';
+import {
+  initial as initializeInitial,
+  pending as initializePending,
+  success as initializeSuccess,
+} from '../tasks/initialize';
 import * as snapshot from '../tasks/snapshot.stories';
 import {
   initial as storybookInfoInitial,
@@ -47,6 +51,15 @@ const storybookInfo = {
   Initial: () => storybookInfoInitial(storybookInfoContext),
   Pending: () => storybookInfoPending(storybookInfoContext),
   Success: () => storybookInfoSuccess(storybookInfoContext),
+};
+
+// initialize.stories now returns rendered ANSI strings (Clack capture), which the old task() path
+// can't consume, so rebuild the states the workflow needs from the raw task source.
+const announcedBuild = { number: 42 };
+const initialize = {
+  Initial: () => initializeInitial,
+  Pending: () => initializePending(),
+  Success: () => initializeSuccess({ announcedBuild } as any),
 };
 
 export default {

--- a/node-src/ui/workflows/uploadBuildE2E.stories.ts
+++ b/node-src/ui/workflows/uploadBuildE2E.stories.ts
@@ -11,7 +11,11 @@ import {
   pending as gitInfoPending,
   success as gitInfoSuccess,
 } from '../tasks/gitInfo';
-import * as initialize from '../tasks/initialize.stories';
+import {
+  initial as initializeInitial,
+  pending as initializePending,
+  success as initializeSuccess,
+} from '../tasks/initialize';
 import * as snapshot from '../tasks/snapshotE2E.stories';
 import {
   initial as storybookInfoInitial,
@@ -47,6 +51,15 @@ const storybookInfo = {
   Initial: () => storybookInfoInitial(ctx),
   Pending: () => storybookInfoPending(ctx),
   Success: () => storybookInfoSuccess(ctx),
+};
+
+// initialize.stories now returns rendered ANSI strings (Clack capture), which the old task() path
+// can't consume, so rebuild the states the workflow needs from the raw task source.
+const announcedBuild = { number: 42 };
+const initialize = {
+  Initial: () => initializeInitial,
+  Pending: () => initializePending(),
+  Success: () => initializeSuccess({ announcedBuild } as any),
 };
 
 export default {


### PR DESCRIPTION
# Description

This PR migrates the `initialize` task to Clack. There is no special casing for this task. Pure boilerplate refactor following the pattern previously established.

# Manual QA

**Build 1:** happy path: https://www.staging-chromatic.com/build?appId=686421bc987fc91fe84cd22e&number=208
<img width="1772" height="990" alt="CleanShot 2026-06-12 at 14 04 20@2x" src="https://github.com/user-attachments/assets/53e47511-ff04-4cf8-a178-e8b655523779" />

Log file head:
```
14:04:02.949 Chromatic CLI v17.1.0
             https://www.chromatic.com/docs/cli 
14:04:02.953 Authenticating with Chromatic [staging] 
14:04:02.953     → Connecting to https://index.staging-chromatic.com
14:04:03.451 Authenticated with Chromatic [staging]
14:04:03.451     → Using project token '****************1c89'
14:04:03.451 Retrieving git information
14:04:04.721 Retrieved git information
14:04:04.721     → Commit '763e9d9' on branch 'HEAD'; found 1 parent build
14:04:04.722 Collecting Storybook metadata
14:04:04.767 Collected Storybook metadata
14:04:04.768     → Build metadata gathered
14:04:04.768 Initializing build
14:04:05.443 Initialized build
14:04:05.443     → Build 208 initialized
14:04:05.450 Building your Storybook
14:04:05.450     → Running command: yarn run build-storybook --output-dir=/private/var/folders/gn/p0bks3451f38s12kbrmdxznh0000gn/T/chromatic--45216-zIgM9Jt9omgc
```

**Build 2:** failure path

I added a manual error throw to the announce build step.
<img width="1664" height="976" alt="CleanShot 2026-06-12 at 14 06 43@2x" src="https://github.com/user-attachments/assets/a673e703-376a-4d36-90c9-d1c3f3dab924" />

Log file head:
```
14:06:31.135 Chromatic CLI v17.1.0
             https://www.chromatic.com/docs/cli 
14:06:31.158 Authenticating with Chromatic [staging] 
14:06:31.158     → Connecting to https://index.staging-chromatic.com
14:06:31.760 Authenticated with Chromatic [staging]
14:06:31.760     → Using project token '****************1c89'
14:06:31.761 Retrieving git information
14:06:32.801 Retrieved git information
14:06:32.802     → Commit '763e9d9' on branch 'HEAD'; found 1 parent build
14:06:32.802 Collecting Storybook metadata
14:06:32.840 Collected Storybook metadata
14:06:32.840     → Build metadata gathered
14:06:32.840 Initializing build
14:06:32.928 Initializing build failed
14:06:32.929     → announceBuild boom

14:06:32.934 ✖ Failed to initialize build
             announceBuild boom
             → View the full stacktrace below
```


<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>18.0.1--canary.1393.28528490518.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@18.0.1--canary.1393.28528490518.0
  # or 
  yarn add chromatic@18.0.1--canary.1393.28528490518.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
