### PR TITLE
Implement a spinner renderer

### DIFF
--- a/node-src/renderer/engine/clack/spinner.frames.ts
+++ b/node-src/renderer/engine/clack/spinner.frames.ts
@@ -1,0 +1,30 @@
+import { Task } from '../../../types';
+import { captureTask } from '../../storybook/captureTask';
+import { clackSpinnerRenderer } from './spinnerRenderer';
+
+// Node-side proof-of-concept scenarios for the spinner renderer. The `?clack` Vite plugin runs this
+// module in Node, renders each export through the real Clack spinner, and hands the resulting ANSI
+// strings to the browser story (`spinner.stories.ts`).
+
+const make = (state: Task, starting?: Task) => captureTask(state, starting, clackSpinnerRenderer);
+
+const starting: Task = { status: 'pending', title: 'Building Storybook' };
+
+// pending → drive calls start() only; one fake tick renders the spinner labeled with the title.
+export const Start = () => make({ status: 'pending', title: 'Building Storybook' });
+
+// updating → drive calls start(starting) then update(); one fake tick renders the spinner relabeled.
+export const InProgress = () =>
+  make(
+    { status: 'updating', title: 'Building Storybook', output: 'Compiling 42 modules' },
+    starting
+  );
+
+// success → drive calls start(starting) then succeed(); clear() removes the spinner and
+// log.success() writes the success line.
+export const Success = () =>
+  make({ status: 'success', title: 'Build complete', output: 'Built 42 stories' }, starting);
+
+// failure → drive calls start(starting) then fail(); clear() removes the spinner and log.error()
+// writes the failure line.
+export const Failure = () => make({ status: 'error', title: 'Build failed' }, starting);

--- a/node-src/renderer/engine/clack/spinner.stories.ts
+++ b/node-src/renderer/engine/clack/spinner.stories.ts
@@ -1,0 +1,10 @@
+import frames from './spinner.frames?clack';
+
+export default {
+  title: 'CLI/Renderers/Spinner',
+};
+
+export const Start = () => frames.Start;
+export const InProgress = () => frames.InProgress;
+export const Success = () => frames.Success;
+export const Failure = () => frames.Failure;

