### PR TITLE
Migrate `build` to Clack renderer

### DIFF
--- a/bin-src/generateManifest.test.ts
+++ b/bin-src/generateManifest.test.ts
@@ -34,8 +34,8 @@ describe('generate-manifest', () => {
         options: expect.objectContaining({
           storybookConfigDir: '.rnstorybook', // default
         }),
-        sourceDir: expect.stringContaining('.storybook-static'),
-      })
+      }),
+      { sourceDir: expect.stringContaining('.storybook-static') }
     );
   });
 
@@ -47,8 +47,8 @@ describe('generate-manifest', () => {
         options: expect.objectContaining({
           storybookConfigDir: './custom-config',
         }),
-        sourceDir: expect.stringContaining('.storybook-static'),
-      })
+      }),
+      { sourceDir: expect.stringContaining('.storybook-static') }
     );
   });
 

--- a/bin-src/generateManifest.ts
+++ b/bin-src/generateManifest.ts
@@ -73,7 +73,7 @@ export async function main(argv: string[]) {
 
   try {
     await validateStorybookReactNativeVersion(ctx);
-    await generateManifest(ctx);
+    await generateManifest(ctx, { sourceDir: ctx.sourceDir });
   } catch (err) {
     log.error(`Error: ${err.message}`);
     process.exit(1);

--- a/node-src/index.ts
+++ b/node-src/index.ts
@@ -33,6 +33,7 @@ import { rewriteErrorMessage } from './lib/utilities';
 import { writeChromaticDiagnostics } from './lib/writeChromaticDiagnostics';
 import { intro as clackIntro } from './renderer';
 import { renderAuth } from './renderer/auth';
+import { renderBuild } from './renderer/build';
 import { renderGitInfo } from './renderer/gitInfo';
 import { renderInitialize } from './renderer/initialize';
 import { renderStorybookInfo } from './renderer/storybookInfo';
@@ -294,6 +295,7 @@ async function runBuild(ctx: Context) {
       await renderGitInfo(ctx);
       await renderStorybookInfo(ctx);
       await renderInitialize(ctx);
+      await renderBuild(ctx);
       await new Listr(getTasks(ctx), options).run(ctx);
       ctx.log.debug('Tasks completed');
     } catch (err) {

--- a/node-src/lib/e2e.test.ts
+++ b/node-src/lib/e2e.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+
+import { getE2EBuildCommand } from './e2e';
+import { exitCodes } from './setExitCode';
+import TestLogger from './testLogger';
+
+describe('getE2EBuildCommand', () => {
+  it('throws a TaskFailure with the MISSING_DEPENDENCY exit code when the E2E package is not installed', async () => {
+    const deps = { options: { inAction: false } as any, log: new TestLogger() };
+
+    await expect(
+      getE2EBuildCommand(deps, 'playwright', ['--output-dir=./source-dir/'])
+    ).rejects.toMatchObject({
+      name: 'TaskFailure',
+      exitCode: exitCodes.MISSING_DEPENDENCY,
+      userError: true,
+    });
+  });
+});

--- a/node-src/lib/e2e.ts
+++ b/node-src/lib/e2e.ts
@@ -1,9 +1,8 @@
 import { AGENTS, getCliCommand, Runner } from '@antfu/ni';
 
-import { Context } from '../types';
+import { Deps } from '../types';
 import missingDependency from '../ui/messages/errors/missingDependency';
-import { failed } from '../ui/tasks/build';
-import { exitCodes, setExitCode } from './setExitCode';
+import { exitCodes, TaskFailure } from './setExitCode';
 
 export const buildBinName = 'build-archive-storybook';
 
@@ -29,20 +28,20 @@ const parseNexec = ((agent, args) => {
 
 /**
  *
- * @param ctx The context set when executing the CLI.
+ * @param deps The cross-cutting dependencies the build command resolution needs.
  * @param flag The E2E testing tool used for the build.
  * @param buildCommandOptions Options to pass to the build command (such as --output-dir).
  *
  * @returns The command for building the E2E project.
  */
 export async function getE2EBuildCommand(
-  ctx: Context,
+  deps: Pick<Deps, 'options' | 'log'>,
   flag: 'playwright' | 'cypress' | 'vitest',
   buildCommandOptions: string[]
 ) {
   // The action cannot "peer depend" on or import anything. So instead, we must attempt to exec
   // the binary directly.
-  if (ctx.options.inAction) {
+  if (deps.options.inAction) {
     return await getCliCommand(parseNexec, [buildBinName, ...buildCommandOptions], {
       programmatic: true,
     });
@@ -58,9 +57,11 @@ export async function getE2EBuildCommand(
     ].join(' ');
   } catch (err) {
     if (err.code === 'MODULE_NOT_FOUND') {
-      ctx.log.error(missingDependency({ dependencyName, flag }));
-      setExitCode(ctx, exitCodes.MISSING_DEPENDENCY, true);
-      throw new Error(failed(ctx).output);
+      deps.log.error(missingDependency({ dependencyName, flag }));
+      throw new TaskFailure(missingDependency({ dependencyName, flag }), {
+        exitCode: exitCodes.MISSING_DEPENDENCY,
+        userError: true,
+      });
     }
 
     throw err;

--- a/node-src/lib/react-native/generateManifest.test.ts
+++ b/node-src/lib/react-native/generateManifest.test.ts
@@ -40,14 +40,15 @@ const existsFileSync = vi.mocked(fs.existsSync);
 
 const sourceDirectory = '/tmp/chromatic';
 
-function getContext(overrides: Record<string, any> = {}) {
+function getDeps(overrides: Record<string, any> = {}) {
   return {
-    sourceDir: sourceDirectory,
     log: new TestLogger(),
     options: {},
     ...overrides,
   } as any;
 }
+
+const input = { sourceDir: sourceDirectory };
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -69,8 +70,7 @@ describe('generateManifest', () => {
       },
     });
 
-    const ctx = getContext();
-    await generateManifest(ctx);
+    await generateManifest(getDeps(), input);
 
     const content = writeFileSync.mock.calls[0][1] as string;
     const manifest = JSON.parse(content);
@@ -93,8 +93,7 @@ describe('generateManifest', () => {
   it('uses default config path when storybookConfigDir is unset', async () => {
     mockBuildIndex.mockResolvedValue({ entries: {} });
 
-    const ctx = getContext();
-    await generateManifest(ctx);
+    await generateManifest(getDeps(), input);
 
     expect(mockBuildIndex).toHaveBeenCalledWith({ configPath: '.rnstorybook' });
   });
@@ -102,10 +101,7 @@ describe('generateManifest', () => {
   it('uses custom storybookConfigDir when provided', async () => {
     mockBuildIndex.mockResolvedValue({ entries: {} });
 
-    const ctx = getContext({
-      options: { storybookConfigDir: 'custom-dir' },
-    });
-    await generateManifest(ctx);
+    await generateManifest(getDeps({ options: { storybookConfigDir: 'custom-dir' } }), input);
 
     expect(mockBuildIndex).toHaveBeenCalledWith({ configPath: 'custom-dir' });
   });
@@ -113,8 +109,7 @@ describe('generateManifest', () => {
   it('empty index produces empty arrays', async () => {
     mockBuildIndex.mockResolvedValue({ entries: {} });
 
-    const ctx = getContext();
-    await generateManifest(ctx);
+    await generateManifest(getDeps(), input);
 
     const content = writeFileSync.mock.calls[0][1] as string;
     const manifest = JSON.parse(content);
@@ -141,8 +136,7 @@ describe('generateManifest', () => {
       },
     });
 
-    const ctx = getContext();
-    await generateManifest(ctx);
+    await generateManifest(getDeps(), input);
 
     const content = writeFileSync.mock.calls[0][1] as string;
     const manifest = JSON.parse(content);
@@ -192,8 +186,7 @@ describe('generateManifest', () => {
       },
     });
 
-    const ctx = getContext();
-    await generateManifest(ctx);
+    await generateManifest(getDeps(), input);
 
     const content = writeFileSync.mock.calls[0][1] as string;
     const manifest = JSON.parse(content);
@@ -245,8 +238,7 @@ describe('generateManifest', () => {
   it('should throw if the config directory does not exist', async () => {
     existsFileSync.mockReturnValue(false);
 
-    const ctx = getContext();
-    await expect(() => generateManifest(ctx)).rejects.toThrow(
+    await expect(() => generateManifest(getDeps(), input)).rejects.toThrow(
       /React Native Storybook config directory not found at ".*\.rnstorybook"\. Please specify the correct path with --storybook-config-dir\./
     );
   });

--- a/node-src/lib/react-native/generateManifest.ts
+++ b/node-src/lib/react-native/generateManifest.ts
@@ -3,7 +3,13 @@ import { createRequire } from 'module';
 import path from 'path';
 import { pathToFileURL } from 'url';
 
-import { Context } from '../../types';
+import { Deps } from '../../types';
+
+type GenerateManifestDeps = Pick<Deps, 'options' | 'log'>;
+
+interface GenerateManifestInput {
+  sourceDir: string;
+}
 
 interface StoryIndex {
   entries: Record<string, StoryEntry>;
@@ -32,16 +38,17 @@ interface Story {
 /**
  * Builds a story manifest for React Native Storybook and writes it to manifest.json in the source directory.
  *
- * @param ctx - Build context with options and source directory
+ * @param deps - Cross-cutting dependencies (options and logger).
+ * @param input - The source directory the manifest is written to.
  */
-export async function generateManifest(ctx: Context) {
-  const index = await buildStoryIndex(ctx);
-  const { stories, entries } = parseStoryIndex(ctx, index);
-  writeManifest(ctx, JSON.stringify({ stories, json: entries }, undefined, 2));
+export async function generateManifest(deps: GenerateManifestDeps, input: GenerateManifestInput) {
+  const index = await buildStoryIndex(deps);
+  const { stories, entries } = parseStoryIndex(deps, index);
+  writeManifest(deps, input.sourceDir, JSON.stringify({ stories, json: entries }, undefined, 2));
 }
 
-async function buildStoryIndex(ctx: Context): Promise<StoryIndex> {
-  const configPath = ctx.options.storybookConfigDir ?? '.rnstorybook';
+async function buildStoryIndex(deps: GenerateManifestDeps): Promise<StoryIndex> {
+  const configPath = deps.options.storybookConfigDir ?? '.rnstorybook';
   const fullConfigPath = path.join(process.cwd(), configPath);
 
   if (!existsSync(fullConfigPath)) {
@@ -66,10 +73,10 @@ async function buildStoryIndex(ctx: Context): Promise<StoryIndex> {
 }
 
 function parseStoryIndex(
-  ctx: Context,
+  deps: GenerateManifestDeps,
   index: StoryIndex
 ): { stories: Story[]; entries: StoryEntry[] } {
-  ctx.log.debug('Building story manifest');
+  deps.log.debug('Building story manifest');
 
   const entries = Object.values(index.entries).filter((entry) => entry.type === 'story');
   const stories = entries.map((entry) => ({
@@ -84,16 +91,16 @@ function parseStoryIndex(
     },
   }));
 
-  ctx.log.debug(`Found ${stories.length} stories`);
+  deps.log.debug(`Found ${stories.length} stories`);
   return { stories, entries };
 }
 
-function writeManifest(ctx: Context, storyData: string) {
-  const outputFile = path.resolve(ctx.sourceDir, 'manifest.json');
-  ctx.log.debug(`Writing manifest to file at "${outputFile}"`);
+function writeManifest(deps: GenerateManifestDeps, sourceDirectory: string, storyData: string) {
+  const outputFile = path.resolve(sourceDirectory, 'manifest.json');
+  deps.log.debug(`Writing manifest to file at "${outputFile}"`);
 
-  mkdirSync(ctx.sourceDir, { recursive: true });
+  mkdirSync(sourceDirectory, { recursive: true });
   writeFileSync(outputFile, storyData);
 
-  ctx.log.debug('Manifest generation complete');
+  deps.log.debug('Manifest generation complete');
 }

--- a/node-src/renderer/build.ts
+++ b/node-src/renderer/build.ts
@@ -1,0 +1,41 @@
+import { applyBuildOutput, BuildOutput, buildProject, extractBuildInput } from '../tasks/build';
+import { Context } from '../types';
+import { initial, pending, skipped, success } from '../ui/tasks/build';
+import {
+  pending as reactNativePending,
+  skipped as reactNativeSkipped,
+  success as reactNativeSuccess,
+} from '../ui/tasks/buildReactNative';
+import { runTask } from './engine';
+import { clackSpinnerRenderer } from './engine/clack/spinnerRenderer';
+import { getRenderer } from './engine/getRenderer';
+
+/**
+ * Render the build task.
+ *
+ * @param ctx The CLI context.
+ */
+export async function renderBuild(ctx: Context): Promise<void> {
+  await runTask(
+    ctx,
+    {
+      name: 'build',
+      // Generic until the task starts; the fork-specific copy comes from the transitions below.
+      title: initial(ctx).title,
+      transitions: {
+        pending: (context: Context) =>
+          context.isReactNativeApp ? reactNativePending() : pending(context),
+        success: (context: Context, output?: BuildOutput) => {
+          if (context.isReactNativeApp) {
+            return output?.skippedWithPrebuilt ? reactNativeSkipped() : reactNativeSuccess(context);
+          }
+          return output?.skippedWithPrebuilt ? skipped(context) : success(context);
+        },
+      },
+      extractInput: extractBuildInput,
+      run: buildProject,
+      applyOutput: applyBuildOutput,
+    },
+    getRenderer(ctx, clackSpinnerRenderer)
+  );
+}

--- a/node-src/renderer/engine/index.ts
+++ b/node-src/renderer/engine/index.ts
@@ -39,7 +39,7 @@ export interface TaskConfig<TInput, TOutput, TPartial = never> {
   title: string;
   transitions: {
     pending: (ctx: Context) => Task;
-    success: (ctx: Context) => Task;
+    success: (ctx: Context, output?: TOutput) => Task;
     partial?: (ctx: Context, partial: TPartial) => Task;
     failure?: (ctx: Context, error: Error) => Task;
   };
@@ -138,7 +138,7 @@ async function applyResult<TInput, TOutput, TPartial>(
   switch (result.kind) {
     case 'continue': {
       await config.applyOutput?.(ctx, result.output);
-      const success = config.transitions.success(ctx);
+      const success = config.transitions.success(ctx, result.output);
       ctx.title = success.title;
       renderer.succeed(success);
       return;

--- a/node-src/renderer/storybook/captureTask.ts
+++ b/node-src/renderer/storybook/captureTask.ts
@@ -78,7 +78,10 @@ function drive(renderer: TaskRenderer, state: Task, startingState?: Task): void 
       renderer.update(state);
       return;
     }
-    case 'success': {
+    // `skipped` renders identically to `success` at runtime: build's `transitions.success` returns a
+    // `skipped`-status state and `runTask` drives it through `renderer.succeed`.
+    case 'success':
+    case 'skipped': {
       renderer.start(startingState);
       renderer.succeed(state);
       return;

--- a/node-src/share.ts
+++ b/node-src/share.ts
@@ -10,6 +10,7 @@ import { createLogger } from './lib/log';
 import NonTTYRenderer from './lib/nonTTYRenderer';
 import parseArguments from './lib/parseArguments';
 import { confirmShare, ConfirmShareStatus, reserveShare } from './lib/share';
+import { renderBuild } from './renderer/build';
 import { runShare } from './tasks';
 import { Context, Options } from './types';
 import { endActivity } from './ui/components/activity';
@@ -159,6 +160,7 @@ async function runShareTasks(ctx: Context): Promise<void> {
   };
 
   try {
+    await renderBuild(ctx);
     await new Listr(
       runShare.map((task) => task(ctx)),
       listrOptions

--- a/node-src/tasks/build/buildReactNative.test.ts
+++ b/node-src/tasks/build/buildReactNative.test.ts
@@ -8,6 +8,7 @@ import {
 } from '../../lib/react-native/build';
 import { readExpoConfig as readExpoConfigDefault } from '../../lib/react-native/expoConfig';
 import { generateManifest } from '../../lib/react-native/generateManifest';
+import { exitCodes } from '../../lib/setExitCode';
 import TestLogger from '../../lib/testLogger';
 import { buildArtifacts, generateManifestStep } from './buildReactNative';
 
@@ -62,7 +63,9 @@ const buildAndroid = vi.mocked(buildAndroidDefault);
 const buildIos = vi.mocked(buildIosDefault);
 const readExpoConfig = vi.mocked(readExpoConfigDefault);
 
-const baseContext = { options: {}, flags: {} } as any;
+function makeDeps(overrides = {}) {
+  return { options: {}, log: new TestLogger(), report: vi.fn(), ...overrides } as any;
+}
 
 beforeEach(() => {
   execa.mockClear();
@@ -72,8 +75,6 @@ beforeEach(() => {
 });
 
 describe('buildArtifacts', () => {
-  const task = { title: '', output: '' } as any;
-
   beforeEach(() => {
     mockLogStream.write.mockClear();
     mockLogStream.end.mockClear();
@@ -84,41 +85,32 @@ describe('buildArtifacts', () => {
   });
 
   it('throws when no valid platforms are in browsers', async () => {
-    const ctx = {
-      ...baseContext,
-      announcedBuild: { browsers: [] },
-      log: new TestLogger(),
-    } as any;
-    await expect(buildArtifacts(ctx, task)).rejects.toThrow(
-      'Unable to build for React Native, your project does not include any supported platforms'
-    );
+    await expect(
+      buildArtifacts(makeDeps(), { sourceDir: '/path/to/build', browsers: [] })
+    ).rejects.toMatchObject({
+      name: 'TaskFailure',
+      exitCode: exitCodes.NPM_BUILD_STORYBOOK_FAILED,
+      message:
+        'Unable to build for React Native, your project does not include any supported platforms',
+    });
     expect(buildAndroid).not.toHaveBeenCalled();
     expect(buildIos).not.toHaveBeenCalled();
   });
 
-  it('sets ctx.reactNativeBuildLogFile and creates the .chromatic directory', async () => {
+  it('returns reactNativeBuildLogFile and creates the .chromatic directory', async () => {
     const { mkdirSync } = await import('fs');
-    const ctx = {
-      ...baseContext,
-      announcedBuild: { browsers: ['android'] },
-      log: new TestLogger(),
+    const { reactNativeBuildLogFile } = await buildArtifacts(makeDeps(), {
       sourceDir: '/path/to/build',
-    } as any;
-    await buildArtifacts(ctx, task);
+      browsers: ['android'],
+    });
     expect(vi.mocked(mkdirSync)).toHaveBeenCalledWith('/path/to/build/.chromatic', {
       recursive: true,
     });
-    expect(ctx.reactNativeBuildLogFile).toBe('/path/to/build/.chromatic/react-native-build.log');
+    expect(reactNativeBuildLogFile).toBe('/path/to/build/.chromatic/react-native-build.log');
   });
 
   it('calls buildAndroid with output path when android is in browsers', async () => {
-    const ctx = {
-      ...baseContext,
-      announcedBuild: { browsers: ['android'] },
-      log: new TestLogger(),
-      sourceDir: '/path/to/build',
-    } as any;
-    await buildArtifacts(ctx, task);
+    await buildArtifacts(makeDeps(), { sourceDir: '/path/to/build', browsers: ['android'] });
     expect(buildAndroid).toHaveBeenCalledWith(
       '/path/to/build/storybook.apk',
       mockLogStream,
@@ -127,41 +119,26 @@ describe('buildArtifacts', () => {
   });
 
   it('passes androidBuildArchitectures to buildAndroid', async () => {
-    const ctx = {
-      ...baseContext,
-      announcedBuild: { browsers: ['android'] },
-      log: new TestLogger(),
+    const deps = makeDeps({
       options: { reactNative: { androidBuildArchitectures: ['arm64-v8a'] } },
-      sourceDir: '/path/to/build',
-    } as any;
-    await buildArtifacts(ctx, task);
+    });
+    await buildArtifacts(deps, { sourceDir: '/path/to/build', browsers: ['android'] });
     expect(buildAndroid).toHaveBeenCalledWith('/path/to/build/storybook.apk', mockLogStream, [
       'arm64-v8a',
     ]);
   });
 
   it('reads expo config and calls buildIos with output path when ios is in browsers', async () => {
-    const ctx = {
-      ...baseContext,
-      announcedBuild: { browsers: ['ios'] },
-      log: new TestLogger(),
-      options: {},
-      sourceDir: '/path/to/build',
-    } as any;
-    await buildArtifacts(ctx, task);
+    await buildArtifacts(makeDeps(), { sourceDir: '/path/to/build', browsers: ['ios'] });
     expect(readExpoConfig).toHaveBeenCalled();
     expect(buildIos).toHaveBeenCalledWith('MyApp', '/path/to/build/storybook.app', mockLogStream);
   });
 
   it('uses androidBuildCommand when set and does not call buildAndroid', async () => {
-    const ctx = {
-      ...baseContext,
-      announcedBuild: { browsers: ['android'] },
-      log: new TestLogger(),
+    const deps = makeDeps({
       options: { reactNative: { androidBuildCommand: 'my-android-build' } },
-      sourceDir: '/path/to/build',
-    } as any;
-    await buildArtifacts(ctx, task);
+    });
+    await buildArtifacts(deps, { sourceDir: '/path/to/build', browsers: ['android'] });
     expect(buildAndroid).not.toHaveBeenCalled();
     const [cmd, ...args] = parseCommandString('my-android-build');
     expect(execa).toHaveBeenCalledWith(
@@ -174,35 +151,24 @@ describe('buildArtifacts', () => {
   });
 
   it('ignores androidBuildArchitectures when androidBuildCommand is set and logs debug message', async () => {
-    const log = new TestLogger();
-    const ctx = {
-      ...baseContext,
-      announcedBuild: { browsers: ['android'] },
-      log,
+    const deps = makeDeps({
       options: {
         reactNative: {
           androidBuildCommand: 'my-android-build',
           androidBuildArchitectures: ['arm64-v8a'],
         },
       },
-      sourceDir: '/path/to/build',
-    } as any;
-    await buildArtifacts(ctx, task);
+    });
+    await buildArtifacts(deps, { sourceDir: '/path/to/build', browsers: ['android'] });
     expect(buildAndroid).not.toHaveBeenCalled();
-    expect(log.debug).toHaveBeenCalledWith(
+    expect(deps.log.debug).toHaveBeenCalledWith(
       'androidBuildArchitectures is ignored when androidBuildCommand is set'
     );
   });
 
   it('uses iosBuildCommand when set and does not call buildIos or readExpoConfig', async () => {
-    const ctx = {
-      ...baseContext,
-      announcedBuild: { browsers: ['ios'] },
-      log: new TestLogger(),
-      options: { reactNative: { iosBuildCommand: 'my-ios-build' } },
-      sourceDir: '/path/to/build',
-    } as any;
-    await buildArtifacts(ctx, task);
+    const deps = makeDeps({ options: { reactNative: { iosBuildCommand: 'my-ios-build' } } });
+    await buildArtifacts(deps, { sourceDir: '/path/to/build', browsers: ['ios'] });
     expect(buildIos).not.toHaveBeenCalled();
     expect(readExpoConfig).not.toHaveBeenCalled();
     const [cmd, ...args] = parseCommandString('my-ios-build');
@@ -216,14 +182,10 @@ describe('buildArtifacts', () => {
   });
 
   it('calls buildAndroid and buildIos when both are in browsers', async () => {
-    const ctx = {
-      ...baseContext,
-      announcedBuild: { browsers: ['android', 'ios'] },
-      log: new TestLogger(),
-      options: {},
+    await buildArtifacts(makeDeps(), {
       sourceDir: '/path/to/build',
-    } as any;
-    await buildArtifacts(ctx, task);
+      browsers: ['android', 'ios'],
+    });
     expect(buildAndroid).toHaveBeenCalledWith(
       '/path/to/build/storybook.apk',
       mockLogStream,
@@ -234,38 +196,23 @@ describe('buildArtifacts', () => {
   });
 
   it('closes the log stream after a successful build', async () => {
-    const ctx = {
-      ...baseContext,
-      announcedBuild: { browsers: ['android'] },
-      log: new TestLogger(),
-      sourceDir: '/path/to/build',
-    } as any;
-    await buildArtifacts(ctx, task);
+    await buildArtifacts(makeDeps(), { sourceDir: '/path/to/build', browsers: ['android'] });
     expect(mockLogStream.end).toHaveBeenCalled();
   });
 
   it('closes the log stream and includes a truncated tail on build error', async () => {
     buildAndroid.mockRejectedValueOnce(new Error('Gradle build failed'));
-    const ctx = {
-      ...baseContext,
-      announcedBuild: { browsers: ['android'] },
-      log: new TestLogger(),
-      sourceDir: '/path/to/build',
-    } as any;
-    await expect(buildArtifacts(ctx, task)).rejects.toThrow(
-      'Build failed, see logs at /path/to/build/.chromatic/react-native-build.log'
-    );
+    await expect(
+      buildArtifacts(makeDeps(), { sourceDir: '/path/to/build', browsers: ['android'] })
+    ).rejects.toThrow('Build failed, see logs at /path/to/build/.chromatic/react-native-build.log');
     expect(mockLogStream.end).toHaveBeenCalled();
   });
 });
 
 describe('generateManifestStep', () => {
   it('generates manifest', async () => {
-    const ctx = {
-      ...baseContext,
-      log: { debug: vi.fn() },
-    } as any;
-    await generateManifestStep(ctx);
-    expect(generateManifest).toHaveBeenCalledWith(ctx);
+    const deps = { log: { debug: vi.fn() }, options: {} } as any;
+    await generateManifestStep(deps, { sourceDir: '/path/to/build' });
+    expect(generateManifest).toHaveBeenCalledWith(deps, { sourceDir: '/path/to/build' });
   });
 });

--- a/node-src/tasks/build/buildReactNative.ts
+++ b/node-src/tasks/build/buildReactNative.ts
@@ -6,16 +6,22 @@ import { openLogFileStream } from '../../lib/logFile';
 import { buildAndroid, buildIos, execWithBuildEnvironment } from '../../lib/react-native/build';
 import { readExpoConfig } from '../../lib/react-native/expoConfig';
 import { generateManifest } from '../../lib/react-native/generateManifest';
-import { exitCodes, setExitCode } from '../../lib/setExitCode';
-import { transitionTo } from '../../lib/tasks';
-import { Context, Task } from '../../types';
+import { exitCodes, TaskFailure } from '../../lib/setExitCode';
+import { Context, Deps } from '../../types';
 import { reactNativeBuildFailed } from '../../ui/messages/errors/buildFailed';
-import {
-  failed,
-  failedNoValidPlatforms,
-  pendingAndroid,
-  pendingIOS,
-} from '../../ui/tasks/buildReactNative';
+import { failedNoValidPlatforms, pendingAndroid, pendingIOS } from '../../ui/tasks/buildReactNative';
+
+type BuildReactNativeDeps = Pick<Deps, 'options' | 'log' | 'report'>;
+
+interface BuildArtifactsInput {
+  sourceDir: string;
+  browsers?: string[];
+  runtimeMetadata?: Context['runtimeMetadata'];
+}
+
+interface BuildArtifactsOutput {
+  reactNativeBuildLogFile: string;
+}
 
 const MAX_REACT_NATIVE_LOG_LINES = 20;
 
@@ -32,13 +38,18 @@ async function readLastLines(filePath: string, lineCount: number): Promise<strin
   });
 }
 
-const runPlatformCommand = async (ctx: Context, command: string, logStream: WriteStream) => {
-  ctx.log.debug('Running React Native build command:', command);
+const runPlatformCommand = async (
+  deps: BuildReactNativeDeps,
+  sourceDir: string,
+  command: string,
+  logStream: WriteStream
+) => {
+  deps.log.debug('Running React Native build command:', command);
   try {
     await execWithBuildEnvironment(
       command,
       [],
-      { env: { CHROMATIC_ARTIFACT_DIRECTORY: ctx.sourceDir } },
+      { env: { CHROMATIC_ARTIFACT_DIRECTORY: sourceDir } },
       logStream
     );
   } catch (err) {
@@ -46,72 +57,96 @@ const runPlatformCommand = async (ctx: Context, command: string, logStream: Writ
   }
 };
 
-const resolvePlatforms = (ctx: Context) => {
-  return (ctx.announcedBuild?.browsers ?? []).filter(
+const resolvePlatforms = (browsers?: string[]) => {
+  return (browsers ?? []).filter(
     (b): b is 'ios' | 'android' => b === 'ios' || b === 'android'
   );
 };
 
-const buildAndroidArtifact = async (ctx: Context, task: Task, logStream: WriteStream) => {
-  transitionTo(pendingAndroid)(ctx, task);
-  const { androidBuildCommand, androidBuildArchitectures } = ctx.options.reactNative ?? {};
-  ctx.log.debug({ androidBuildCommand }, 'Running Android build');
+const buildAndroidArtifact = async (
+  deps: BuildReactNativeDeps,
+  sourceDir: string,
+  logStream: WriteStream
+) => {
+  const { title, output } = pendingAndroid(deps.options.reactNative);
+  deps.report({ title, output });
+  const { androidBuildCommand, androidBuildArchitectures } = deps.options.reactNative ?? {};
+  deps.log.debug({ androidBuildCommand }, 'Running Android build');
   if (androidBuildCommand) {
     if (androidBuildArchitectures?.length) {
-      ctx.log.debug('androidBuildArchitectures is ignored when androidBuildCommand is set');
+      deps.log.debug('androidBuildArchitectures is ignored when androidBuildCommand is set');
     }
-    await runPlatformCommand(ctx, androidBuildCommand, logStream);
+    await runPlatformCommand(deps, sourceDir, androidBuildCommand, logStream);
   } else {
-    await buildAndroid(
-      path.join(ctx.sourceDir, 'storybook.apk'),
-      logStream,
-      androidBuildArchitectures
-    );
+    await buildAndroid(path.join(sourceDir, 'storybook.apk'), logStream, androidBuildArchitectures);
   }
 };
 
-const buildIosArtifact = async (ctx: Context, task: Task, logStream: WriteStream) => {
-  transitionTo(pendingIOS)(ctx, task);
-  const { iosBuildCommand } = ctx.options.reactNative ?? {};
-  ctx.log.debug({ iosBuildCommand }, 'Running iOS build');
+const buildIosArtifact = async (
+  deps: BuildReactNativeDeps,
+  sourceDir: string,
+  logStream: WriteStream
+) => {
+  const { title, output } = pendingIOS(deps.options.reactNative);
+  deps.report({ title, output });
+  const { iosBuildCommand } = deps.options.reactNative ?? {};
+  deps.log.debug({ iosBuildCommand }, 'Running iOS build');
   if (iosBuildCommand) {
-    await runPlatformCommand(ctx, iosBuildCommand, logStream);
+    await runPlatformCommand(deps, sourceDir, iosBuildCommand, logStream);
   } else {
     const config = await readExpoConfig();
-    await buildIos(config.name, path.join(ctx.sourceDir, 'storybook.app'), logStream);
+    await buildIos(config.name, path.join(sourceDir, 'storybook.app'), logStream);
   }
 };
 
-export const buildArtifacts = async (ctx: Context, task: Task) => {
-  const platforms = resolvePlatforms(ctx);
+export const buildArtifacts = async (
+  deps: BuildReactNativeDeps,
+  input: BuildArtifactsInput
+): Promise<BuildArtifactsOutput> => {
+  const platforms = resolvePlatforms(input.browsers);
   const needsAndroid = platforms.includes('android');
   const needsIos = platforms.includes('ios');
 
   if (!needsAndroid && !needsIos) {
-    setExitCode(ctx, exitCodes.NPM_BUILD_STORYBOOK_FAILED, true);
-    ctx.log.debug('No supported platforms found for React Native build:', platforms);
-    throw new Error(failedNoValidPlatforms().output);
+    deps.log.debug('No supported platforms found for React Native build:', platforms);
+    throw new TaskFailure(failedNoValidPlatforms().output, {
+      exitCode: exitCodes.NPM_BUILD_STORYBOOK_FAILED,
+      userError: true,
+    });
   }
 
-  mkdirSync(path.join(ctx.sourceDir, '.chromatic'), { recursive: true });
-  ctx.reactNativeBuildLogFile = path.join(ctx.sourceDir, '.chromatic', 'react-native-build.log');
+  mkdirSync(path.join(input.sourceDir, '.chromatic'), { recursive: true });
+  const reactNativeBuildLogFile = path.join(input.sourceDir, '.chromatic', 'react-native-build.log');
 
-  const logStream = await openLogFileStream(ctx.reactNativeBuildLogFile);
+  const logStream = await openLogFileStream(reactNativeBuildLogFile);
 
   try {
-    if (needsAndroid) await buildAndroidArtifact(ctx, task, logStream);
-    if (needsIos) await buildIosArtifact(ctx, task, logStream);
+    if (needsAndroid) await buildAndroidArtifact(deps, input.sourceDir, logStream);
+    if (needsIos) await buildIosArtifact(deps, input.sourceDir, logStream);
     await new Promise<void>((resolve) => logStream.end(resolve));
   } catch (buildError) {
-    setExitCode(ctx, exitCodes.NPM_BUILD_STORYBOOK_FAILED, true);
     await new Promise<void>((resolve) => logStream.end(resolve));
-    const tail = await readLastLines(ctx.reactNativeBuildLogFile, MAX_REACT_NATIVE_LOG_LINES);
-    ctx.log.error(reactNativeBuildFailed(ctx, buildError, tail));
-    throw new Error(failed(ctx).output);
+    const tail = await readLastLines(reactNativeBuildLogFile, MAX_REACT_NATIVE_LOG_LINES);
+    deps.log.error(
+      reactNativeBuildFailed(
+        { reactNativeBuildLogFile, runtimeMetadata: input.runtimeMetadata },
+        buildError,
+        tail
+      )
+    );
+    throw new TaskFailure(`Build failed, see logs at ${reactNativeBuildLogFile}`, {
+      exitCode: exitCodes.NPM_BUILD_STORYBOOK_FAILED,
+      userError: true,
+    });
   }
+
+  return { reactNativeBuildLogFile };
 };
 
-export const generateManifestStep = async (ctx: Context) => {
-  ctx.log.debug('Generating manifest.json file for React Native build');
-  return await generateManifest(ctx);
+export const generateManifestStep = async (
+  deps: Pick<Deps, 'options' | 'log'>,
+  input: { sourceDir: string }
+) => {
+  deps.log.debug('Generating manifest.json file for React Native build');
+  return await generateManifest(deps, { sourceDir: input.sourceDir });
 };

--- a/node-src/tasks/build/buildStorybook.test.ts
+++ b/node-src/tasks/build/buildStorybook.test.ts
@@ -4,6 +4,7 @@ import { execa as execaDefault, parseCommandString } from 'execa';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import TestLogger from '../../lib/testLogger';
+import { exitCodes, TaskFailure } from '../../lib/setExitCode';
 import { buildStorybook } from './buildStorybook';
 
 vi.mock('execa', async (importOriginal) => {
@@ -28,57 +29,74 @@ vi.mock('@sentry/node', () => ({
 
 const execa = vi.mocked(execaDefault);
 
-const baseContext = { options: {}, flags: {} } as any;
+const baseInput = { git: {} } as any;
 
 beforeEach(() => {
   execa.mockClear();
 });
 
 describe('buildStorybook', () => {
-  it('runs the build command', async () => {
-    const ctx = {
-      ...baseContext,
-      buildCommand: 'npm run build:storybook --script-args',
+  it('runs the build command and returns the build log file', async () => {
+    const deps = {
       env: { STORYBOOK_BUILD_TIMEOUT: 1000 },
       log: new TestLogger(),
       options: { storybookLogFile: 'build-storybook.log' },
     } as any;
-    await buildStorybook(ctx);
-    expect(ctx.buildLogFile).toMatch(/build-storybook\.log$/);
-    const [cmd, ...args] = parseCommandString(ctx.buildCommand);
+    const input = { ...baseInput, buildCommand: 'npm run build:storybook --script-args' };
+
+    const { buildLogFile } = await buildStorybook(deps, input);
+
+    expect(buildLogFile).toMatch(/build-storybook\.log$/);
+    const [cmd, ...args] = parseCommandString(input.buildCommand);
     expect(execa).toHaveBeenCalledWith(
       cmd,
       args,
       expect.objectContaining({ stdio: expect.any(Array) })
     );
-    expect(ctx.log.debug).toHaveBeenCalledWith('Running build command:', ctx.buildCommand);
+    expect(deps.log.debug).toHaveBeenCalledWith('Running build command:', input.buildCommand);
   });
 
   it('fails when build times out', async () => {
-    const ctx = {
-      ...baseContext,
-      buildCommand: 'npm run build:storybook --script-args',
+    const deps = {
       options: { buildScriptName: '' },
       env: { STORYBOOK_BUILD_TIMEOUT: 0 },
       log: new TestLogger(),
     } as any;
+    const input = { ...baseInput, buildCommand: 'npm run build:storybook --script-args' };
+
     execa.mockReturnValue(new Promise((resolve) => setTimeout(resolve, 100)) as any);
-    await expect(buildStorybook(ctx)).rejects.toThrow('Command failed');
-    expect(ctx.log.error).toHaveBeenCalledWith(
+    await expect(buildStorybook(deps, input)).rejects.toThrow('Command failed');
+    expect(deps.log.error).toHaveBeenCalledWith(
       expect.stringContaining('Command timed out after 0ms')
     );
   });
 
+  it('throws a TaskFailure carrying the NPM_BUILD_STORYBOOK_FAILED exit code', async () => {
+    const deps = {
+      options: {},
+      env: { STORYBOOK_BUILD_TIMEOUT: 0 },
+      log: new TestLogger(),
+    } as any;
+    const input = { ...baseInput, buildCommand: 'npm run build:storybook' };
+
+    execa.mockRejectedValueOnce(new Error('build failed'));
+    await expect(buildStorybook(deps, input)).rejects.toMatchObject({
+      name: 'TaskFailure',
+      exitCode: exitCodes.NPM_BUILD_STORYBOOK_FAILED,
+      userError: true,
+    });
+  });
+
   it('passes NODE_ENV=production', async () => {
-    const ctx = {
-      ...baseContext,
-      buildCommand: 'npm run build:storybook --script-args',
+    const deps = {
       env: { STORYBOOK_BUILD_TIMEOUT: 1000 },
       log: new TestLogger(),
       options: { storybookLogFile: 'build-storybook.log' },
     } as any;
-    await buildStorybook(ctx);
-    const [cmd, ...args] = parseCommandString(ctx.buildCommand);
+    const input = { ...baseInput, buildCommand: 'npm run build:storybook --script-args' };
+
+    await buildStorybook(deps, input);
+    const [cmd, ...args] = parseCommandString(input.buildCommand);
     expect(execa).toHaveBeenCalledWith(
       cmd,
       args,
@@ -89,15 +107,15 @@ describe('buildStorybook', () => {
   });
 
   it('allows overriding NODE_ENV with STORYBOOK_NODE_ENV', async () => {
-    const ctx = {
-      ...baseContext,
-      buildCommand: 'npm run build:storybook --script-args',
+    const deps = {
       env: { STORYBOOK_BUILD_TIMEOUT: 1000, STORYBOOK_NODE_ENV: 'test' },
       log: { debug: vi.fn() },
       options: { storybookLogFile: 'build-storybook.log' },
     } as any;
-    await buildStorybook(ctx);
-    const [cmd, ...args] = parseCommandString(ctx.buildCommand);
+    const input = { ...baseInput, buildCommand: 'npm run build:storybook --script-args' };
+
+    await buildStorybook(deps, input);
+    const [cmd, ...args] = parseCommandString(input.buildCommand);
     expect(execa).toHaveBeenCalledWith(
       cmd,
       args,
@@ -128,73 +146,79 @@ describe('buildStorybook E2E', () => {
   it.each(missingDependencyErrorMessages)(
     'fails with missing dependency error when error message is $name',
     async ({ error }) => {
-      const ctx = {
-        ...baseContext,
-        buildCommand: 'npm exec build-archive-storybook',
+      const deps = {
         options: { buildScriptName: '', playwright: true },
         env: { STORYBOOK_BUILD_TIMEOUT: 0 },
         log: { debug: vi.fn(), error: vi.fn() },
       } as any;
+      const input = { ...baseInput, buildCommand: 'npm exec build-archive-storybook' };
 
       execa.mockRejectedValueOnce(new Error(error));
-      await expect(buildStorybook(ctx)).rejects.toThrow('Command failed');
-      expect(ctx.log.error).toHaveBeenCalledWith(
+      await expect(buildStorybook(deps, input)).rejects.toMatchObject({
+        name: 'TaskFailure',
+        exitCode: exitCodes.MISSING_DEPENDENCY,
+      });
+      expect(deps.log.error).toHaveBeenCalledWith(
         expect.stringContaining('Failed to import `@chromatic-com/playwright`')
       );
 
-      ctx.log.error.mockClear();
+      deps.log.error.mockClear();
     }
   );
 
   it('fails with generic error message when not missing dependency error', async () => {
-    const ctx = {
-      ...baseContext,
-      buildCommand: 'npm exec build-archive-storybook',
+    const deps = {
       options: { buildScriptName: '', playwright: true },
       env: { STORYBOOK_BUILD_TIMEOUT: 0 },
       log: { debug: vi.fn(), error: vi.fn() },
     } as any;
+    const input = { ...baseInput, buildCommand: 'npm exec build-archive-storybook' };
 
     const errorMessage =
       'Command failed with exit code 1: npm exec build-archive-storybook --output-dir /tmp/chromatic--4210-0cyodqfYZabe\n\nMore error message lines\n\nAnd more';
     execa.mockRejectedValueOnce(new Error(errorMessage));
-    await expect(buildStorybook(ctx)).rejects.toThrow('Command failed');
-    expect(ctx.log.error).not.toHaveBeenCalledWith(
+    await expect(buildStorybook(deps, input)).rejects.toMatchObject({
+      name: 'TaskFailure',
+      exitCode: exitCodes.E2E_BUILD_FAILED,
+    });
+    expect(deps.log.error).not.toHaveBeenCalledWith(
       expect.stringContaining('Failed to import `@chromatic-com/playwright`')
     );
-    expect(ctx.log.error).toHaveBeenCalledWith(
+    expect(deps.log.error).toHaveBeenCalledWith(
       expect.stringContaining('Failed to run `chromatic --playwright`')
     );
-    expect(ctx.log.error).toHaveBeenCalledWith(expect.stringContaining(errorMessage));
+    expect(deps.log.error).toHaveBeenCalledWith(expect.stringContaining(errorMessage));
   });
 });
 
-function makeAnalyticsContext(overrides = {}) {
+function makeAnalyticsDeps(overrides = {}) {
   return {
-    ...baseContext,
-    buildCommand: 'npm run build:storybook',
+    options: {},
     env: { STORYBOOK_BUILD_TIMEOUT: 0 },
     log: new TestLogger(),
     pkg: { version: '1.0.0' },
+    analytics: { trackEvent: vi.fn(), shutdown: vi.fn() },
+    ...overrides,
+  } as any;
+}
+
+function makeAnalyticsInput(overrides = {}) {
+  return {
+    buildCommand: 'npm run build:storybook',
     storybook: { version: '8.0.0' },
     git: { gitUserEmail: 'test@example.com', ciService: 'github-actions' },
-    announcedBuild: { app: { id: 'app-123', account: { id: 'account-456' } } },
-    analytics: { trackEvent: vi.fn(), shutdown: vi.fn() },
     ...overrides,
   } as any;
 }
 
 describe('buildStorybook analytics', () => {
   it('tracks storybook_build_failed on build failure', async () => {
-    // arrange
-    const ctx = makeAnalyticsContext();
+    const deps = makeAnalyticsDeps();
     execa.mockRejectedValueOnce(new Error('build failed'));
 
-    // act
-    await expect(buildStorybook(ctx)).rejects.toThrow();
+    await expect(buildStorybook(deps, makeAnalyticsInput())).rejects.toThrow();
 
-    // assert
-    expect(ctx.analytics.trackEvent).toHaveBeenCalledWith(
+    expect(deps.analytics.trackEvent).toHaveBeenCalledWith(
       AnalyticsEvent.CLI_STORYBOOK_BUILD_FAILED,
       expect.objectContaining({
         errorCategory: 'storybook_build_failed',
@@ -210,67 +234,55 @@ describe('buildStorybook analytics', () => {
   });
 
   it('tracks e2e_missing_dependency when E2E dependency is not found', async () => {
-    // arrange
-    const ctx = makeAnalyticsContext({ options: { playwright: true, buildScriptName: '' } });
+    const deps = makeAnalyticsDeps({ options: { playwright: true, buildScriptName: '' } });
     execa.mockRejectedValueOnce(new Error('Command not found: build-archive-storybook'));
 
-    // act
-    await expect(buildStorybook(ctx)).rejects.toThrow();
+    await expect(buildStorybook(deps, makeAnalyticsInput())).rejects.toThrow();
 
-    // assert
-    expect(ctx.analytics.trackEvent).toHaveBeenCalledWith(
+    expect(deps.analytics.trackEvent).toHaveBeenCalledWith(
       AnalyticsEvent.CLI_STORYBOOK_BUILD_FAILED,
       expect.objectContaining({ errorCategory: 'e2e_missing_dependency' })
     );
   });
 
   it('tracks e2e_build_failed on generic E2E build failure', async () => {
-    // arrange
-    const ctx = makeAnalyticsContext({ options: { playwright: true, buildScriptName: '' } });
+    const deps = makeAnalyticsDeps({ options: { playwright: true, buildScriptName: '' } });
     const error = 'Command failed with exit code 1: build-archive-storybook\n\nMultiple lines';
     execa.mockRejectedValueOnce(new Error(`${error}\n\nOf error`));
 
-    // act
-    await expect(buildStorybook(ctx)).rejects.toThrow();
+    await expect(buildStorybook(deps, makeAnalyticsInput())).rejects.toThrow();
 
-    // assert
-    expect(ctx.analytics.trackEvent).toHaveBeenCalledWith(
+    expect(deps.analytics.trackEvent).toHaveBeenCalledWith(
       AnalyticsEvent.CLI_STORYBOOK_BUILD_FAILED,
       expect.objectContaining({ errorCategory: 'e2e_build_failed' })
     );
   });
 
   it('tracks aborted when build is cancelled via abort signal', async () => {
-    // arrange
     const controller = new AbortController();
     controller.abort();
-    const ctx = makeAnalyticsContext({
+    const deps = makeAnalyticsDeps({
       options: { experimental_abortSignal: controller.signal, buildScriptName: '' },
     });
     execa.mockRejectedValueOnce(new Error('aborted'));
 
-    // act
-    await expect(buildStorybook(ctx)).rejects.toThrow();
+    await expect(buildStorybook(deps, makeAnalyticsInput())).rejects.toThrow();
 
-    // assert
-    expect(ctx.analytics.trackEvent).toHaveBeenCalledWith(
+    expect(deps.analytics.trackEvent).toHaveBeenCalledWith(
       AnalyticsEvent.CLI_STORYBOOK_BUILD_FAILED,
       expect.objectContaining({ errorCategory: 'aborted' })
     );
   });
 
   it('sanitizes the stack trace before sending', async () => {
-    // arrange
-    const ctx = makeAnalyticsContext();
+    const deps = makeAnalyticsDeps();
     const err = new Error('build failed');
     err.stack = 'Error: build failed\n    at x (/Users/user/secret/project/file.js:1:1)';
     execa.mockRejectedValueOnce(err);
 
-    // act
-    await expect(buildStorybook(ctx)).rejects.toThrow();
+    await expect(buildStorybook(deps, makeAnalyticsInput())).rejects.toThrow();
 
-    // assert
-    expect(ctx.analytics.trackEvent).toHaveBeenCalledWith(
+    expect(deps.analytics.trackEvent).toHaveBeenCalledWith(
       AnalyticsEvent.CLI_STORYBOOK_BUILD_FAILED,
       expect.objectContaining({
         stackTrace: 'Error: build failed\n    at x (<path>/file.js:1:1)',
@@ -279,10 +291,9 @@ describe('buildStorybook analytics', () => {
   });
 
   it('reports to Sentry and still throws the build failure when analytics throws', async () => {
-    // arrange
     vi.mocked(Sentry.captureException).mockClear();
     const analyticsError = new Error('analytics exploded');
-    const ctx = makeAnalyticsContext({
+    const deps = makeAnalyticsDeps({
       analytics: {
         trackEvent: vi.fn(() => {
           throw analyticsError;
@@ -292,11 +303,10 @@ describe('buildStorybook analytics', () => {
     });
     execa.mockRejectedValueOnce(new Error('build failed'));
 
-    // act
-    const thrown = await buildStorybook(ctx).catch((err) => err);
+    const thrown = await buildStorybook(deps, makeAnalyticsInput()).catch((err) => err);
 
     // assert: outer throw is the build failure, not the analytics failure
-    expect(thrown).toBeInstanceOf(Error);
+    expect(thrown).toBeInstanceOf(TaskFailure);
     expect(thrown).not.toBe(analyticsError);
     expect(Sentry.captureException).toHaveBeenCalledWith(analyticsError);
   });

--- a/node-src/tasks/build/buildStorybook.ts
+++ b/node-src/tasks/build/buildStorybook.ts
@@ -41,7 +41,7 @@ function e2eBuildErrorMessage(
   workingDirectory: string,
   ctx: Context
 ): { exitCode: number; message: string } {
-  const flag = resolveE2EFramework(ctx);
+  const flag = resolveE2EFramework(ctx.options);
   const errorMessage = err.message;
 
   // If we tried to run the E2E package's bin directly (due to being in the action)

--- a/node-src/tasks/build/buildStorybook.ts
+++ b/node-src/tasks/build/buildStorybook.ts
@@ -8,14 +8,26 @@ import { buildBinName as e2eBuildBinName } from '../../lib/e2e';
 import { isE2EBuild } from '../../lib/e2eUtils';
 import { emailHash } from '../../lib/emailHash';
 import { openLogFileStream } from '../../lib/logFile';
-import { exitCodes, setExitCode } from '../../lib/setExitCode';
+import { exitCodes, TaskFailure } from '../../lib/setExitCode';
 import { runCommand } from '../../lib/shell/shell';
-import { Context } from '../../types';
+import { Context, Deps } from '../../types';
 import { buildFailed } from '../../ui/messages/errors/buildFailed';
 import e2eBuildFailed from '../../ui/messages/errors/e2eBuildFailed';
 import missingDependency from '../../ui/messages/errors/missingDependency';
-import { failed } from '../../ui/tasks/build';
 import { resolveE2EFramework } from './resolveE2EFramework';
+
+type BuildStorybookDeps = Pick<Deps, 'options' | 'log' | 'env' | 'analytics' | 'pkg'>;
+
+interface BuildStorybookInput {
+  buildCommand?: string;
+  runtimeMetadata?: Context['runtimeMetadata'];
+  storybook?: Context['storybook'];
+  git: Context['git'];
+}
+
+interface BuildStorybookOutput {
+  buildLogFile?: string;
+}
 
 function isE2EBuildCommandNotFoundError(errorMessage: string) {
   // It's hard to know if this is the case as each package manager has a different type of
@@ -39,9 +51,9 @@ function isE2EBuildCommandNotFoundError(errorMessage: string) {
 function e2eBuildErrorMessage(
   err,
   workingDirectory: string,
-  ctx: Context
+  options: Context['options']
 ): { exitCode: number; message: string } {
-  const flag = resolveE2EFramework(ctx.options);
+  const flag = resolveE2EFramework(options);
   const errorMessage = err.message;
 
   // If we tried to run the E2E package's bin directly (due to being in the action)
@@ -61,46 +73,72 @@ function e2eBuildErrorMessage(
   };
 }
 
-function handleBuildFailure(ctx: Context, err: any, signal?: AbortSignal): never {
-  if (isE2EBuild(ctx.options)) {
+function handleBuildFailure(
+  deps: BuildStorybookDeps,
+  input: BuildStorybookInput,
+  err: any,
+  buildLogFile?: string,
+  signal?: AbortSignal
+): never {
+  if (isE2EBuild(deps.options)) {
     // If we tried to run the E2E package's bin directly (due to being in the action)
     // and it failed, that means we couldn't find it. This probably means they haven't
     // installed the right dependency or run from the right directory
-    const errorInfo = e2eBuildErrorMessage(err, process.cwd(), ctx);
+    const errorInfo = e2eBuildErrorMessage(err, process.cwd(), deps.options);
     const errorCategory =
       errorInfo.exitCode === exitCodes.MISSING_DEPENDENCY
         ? 'e2e_missing_dependency'
         : 'e2e_build_failed';
-    trackBuildFailure(ctx, errorCategory, err);
-    ctx.log.error(errorInfo.message);
-    setExitCode(ctx, errorInfo.exitCode, true);
-    throw new Error(failed(ctx).output);
+    trackBuildFailure(deps, input, errorCategory, err);
+    deps.log.error(errorInfo.message);
+    throw new TaskFailure(`Command failed: ${input.buildCommand}`, {
+      exitCode: errorInfo.exitCode,
+      userError: true,
+    });
   }
 
   if (signal?.aborted) {
-    trackBuildFailure(ctx, 'aborted', err);
+    trackBuildFailure(deps, input, 'aborted', err);
     signal.throwIfAborted();
   }
 
-  trackBuildFailure(ctx, 'storybook_build_failed', err);
-  const buildLog = ctx.buildLogFile && readFileSync(ctx.buildLogFile, 'utf8');
-  ctx.log.error(buildFailed(ctx, err, buildLog));
-  setExitCode(ctx, exitCodes.NPM_BUILD_STORYBOOK_FAILED, true);
-  throw new Error(failed(ctx).output);
+  trackBuildFailure(deps, input, 'storybook_build_failed', err);
+  const buildLog = buildLogFile && readFileSync(buildLogFile, 'utf8');
+  deps.log.error(
+    buildFailed(
+      {
+        options: deps.options,
+        buildCommand: input.buildCommand,
+        buildLogFile,
+        runtimeMetadata: input.runtimeMetadata,
+      },
+      err,
+      buildLog
+    )
+  );
+  throw new TaskFailure(`Command failed: ${input.buildCommand}`, {
+    exitCode: exitCodes.NPM_BUILD_STORYBOOK_FAILED,
+    userError: true,
+  });
 }
 
-function trackBuildFailure(ctx: Context, errorCategory: string, err: any) {
+function trackBuildFailure(
+  deps: BuildStorybookDeps,
+  input: BuildStorybookInput,
+  errorCategory: string,
+  err: any
+) {
   try {
-    ctx.analytics?.trackEvent(AnalyticsEvent.CLI_STORYBOOK_BUILD_FAILED, {
+    deps.analytics?.trackEvent(AnalyticsEvent.CLI_STORYBOOK_BUILD_FAILED, {
       errorCategory,
       stackTrace: sanitizeStackTrace(err?.stack),
-      buildCommand: ctx.buildCommand,
+      buildCommand: input.buildCommand,
       source: 'cli',
-      cliVersion: ctx.pkg?.version,
-      storybookVersion: ctx.storybook?.version,
+      cliVersion: deps.pkg?.version,
+      storybookVersion: input.storybook?.version,
       isCI: !!process.env.CI,
-      ciService: ctx.git?.ciService,
-      gitUserEmailHash: ctx.git?.gitUserEmail ? emailHash(ctx.git.gitUserEmail) : undefined, // avoid hashing empty string
+      ciService: input.git?.ciService,
+      gitUserEmailHash: input.git?.gitUserEmail ? emailHash(input.git.gitUserEmail) : undefined, // avoid hashing empty string
     });
   } catch (error) {
     // Analytics should be best-effort, never fail the build, but we want to know about it
@@ -108,38 +146,44 @@ function trackBuildFailure(ctx: Context, errorCategory: string, err: any) {
   }
 }
 
-export const buildStorybook = async (ctx: Context) => {
+export const buildStorybook = async (
+  deps: BuildStorybookDeps,
+  input: BuildStorybookInput
+): Promise<BuildStorybookOutput> => {
   let logFile;
-  if (ctx.options.storybookLogFile) {
-    ctx.buildLogFile = path.resolve(ctx.options.storybookLogFile);
-    logFile = await openLogFileStream(ctx.buildLogFile);
+  let buildLogFile: string | undefined;
+  if (deps.options.storybookLogFile) {
+    buildLogFile = path.resolve(deps.options.storybookLogFile);
+    logFile = await openLogFileStream(buildLogFile);
   }
 
-  const { experimental_abortSignal: signal } = ctx.options;
+  const { experimental_abortSignal: signal } = deps.options;
   try {
-    ctx.log.debug('Running build command:', ctx.buildCommand);
-    ctx.log.debug('Runtime metadata:', JSON.stringify(ctx.runtimeMetadata, undefined, 2));
+    deps.log.debug('Running build command:', input.buildCommand);
+    deps.log.debug('Runtime metadata:', JSON.stringify(input.runtimeMetadata, undefined, 2));
 
-    if (!ctx.buildCommand) {
+    if (!input.buildCommand) {
       throw new Error('No build command configured');
     }
 
-    await runCommand(ctx.buildCommand, {
+    await runCommand(input.buildCommand, {
       stdio: [undefined, logFile, undefined],
       // When `true`, this will run in the node version set by the
       // action (node20), not the version set in the workflow
       preferLocal: false,
       cancelSignal: signal,
-      timeout: ctx.env.STORYBOOK_BUILD_TIMEOUT,
+      timeout: deps.env.STORYBOOK_BUILD_TIMEOUT,
       env: {
         CI: '1',
-        NODE_ENV: ctx.env.STORYBOOK_NODE_ENV || 'production',
+        NODE_ENV: deps.env.STORYBOOK_NODE_ENV || 'production',
         STORYBOOK_INVOKED_BY: 'chromatic',
       },
     });
   } catch (err) {
-    handleBuildFailure(ctx, err, signal);
+    handleBuildFailure(deps, input, err, buildLogFile, signal);
   } finally {
     logFile?.end();
   }
+
+  return { buildLogFile };
 };

--- a/node-src/tasks/build/index.test.ts
+++ b/node-src/tasks/build/index.test.ts
@@ -1,7 +1,7 @@
 import { existsSync as existsSyncDefault } from 'fs';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import buildTask from './index';
+import { applyBuildOutput, buildProject, extractBuildInput } from './index';
 
 vi.mock('fs', async (importOriginal) => {
   const actual = await importOriginal<typeof import('fs')>();
@@ -11,65 +11,146 @@ vi.mock('fs', async (importOriginal) => {
   };
 });
 
+vi.mock('./setSourceDirectory', () => ({
+  setSourceDirectory: vi.fn(async () => '/sourceDir'),
+}));
+vi.mock('./setBuildCommand', () => ({
+  setBuildCommand: vi.fn(async () => 'build-command'),
+}));
+vi.mock('./buildStorybook', () => ({
+  buildStorybook: vi.fn(async () => ({ buildLogFile: '/build.log' })),
+}));
+vi.mock('./buildReactNative', () => ({
+  buildArtifacts: vi.fn(async () => ({ reactNativeBuildLogFile: '/rn-build.log' })),
+  generateManifestStep: vi.fn(async () => {}),
+}));
+
+const { buildArtifacts, generateManifestStep } = await import('./buildReactNative');
 const existsSync = vi.mocked(existsSyncDefault);
 
-const baseContext = { options: {}, flags: {} } as any;
+const makeDeps = (options: Record<string, any> = {}) =>
+  ({
+    options,
+    log: { debug: vi.fn(), warn: vi.fn() },
+    env: {},
+    report: vi.fn(),
+  }) as any;
+
+const baseInput = { isReactNativeApp: false, flags: {}, git: {} } as any;
 
 beforeEach(() => {
-  existsSync.mockClear();
+  vi.clearAllMocks();
 });
 
-describe('build task skip', () => {
-  it('returns true when ctx.skip is set', async () => {
-    const ctx = { ...baseContext, skip: true } as any;
-    const task = buildTask(ctx);
-    expect(await task.skip?.(ctx)).toBe(true);
+describe('buildProject (web)', () => {
+  it('skips with prebuilt artifacts when storybookBuildDir is set', async () => {
+    const result = await buildProject(makeDeps({ storybookBuildDir: '/prebuilt' }), baseInput);
+    expect(result).toEqual({
+      kind: 'continue',
+      output: { sourceDir: '/prebuilt', skippedWithPrebuilt: true },
+    });
   });
 
-  it('returns false when isReactNativeApp and no storybookBuildDir', async () => {
-    const ctx = { ...baseContext, isReactNativeApp: true } as any;
-    const task = buildTask(ctx);
-    expect(await task.skip?.(ctx)).toBe(false);
+  it('builds the Storybook when no prebuilt dir is provided', async () => {
+    const deps = makeDeps({});
+    const result = await buildProject(deps, baseInput);
+    expect(result).toEqual({
+      kind: 'continue',
+      output: {
+        sourceDir: '/sourceDir',
+        skippedWithPrebuilt: false,
+        buildCommand: 'build-command',
+        buildLogFile: '/build.log',
+      },
+    });
+    expect(deps.report).toHaveBeenCalledWith({ output: 'Running command: build-command' });
   });
+});
 
-  it('sets sourceDir and returns false when isReactNativeApp, storybookBuildDir set, and no manifest', async () => {
-    existsSync.mockReturnValueOnce(false);
-    const ctx = {
-      ...baseContext,
-      isReactNativeApp: true,
-      options: { storybookBuildDir: '/path/to/rn-build' },
-    } as any;
-    const task = buildTask(ctx);
-    expect(await task.skip?.(ctx)).toBe(false);
-    expect(ctx.sourceDir).toBe('/path/to/rn-build');
-  });
+describe('buildProject (react native)', () => {
+  const rnInput = { ...baseInput, isReactNativeApp: true };
 
-  it('sets sourceDir and returns skipped message when isReactNativeApp and manifest.json exists', async () => {
+  it('skips when prebuilt dir contains a manifest', async () => {
     existsSync.mockReturnValueOnce(true);
+    const result = await buildProject(makeDeps({ storybookBuildDir: '/prebuilt' }), rnInput);
+    expect(buildArtifacts).not.toHaveBeenCalled();
+    expect(generateManifestStep).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      kind: 'continue',
+      output: { sourceDir: '/prebuilt', skippedWithPrebuilt: true },
+    });
+  });
+
+  it('generates only the manifest when prebuilt dir lacks a manifest', async () => {
+    existsSync.mockReturnValueOnce(false);
+    const result = await buildProject(makeDeps({ storybookBuildDir: '/prebuilt' }), rnInput);
+    expect(buildArtifacts).not.toHaveBeenCalled();
+    expect(generateManifestStep).toHaveBeenCalled();
+    expect(result).toMatchObject({
+      output: {
+        sourceDir: '/sourceDir',
+        skippedWithPrebuilt: false,
+        reactNativeBuildLogFile: undefined,
+      },
+    });
+  });
+
+  it('builds artifacts and the manifest when no prebuilt dir is provided', async () => {
+    const result = await buildProject(makeDeps({}), rnInput);
+    expect(buildArtifacts).toHaveBeenCalled();
+    expect(generateManifestStep).toHaveBeenCalled();
+    expect(result).toMatchObject({
+      output: {
+        sourceDir: '/sourceDir',
+        skippedWithPrebuilt: false,
+        reactNativeBuildLogFile: '/rn-build.log',
+      },
+    });
+  });
+});
+
+describe('extractBuildInput', () => {
+  it('reads build-relevant fields off the context', () => {
     const ctx = {
-      ...baseContext,
       isReactNativeApp: true,
-      options: { storybookBuildDir: '/path/to/rn-build' },
+      sourceDir: '/src',
+      storybook: { version: '7' },
+      flags: { buildCommand: 'x' },
+      git: { changedFiles: ['a.js'] },
+      announcedBuild: { browsers: ['ios'] },
+      runtimeMetadata: { nodePlatform: 'darwin' },
     } as any;
-    const task = buildTask(ctx);
-    expect(await task.skip?.(ctx)).toBe('Using prebuilt React Native assets');
-    expect(ctx.sourceDir).toBe('/path/to/rn-build');
+    expect(extractBuildInput(ctx)).toEqual({
+      isReactNativeApp: true,
+      sourceDir: '/src',
+      storybook: { version: '7' },
+      flags: { buildCommand: 'x' },
+      browsers: ['ios'],
+      runtimeMetadata: { nodePlatform: 'darwin' },
+      git: { changedFiles: ['a.js'] },
+    });
+  });
+});
+
+describe('applyBuildOutput', () => {
+  it('writes build artifacts to the context', () => {
+    const ctx = {} as any;
+    applyBuildOutput(ctx, {
+      sourceDir: '/src',
+      skippedWithPrebuilt: false, // not set on ctx
+      buildCommand: 'cmd',
+      buildLogFile: '/log',
+    });
+    expect(ctx).toMatchObject({ sourceDir: '/src', buildCommand: 'cmd', buildLogFile: '/log' });
   });
 
-  it('sets sourceDir and returns skipped message when storybookBuildDir is set for web', async () => {
-    const ctx = {
-      ...baseContext,
-      options: { storybookBuildDir: '/path/to/sb-build' },
-    } as any;
-    const task = buildTask(ctx);
-    const result = await task.skip?.(ctx);
-    expect(result).toContain('/path/to/sb-build');
-    expect(ctx.sourceDir).toBe('/path/to/sb-build');
-  });
-
-  it('returns false when no storybookBuildDir for web', async () => {
-    const ctx = { ...baseContext } as any;
-    const task = buildTask(ctx);
-    expect(await task.skip?.(ctx)).toBe(false);
+  it('writes the React Native build log when present', () => {
+    const ctx = {} as any;
+    applyBuildOutput(ctx, {
+      sourceDir: '/src',
+      skippedWithPrebuilt: false, // not set on ctx
+      reactNativeBuildLogFile: '/rn.log',
+    });
+    expect(ctx).toMatchObject({ sourceDir: '/src', reactNativeBuildLogFile: '/rn.log' });
   });
 });

--- a/node-src/tasks/build/index.ts
+++ b/node-src/tasks/build/index.ts
@@ -57,14 +57,22 @@ export default function main(ctx: Context) {
       // to avoid duplicated UI, we handle both paths of the build process in one task
       async (ctx: Context, task: Task) => {
         if (ctx.isReactNativeApp) {
+          // Mid-run reports are inert in the legacy phase (buildDeps supplies a no-op `report`);
+          // runTask wires the real renderer-aware reporter once the build task swaps onto it.
+          const deps = { options: ctx.options, log: ctx.log, report: () => {} };
           transitionTo(pending)(ctx, task);
           await startActivity(ctx, task);
           // if the user has not provided build artifacts, we need to build them ourselves
           if (!ctx.options.storybookBuildDir) {
-            await buildArtifacts(ctx, task);
+            const artifacts = await buildArtifacts(deps, {
+              sourceDir: ctx.sourceDir,
+              browsers: ctx.announcedBuild?.browsers,
+              runtimeMetadata: ctx.runtimeMetadata,
+            });
+            ctx.reactNativeBuildLogFile = artifacts.reactNativeBuildLogFile;
           }
           transitionTo(pendingManifest)(ctx, task);
-          await generateManifestStep(ctx);
+          await generateManifestStep(deps, { sourceDir: ctx.sourceDir });
           endActivity(ctx);
           transitionTo(reactNativeSuccess, true)(ctx, task);
         } else {

--- a/node-src/tasks/build/index.ts
+++ b/node-src/tasks/build/index.ts
@@ -1,112 +1,153 @@
 import { existsSync } from 'fs';
 import path from 'path';
 
-import { createTask, transitionTo } from '../../lib/tasks';
-import { Context, Task } from '../../types';
-import { endActivity, startActivity } from '../../ui/components/activity';
-import { initial, pending, skipped, success } from '../../ui/tasks/build';
-import {
-  pendingManifest,
-  skipped as reactNativeSkipped,
-  success as reactNativeSuccess,
-} from '../../ui/tasks/buildReactNative';
+import { Context, Deps, TaskResult } from '../../types';
+import { pendingManifest } from '../../ui/tasks/buildReactNative';
 import { buildArtifacts, generateManifestStep } from './buildReactNative';
 import { buildStorybook } from './buildStorybook';
 import { setBuildCommand } from './setBuildCommand';
 import { setSourceDirectory } from './setSourceDirectory';
 
-/**
- * Sets up the Listr task for building the user's Storybook or E2E project.
- *
- * @param ctx The context set when executing the CLI.
- *
- * @returns A Listr task.
- */
-export default function main(ctx: Context) {
-  return createTask({
-    name: 'build',
-    title: initial(ctx).title,
-    skip: async (ctx) => {
-      if (ctx.skip) return true;
-
-      if (ctx.isReactNativeApp) {
-        // react native build can be skipped if the user has provided build artifacts AND included a manifest
-        if (ctx.options.storybookBuildDir) {
-          ctx.sourceDir = ctx.options.storybookBuildDir;
-          if (existsSync(path.resolve(ctx.options.storybookBuildDir, 'manifest.json'))) {
-            return reactNativeSkipped().output;
-          }
-          return false;
-        }
-      } else {
-        // web build can be skipped if the user has already built their storybook and provided the output directory
-        if (ctx.options.storybookBuildDir) {
-          ctx.sourceDir = ctx.options.storybookBuildDir;
-          return skipped(ctx).output;
-        }
-      }
-      return false;
-    },
-    steps: [
-      async (ctx: Context) => {
-        ctx.sourceDir = await setSourceDirectory(
-          { options: ctx.options },
-          { sourceDir: ctx.sourceDir, storybook: ctx.storybook }
-        );
-      },
-      // to avoid duplicated UI, we handle both paths of the build process in one task
-      async (ctx: Context, task: Task) => {
-        if (ctx.isReactNativeApp) {
-          // Mid-run reports are inert in the legacy phase (buildDeps supplies a no-op `report`);
-          // runTask wires the real renderer-aware reporter once the build task swaps onto it.
-          const deps = { options: ctx.options, log: ctx.log, report: () => {} };
-          transitionTo(pending)(ctx, task);
-          await startActivity(ctx, task);
-          // if the user has not provided build artifacts, we need to build them ourselves
-          if (!ctx.options.storybookBuildDir) {
-            const artifacts = await buildArtifacts(deps, {
-              sourceDir: ctx.sourceDir,
-              browsers: ctx.announcedBuild?.browsers,
-              runtimeMetadata: ctx.runtimeMetadata,
-            });
-            ctx.reactNativeBuildLogFile = artifacts.reactNativeBuildLogFile;
-          }
-          transitionTo(pendingManifest)(ctx, task);
-          await generateManifestStep(deps, { sourceDir: ctx.sourceDir });
-          endActivity(ctx);
-          transitionTo(reactNativeSuccess, true)(ctx, task);
-        } else {
-          ctx.buildCommand = await setBuildCommand(
-            { options: ctx.options, log: ctx.log },
-            {
-              sourceDir: ctx.sourceDir,
-              flags: ctx.flags,
-              storybook: ctx.storybook,
-              changedFiles: ctx.git.changedFiles,
-            }
-          );
-          transitionTo(pending)(ctx, task);
-          await startActivity(ctx, task);
-          const builtStorybook = await buildStorybook(
-            {
-              options: ctx.options,
-              log: ctx.log,
-              env: ctx.env,
-              analytics: ctx.analytics,
-              pkg: ctx.pkg,
-            },
-            {
-              buildCommand: ctx.buildCommand,
-              runtimeMetadata: ctx.runtimeMetadata,
-              storybook: ctx.storybook,
-              git: ctx.git,
-            }
-          );
-          ctx.buildLogFile = builtStorybook.buildLogFile;
-          endActivity(ctx);
-          transitionTo(success, true)(ctx, task);
-        }
-      },
-    ],
-  });
+export interface BuildInput {
+  isReactNativeApp: boolean;
+  sourceDir?: string;
+  storybook?: Context['storybook'];
+  flags: Context['flags'];
+  browsers?: string[];
+  runtimeMetadata?: Context['runtimeMetadata'];
+  git: Context['git'];
 }
+
+export interface BuildOutput {
+  sourceDir: string;
+  // The user provided prebuilt artifacts (and, for React Native, a manifest), so no build ran.
+  skippedWithPrebuilt: boolean;
+  buildCommand?: string;
+  buildLogFile?: string;
+  reactNativeBuildLogFile?: string;
+}
+
+async function buildReactNativeProject(
+  deps: Deps,
+  input: BuildInput
+): Promise<TaskResult<BuildOutput>> {
+  const { storybookBuildDir } = deps.options;
+
+  if (storybookBuildDir && existsSync(path.resolve(storybookBuildDir, 'manifest.json'))) {
+    return {
+      kind: 'continue',
+      output: { sourceDir: storybookBuildDir, skippedWithPrebuilt: true },
+    };
+  }
+
+  const sourceDir = await setSourceDirectory(
+    { options: deps.options },
+    { sourceDir: storybookBuildDir ?? input.sourceDir, storybook: input.storybook }
+  );
+
+  let reactNativeBuildLogFile: string | undefined;
+  // If the user has not provided build artifacts, we need to build them ourselves.
+  if (!storybookBuildDir) {
+    const artifacts = await buildArtifacts(
+      { options: deps.options, log: deps.log, report: deps.report },
+      { sourceDir, browsers: input.browsers, runtimeMetadata: input.runtimeMetadata }
+    );
+    reactNativeBuildLogFile = artifacts.reactNativeBuildLogFile;
+  }
+
+  const { title, output } = pendingManifest();
+  deps.report({ title, output });
+  await generateManifestStep({ options: deps.options, log: deps.log }, { sourceDir });
+
+  return {
+    kind: 'continue',
+    output: { sourceDir, skippedWithPrebuilt: false, reactNativeBuildLogFile },
+  };
+}
+
+async function buildWebProject(deps: Deps, input: BuildInput): Promise<TaskResult<BuildOutput>> {
+  const { storybookBuildDir } = deps.options;
+
+  // The user has already built their Storybook and provided the output directory.
+  if (storybookBuildDir) {
+    return {
+      kind: 'continue',
+      output: { sourceDir: storybookBuildDir, skippedWithPrebuilt: true },
+    };
+  }
+
+  const sourceDir = await setSourceDirectory(
+    { options: deps.options },
+    { sourceDir: input.sourceDir, storybook: input.storybook }
+  );
+
+  const buildCommand = await setBuildCommand(
+    { options: deps.options, log: deps.log },
+    {
+      sourceDir,
+      flags: input.flags,
+      storybook: input.storybook,
+      changedFiles: input.git.changedFiles,
+    }
+  );
+
+  deps.report({ output: `Running command: ${buildCommand}` });
+
+  const { buildLogFile } = await buildStorybook(
+    {
+      options: deps.options,
+      log: deps.log,
+      env: deps.env,
+      analytics: deps.analytics,
+      pkg: deps.pkg,
+    },
+    {
+      buildCommand,
+      runtimeMetadata: input.runtimeMetadata,
+      storybook: input.storybook,
+      git: input.git,
+    }
+  );
+
+  return {
+    kind: 'continue',
+    output: { sourceDir, skippedWithPrebuilt: false, buildCommand, buildLogFile },
+  };
+}
+
+/**
+ * Build the user's Storybook, E2E, or React Native project, or skip when prebuilt artifacts were
+ * provided.
+ *
+ * @param deps Narrow set of cross-cutting dependencies the task needs.
+ * @param input Per-pipeline-run input extracted from Context at the seam.
+ *
+ * @returns A TaskResult conveying the build artifacts (or the prebuilt skip).
+ */
+export async function buildProject(
+  deps: Deps,
+  input: BuildInput
+): Promise<TaskResult<BuildOutput>> {
+  return input.isReactNativeApp
+    ? buildReactNativeProject(deps, input)
+    : buildWebProject(deps, input);
+}
+
+export const extractBuildInput = (ctx: Context): BuildInput => ({
+  isReactNativeApp: !!ctx.isReactNativeApp,
+  sourceDir: ctx.sourceDir,
+  storybook: ctx.storybook,
+  flags: ctx.flags,
+  browsers: ctx.announcedBuild?.browsers,
+  runtimeMetadata: ctx.runtimeMetadata,
+  git: ctx.git,
+});
+
+export const applyBuildOutput = (ctx: Context, output: BuildOutput) => {
+  ctx.sourceDir = output.sourceDir;
+  if (output.buildCommand) ctx.buildCommand = output.buildCommand;
+  if (output.buildLogFile) ctx.buildLogFile = output.buildLogFile;
+  if (output.reactNativeBuildLogFile) {
+    ctx.reactNativeBuildLogFile = output.reactNativeBuildLogFile;
+  }
+};

--- a/node-src/tasks/build/index.ts
+++ b/node-src/tasks/build/index.ts
@@ -79,7 +79,22 @@ export default function main(ctx: Context) {
           );
           transitionTo(pending)(ctx, task);
           await startActivity(ctx, task);
-          await buildStorybook(ctx);
+          const builtStorybook = await buildStorybook(
+            {
+              options: ctx.options,
+              log: ctx.log,
+              env: ctx.env,
+              analytics: ctx.analytics,
+              pkg: ctx.pkg,
+            },
+            {
+              buildCommand: ctx.buildCommand,
+              runtimeMetadata: ctx.runtimeMetadata,
+              storybook: ctx.storybook,
+              git: ctx.git,
+            }
+          );
+          ctx.buildLogFile = builtStorybook.buildLogFile;
           endActivity(ctx);
           transitionTo(success, true)(ctx, task);
         }

--- a/node-src/tasks/build/index.ts
+++ b/node-src/tasks/build/index.ts
@@ -68,7 +68,15 @@ export default function main(ctx: Context) {
           endActivity(ctx);
           transitionTo(reactNativeSuccess, true)(ctx, task);
         } else {
-          await setBuildCommand(ctx);
+          ctx.buildCommand = await setBuildCommand(
+            { options: ctx.options, log: ctx.log },
+            {
+              sourceDir: ctx.sourceDir,
+              flags: ctx.flags,
+              storybook: ctx.storybook,
+              changedFiles: ctx.git.changedFiles,
+            }
+          );
           transitionTo(pending)(ctx, task);
           await startActivity(ctx, task);
           await buildStorybook(ctx);

--- a/node-src/tasks/build/index.ts
+++ b/node-src/tasks/build/index.ts
@@ -48,7 +48,12 @@ export default function main(ctx: Context) {
       return false;
     },
     steps: [
-      setSourceDirectory,
+      async (ctx: Context) => {
+        ctx.sourceDir = await setSourceDirectory(
+          { options: ctx.options },
+          { sourceDir: ctx.sourceDir, storybook: ctx.storybook }
+        );
+      },
       // to avoid duplicated UI, we handle both paths of the build process in one task
       async (ctx: Context, task: Task) => {
         if (ctx.isReactNativeApp) {

--- a/node-src/tasks/build/resolveE2EFramework.ts
+++ b/node-src/tasks/build/resolveE2EFramework.ts
@@ -1,11 +1,11 @@
 import { Context } from '../../types';
 
-export function resolveE2EFramework(ctx: Context) {
-  if (ctx.options.playwright) {
+export function resolveE2EFramework(options: Context['options']) {
+  if (options.playwright) {
     return 'playwright';
   }
 
-  if (ctx.options.vitest) {
+  if (options.vitest) {
     return 'vitest';
   }
 

--- a/node-src/tasks/build/setBuildCommand.test.ts
+++ b/node-src/tasks/build/setBuildCommand.test.ts
@@ -9,102 +9,106 @@ vi.mock('@antfu/ni');
 
 const getCliCommand = vi.mocked(getCliCommandDefault);
 
-const baseContext = { options: {}, flags: {} } as any;
+const baseDeps = { options: {}, log: new TestLogger() } as any;
+const baseInput = { flags: {} } as any;
 
 beforeEach(() => {
   getCliCommand.mockClear();
 });
 
 describe('setBuildCommand', () => {
-  it('sets the build command on the context', async () => {
+  it('returns the build command', async () => {
     getCliCommand.mockReturnValue(Promise.resolve('npm run build:storybook'));
 
-    const ctx = {
-      ...baseContext,
-      sourceDir: './source-dir/',
-      options: { buildScriptName: 'build:storybook' },
-      storybook: { version: '6.2.0' },
-      git: { changedFiles: ['./index.js'] },
-    } as any;
-    await setBuildCommand(ctx);
+    const result = await setBuildCommand(
+      { ...baseDeps, options: { buildScriptName: 'build:storybook' } },
+      {
+        ...baseInput,
+        sourceDir: './source-dir/',
+        storybook: { version: '6.2.0' },
+        changedFiles: ['./index.js'],
+      }
+    );
 
     expect(getCliCommand).toHaveBeenCalledWith(
       expect.anything(),
       ['build:storybook', '--output-dir=./source-dir/', '--webpack-stats-json=./source-dir/'],
       { programmatic: true }
     );
-    expect(ctx.buildCommand).toEqual('npm run build:storybook');
+    expect(result).toEqual('npm run build:storybook');
   });
 
   it('supports yarn', async () => {
     getCliCommand.mockReturnValue(Promise.resolve('yarn run build:storybook'));
 
-    const ctx = {
-      ...baseContext,
-      sourceDir: './source-dir/',
-      options: { buildScriptName: 'build:storybook' },
-      storybook: { version: '6.2.0' },
-      git: { changedFiles: ['./index.js'] },
-    } as any;
-    await setBuildCommand(ctx);
+    const result = await setBuildCommand(
+      { ...baseDeps, options: { buildScriptName: 'build:storybook' } },
+      {
+        ...baseInput,
+        sourceDir: './source-dir/',
+        storybook: { version: '6.2.0' },
+        changedFiles: ['./index.js'],
+      }
+    );
 
     expect(getCliCommand).toHaveBeenCalledWith(
       expect.anything(),
       ['build:storybook', '--output-dir=./source-dir/', '--webpack-stats-json=./source-dir/'],
       { programmatic: true }
     );
-    expect(ctx.buildCommand).toEqual('yarn run build:storybook');
+    expect(result).toEqual('yarn run build:storybook');
   });
 
   it('supports pnpm', async () => {
     getCliCommand.mockReturnValue(Promise.resolve('pnpm run build:storybook'));
 
-    const ctx = {
-      ...baseContext,
-      sourceDir: './source-dir/',
-      options: { buildScriptName: 'build:storybook' },
-      storybook: { version: '6.2.0' },
-      git: { changedFiles: ['./index.js'] },
-    } as any;
-    await setBuildCommand(ctx);
+    const result = await setBuildCommand(
+      { ...baseDeps, options: { buildScriptName: 'build:storybook' } },
+      {
+        ...baseInput,
+        sourceDir: './source-dir/',
+        storybook: { version: '6.2.0' },
+        changedFiles: ['./index.js'],
+      }
+    );
 
     expect(getCliCommand).toHaveBeenCalledWith(
       expect.anything(),
       ['build:storybook', '--output-dir=./source-dir/', '--webpack-stats-json=./source-dir/'],
       { programmatic: true }
     );
-    expect(ctx.buildCommand).toEqual('pnpm run build:storybook');
+    expect(result).toEqual('pnpm run build:storybook');
   });
 
   it('uses --build-command, if set', async () => {
     getCliCommand.mockReturnValue(Promise.resolve('npm run build:storybook'));
 
-    const ctx = {
-      ...baseContext,
-      sourceDir: './source-dir/',
-      options: { buildCommand: 'nx run my-app:build-storybook' },
-      storybook: { version: '6.2.0' },
-      git: { changedFiles: ['./index.js'] },
-    } as any;
-    await setBuildCommand(ctx);
+    const result = await setBuildCommand(
+      { ...baseDeps, options: { buildCommand: 'nx run my-app:build-storybook' } },
+      {
+        ...baseInput,
+        sourceDir: './source-dir/',
+        storybook: { version: '6.2.0' },
+        changedFiles: ['./index.js'],
+      }
+    );
 
     expect(getCliCommand).not.toHaveBeenCalled();
-    expect(ctx.buildCommand).toEqual(
-      'nx run my-app:build-storybook --webpack-stats-json=./source-dir/'
-    );
+    expect(result).toEqual('nx run my-app:build-storybook --webpack-stats-json=./source-dir/');
   });
 
   it('warns if --only-changes is not supported', async () => {
-    const ctx = {
-      ...baseContext,
-      sourceDir: './source-dir/',
-      options: { buildScriptName: 'build:storybook' },
-      storybook: { version: '6.1.0' },
-      git: { changedFiles: ['./index.js'] },
-      log: new TestLogger(),
-    } as any;
-    await setBuildCommand(ctx);
-    expect(ctx.log.warn).toHaveBeenCalledWith(
+    const log = new TestLogger();
+    await setBuildCommand(
+      { ...baseDeps, options: { buildScriptName: 'build:storybook' }, log },
+      {
+        ...baseInput,
+        sourceDir: './source-dir/',
+        storybook: { version: '6.1.0' },
+        changedFiles: ['./index.js'],
+      }
+    );
+    expect(log.warn).toHaveBeenCalledWith(
       'Storybook version 6.2.0 or later is required to use the --only-changed flag'
     );
   });
@@ -112,57 +116,59 @@ describe('setBuildCommand', () => {
   it('uses the correct flag for webpack stats for < 8.5.0', async () => {
     getCliCommand.mockReturnValue(Promise.resolve('npm run build:storybook'));
 
-    const ctx = {
-      sourceDir: './source-dir/',
-      options: { buildScriptName: 'build:storybook' },
-      storybook: { version: '8.4.0' },
-      git: { changedFiles: ['./index.js'] },
-    } as any;
-    await setBuildCommand(ctx);
+    const result = await setBuildCommand(
+      { ...baseDeps, options: { buildScriptName: 'build:storybook' } },
+      {
+        ...baseInput,
+        sourceDir: './source-dir/',
+        storybook: { version: '8.4.0' },
+        changedFiles: ['./index.js'],
+      }
+    );
 
     expect(getCliCommand).toHaveBeenCalledWith(
       expect.anything(),
       ['build:storybook', '--output-dir=./source-dir/', '--webpack-stats-json=./source-dir/'],
       { programmatic: true }
     );
-    expect(ctx.buildCommand).toEqual('npm run build:storybook');
+    expect(result).toEqual('npm run build:storybook');
   });
 
   it('uses the correct flag for webpack stats for >= 8.5.0', async () => {
     getCliCommand.mockReturnValue(Promise.resolve('npm run build:storybook'));
 
-    const ctx = {
-      sourceDir: './source-dir/',
-      options: { buildScriptName: 'build:storybook' },
-      storybook: { version: '8.5.0' },
-      git: { changedFiles: ['./index.js'] },
-    } as any;
-    await setBuildCommand(ctx);
+    const result = await setBuildCommand(
+      { ...baseDeps, options: { buildScriptName: 'build:storybook' } },
+      {
+        ...baseInput,
+        sourceDir: './source-dir/',
+        storybook: { version: '8.5.0' },
+        changedFiles: ['./index.js'],
+      }
+    );
 
     expect(getCliCommand).toHaveBeenCalledWith(
       expect.anything(),
       ['build:storybook', '--output-dir=./source-dir/', '--stats-json=./source-dir/'],
       { programmatic: true }
     );
-    expect(ctx.buildCommand).toEqual('npm run build:storybook');
+    expect(result).toEqual('npm run build:storybook');
   });
 
-  it('uses the old flag when it storybook version is undetected', async () => {
+  it('uses the old flag when the storybook version is undetected', async () => {
     getCliCommand.mockReturnValue(Promise.resolve('npm run build:storybook'));
 
-    const ctx = {
-      sourceDir: './source-dir/',
-      options: { buildScriptName: 'build:storybook' },
-      git: { changedFiles: ['./index.js'] },
-    } as any;
-    await setBuildCommand(ctx);
+    const result = await setBuildCommand(
+      { ...baseDeps, options: { buildScriptName: 'build:storybook' } },
+      { ...baseInput, sourceDir: './source-dir/', changedFiles: ['./index.js'] }
+    );
 
     expect(getCliCommand).toHaveBeenCalledWith(
       expect.anything(),
       ['build:storybook', '--output-dir=./source-dir/', '--webpack-stats-json=./source-dir/'],
       { programmatic: true }
     );
-    expect(ctx.buildCommand).toEqual('npm run build:storybook');
+    expect(result).toEqual('npm run build:storybook');
   });
 
   it.each(['playwright', 'cypress', 'vitest'])(
@@ -174,16 +180,15 @@ describe('setBuildCommand', () => {
       );
       onTestFinished(revertPatch);
 
-      const ctx = {
-        ...baseContext,
-        options: { [e2ePackage]: true, buildScriptName: 'build:storybook', inAction: false },
-        sourceDir: './source-dir/',
-        git: {},
-        log: new TestLogger(),
-      } as any;
+      const result = await setBuildCommand(
+        {
+          ...baseDeps,
+          options: { [e2ePackage]: true, buildScriptName: 'build:storybook', inAction: false },
+        },
+        { ...baseInput, sourceDir: './source-dir/' }
+      );
 
-      await setBuildCommand(ctx);
-      expect(ctx.buildCommand).toEqual(
+      expect(result).toEqual(
         `node path/to/@chromatic-com/${e2ePackage}/bin/build-archive-storybook --output-dir=./source-dir/`
       );
     }
@@ -192,18 +197,11 @@ describe('setBuildCommand', () => {
   it('forwards E2E build arguments through npm exec when running in the action', async () => {
     getCliCommand.mockImplementation(async (runner, args) => runner('npm', args as string[]));
 
-    const ctx = {
-      ...baseContext,
-      sourceDir: './source-dir/',
-      options: { playwright: true, inAction: true },
-      git: {},
-      log: new TestLogger(),
-    } as any;
-
-    await setBuildCommand(ctx);
-
-    expect(ctx.buildCommand).toEqual(
-      'npm exec -- build-archive-storybook --output-dir=./source-dir/'
+    const result = await setBuildCommand(
+      { ...baseDeps, options: { playwright: true, inAction: true } },
+      { ...baseInput, sourceDir: './source-dir/' }
     );
+
+    expect(result).toEqual('npm exec -- build-archive-storybook --output-dir=./source-dir/');
   });
 });

--- a/node-src/tasks/build/setBuildCommand.ts
+++ b/node-src/tasks/build/setBuildCommand.ts
@@ -3,56 +3,62 @@ import semver from 'semver';
 import { getE2EBuildCommand } from '../../lib/e2e';
 import { isE2EBuild } from '../../lib/e2eUtils';
 import { getPackageManagerRunCommand } from '../../lib/getPackageManager';
-import { Context } from '../../types';
+import { Context, Deps } from '../../types';
 import { resolveE2EFramework } from './resolveE2EFramework';
 
-const isStatsFlagSupported = (ctx: Context) => {
-  return ctx.storybook && ctx.storybook.version
-    ? semver.gte(semver.coerce(ctx.storybook.version) || '0.0.0', '6.2.0')
+type SetBuildCommandDeps = Pick<Deps, 'options' | 'log'>;
+
+interface SetBuildCommandInput {
+  sourceDir: string;
+  flags: Context['flags'];
+  storybook?: Context['storybook'];
+  changedFiles?: string[];
+}
+
+const isStatsFlagSupported = (storybook?: Context['storybook']) => {
+  return storybook?.version
+    ? semver.gte(semver.coerce(storybook.version) || '0.0.0', '6.2.0')
     : true;
 };
 
 // Storybook 8.0.0 deprecated --webpack-stats-json in favor of --stats-json.
 // However, the angular builder did not support it until 8.5.0
-const getStatsFlag = (ctx: Context) => {
-  return ctx?.storybook?.version &&
-    semver.gte(semver.coerce(ctx.storybook.version) || '0.0.0', '8.5.0')
+const getStatsFlag = (storybook?: Context['storybook']) => {
+  return storybook?.version && semver.gte(semver.coerce(storybook.version) || '0.0.0', '8.5.0')
     ? '--stats-json'
     : '--webpack-stats-json';
 };
 
-export const setBuildCommand = async (ctx: Context) => {
-  const buildCommand = ctx.flags?.buildCommand || ctx.options.buildCommand;
+export const setBuildCommand = async (
+  deps: SetBuildCommandDeps,
+  input: SetBuildCommandInput
+): Promise<string | undefined> => {
+  const buildCommand = input.flags?.buildCommand || deps.options.buildCommand;
   const buildCommandOptions: string[] = [];
 
   if (!buildCommand) {
-    buildCommandOptions.push(`--output-dir=${ctx.sourceDir}`);
+    buildCommandOptions.push(`--output-dir=${input.sourceDir}`);
   }
 
-  if (ctx.git.changedFiles) {
-    if (isStatsFlagSupported(ctx)) {
-      buildCommandOptions.push(`${getStatsFlag(ctx)}=${ctx.sourceDir}`);
+  if (input.changedFiles) {
+    if (isStatsFlagSupported(input.storybook)) {
+      buildCommandOptions.push(`${getStatsFlag(input.storybook)}=${input.sourceDir}`);
     } else {
-      ctx.log.warn('Storybook version 6.2.0 or later is required to use the --only-changed flag');
+      deps.log.warn('Storybook version 6.2.0 or later is required to use the --only-changed flag');
     }
   }
 
   if (buildCommand) {
-    ctx.buildCommand = `${buildCommand} ${buildCommandOptions.join(' ')}`;
-    return;
+    return `${buildCommand} ${buildCommandOptions.join(' ')}`;
   }
 
-  if (isE2EBuild(ctx.options)) {
-    ctx.buildCommand = await getE2EBuildCommand(ctx, resolveE2EFramework(ctx), buildCommandOptions);
-    return;
+  if (isE2EBuild(deps.options)) {
+    return getE2EBuildCommand(deps, resolveE2EFramework(deps.options), buildCommandOptions);
   }
 
-  if (!ctx.options.buildScriptName) {
+  if (!deps.options.buildScriptName) {
     throw new Error('Unable to determine build script');
   }
 
-  ctx.buildCommand = await getPackageManagerRunCommand([
-    ctx.options.buildScriptName,
-    ...buildCommandOptions,
-  ]);
+  return getPackageManagerRunCommand([deps.options.buildScriptName, ...buildCommandOptions]);
 };

--- a/node-src/tasks/build/setSourceDirectory.test.ts
+++ b/node-src/tasks/build/setSourceDirectory.test.ts
@@ -2,38 +2,44 @@ import { describe, expect, it } from 'vitest';
 
 import { setSourceDirectory } from './setSourceDirectory';
 
-const baseContext = { options: {}, flags: {} } as any;
-
-describe('setSourceDir', () => {
-  it('sets a random temp directory path on the context', async () => {
-    const ctx = { ...baseContext, storybook: { version: '5.0.0' } } as any;
-    await setSourceDirectory(ctx);
-    expect(ctx.sourceDir).toMatch(/chromatic-/);
+describe('setSourceDirectory', () => {
+  it('returns a random temp directory path', async () => {
+    const result = await setSourceDirectory(
+      { options: {} } as any,
+      { storybook: { version: '5.0.0' } as any }
+    );
+    expect(result).toMatch(/chromatic-/);
   });
 
   it('falls back to the default output dir for older Storybooks', async () => {
-    const ctx = { ...baseContext, storybook: { version: '4.0.0' } } as any;
-    await setSourceDirectory(ctx);
-    expect(ctx.sourceDir).toBe('storybook-static');
+    const result = await setSourceDirectory(
+      { options: {} } as any,
+      { storybook: { version: '4.0.0' } as any }
+    );
+    expect(result).toBe('storybook-static');
   });
 
   it('uses the outputDir option if provided', async () => {
-    const ctx = {
-      ...baseContext,
-      options: { outputDir: 'storybook-out' },
-      storybook: { version: '5.0.0' },
-    } as any;
-    await setSourceDirectory(ctx);
-    expect(ctx.sourceDir).toBe('storybook-out');
+    const result = await setSourceDirectory(
+      { options: { outputDir: 'storybook-out' } } as any,
+      { storybook: { version: '5.0.0' } as any }
+    );
+    expect(result).toBe('storybook-out');
   });
 
   it('uses the outputDir option if provided, even for older Storybooks', async () => {
-    const ctx = {
-      ...baseContext,
-      options: { outputDir: 'storybook-out' },
-      storybook: { version: '4.0.0' },
-    } as any;
-    await setSourceDirectory(ctx);
-    expect(ctx.sourceDir).toBe('storybook-out');
+    const result = await setSourceDirectory(
+      { options: { outputDir: 'storybook-out' } } as any,
+      { storybook: { version: '4.0.0' } as any }
+    );
+    expect(result).toBe('storybook-out');
+  });
+
+  it('keeps a preset sourceDir (React Native skip path)', async () => {
+    const result = await setSourceDirectory(
+      { options: { outputDir: 'ignored' } } as any,
+      { sourceDir: 'preset-dir', storybook: { version: '5.0.0' } as any }
+    );
+    expect(result).toBe('preset-dir');
   });
 });

--- a/node-src/tasks/build/setSourceDirectory.ts
+++ b/node-src/tasks/build/setSourceDirectory.ts
@@ -1,20 +1,29 @@
 import semver from 'semver';
 import tmp from 'tmp-promise';
 
-import { Context } from '../../types';
+import { Context, Deps } from '../../types';
 
-export const setSourceDirectory = async (ctx: Context) => {
-  // do not overwrite if it is already set, for instance in
-  // the skip condition of the build task on React Native
-  if (ctx.sourceDir) return;
+type SetSourceDirectoryDeps = Pick<Deps, 'options'>;
 
-  if (ctx.options.outputDir) {
-    ctx.sourceDir = ctx.options.outputDir;
-  } else if (ctx.storybook && ctx.storybook.version && semver.lt(ctx.storybook.version, '5.0.0')) {
-    // Storybook v4 doesn't support absolute paths like tmp.dir would yield
-    ctx.sourceDir = 'storybook-static';
-  } else {
-    const temporaryDirectory = await tmp.dir({ unsafeCleanup: true, prefix: `chromatic-` });
-    ctx.sourceDir = temporaryDirectory.path;
+interface SetSourceDirectoryInput {
+  // Preset by the build task's React Native skip path; when present we keep it as-is.
+  sourceDir?: string;
+  storybook?: Context['storybook'];
+}
+
+export const setSourceDirectory = async (
+  deps: SetSourceDirectoryDeps,
+  input: SetSourceDirectoryInput
+): Promise<string> => {
+  if (input.sourceDir) return input.sourceDir;
+
+  if (deps.options.outputDir) return deps.options.outputDir;
+
+  // Storybook v4 doesn't support absolute paths like tmp.dir would yield
+  if (input.storybook?.version && semver.lt(input.storybook.version, '5.0.0')) {
+    return 'storybook-static';
   }
+
+  const temporaryDirectory = await tmp.dir({ unsafeCleanup: true, prefix: `chromatic-` });
+  return temporaryDirectory.path;
 };

--- a/node-src/tasks/index.ts
+++ b/node-src/tasks/index.ts
@@ -1,7 +1,6 @@
 import Listr from 'listr';
 
 import { Context } from '../types';
-import build from './build';
 import prepare from './prepare';
 import prepareWorkspace from './prepareWorkspace';
 import report from './report';
@@ -11,9 +10,9 @@ import upload from './upload';
 import uploadShare from './uploadShare';
 import verify from './verify';
 
-export const runShare = [build, prepare, uploadShare];
+export const runShare = [prepare, uploadShare];
 
-export const runUploadBuild = [build, prepare, upload, verify, snapshot];
+export const runUploadBuild = [prepare, upload, verify, snapshot];
 
 export const runPatchBuild = [prepareWorkspace, ...runUploadBuild, restoreWorkspace];
 

--- a/node-src/ui/messages/errors/buildFailed.ts
+++ b/node-src/ui/messages/errors/buildFailed.ts
@@ -7,7 +7,12 @@ import { info } from '../../components/icons';
 import link from '../../components/link';
 
 export const buildFailed = (
-  { options, buildCommand, buildLogFile, runtimeMetadata }: Context,
+  {
+    options,
+    buildCommand,
+    buildLogFile,
+    runtimeMetadata,
+  }: Pick<Context, 'options' | 'buildCommand' | 'buildLogFile' | 'runtimeMetadata'>,
   { message },
   buildLog?: string
 ) => {

--- a/node-src/ui/messages/errors/buildFailed.ts
+++ b/node-src/ui/messages/errors/buildFailed.ts
@@ -43,7 +43,10 @@ export const buildFailed = (
 };
 
 export const reactNativeBuildFailed = (
-  { reactNativeBuildLogFile, runtimeMetadata }: Context,
+  {
+    reactNativeBuildLogFile,
+    runtimeMetadata,
+  }: Pick<Context, 'reactNativeBuildLogFile' | 'runtimeMetadata'>,
   { message },
   buildLog?: string
 ) => {

--- a/node-src/ui/tasks/build.frames.ts
+++ b/node-src/ui/tasks/build.frames.ts
@@ -1,0 +1,52 @@
+import { fallbackFailureState } from '../../renderer/engine';
+import { clackSpinnerRenderer } from '../../renderer/engine/clack/spinnerRenderer';
+import { captureTask } from '../../renderer/storybook/captureTask';
+import { Task } from '../../types';
+import { pending, skipped, success } from './build';
+
+// Node-side scenarios for the build task. The `?clack` Vite plugin runs this module in Node, renders
+// each export through the real Clack spinner renderer (build wires the spinner, not the task log),
+// and hands the resulting ANSI strings to the browser story (`build.stories.ts`).
+
+const ctx = { options: {} } as any;
+const buildCommand = 'yarn run build-storybook -o storybook-static';
+
+const make = (state: Task, starting?: Task) => captureTask(state, starting, clackSpinnerRenderer);
+
+export const BuildingStart = () => make(pending(ctx));
+
+// The build command isn't known until the task body computes it, then reports it mid-run via
+// `deps.report`, so the running frame is an update over the started spinner.
+export const Building = () =>
+  make(
+    { status: 'updating', title: pending(ctx).title, output: `Running command: ${buildCommand}` },
+    pending(ctx)
+  );
+
+export const Built = () =>
+  make(
+    success({
+      ...ctx,
+      now: 0,
+      startedAt: -32_100,
+      buildLogFile: '/users/me/project/build-storybook.log',
+    }),
+    pending(ctx)
+  );
+
+export const Skipped = () =>
+  make(
+    skipped({
+      ...ctx,
+      options: { ...ctx.options, storybookBuildDir: '/users/me/project/storybook-static' },
+    }),
+    pending(ctx)
+  );
+
+// build registers no `failure` transition, so a build failure renders the engine's fallback failure
+// state, built from the pending title and the `Command failed` message buildStorybook throws.
+export const Failed = () =>
+  make(
+    fallbackFailureState(pending(ctx).title, new Error(`Command failed: ${buildCommand}`)),
+    pending(ctx)
+  );

--- a/node-src/ui/tasks/build.stories.ts
+++ b/node-src/ui/tasks/build.stories.ts
@@ -1,31 +1,9 @@
-import task from '../components/task';
-import { failed, initial, pending, skipped, success } from './build';
+import frames from './build.frames?clack';
 
-export default {
-  title: 'CLI/Tasks/Build',
-  decorators: [(storyFunction) => task(storyFunction())],
-};
+export default { title: 'CLI/Tasks/Build' };
 
-const ctx = { options: {} } as any;
-
-const buildCommand = 'yarn run build-storybook -o storybook-static';
-
-export const Initial = () => initial(ctx);
-
-export const Building = () => pending({ ...ctx, buildCommand } as any);
-
-export const Built = () =>
-  success({
-    ...ctx,
-    now: 0,
-    startedAt: -32_100,
-    buildLogFile: '/users/me/project/build-storybook.log',
-  } as any);
-
-export const Skipped = () =>
-  skipped({
-    ...ctx,
-    options: { ...ctx.options, storybookBuildDir: '/users/me/project/storybook-static' },
-  } as any);
-
-export const Failed = () => failed({ ...ctx, buildCommand } as any);
+export const BuildingStart = () => frames.BuildingStart;
+export const Building = () => frames.Building;
+export const Built = () => frames.Built;
+export const Skipped = () => frames.Skipped;
+export const Failed = () => frames.Failed;

--- a/node-src/ui/tasks/build.ts
+++ b/node-src/ui/tasks/build.ts
@@ -10,7 +10,8 @@ export const initial = (ctx: Context) => ({
 export const pending = (ctx: Context) => ({
   status: 'pending',
   title: `Building your ${buildType(ctx)}`,
-  output: `Running command: ${ctx.buildCommand}`,
+  // buildCommand isn't known until the task body computes it; the task reports it mid-run.
+  output: ctx.buildCommand ? `Running command: ${ctx.buildCommand}` : undefined,
 });
 
 export const success = (ctx: Context) => ({

--- a/node-src/ui/tasks/build.ts
+++ b/node-src/ui/tasks/build.ts
@@ -25,9 +25,3 @@ export const skipped = (ctx: Context) => ({
   title: `Build ${buildType(ctx)} [skipped]`,
   output: `Using prebuilt ${buildType(ctx)} at ${ctx.options.storybookBuildDir}`,
 });
-
-export const failed = (ctx: Context) => ({
-  status: 'error',
-  title: `Building your ${buildType(ctx)}`,
-  output: `Command failed: ${ctx.buildCommand}`,
-});

--- a/node-src/ui/tasks/buildE2E.frames.ts
+++ b/node-src/ui/tasks/buildE2E.frames.ts
@@ -1,0 +1,47 @@
+import { fallbackFailureState } from '../../renderer/engine';
+import { clackSpinnerRenderer } from '../../renderer/engine/clack/spinnerRenderer';
+import { captureTask } from '../../renderer/storybook/captureTask';
+import { Task } from '../../types';
+import { pending, skipped, success } from './build';
+
+// Node-side scenarios for the build task in an E2E project, where the task reports on the "test
+// suite" rather than "Storybook". Same state functions as `build.frames.ts`, different `ctx.options`.
+
+const ctx = { options: { playwright: true } } as any;
+const buildCommand = 'yarn build-archive-storybook';
+
+const make = (state: Task, starting?: Task) => captureTask(state, starting, clackSpinnerRenderer);
+
+export const BuildingStart = () => make(pending(ctx));
+
+export const Building = () =>
+  make(
+    { status: 'updating', title: pending(ctx).title, output: `Running command: ${buildCommand}` },
+    pending(ctx)
+  );
+
+export const Built = () =>
+  make(
+    success({
+      ...ctx,
+      now: 0,
+      startedAt: -32_100,
+      buildLogFile: '/users/me/project/build-archive.log',
+    }),
+    pending(ctx)
+  );
+
+export const Skipped = () =>
+  make(
+    skipped({
+      ...ctx,
+      options: { ...ctx.options, storybookBuildDir: '/users/me/project/archive-static' },
+    }),
+    pending(ctx)
+  );
+
+export const Failed = () =>
+  make(
+    fallbackFailureState(pending(ctx).title, new Error(`Command failed: ${buildCommand}`)),
+    pending(ctx)
+  );

--- a/node-src/ui/tasks/buildE2E.stories.ts
+++ b/node-src/ui/tasks/buildE2E.stories.ts
@@ -1,31 +1,9 @@
-import task from '../components/task';
-import { failed, initial, pending, skipped, success } from './build';
+import frames from './buildE2E.frames?clack';
 
-export default {
-  title: 'CLI/Tasks/Build/E2E',
-  decorators: [(storyFunction) => task(storyFunction())],
-};
+export default { title: 'CLI/Tasks/Build/E2E' };
 
-const ctx = { options: { playwright: true } } as any;
-
-const buildCommand = 'yarn build-archive-storybook';
-
-export const Initial = () => initial(ctx);
-
-export const Building = () => pending({ ...ctx, buildCommand } as any);
-
-export const Built = () =>
-  success({
-    ...ctx,
-    now: 0,
-    startedAt: -32_100,
-    buildLogFile: '/users/me/project/build-archive.log',
-  } as any);
-
-export const Skipped = () =>
-  skipped({
-    ...ctx,
-    options: { ...ctx.options, storybookBuildDir: '/users/me/project/archive-static' },
-  } as any);
-
-export const Failed = () => failed({ ...ctx, buildCommand } as any);
+export const BuildingStart = () => frames.BuildingStart;
+export const Building = () => frames.Building;
+export const Built = () => frames.Built;
+export const Skipped = () => frames.Skipped;
+export const Failed = () => frames.Failed;

--- a/node-src/ui/tasks/buildReactNative.frames.ts
+++ b/node-src/ui/tasks/buildReactNative.frames.ts
@@ -1,0 +1,59 @@
+import { fallbackFailureState } from '../../renderer/engine';
+import { clackSpinnerRenderer } from '../../renderer/engine/clack/spinnerRenderer';
+import { captureTask } from '../../renderer/storybook/captureTask';
+import { Task } from '../../types';
+import {
+  failedNoValidPlatforms,
+  pending,
+  pendingAndroid,
+  pendingIOS,
+  pendingManifest,
+  skipped,
+  success,
+} from './buildReactNative';
+
+// Node-side scenarios for the React Native build, rendered through the real Clack spinner renderer.
+// The platform/manifest states are mid-run updates (`deps.report`); failures render the engine's
+// fallback failure state, since build registers no `failure` transition.
+
+const reactNativeBuildLogFile =
+  '/users/me/project/storybook-static/.chromatic/react-native-build.log';
+
+const make = (state: Task, starting?: Task) => captureTask(state, starting, clackSpinnerRenderer);
+
+export const Building = () => make(pending());
+
+export const BuildingAndroid = () => make(pendingAndroid(), pending());
+
+export const BuildingAndroidWithCommand = () =>
+  make(pendingAndroid({ androidBuildCommand: 'my-android-build' } as any), pending());
+
+export const BuildingIOS = () => make(pendingIOS(), pending());
+
+export const BuildingIOSWithCommand = () =>
+  make(pendingIOS({ iosBuildCommand: 'my-ios-build' } as any), pending());
+
+export const GeneratingManifest = () => make(pendingManifest(), pending());
+
+export const Built = () =>
+  make(
+    success({ options: {}, now: 0, startedAt: -32_100, reactNativeBuildLogFile } as any),
+    pending()
+  );
+
+export const Skipped = () => make(skipped(), pending());
+
+export const NoValidPlatforms = () =>
+  make(
+    fallbackFailureState(pending().title, new Error(failedNoValidPlatforms().output)),
+    pending()
+  );
+
+export const Failed = () =>
+  make(
+    fallbackFailureState(
+      pending().title,
+      new Error(`Build failed, see logs at ${reactNativeBuildLogFile}`)
+    ),
+    pending()
+  );

--- a/node-src/ui/tasks/buildReactNative.stories.ts
+++ b/node-src/ui/tasks/buildReactNative.stories.ts
@@ -22,21 +22,14 @@ export const Initial = () => initial();
 
 export const Building = () => pending();
 
-export const BuildingAndroid = () => pendingAndroid(ctx);
+export const BuildingAndroid = () => pendingAndroid();
 
 export const BuildingAndroidWithCommand = () =>
-  pendingAndroid({
-    ...ctx,
-    options: { reactNative: { androidBuildCommand: 'my-android-build' } },
-  } as any);
+  pendingAndroid({ androidBuildCommand: 'my-android-build' });
 
-export const BuildingIOS = () => pendingIOS(ctx);
+export const BuildingIOS = () => pendingIOS();
 
-export const BuildingIOSWithCommand = () =>
-  pendingIOS({
-    ...ctx,
-    options: { reactNative: { iosBuildCommand: 'my-ios-build' } },
-  } as any);
+export const BuildingIOSWithCommand = () => pendingIOS({ iosBuildCommand: 'my-ios-build' });
 
 export const GeneratingManifest = () => pendingManifest();
 

--- a/node-src/ui/tasks/buildReactNative.stories.ts
+++ b/node-src/ui/tasks/buildReactNative.stories.ts
@@ -1,52 +1,14 @@
-import task from '../components/task';
-import {
-  failed,
-  failedNoValidPlatforms,
-  initial,
-  pending,
-  pendingAndroid,
-  pendingIOS,
-  pendingManifest,
-  skipped,
-  success,
-} from './buildReactNative';
+import frames from './buildReactNative.frames?clack';
 
-export default {
-  title: 'CLI/Tasks/Build/React Native',
-  decorators: [(storyFunction) => task(storyFunction())],
-};
+export default { title: 'CLI/Tasks/Build/React Native' };
 
-const ctx = { options: {} } as any;
-
-export const Initial = () => initial();
-
-export const Building = () => pending();
-
-export const BuildingAndroid = () => pendingAndroid();
-
-export const BuildingAndroidWithCommand = () =>
-  pendingAndroid({ androidBuildCommand: 'my-android-build' });
-
-export const BuildingIOS = () => pendingIOS();
-
-export const BuildingIOSWithCommand = () => pendingIOS({ iosBuildCommand: 'my-ios-build' });
-
-export const GeneratingManifest = () => pendingManifest();
-
-export const Built = () =>
-  success({
-    ...ctx,
-    now: 0,
-    startedAt: -32_100,
-    reactNativeBuildLogFile: '/users/me/project/storybook-static/.chromatic/react-native-build.log',
-  } as any);
-
-export const Skipped = () => skipped();
-
-export const NoValidPlatforms = () => failedNoValidPlatforms();
-
-export const Failed = () =>
-  failed({
-    ...ctx,
-    reactNativeBuildLogFile: '/users/me/project/storybook-static/.chromatic/react-native-build.log',
-  } as any);
+export const Building = () => frames.Building;
+export const BuildingAndroid = () => frames.BuildingAndroid;
+export const BuildingAndroidWithCommand = () => frames.BuildingAndroidWithCommand;
+export const BuildingIOS = () => frames.BuildingIOS;
+export const BuildingIOSWithCommand = () => frames.BuildingIOSWithCommand;
+export const GeneratingManifest = () => frames.GeneratingManifest;
+export const Built = () => frames.Built;
+export const Skipped = () => frames.Skipped;
+export const NoValidPlatforms = () => frames.NoValidPlatforms;
+export const Failed = () => frames.Failed;

--- a/node-src/ui/tasks/buildReactNative.ts
+++ b/node-src/ui/tasks/buildReactNative.ts
@@ -18,19 +18,19 @@ export const pendingManifest = () => ({
   output: 'Generating manifest.json file for React Native build',
 });
 
-export const pendingAndroid = (ctx: Context) => ({
+export const pendingAndroid = (reactNative?: Context['options']['reactNative']) => ({
   status: 'pending',
   title: 'Building your React Native Storybook',
-  output: ctx.options?.reactNative?.androidBuildCommand
-    ? `Running command: ${ctx.options.reactNative.androidBuildCommand}`
+  output: reactNative?.androidBuildCommand
+    ? `Running command: ${reactNative.androidBuildCommand}`
     : 'Building Android',
 });
 
-export const pendingIOS = (ctx: Context) => ({
+export const pendingIOS = (reactNative?: Context['options']['reactNative']) => ({
   status: 'pending',
   title: 'Building your React Native Storybook',
-  output: ctx.options?.reactNative?.iosBuildCommand
-    ? `Running command: ${ctx.options.reactNative.iosBuildCommand}`
+  output: reactNative?.iosBuildCommand
+    ? `Running command: ${reactNative.iosBuildCommand}`
     : 'Building iOS',
 });
 

--- a/node-src/ui/tasks/buildReactNative.ts
+++ b/node-src/ui/tasks/buildReactNative.ts
@@ -13,13 +13,13 @@ export const pending = () => ({
 });
 
 export const pendingManifest = () => ({
-  status: 'pending',
+  status: 'updating',
   title: 'Generating story manifest',
   output: 'Generating manifest.json file for React Native build',
 });
 
 export const pendingAndroid = (reactNative?: Context['options']['reactNative']) => ({
-  status: 'pending',
+  status: 'updating',
   title: 'Building your React Native Storybook',
   output: reactNative?.androidBuildCommand
     ? `Running command: ${reactNative.androidBuildCommand}`
@@ -27,7 +27,7 @@ export const pendingAndroid = (reactNative?: Context['options']['reactNative']) 
 });
 
 export const pendingIOS = (reactNative?: Context['options']['reactNative']) => ({
-  status: 'pending',
+  status: 'updating',
   title: 'Building your React Native Storybook',
   output: reactNative?.iosBuildCommand
     ? `Running command: ${reactNative.iosBuildCommand}`

--- a/node-src/ui/workflows/uploadBuild.stories.ts
+++ b/node-src/ui/workflows/uploadBuild.stories.ts
@@ -5,7 +5,11 @@ import { BuildPassed, FirstBuildPassed } from '../messages/info/buildPassed.stor
 import { Intro } from '../messages/info/intro.stories';
 import { StorybookPublished } from '../messages/info/storybookPublished.stories';
 import { authenticated, authenticating, initial } from '../tasks/auth';
-import * as build from '../tasks/build.stories';
+import {
+  initial as buildInitial,
+  pending as buildPending,
+  success as buildSuccess,
+} from '../tasks/build';
 import {
   initial as gitInfoInitial,
   pending as gitInfoPending,
@@ -51,6 +55,22 @@ const storybookInfo = {
   Initial: () => storybookInfoInitial(storybookInfoContext),
   Pending: () => storybookInfoPending(storybookInfoContext),
   Success: () => storybookInfoSuccess(storybookInfoContext),
+};
+
+// build.stories now returns rendered ANSI strings (Clack capture), which the old task() path can't
+// consume, so rebuild the states the workflow needs from the raw task source.
+const buildContext = { options: {} } as any;
+const buildCommand = 'yarn run build-storybook -o storybook-static';
+const build = {
+  Initial: () => buildInitial(buildContext),
+  Building: () => buildPending({ ...buildContext, buildCommand } as any),
+  Built: () =>
+    buildSuccess({
+      ...buildContext,
+      now: 0,
+      startedAt: -32_100,
+      buildLogFile: '/users/me/project/build-storybook.log',
+    } as any),
 };
 
 // initialize.stories now returns rendered ANSI strings (Clack capture), which the old task() path

--- a/node-src/ui/workflows/uploadBuildE2E.stories.ts
+++ b/node-src/ui/workflows/uploadBuildE2E.stories.ts
@@ -5,7 +5,11 @@ import { BuildPassed, FirstBuildPassed } from '../messages/info/buildPassedE2E.s
 import { Intro } from '../messages/info/intro.stories';
 import { StorybookPublished } from '../messages/info/storybookPublishedE2E.stories';
 import { authenticated, authenticating, initial } from '../tasks/auth';
-import * as build from '../tasks/buildE2E.stories';
+import {
+  initial as buildInitial,
+  pending as buildPending,
+  success as buildSuccess,
+} from '../tasks/build';
 import {
   initial as gitInfoInitial,
   pending as gitInfoPending,
@@ -51,6 +55,22 @@ const storybookInfo = {
   Initial: () => storybookInfoInitial(ctx),
   Pending: () => storybookInfoPending(ctx),
   Success: () => storybookInfoSuccess(ctx),
+};
+
+// build.stories now returns rendered ANSI strings (Clack capture), which the old task() path can't
+// consume, so rebuild the states the workflow needs from the raw task source. The file-level `ctx`
+// (playwright) is forwarded by the `steps()` helper.
+const buildCommand = 'yarn build-archive-storybook';
+const build = {
+  Initial: () => buildInitial(ctx),
+  Building: () => buildPending({ ...ctx, buildCommand } as any),
+  Built: () =>
+    buildSuccess({
+      ...ctx,
+      now: 0,
+      startedAt: -32_100,
+      buildLogFile: '/users/me/project/build-archive.log',
+    } as any),
 };
 
 // initialize.stories now returns rendered ANSI strings (Clack capture), which the old task() path


### PR DESCRIPTION
# Description

This PR migrates the `build` task to Clack. In the chain of Clack task PRs, this is the first one migrating a legacy Listr task (one not migrated to the `extractInput -> run -> applyOutput` form). As such, it's quite large, but each piece is straightforward. As usual, I recommend reviewing commit-by-commit.

The basic structure:
- `Pass task output to success transition` commit adds an optional parameter to the success transition, allowing passing the task output to the transition, which the `build` task needs to fork off of.
- The next four commits refactor different functions away from the "mutate context" pattern and to a "return output" pattern. Each commit here is still functional (and unit tested at every step) via a thin context mutation shim in the legacy task steps array.
- `Swap build task onto runTask + spinner renderer` commit makes the swap to Clack.
- `Migrate build task stories to Clack capture` migrates the `build` task stories to Clack.

# Manual QA

I tested at least one happy path and one error state for Storybook builds, React Native builds, and E2E builds.

## Storybook

**Build 1:** happy path.
<img width="1980" height="1058" alt="CleanShot 2026-06-22 at 09 28 40@2x" src="https://github.com/user-attachments/assets/ba3742b0-1d07-4c63-aed6-7f796c2f0bcc" />

<img width="660" height="800" alt="CleanShot 2026-06-22 at 09 31 12" src="https://github.com/user-attachments/assets/ecabeb38-76e8-4ffd-9e6e-f24150c2a284" />

```
09:29:36.712 Chromatic CLI v17.4.1
             https://www.chromatic.com/docs/cli 
09:29:36.729 Authenticating with Chromatic [staging] 
09:29:36.729     → Connecting to https://index.staging-chromatic.com
09:29:37.113 Authenticated with Chromatic [staging]
09:29:37.114     → Using project token '****************1c89'
09:29:37.114 Retrieving git information
09:29:38.398 Retrieved git information
09:29:38.398     → Commit '763e9d9' on branch 'HEAD'; found 1 parent build
09:29:38.398 Collecting Storybook metadata
09:29:38.433 Collected Storybook metadata
09:29:38.433     → Build metadata gathered
09:29:38.433 Initializing build
09:29:38.959 Initialized build
09:29:38.959     → Build 212 initialized
09:29:38.961 Building your Storybook
09:29:38.965     → Running command: yarn run build-storybook --output-dir=/private/var/folders/gn/p0bks3451f38s12kbrmdxznh0000gn/T/chromatic--13209-rRzVe1iggQW0
09:29:42.607 Storybook built in 4 seconds
09:29:42.608     → View build log at /Users/justin/development/chromatic-repos/storybook-scaffold/build-storybook.log
09:29:42.608 Prepare your built Storybook
```

**Build 2:** invalid build command. Note the CLI flags at the end.
<img width="2062" height="1488" alt="CleanShot 2026-06-22 at 09 33 10@2x" src="https://github.com/user-attachments/assets/9b11c98e-2b07-42a2-9357-1b6480b6b968" />

```
09:32:53.549 Chromatic CLI v17.4.1
             https://www.chromatic.com/docs/cli 
09:32:53.554 Authenticating with Chromatic [staging] 
09:32:53.554     → Connecting to https://index.staging-chromatic.com
09:32:53.912 Authenticated with Chromatic [staging]
09:32:53.913     → Using project token '****************1c89'
09:32:53.913 Retrieving git information
09:32:54.791 Retrieved git information
09:32:54.791     → Commit '763e9d9' on branch 'HEAD'; found 1 parent build
09:32:54.792 Collecting Storybook metadata
09:32:54.818 Collected Storybook metadata
09:32:54.819     → Build metadata gathered
09:32:54.819 Initializing build
09:32:55.277 Initialized build
09:32:55.277     → Build 215 initialized
09:32:55.280 Building your Storybook
09:32:55.281     → Running command: foo
09:32:55.301 The CLI tried to run your foo script, but the command failed. This indicates a problem with your Storybook. Here's what to do:
             
             - Check the Storybook build log printed below.
             - Run foo yourself and make sure it outputs a valid Storybook by opening the generated index.html in your browser.
             - Review the build-storybook CLI options at https://storybook.js.org/docs/api/cli-options#build
             
             Command failed with ENOENT: foo
             spawn foo ENOENT
             
             ℹ Build command:
             foo 
             
             ℹ Runtime metadata:
```

**Build 3:** generic error. Manually throwing an error in `buildStorybook.ts`. Note the `Bad stuff happened` in the error details.
<img width="2542" height="1408" alt="image" src="https://github.com/user-attachments/assets/4f85d87c-dc00-4c96-801d-2e291a0347b5" />

```
09:35:15.556 Chromatic CLI v17.4.1
             https://www.chromatic.com/docs/cli
09:35:15.572 Authenticating with Chromatic [staging]
09:35:15.572     → Connecting to https://index.staging-chromatic.com/
09:35:15.912 Authenticated with Chromatic [staging]
09:35:15.913     → Using project token '****************1c89'
09:35:15.913 Retrieving git information
09:35:16.882 Retrieved git information
09:35:16.883     → Commit '763e9d9' on branch 'HEAD'; found 1 parent build
09:35:16.883 Collecting Storybook metadata
09:35:16.919 Collected Storybook metadata
09:35:16.920     → Build metadata gathered
09:35:16.920 Initializing build
09:35:17.436 Initialized build
09:35:17.437     → Build 216 initialized
09:35:17.438 Building your Storybook
09:35:17.442     → Running command: yarn run build-storybook --output-dir=/private/var/folders/gn/p0bks3451f38s12kbrmdxznh0000gn/T/chromatic--14276-yDXVtq7JKHzp
09:35:17.453 The CLI tried to run your build-storybook script, but the command failed. This indicates a problem with your Storybook. Here's what to do:

             - Check the Storybook build log printed below.
             - Run npm run build-storybook or yarn build-storybook yourself and make sure it outputs a valid Storybook by opening the generated index.html in your browser.
             - Review the build-storybook CLI options at https://storybook.js.org/docs/api/cli-options#build

             Bad stuff happened

             ℹ Build command:
             yarn run build-storybook --output-dir=/private/var/folders/gn/p0bks3451f38s12kbrmdxznh0000gn/T/chromatic--14276-yDXVtq7JKHzp

             ℹ Runtime metadata:
             {
```

This is arguably not a great error message, as there's no real stack trace, but this is a pre-existing problem. Here's the same situation on `main`:
<img width="2542" height="1444" alt="image" src="https://github.com/user-attachments/assets/e0fc8528-3a6b-4f1f-aba9-954c7531c352" />

Maybe something to revisit later.

## React Native

**Build 1:** happy path.
<img width="1594" height="1130" alt="CleanShot 2026-06-22 at 10 41 25@2x" src="https://github.com/user-attachments/assets/4e2fccd7-e663-4a83-b4d5-65870a0f9699" />

In-progress spinner:
<img width="1574" height="690" alt="image" src="https://github.com/user-attachments/assets/f404dd6c-1e2b-4da6-bf93-87978a8c25fd" />

React Native build log head:
```
[chromatic] iOS build: npx expo prebuild --platform ios

[chromatic] build: "npx expo prebuild --platform ios"
- Creating native directory (./ios)
✔ Created native directory | reusing /ios
- Updating package.json
✔ Updated package.json | no changes
- Running prebuild
✔ Finished prebuild

[chromatic] iOS build: xcodebuild -workspace petsinpajamas.xcworkspace -scheme petsinpajamas -configuration Release -sdk iphonesimulator -derivedDataPath /var/folders/gn/p0bks3451f38s12kbrmdxznh0000gn/T/chromatic-rn-ios-cLezcS CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_ENTITLEMENTS="" CODE_SIGN_IDENTITY="" build
```

Here's the [app](https://www.staging-chromatic.com/builds?appId=6a3944573d176950a16ea795) I ran this against. As you can see in the logs, build 3, the one on this branch, is full of errors, so I can another build on `main` (screenshot below). This is build 4. Same errors. So looks like this isn't related to the CLI.
<img width="1742" height="732" alt="CleanShot 2026-06-22 at 10 56 14@2x" src="https://github.com/user-attachments/assets/26bf6b18-b8ff-4b3f-95f7-61fa731b36db" />

**Build 2:** using prebuilt assets.
<img width="1668" height="1008" alt="CleanShot 2026-06-22 at 11 34 08@2x" src="https://github.com/user-attachments/assets/b4e49e2d-e658-4856-ab41-0b506dee885d" />

**Build 3:** failure path via intentionally wrong `--storybook-build-dir`
<img width="1780" height="650" alt="CleanShot 2026-06-22 at 11 35 26@2x" src="https://github.com/user-attachments/assets/2de0d5ec-493f-4340-82d7-aed4eefcaf26" />

## E2E

App: https://www.staging-chromatic.com/builds?appId=6a3957983d176950a16ea805

**Build 1:** happy path
<img width="1556" height="892" alt="CleanShot 2026-06-22 at 11 47 26@2x" src="https://github.com/user-attachments/assets/03486297-c701-4629-854f-238fc5931184" />

**Build 2:** failure due to removing bundled archives (the error about one commit is unrelated, just part of how I set up my QA repo).
<img width="1820" height="1158" alt="CleanShot 2026-06-22 at 11 49 05@2x" src="https://github.com/user-attachments/assets/6f80da35-4a3a-4cb1-8bf2-f4d94527bfb6" />

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>18.0.1--canary.1398.28528476900.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@18.0.1--canary.1398.28528476900.0
  # or 
  yarn add chromatic@18.0.1--canary.1398.28528476900.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
