### PR TITLE
Add error class to carry exit code information to `runTask`

### DIFF
--- a/node-src/lib/setExitCode.ts
+++ b/node-src/lib/setExitCode.ts
@@ -50,3 +50,20 @@ export const setExitCode = (ctx: Partial<Context>, exitCode: number, userError =
   ctx.exitCodeKey = exitCodeKey;
   ctx.userError = userError;
 };
+
+/**
+ * Thrown by a task's `run` to fail with a specific exit code. `run` has no `ctx`, so it
+ * can't call `setExitCode` directly. `runTask` catches this and applies the exit code before
+ * rendering the failure and rethrowing.
+ */
+export class TaskFailure extends Error {
+  readonly exitCode: number;
+  readonly userError: boolean;
+
+  constructor(message: string, options: { exitCode: number; userError?: boolean }) {
+    super(message);
+    this.name = 'TaskFailure';
+    this.exitCode = options.exitCode;
+    this.userError = options.userError ?? false;
+  }
+}

--- a/node-src/renderer/engine/index.test.ts
+++ b/node-src/renderer/engine/index.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 
+import { exitCodes, TaskFailure } from '../../lib/setExitCode';
 import { Context, Task } from '../../types';
 import { runTask, TaskConfig, TaskRenderer } from './index';
 
@@ -202,6 +203,50 @@ describe('runTask', () => {
 
     const fail = calls.find((c) => c.hook === 'fail');
     expect(fail?.state.title).toBe('Authentication failed');
+  });
+
+  it('applies the exit code from a TaskFailure before failing', async () => {
+    const ctx = fakeContext();
+    const { renderer, calls } = recordingRenderer();
+
+    const config: TaskConfig<unknown, unknown> = {
+      name: 'build',
+      title: 'Build',
+      transitions,
+      extractInput: () => ({}),
+      run: async () => {
+        throw new TaskFailure('Command failed', {
+          exitCode: exitCodes.NPM_BUILD_STORYBOOK_FAILED,
+          userError: true,
+        });
+      },
+    };
+
+    await expect(runTask(ctx, config, renderer)).rejects.toThrow('Command failed');
+
+    expect(ctx.exitCode).toBe(exitCodes.NPM_BUILD_STORYBOOK_FAILED);
+    expect(ctx.exitCodeKey).toBe('NPM_BUILD_STORYBOOK_FAILED');
+    expect(ctx.userError).toBe(true);
+    expect(calls.some((c) => c.hook === 'fail')).toBe(true);
+  });
+
+  it('leaves the exit code untouched for a plain Error', async () => {
+    const ctx = fakeContext();
+    const { renderer } = recordingRenderer();
+
+    const config: TaskConfig<unknown, unknown> = {
+      name: 'build',
+      title: 'Build',
+      transitions,
+      extractInput: () => ({}),
+      run: async () => {
+        throw new Error('boom');
+      },
+    };
+
+    await expect(runTask(ctx, config, renderer)).rejects.toThrow('boom');
+
+    expect(ctx.exitCode).toBeUndefined();
   });
 
   describe('deps.report (mid-task updates)', () => {

--- a/node-src/renderer/engine/index.ts
+++ b/node-src/renderer/engine/index.ts
@@ -1,6 +1,7 @@
 // NOTE: buildDeps currently lives in lib/tasks.ts (the Listr engine). It isn't Listr-specific —
 // it just projects Context into Deps — so when Listr is deleted it should move here. Leaving it
 // alone for now to avoid a noisy diff.
+import { setExitCode, TaskFailure } from '@cli/setExitCode';
 import { buildDeps } from '@cli/tasks';
 
 import { Context, Deps, Task, TaskFunction, TaskName, TaskReporter, TaskResult } from '../../types';
@@ -83,6 +84,9 @@ export async function runTask<TInput, TOutput, TPartial = never>(
     const result = await config.run(deps, input);
     await applyResult(ctx, config, result, renderer);
   } catch (error) {
+    if (error instanceof TaskFailure) {
+      setExitCode(ctx, error.exitCode, error.userError);
+    }
     renderer.fail(failureState(ctx, config, error as Error, pending.title));
     throw error;
   }


### PR DESCRIPTION
# Description

Our `setExitCode` helper function, which is used to set a specific exit code for certain failure states in the CLI, requires access to `ctx`. Since migrated tasks don't have access to `ctx` in the business logic, we need a way to get that information up to the orchestration layer at `runTask`. I added a `TaskFailure` error class that carries the exit code and other relevant information. `runTask` then checks for this error class when catching an error and, if found, calls `setExitCode`.

This PR is just the scaffolding. It's not wired up anywhere yet. I'm doing it now because the next task to migrate, `build`, needs this functionality.

# Manual QA

None.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>18.0.1--canary.1397.28528474360.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@18.0.1--canary.1397.28528474360.0
  # or 
  yarn add chromatic@18.0.1--canary.1397.28528474360.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
