### PR TITLE
Write `chromatic.log` by default

### DIFF
--- a/node-src/lib/getOptions.test.ts
+++ b/node-src/lib/getOptions.test.ts
@@ -50,7 +50,7 @@ describe('getOptions', () => {
       externals: undefined,
       traceChanged: undefined,
       list: undefined,
-      logFile: undefined,
+      logFile: 'chromatic.log',
       skip: undefined,
       forceRebuild: undefined,
       junitReport: undefined,
@@ -224,6 +224,20 @@ describe('getOptions', () => {
       diagnosticsFile: 'chromatic-diagnostics.json',
       logFile: 'chromatic.log',
       uploadMetadata: true,
+    });
+  });
+
+  it('writes a log file by default, but allows a custom path or disabling it', async () => {
+    expect(getOptions(getContext(['--project-token', 'cli-code']))).toMatchObject({
+      logFile: 'chromatic.log',
+    });
+    expect(
+      getOptions(getContext(['--project-token', 'cli-code', '--log-file', 'custom.log']))
+    ).toMatchObject({
+      logFile: 'custom.log',
+    });
+    expect(getOptions(getContext(['--project-token', 'cli-code', '--no-log-file']))).toMatchObject({
+      logFile: false,
     });
   });
 

--- a/node-src/lib/getOptions.ts
+++ b/node-src/lib/getOptions.ts
@@ -132,7 +132,7 @@ export const getPartialOptions = (ctx: InitialContext): Partial<Options> => {
     externals: undefinedIfEmpty(ensureArray(flags.externals)),
     traceChanged: trueIfSet(flags.traceChanged),
     list: flags.list,
-    logFile: defaultIfSet(flags.logFile, DEFAULT_LOG_FILE),
+    logFile: defaultUnlessSet(flags.logFile, DEFAULT_LOG_FILE),
     fromCI: flags.ci,
     skip: trueIfSet(flags.skip),
     dryRun: flags.dryRun,
@@ -207,8 +207,8 @@ export const getPartialOptions = (ctx: InitialContext): Partial<Options> => {
   }
 
   if (partialOptions.debug || partialOptions.uploadMetadata) {
-    // Implicitly enable these options unless they're already enabled or explicitly disabled
-    partialOptions.logFile = partialOptions.logFile ?? DEFAULT_LOG_FILE;
+    // Implicitly enable the diagnostics file unless it's already enabled or explicitly disabled.
+    // The log file is always enabled by default (see DEFAULT_LOG_FILE above).
     partialOptions.diagnosticsFile = partialOptions.diagnosticsFile ?? DEFAULT_DIAGNOSTICS_FILE;
   }
 


### PR DESCRIPTION
We want to improve debugging (especially in the case of TurboSnap bails). In order to do that effectively, we want to write the log file by default to match the `build-storybook.log` file.

This change is used in an upcoming PR but I wanted to make this a separate change so it's explicit in the release notes that we did this on purpose.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>17.5.1--canary.1399.27791147265.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@17.5.1--canary.1399.27791147265.0
  # or 
  yarn add chromatic@17.5.1--canary.1399.27791147265.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