--- a/node-src/renderer/engine/clack/spinnerRenderer.test.ts
+++ b/node-src/renderer/engine/clack/spinnerRenderer.test.ts
@@ -1,0 +1,89 @@
+import { log as clackLog, spinner as clackSpinner } from '@clack/prompts';
+import { describe, expect, it, vi } from 'vitest';
+
+import { clackSpinnerRenderer } from './spinnerRenderer';
+
+vi.mock('@clack/prompts', () => ({
+  spinner: vi.fn(() => ({
+    start: vi.fn(),
+    message: vi.fn(),
+    stop: vi.fn(),
+    error: vi.fn(),
+    clear: vi.fn(),
+  })),
+  log: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+const spinnerFactory = vi.mocked(clackSpinner);
+
+function lastSpinner() {
+  return spinnerFactory.mock.results.at(-1)?.value as {
+    start: ReturnType<typeof vi.fn>;
+    message: ReturnType<typeof vi.fn>;
+    stop: ReturnType<typeof vi.fn>;
+    error: ReturnType<typeof vi.fn>;
+    clear: ReturnType<typeof vi.fn>;
+  };
+}
+
+function started(title = 'Building') {
+  const renderer = clackSpinnerRenderer();
+  renderer.start({ title });
+  return renderer;
+}
+
+describe('clackSpinnerRenderer', () => {
+  it('starts a spinner labeled with the task title', () => {
+    started('Building');
+
+    expect(spinnerFactory).toHaveBeenCalledOnce();
+    expect(lastSpinner().start).toHaveBeenCalledExactlyOnceWith('Building');
+  });
+
+  it('relabels the spinner with state.output on update', () => {
+    const renderer = started('Building');
+
+    renderer.update({ title: 'Building', output: 'Compiling 42 modules' });
+
+    expect(lastSpinner().message).toHaveBeenCalledExactlyOnceWith('Compiling 42 modules');
+  });
+
+  it('falls back to the task title as the message when output is absent', () => {
+    const renderer = started('Building');
+
+    renderer.update({ title: 'Building' });
+
+    expect(lastSpinner().message).toHaveBeenCalledExactlyOnceWith('Building');
+  });
+
+  // Clack's `stop`/`error` hardcode a hollow `◇` and skip the per-line gutter, so the terminal
+  // frame is emitted through `clack.log.*` (matching `clackTaskLogRenderer`) after `clear()` tears
+  // the spinner down without writing — never through the spinner's own `stop`/`error`.
+  it('clears the spinner and emits a guttered success line through the log path on success', () => {
+    const renderer = started('Building');
+
+    renderer.succeed({ title: 'Build complete', output: 'Built 42 stories' });
+
+    expect(lastSpinner().clear).toHaveBeenCalledOnce();
+    expect(lastSpinner().stop).not.toHaveBeenCalled();
+    const [message, options] = vi.mocked(clackLog.success).mock.calls.at(-1) ?? [];
+    expect(message).toContain('Build complete');
+    expect(message).toContain('Built 42 stories');
+    expect(options).toMatchObject({ spacing: 0 });
+  });
+
+  it('clears the spinner and emits the failure title through the log path on failure', () => {
+    const renderer = started('Building');
+
+    renderer.fail({ title: 'Build failed' });
+
+    expect(lastSpinner().clear).toHaveBeenCalledOnce();
+    expect(lastSpinner().error).not.toHaveBeenCalled();
+    const [message, options] = vi.mocked(clackLog.error).mock.calls.at(-1) ?? [];
+    expect(message).toContain('Build failed');
+    expect(options).toMatchObject({ spacing: 0 });
+  });
+});

--- a/node-src/renderer/engine/clack/spinnerRenderer.ts
+++ b/node-src/renderer/engine/clack/spinnerRenderer.ts
@@ -1,0 +1,45 @@
+import { Writable } from 'node:stream';
+
+import { log as clackLog, spinner as clackSpinner } from '@clack/prompts';
+
+import { Task } from '../../../types';
+import { TaskRenderer } from '../index';
+import { taskMessageFormatter } from './taskMessageFormatter';
+import { wrapTextForClack } from './wrap';
+
+/**
+ * Create a Clack `spinner`-backed `TaskRenderer`. Used for liveness-only tasks that report textual
+ * updates but no numeric progress (e.g. build, verify).
+ *
+ * @param output Stream Clack writes to. Defaults to `process.stdout`; the Storybook capture
+ * harness injects an in-memory sink instead.
+ *
+ * @returns A `TaskRenderer` that renders via a Clack spinner.
+ */
+export function clackSpinnerRenderer(output?: Writable): TaskRenderer {
+  let spinner: ReturnType<typeof clackSpinner>;
+
+  return {
+    start: (state: Task) => {
+      spinner = clackSpinner({ output });
+      spinner.start(state.title);
+    },
+    update: (state: Task) => {
+      spinner.message(wrapTextForClack(state.output || state.title));
+    },
+    // Clack's `spinner.stop`/`error` write their own terminal line with a hardcoded hollow `◇` and
+    // no per-line gutter, so a multi-line message diverges from the taskLog-backed tasks (filled `◆`
+    // + `│  ` gutter). `clear()` tears the spinner down without writing anything, so the completed
+    // line can go through `clack.log.*` — the same path `clackTaskLogRenderer` uses — for an
+    // identical frame. `spacing: 0` because the spinner's lifecycle already emits the leading blank
+    // gutter line.
+    succeed: (state: Task) => {
+      spinner.clear();
+      clackLog.success(taskMessageFormatter(state), { output, spacing: 0 });
+    },
+    fail: (state: Task) => {
+      spinner.clear();
+      clackLog.error(wrapTextForClack(state.title), { output, spacing: 0 });
+    },
+  };
+}


### PR DESCRIPTION
# Description

Adds a Clack spinner renderer. This PR follows the pattern of the progress bar renderer shipped in #1395. Clack's progress bar is essentially a subclass of spinner (which is why I did the progress bar first -- figuring out all its wrinkles also solves the spinner renderer). Because of this, we have the same terminal UI state logic, where we clear the spinner and then route terminal messages through Clack's log primitive.

# Manual QA

None, it's not wired up yet. The Storybook is the proof of concept.

To test consistency, I accepted the build on this branch and then ran five builds against that baseline. No changes. https://www.chromatic.com/builds?appId=5d67dc0374b2e300209c41e7&branch=CAP-4636

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>17.4.2--canary.1396.27618907020.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@17.4.2--canary.1396.27618907020.0
  # or 
  yarn add chromatic@17.4.2--canary.1396.27618907020.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
