### PR TITLE
Automatically upload metadata files on TurboSnap bails

### DIFF
--- a/action-src/main.ts
+++ b/action-src/main.ts
@@ -202,7 +202,7 @@ async function run() {
         storybookLogFile: maybe(storybookLogFile),
         traceChanged: maybe(traceChanged),
         untraced: maybe(untraced),
-        uploadMetadata: maybe(uploadMetadata, false),
+        uploadMetadata: maybe(uploadMetadata),
         vitest: maybe(vitest),
         zip: maybe(zip, false),
         junitReport: maybe(junitReport),

--- a/action.yml
+++ b/action.yml
@@ -114,7 +114,7 @@ inputs:
     description: 'Disregard these files and their dependencies when tracing dependent stories for TurboSnap'
     required: false
   uploadMetadata:
-    description: 'Upload Chromatic metadata files as part of the published Storybook. Defaults to enabled when TurboSnap bails.'
+    description: 'Upload Chromatic metadata files as part of the published Storybook. Defaults to enabled when TurboSnap is requested.'
     required: false
   vitest:
     description: 'Run build against `@chromatic-com/vitest` test archives'

--- a/action.yml
+++ b/action.yml
@@ -114,7 +114,7 @@ inputs:
     description: 'Disregard these files and their dependencies when tracing dependent stories for TurboSnap'
     required: false
   uploadMetadata:
-    description: 'Upload Chromatic metadata files as part of the published Storybook'
+    description: 'Upload Chromatic metadata files as part of the published Storybook. Defaults to enabled when TurboSnap bails.'
     required: false
   vitest:
     description: 'Run build against `@chromatic-com/vitest` test archives'

--- a/node-src/index.test.ts
+++ b/node-src/index.test.ts
@@ -8,7 +8,7 @@ import path from 'path';
 import { Readable } from 'stream';
 import { afterEach, beforeEach, describe, expect, it, onTestFinished, vi } from 'vitest';
 
-import { getGitInfo, run, runAll } from '.';
+import { getGitInfo, run, runAll, shouldUploadMetadata } from '.';
 import * as git from './git/git';
 import { DNSResolveAgent } from './io/getDNSResolveAgent';
 import * as checkPackageJson from './lib/checkPackageJson';
@@ -863,6 +863,31 @@ it('should upload metadata files if --upload-metadata is passed', async () => {
       },
     ])
   );
+});
+
+describe('shouldUploadMetadata', () => {
+  it('uploads when --upload-metadata is explicitly enabled', () => {
+    const ctx = { options: { uploadMetadata: true }, turboSnap: undefined } as any;
+    expect(shouldUploadMetadata(ctx)).toBe(true);
+  });
+
+  it('does not upload when --upload-metadata is explicitly disabled, even if TurboSnap bailed', () => {
+    const ctx = {
+      options: { uploadMetadata: false },
+      turboSnap: { bailReason: { rebuild: true } },
+    } as any;
+    expect(shouldUploadMetadata(ctx)).toBe(false);
+  });
+
+  it('uploads by default when TurboSnap bailed and the flag is unset', () => {
+    const ctx = { options: {}, turboSnap: { bailReason: { rebuild: true } } } as any;
+    expect(shouldUploadMetadata(ctx)).toBe(true);
+  });
+
+  it('does not upload by default when TurboSnap did not bail and the flag is unset', () => {
+    const ctx = { options: {}, turboSnap: {} } as any;
+    expect(shouldUploadMetadata(ctx)).toBe(false);
+  });
 });
 
 describe('getGitInfo', () => {

--- a/node-src/index.test.ts
+++ b/node-src/index.test.ts
@@ -865,6 +865,25 @@ it('should upload metadata files if --upload-metadata is passed', async () => {
   );
 });
 
+describe('log file cleanup', () => {
+  it('removes the temporary log file after uploading metadata', async () => {
+    const ctx = getContext(['--project-token=asdf1234', '--upload-metadata', '--only-changed']);
+    await runAll(ctx);
+    expect(ctx.testLogger.removeLogFile).toHaveBeenCalled();
+  });
+
+  it('keeps an explicitly configured log file after uploading metadata', async () => {
+    const ctx = getContext([
+      '--project-token=asdf1234',
+      '--upload-metadata',
+      '--only-changed',
+      '--log-file=custom.log',
+    ]);
+    await runAll(ctx);
+    expect(ctx.testLogger.removeLogFile).not.toHaveBeenCalled();
+  });
+});
+
 describe('shouldUploadMetadata', () => {
   it('uploads when --upload-metadata is explicitly enabled', () => {
     const ctx = { options: { uploadMetadata: true }, turboSnap: undefined } as any;

--- a/node-src/index.test.ts
+++ b/node-src/index.test.ts
@@ -1,6 +1,7 @@
 /* eslint-disable max-lines */
 import dns from 'dns';
 import { execa as execaDefault, parseCommandString } from 'execa';
+import { rmSync } from 'fs';
 import jsonfile from 'jsonfile';
 import { confirm } from 'node-ask';
 import fetchDefault from 'node-fetch';
@@ -289,6 +290,7 @@ vi.mock('fs', async (importOriginal) => {
   return {
     pathExists: async () => true,
     mkdirSync: vi.fn(),
+    rmSync: vi.fn(),
     readFileSync: originalModule.readFileSync,
     writeFileSync: vi.fn(),
     createReadStream: vi.fn(() => mockStatsFile),
@@ -880,6 +882,32 @@ describe('log file cleanup', () => {
       '--log-file=custom.log',
     ]);
     await runAll(ctx);
+    expect(ctx.testLogger.removeLogFile).not.toHaveBeenCalled();
+  });
+});
+
+describe('diagnostics file cleanup', () => {
+  it('removes the temporary diagnostics file after uploading metadata', async () => {
+    const ctx = getContext(['--project-token=asdf1234', '--upload-metadata', '--only-changed']);
+    await runAll(ctx);
+    expect(rmSync).toHaveBeenCalledWith('chromatic-diagnostics.json', { force: true });
+  });
+
+  it('keeps an explicitly configured diagnostics file after uploading metadata', async () => {
+    const ctx = getContext([
+      '--project-token=asdf1234',
+      '--upload-metadata',
+      '--only-changed',
+      '--diagnostics-file=custom.json',
+    ]);
+    await runAll(ctx);
+    expect(rmSync).not.toHaveBeenCalled();
+  });
+
+  it('keeps the default log and diagnostics files when --debug is set', async () => {
+    const ctx = getContext(['--project-token=asdf1234', '--debug', '--only-changed']);
+    await runAll(ctx);
+    expect(rmSync).not.toHaveBeenCalled();
     expect(ctx.testLogger.removeLogFile).not.toHaveBeenCalled();
   });
 });

--- a/node-src/index.test.ts
+++ b/node-src/index.test.ts
@@ -890,12 +890,17 @@ describe('shouldUploadMetadata', () => {
     expect(shouldUploadMetadata(ctx)).toBe(true);
   });
 
-  it('does not upload when --upload-metadata is explicitly disabled, even if TurboSnap bailed', () => {
+  it('does not upload when --upload-metadata is explicitly disabled, even if TurboSnap is requested', () => {
     const ctx = {
       options: { uploadMetadata: false },
-      turboSnap: { bailReason: { rebuild: true } },
+      turboSnap: {},
     } as any;
     expect(shouldUploadMetadata(ctx)).toBe(false);
+  });
+
+  it('uploads by default when TurboSnap is requested and the flag is unset', () => {
+    const ctx = { options: {}, turboSnap: {} } as any;
+    expect(shouldUploadMetadata(ctx)).toBe(true);
   });
 
   it('uploads by default when TurboSnap bailed and the flag is unset', () => {
@@ -903,8 +908,13 @@ describe('shouldUploadMetadata', () => {
     expect(shouldUploadMetadata(ctx)).toBe(true);
   });
 
-  it('does not upload by default when TurboSnap did not bail and the flag is unset', () => {
-    const ctx = { options: {}, turboSnap: {} } as any;
+  it('uploads by default when TurboSnap is unavailable and the flag is unset', () => {
+    const ctx = { options: {}, turboSnap: { unavailable: true } } as any;
+    expect(shouldUploadMetadata(ctx)).toBe(true);
+  });
+
+  it('does not upload by default when TurboSnap is disabled and the flag is unset', () => {
+    const ctx = { options: {}, turboSnap: undefined } as any;
     expect(shouldUploadMetadata(ctx)).toBe(false);
   });
 });

--- a/node-src/index.ts
+++ b/node-src/index.ts
@@ -30,7 +30,10 @@ import parseArguments from './lib/parseArguments';
 import { exitCodes, setExitCode } from './lib/setExitCode';
 import { uploadMetadataFiles } from './lib/uploadMetadataFiles';
 import { rewriteErrorMessage } from './lib/utilities';
-import { writeChromaticDiagnostics } from './lib/writeChromaticDiagnostics';
+import {
+  removeChromaticDiagnostics,
+  writeChromaticDiagnostics,
+} from './lib/writeChromaticDiagnostics';
 import getTasks from './tasks';
 import { Context, Flags, Options } from './types';
 import { endActivity } from './ui/components/activity';
@@ -227,13 +230,26 @@ export async function runAll(initialContext: InitialContext) {
     await uploadMetadataFiles(ctx);
   }
 
-  // Clean up the temporary log file now that it has been uploaded.
-  if (ctx.options.logFile && !ctx.options.persistLogFile) {
-    ctx.log.removeLogFile();
-  }
+  cleanupTemporaryFiles(ctx);
 
   if (!isE2EBuild(ctx.options) && [0, 1].includes(ctx.exitCode)) {
     await checkPackageJson(ctx);
+  }
+}
+
+/**
+ * Remove the log and diagnostics files we wrote during the run, unless they were explicitly
+ * configured (or persisted via --debug). This avoids leaving behind files we only created to
+ * upload as metadata.
+ *
+ * @param ctx The context set when executing the CLI.
+ */
+function cleanupTemporaryFiles(ctx: Context) {
+  if (ctx.options.logFile && !ctx.options.persistLogFile) {
+    ctx.log.removeLogFile();
+  }
+  if (ctx.options.diagnosticsFile && !ctx.options.persistDiagnosticsFile) {
+    removeChromaticDiagnostics(ctx);
   }
 }
 

--- a/node-src/index.ts
+++ b/node-src/index.ts
@@ -221,8 +221,8 @@ export async function runAll(initialContext: InitialContext) {
   }
 
   if (shouldUploadMetadata(ctx)) {
-    if (ctx.turboSnap?.bailReason) {
-      ctx.log.info('Uploading metadata files automatically due to TurboSnap bail');
+    if (ctx.options.uploadMetadata === undefined && isTurboSnapEnabled(ctx)) {
+      ctx.log.info('Uploading metadata files automatically because TurboSnap was enabled');
     }
     await uploadMetadataFiles(ctx);
   }
@@ -243,15 +243,19 @@ function shouldWriteDiagnosticsFile(ctx: Context): boolean {
 
 /**
  * Decide whether to upload metadata files. An explicit --upload-metadata /
- * --no-upload-metadata always wins. Otherwise we default to uploading only when
- * TurboSnap bailed.
+ * --no-upload-metadata always wins. Otherwise we default to uploading when
+ * TurboSnap was enabled.
  *
  * @param ctx The context set when executing the CLI.
  *
  * @returns True if metadata files should be uploaded.
  */
 export function shouldUploadMetadata(ctx: Context): boolean {
-  return ctx.options.uploadMetadata ?? !!ctx.turboSnap?.bailReason;
+  return ctx.options.uploadMetadata ?? isTurboSnapEnabled(ctx);
+}
+
+function isTurboSnapEnabled(ctx: Context): boolean {
+  return !!ctx.turboSnap;
 }
 
 async function shouldSkipWithoutProjectToken(

--- a/node-src/index.ts
+++ b/node-src/index.ts
@@ -165,6 +165,8 @@ export async function run({
  *
  * @returns A promise that resolves when all steps are completed.
  */
+// TODO: refactor this function
+// eslint-disable-next-line complexity
 export async function runAll(initialContext: InitialContext) {
   initialContext.log.info('');
   initialContext.log.info(intro(initialContext));
@@ -219,6 +221,9 @@ export async function runAll(initialContext: InitialContext) {
   }
 
   if (shouldUploadMetadata(ctx)) {
+    if (ctx.turboSnap?.bailReason) {
+      ctx.log.info('Uploading metadata files automatically due to TurboSnap bail');
+    }
     await uploadMetadataFiles(ctx);
   }
 

--- a/node-src/index.ts
+++ b/node-src/index.ts
@@ -211,10 +211,6 @@ export async function runAll(initialContext: InitialContext) {
     onError(error);
   });
 
-  if (!isE2EBuild(ctx.options) && [0, 1].includes(ctx.exitCode)) {
-    await checkPackageJson(ctx);
-  }
-
   if (shouldWriteDiagnosticsFile(ctx)) {
     // Ensure we set the diagnostic file output location (in the case of `uploadMetadata` but no
     // diagnostic file was set)
@@ -224,6 +220,10 @@ export async function runAll(initialContext: InitialContext) {
 
   if (shouldUploadMetadata(ctx)) {
     await uploadMetadataFiles(ctx);
+  }
+
+  if (!isE2EBuild(ctx.options) && [0, 1].includes(ctx.exitCode)) {
+    await checkPackageJson(ctx);
   }
 }
 

--- a/node-src/index.ts
+++ b/node-src/index.ts
@@ -21,7 +21,7 @@ import checkPackageJson from './lib/checkPackageJson';
 import { isE2EBuild } from './lib/e2eUtils';
 import { emailHash } from './lib/emailHash';
 import getEnvironment from './lib/getEnvironment';
-import getOptions, { getPartialOptions } from './lib/getOptions';
+import getOptions, { DEFAULT_DIAGNOSTICS_FILE, getPartialOptions } from './lib/getOptions';
 import { createLogger } from './lib/log';
 import LoggingRenderer from './lib/loggingRenderer';
 import matchesBranch from './lib/matchesBranch';
@@ -215,13 +215,36 @@ export async function runAll(initialContext: InitialContext) {
     await checkPackageJson(ctx);
   }
 
-  if (ctx.options.diagnosticsFile) {
+  if (shouldWriteDiagnosticsFile(ctx)) {
+    // Ensure we set the diagnostic file output location (in the case of `uploadMetadata` but no
+    // diagnostic file was set)
+    ctx.options.diagnosticsFile ??= DEFAULT_DIAGNOSTICS_FILE;
     await writeChromaticDiagnostics(ctx);
   }
 
-  if (ctx.options.uploadMetadata) {
+  if (shouldUploadMetadata(ctx)) {
     await uploadMetadataFiles(ctx);
   }
+}
+
+function shouldWriteDiagnosticsFile(ctx: Context): boolean {
+  return (
+    !!ctx.options.diagnosticsFile ||
+    (ctx.options.diagnosticsFile === undefined && shouldUploadMetadata(ctx))
+  );
+}
+
+/**
+ * Decide whether to upload metadata files. An explicit --upload-metadata /
+ * --no-upload-metadata always wins. Otherwise we default to uploading only when
+ * TurboSnap bailed.
+ *
+ * @param ctx The context set when executing the CLI.
+ *
+ * @returns True if metadata files should be uploaded.
+ */
+export function shouldUploadMetadata(ctx: Context): boolean {
+  return ctx.options.uploadMetadata ?? !!ctx.turboSnap?.bailReason;
 }
 
 async function shouldSkipWithoutProjectToken(

--- a/node-src/index.ts
+++ b/node-src/index.ts
@@ -228,10 +228,7 @@ export async function runAll(initialContext: InitialContext) {
 }
 
 function shouldWriteDiagnosticsFile(ctx: Context): boolean {
-  return (
-    !!ctx.options.diagnosticsFile ||
-    (ctx.options.diagnosticsFile === undefined && shouldUploadMetadata(ctx))
-  );
+  return !!ctx.options.diagnosticsFile || shouldUploadMetadata(ctx);
 }
 
 /**

--- a/node-src/index.ts
+++ b/node-src/index.ts
@@ -222,6 +222,11 @@ export async function runAll(initialContext: InitialContext) {
     await uploadMetadataFiles(ctx);
   }
 
+  // Clean up the temporary log file now that it has been uploaded.
+  if (ctx.options.logFile && !ctx.options.persistLogFile) {
+    ctx.log.removeLogFile();
+  }
+
   if (!isE2EBuild(ctx.options) && [0, 1].includes(ctx.exitCode)) {
     await checkPackageJson(ctx);
   }

--- a/node-src/lib/getOptions.test.ts
+++ b/node-src/lib/getOptions.test.ts
@@ -50,7 +50,7 @@ describe('getOptions', () => {
       externals: undefined,
       traceChanged: undefined,
       list: undefined,
-      logFile: undefined,
+      logFile: 'chromatic.log',
       skip: undefined,
       forceRebuild: undefined,
       junitReport: undefined,
@@ -224,6 +224,20 @@ describe('getOptions', () => {
       diagnosticsFile: 'chromatic-diagnostics.json',
       logFile: 'chromatic.log',
       uploadMetadata: true,
+    });
+  });
+
+  it('writes a log file by default, but allows a custom path or disabling it', async () => {
+    expect(getOptions(getContext(['--project-token', 'cli-code']))).toMatchObject({
+      logFile: 'chromatic.log',
+    });
+    expect(
+      getOptions(getContext(['--project-token', 'cli-code', '--log-file', 'custom.log']))
+    ).toMatchObject({
+      logFile: 'custom.log',
+    });
+    expect(getOptions(getContext(['--project-token', 'cli-code', '--no-log-file']))).toMatchObject({
+      logFile: false,
     });
   });
 

--- a/node-src/lib/getOptions.test.ts
+++ b/node-src/lib/getOptions.test.ts
@@ -241,6 +241,14 @@ describe('getOptions', () => {
     });
   });
 
+  it('respects a logFile path from the config file when no flag is passed', () => {
+    const ctx = {
+      ...getContext(['--project-token', 'cli-code']),
+      configuration: { logFile: 'config.log' },
+    };
+    expect(getOptions(ctx)).toMatchObject({ logFile: 'config.log' });
+  });
+
   it('allows you to specify a diagnostics file name', async () => {
     expect(getOptions(getContext(['--diagnostics-file', 'output.json']))).toMatchObject({
       diagnosticsFile: 'output.json',

--- a/node-src/lib/getOptions.test.ts
+++ b/node-src/lib/getOptions.test.ts
@@ -249,6 +249,39 @@ describe('getOptions', () => {
     expect(getOptions(ctx)).toMatchObject({ logFile: 'config.log' });
   });
 
+  it('marks an explicitly configured log file as persistent, but not the default', () => {
+    // The default log file is temporary (cleaned up after the run)
+    expect(getOptions(getContext(['--project-token', 'cli-code']))).toMatchObject({
+      logFile: 'chromatic.log',
+      persistLogFile: false,
+    });
+
+    // An explicit path is persistent (kept after the run)
+    expect(
+      getOptions(getContext(['--project-token', 'cli-code', '--log-file', 'custom.log']))
+    ).toMatchObject({
+      logFile: 'custom.log',
+      persistLogFile: true,
+    });
+
+    // A path from the config file is persistent
+    expect(
+      getOptions({
+        ...getContext(['--project-token', 'cli-code']),
+        configuration: { logFile: 'config.log' },
+      })
+    ).toMatchObject({
+      logFile: 'config.log',
+      persistLogFile: true,
+    });
+
+    // Disabling the log file leaves nothing to persist
+    expect(getOptions(getContext(['--project-token', 'cli-code', '--no-log-file']))).toMatchObject({
+      logFile: false,
+      persistLogFile: false,
+    });
+  });
+
   it('allows you to specify a diagnostics file name', async () => {
     expect(getOptions(getContext(['--diagnostics-file', 'output.json']))).toMatchObject({
       diagnosticsFile: 'output.json',

--- a/node-src/lib/getOptions.test.ts
+++ b/node-src/lib/getOptions.test.ts
@@ -249,14 +249,22 @@ describe('getOptions', () => {
     expect(getOptions(ctx)).toMatchObject({ logFile: 'config.log' });
   });
 
-  it('marks an explicitly configured log file as persistent, but not the default', () => {
+  it('does not persist the log file when it is not explicitly configured', () => {
     // The default log file is temporary (cleaned up after the run)
     expect(getOptions(getContext(['--project-token', 'cli-code']))).toMatchObject({
       logFile: 'chromatic.log',
       persistLogFile: false,
     });
 
-    // An explicit path is persistent (kept after the run)
+    // Disabling the log file leaves nothing to persist
+    expect(getOptions(getContext(['--project-token', 'cli-code', '--no-log-file']))).toMatchObject({
+      logFile: false,
+      persistLogFile: false,
+    });
+  });
+
+  it('persists an explicitly configured log file', () => {
+    // An explicit path is kept after the run
     expect(
       getOptions(getContext(['--project-token', 'cli-code', '--log-file', 'custom.log']))
     ).toMatchObject({
@@ -264,7 +272,7 @@ describe('getOptions', () => {
       persistLogFile: true,
     });
 
-    // A path from the config file is persistent
+    // A path from the config file is kept
     expect(
       getOptions({
         ...getContext(['--project-token', 'cli-code']),
@@ -274,11 +282,50 @@ describe('getOptions', () => {
       logFile: 'config.log',
       persistLogFile: true,
     });
+  });
 
-    // Disabling the log file leaves nothing to persist
-    expect(getOptions(getContext(['--project-token', 'cli-code', '--no-log-file']))).toMatchObject({
-      logFile: false,
-      persistLogFile: false,
+  it('does not persist the diagnostics file when it is not explicitly configured', () => {
+    // No diagnostics file is enabled by default, so there is nothing to persist
+    expect(getOptions(getContext(['--project-token', 'cli-code']))).toMatchObject({
+      persistDiagnosticsFile: false,
+    });
+
+    // The diagnostics file implicitly enabled by --upload-metadata is temporary
+    expect(
+      getOptions(getContext(['--project-token', 'cli-code', '--upload-metadata']))
+    ).toMatchObject({
+      diagnosticsFile: 'chromatic-diagnostics.json',
+      persistDiagnosticsFile: false,
+    });
+  });
+
+  it('persists an explicitly configured diagnostics file', () => {
+    // An explicit path is kept after the run
+    expect(
+      getOptions(getContext(['--project-token', 'cli-code', '--diagnostics-file', 'custom.json']))
+    ).toMatchObject({
+      diagnosticsFile: 'custom.json',
+      persistDiagnosticsFile: true,
+    });
+
+    // A path from the config file is kept
+    expect(
+      getOptions({
+        ...getContext(['--project-token', 'cli-code']),
+        configuration: { diagnosticsFile: 'config.json' },
+      })
+    ).toMatchObject({
+      diagnosticsFile: 'config.json',
+      persistDiagnosticsFile: true,
+    });
+  });
+
+  it('keeps the default log and diagnostics files when --debug is set', () => {
+    expect(getOptions(getContext(['--project-token', 'cli-code', '--debug']))).toMatchObject({
+      logFile: 'chromatic.log',
+      persistLogFile: true,
+      diagnosticsFile: 'chromatic-diagnostics.json',
+      persistDiagnosticsFile: true,
     });
   });
 

--- a/node-src/lib/getOptions.ts
+++ b/node-src/lib/getOptions.ts
@@ -207,7 +207,9 @@ export const getPartialOptions = (ctx: InitialContext): Partial<Options> => {
   }
 
   // Write a log file by default. A custom path (flag or config) is respected; disable with
-  // `--no-log-file`.
+  // `--no-log-file`. An explicitly configured path is persistent and kept; the default is
+  // temporary and cleaned up after the run.
+  partialOptions.persistLogFile = typeof partialOptions.logFile === 'string';
   partialOptions.logFile ??= DEFAULT_LOG_FILE;
 
   if (partialOptions.debug || partialOptions.uploadMetadata) {

--- a/node-src/lib/getOptions.ts
+++ b/node-src/lib/getOptions.ts
@@ -15,6 +15,12 @@ import missingProjectToken from '../ui/messages/errors/missingProjectToken';
 import deprecatedOption from '../ui/messages/warnings/deprecatedOption';
 import { isE2EBuild } from './e2eUtils';
 
+export const DEFAULT_LOG_FILE = 'chromatic.log';
+export const DEFAULT_DIAGNOSTICS_FILE = 'chromatic-diagnostics.json';
+const DEFAULT_REPORT_FILE = 'chromatic-build-{buildNumber}.xml';
+const DEFAULT_STORYBOOK_LOG_FILE = 'build-storybook.log';
+const DEFAULT_E2E_LOG_FILE = 'build-archive.log';
+
 const takeLast = (input?: string | string[]) => (Array.isArray(input) ? input.at(-1) : input);
 
 const ensureArray = (input?: string | string[]) => {
@@ -114,12 +120,6 @@ export const getPartialOptions = (ctx: InitialContext): Partial<Options> => {
     .filter(Boolean);
   const [branchName, branchOwner] = (flags.branchName || '').split(':').reverse();
   const [repositoryOwner, repositoryName, ...rest] = flags.repositorySlug?.split('/') || [];
-
-  const DEFAULT_LOG_FILE = 'chromatic.log';
-  const DEFAULT_REPORT_FILE = 'chromatic-build-{buildNumber}.xml';
-  const DEFAULT_DIAGNOSTICS_FILE = 'chromatic-diagnostics.json';
-  const DEFAULT_STORYBOOK_LOG_FILE = 'build-storybook.log';
-  const DEFAULT_E2E_LOG_FILE = 'build-archive.log';
 
   // We need to strip out undefined because they otherwise they override anyway
   const optionsFromFlags = stripUndefined({

--- a/node-src/lib/getOptions.ts
+++ b/node-src/lib/getOptions.ts
@@ -132,7 +132,7 @@ export const getPartialOptions = (ctx: InitialContext): Partial<Options> => {
     externals: undefinedIfEmpty(ensureArray(flags.externals)),
     traceChanged: trueIfSet(flags.traceChanged),
     list: flags.list,
-    logFile: defaultIfSet(flags.logFile, DEFAULT_LOG_FILE),
+    logFile: defaultUnlessSet(flags.logFile, DEFAULT_LOG_FILE),
     fromCI: flags.ci,
     skip: trueIfSet(flags.skip),
     dryRun: flags.dryRun,
@@ -207,8 +207,8 @@ export const getPartialOptions = (ctx: InitialContext): Partial<Options> => {
   }
 
   if (partialOptions.debug || partialOptions.uploadMetadata) {
-    // Implicitly enable these options unless they're already enabled or explicitly disabled
-    partialOptions.logFile = partialOptions.logFile ?? DEFAULT_LOG_FILE;
+    // Implicitly enable the diagnostics file unless it's already enabled or explicitly disabled.
+    // The log file is always enabled by default (see DEFAULT_LOG_FILE above).
     partialOptions.diagnosticsFile = partialOptions.diagnosticsFile ?? DEFAULT_DIAGNOSTICS_FILE;
   }
 

--- a/node-src/lib/getOptions.ts
+++ b/node-src/lib/getOptions.ts
@@ -207,11 +207,16 @@ export const getPartialOptions = (ctx: InitialContext): Partial<Options> => {
   }
 
   // Write a log file by default. A custom path (flag or config) is respected; disable with
-  // `--no-log-file`. An explicitly configured path is persistent and kept; the default is
-  // temporary and cleaned up after the run.
-  partialOptions.persistLogFile = typeof partialOptions.logFile === 'string';
+  // `--no-log-file`. An explicitly configured path (or `--debug`) is persistent and kept once the
+  // run is completed. The default is temporary and cleaned up after the run.
+  partialOptions.persistLogFile =
+    typeof partialOptions.logFile === 'string' || !!partialOptions.debug;
   partialOptions.logFile ??= DEFAULT_LOG_FILE;
 
+  // The diagnostics file follows the same persistence rules above but with `--diagnostics-file`
+  // instead.
+  partialOptions.persistDiagnosticsFile =
+    typeof partialOptions.diagnosticsFile === 'string' || !!partialOptions.debug;
   if (partialOptions.debug || partialOptions.uploadMetadata) {
     // Implicitly enable the diagnostics file unless it's already enabled or explicitly disabled.
     partialOptions.diagnosticsFile = partialOptions.diagnosticsFile ?? DEFAULT_DIAGNOSTICS_FILE;

--- a/node-src/lib/getOptions.ts
+++ b/node-src/lib/getOptions.ts
@@ -132,7 +132,7 @@ export const getPartialOptions = (ctx: InitialContext): Partial<Options> => {
     externals: undefinedIfEmpty(ensureArray(flags.externals)),
     traceChanged: trueIfSet(flags.traceChanged),
     list: flags.list,
-    logFile: defaultUnlessSet(flags.logFile, DEFAULT_LOG_FILE),
+    logFile: defaultIfSet(flags.logFile, DEFAULT_LOG_FILE),
     fromCI: flags.ci,
     skip: trueIfSet(flags.skip),
     dryRun: flags.dryRun,
@@ -206,9 +206,12 @@ export const getPartialOptions = (ctx: InitialContext): Partial<Options> => {
     log.setInteractive(false);
   }
 
+  // Write a log file by default. A custom path (flag or config) is respected; disable with
+  // `--no-log-file`.
+  partialOptions.logFile ??= DEFAULT_LOG_FILE;
+
   if (partialOptions.debug || partialOptions.uploadMetadata) {
     // Implicitly enable the diagnostics file unless it's already enabled or explicitly disabled.
-    // The log file is always enabled by default (see DEFAULT_LOG_FILE above).
     partialOptions.diagnosticsFile = partialOptions.diagnosticsFile ?? DEFAULT_DIAGNOSTICS_FILE;
   }
 

--- a/node-src/lib/log.test.ts
+++ b/node-src/lib/log.test.ts
@@ -1,4 +1,4 @@
-import { createWriteStream, rm } from 'fs';
+import { createWriteStream, rmSync } from 'fs';
 import { afterEach, beforeEach, describe, expect, it, MockInstance, vi } from 'vitest';
 
 import { createLogger } from './log';
@@ -10,6 +10,7 @@ vi.mock('fs', async (importOriginal) => {
     createWriteStream: vi.fn(),
     mkdirSync: vi.fn(),
     rm: vi.fn((_path: string, _options: unknown, callback: (err: null) => void) => callback(null)),
+    rmSync: vi.fn(),
   };
 });
 
@@ -224,13 +225,10 @@ describe('log file', () => {
     const logger = createLogger();
     logger.setLogFile('chromatic.log');
 
-    // setLogFile deletes any pre-existing file during initialization; only assert the removal
-    // triggered by removeLogFile itself.
-    vi.mocked(rm).mockClear();
     logger.removeLogFile();
 
     expect(end).toHaveBeenCalled();
-    expect(rm).toHaveBeenCalledWith('chromatic.log', { force: true }, expect.any(Function));
+    expect(rmSync).toHaveBeenCalledWith('chromatic.log', { force: true });
   });
 });
 

--- a/node-src/lib/log.test.ts
+++ b/node-src/lib/log.test.ts
@@ -1,6 +1,17 @@
+import { createWriteStream } from 'fs';
 import { afterEach, beforeEach, describe, expect, it, MockInstance, vi } from 'vitest';
 
 import { createLogger } from './log';
+
+vi.mock('fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('fs')>();
+  return {
+    ...actual,
+    createWriteStream: vi.fn(),
+    mkdirSync: vi.fn(),
+    rm: vi.fn((_path: string, _options: unknown, callback: (err: null) => void) => callback(null)),
+  };
+});
 
 let consoleError: MockInstance<typeof console.error>;
 let consoleWarn: MockInstance<typeof console.warn>;
@@ -165,3 +176,53 @@ it('stringifies non-primitive values', () => {
     JSON.stringify({ key: 'value' })
   );
 });
+
+describe('log file', () => {
+  it('writes debug-level logs to the file even when the console level is info', () => {
+    const writes = captureFileWrites();
+    const logger = createLogger({ logLevel: 'info' });
+    logger.setLogFile('chromatic.log');
+
+    logger.debug('turbosnap detail');
+
+    expect(consoleDebug).not.toHaveBeenCalled();
+    expect(writes.join('')).toContain('turbosnap detail');
+  });
+
+  it('writes info logs to the file even when the console level is higher', () => {
+    const writes = captureFileWrites();
+    const logger = createLogger({ logLevel: 'warn' });
+    logger.setLogFile('chromatic.log');
+
+    logger.info('still logged to file');
+
+    expect(consoleInfo).not.toHaveBeenCalled();
+    expect(writes.join('')).toContain('still logged to file');
+  });
+
+  it('does not write to the file when DISABLE_LOGGING is set', () => {
+    process.env.DISABLE_LOGGING = 'true';
+    const writes = captureFileWrites();
+    const logger = createLogger();
+    logger.setLogFile('chromatic.log');
+
+    logger.error('boom');
+    logger.debug('detail');
+
+    expect(writes.join('')).toBe('');
+  });
+});
+
+function captureFileWrites() {
+  const writes: string[] = [];
+  vi.mocked(createWriteStream).mockReturnValue({
+    write: (chunk: string) => {
+      writes.push(chunk);
+      return true;
+    },
+    cork: () => undefined,
+    uncork: () => undefined,
+    end: () => undefined,
+  } as any);
+  return writes;
+}

--- a/node-src/lib/log.test.ts
+++ b/node-src/lib/log.test.ts
@@ -1,4 +1,4 @@
-import { createWriteStream } from 'fs';
+import { createWriteStream, rm } from 'fs';
 import { afterEach, beforeEach, describe, expect, it, MockInstance, vi } from 'vitest';
 
 import { createLogger } from './log';
@@ -210,6 +210,27 @@ describe('log file', () => {
     logger.debug('detail');
 
     expect(writes.join('')).toBe('');
+  });
+
+  it('removeLogFile ends the stream and deletes the file', () => {
+    const end = vi.fn();
+    vi.mocked(createWriteStream).mockReturnValue({
+      write: () => true,
+      cork: () => undefined,
+      uncork: () => undefined,
+      end,
+    } as any);
+
+    const logger = createLogger();
+    logger.setLogFile('chromatic.log');
+
+    // setLogFile deletes any pre-existing file during initialization; only assert the removal
+    // triggered by removeLogFile itself.
+    vi.mocked(rm).mockClear();
+    logger.removeLogFile();
+
+    expect(end).toHaveBeenCalled();
+    expect(rm).toHaveBeenCalledWith('chromatic.log', { force: true }, expect.any(Function));
   });
 });
 

--- a/node-src/lib/log.ts
+++ b/node-src/lib/log.ts
@@ -1,6 +1,6 @@
 import chalk from 'chalk';
 import debug from 'debug';
-import { createWriteStream, mkdirSync, rm } from 'fs';
+import { createWriteStream, mkdirSync, rm, rmSync } from 'fs';
 import path from 'path';
 import stripAnsi from 'strip-ansi';
 import { format } from 'util';
@@ -108,9 +108,11 @@ const fileLogger = {
   remove(onError: LogFunction) {
     this.disable();
     if (this.filepath) {
-      rm(this.filepath, { force: true }, (err) => {
-        if (err) onError(err);
-      });
+      try {
+        rmSync(this.filepath, { force: true });
+      } catch (err) {
+        onError(err);
+      }
       this.filepath = undefined;
     }
   },

--- a/node-src/lib/log.ts
+++ b/node-src/lib/log.ts
@@ -100,6 +100,8 @@ const fileLogger = {
   disable() {
     this.append = () => {};
     this.queue = [];
+    this.stream?.end();
+    this.stream = undefined;
   },
   pause() {
     if (this.stream && !this.paused) {
@@ -130,7 +132,7 @@ const fileLogger = {
               .trim() + '\n'
           );
         };
-        this.append(...this.queue);
+        if (this.queue.length > 0) this.append(...this.queue);
         this.queue = [];
       }
     });
@@ -151,6 +153,10 @@ export const createLogger = (flags?: Flags, options?: Partial<Options>) => {
     level = 'silent';
   }
 
+  // The log file always captures debug-level logs, independent of the UI level (except when
+  // logging is fully disabled).
+  const fileLevel: keyof typeof LOG_LEVELS = DISABLE_LOGGING === 'true' ? 'silent' : 'debug';
+
   let interactive =
     (options?.interactive || flags?.interactive) && !(options?.debug || flags?.debug);
   let enqueue = false;
@@ -162,11 +168,17 @@ export const createLogger = (flags?: Flags, options?: Partial<Options>) => {
   const log =
     (type: LogType, logFileOnly?: boolean) =>
     (...args: any[]) => {
-      if (LOG_LEVELS[level] < LOG_LEVELS[type]) return;
-
       const logs = logVerbose(type, args);
-      fileLogger.append(...filePrefixer(logs));
+
+      // Always capture debug-level logs in the file, independent of the console level.
+      if (LOG_LEVELS[fileLevel] >= LOG_LEVELS[type]) {
+        fileLogger.append(...filePrefixer(logs));
+      }
+
       if (logFileOnly) return;
+
+      // The console only shows messages at or above the configured level.
+      if (LOG_LEVELS[level] < LOG_LEVELS[type]) return;
 
       const messages = interactive ? logInteractive(args) : logPrefixer(logs);
       if (messages.length === 0) return;

--- a/node-src/lib/log.ts
+++ b/node-src/lib/log.ts
@@ -105,13 +105,13 @@ const fileLogger = {
     this.stream?.end();
     this.stream = undefined;
   },
-  remove(onError: LogFunction) {
+  remove() {
     this.disable();
     if (this.filepath) {
       try {
         rmSync(this.filepath, { force: true });
-      } catch (err) {
-        onError(err);
+      } catch {
+        // Swallow any errors
       }
       this.filepath = undefined;
     }
@@ -218,7 +218,7 @@ export const createLogger = (flags?: Flags, options?: Partial<Options>) => {
       else fileLogger.disable();
     },
     removeLogFile() {
-      fileLogger.remove(log('error'));
+      fileLogger.remove();
     },
     pause: () => {
       fileLogger.pause();

--- a/node-src/lib/log.ts
+++ b/node-src/lib/log.ts
@@ -88,11 +88,13 @@ export interface Logger {
   setLevel: (value: keyof typeof LOG_LEVELS) => void;
   setInteractive: (value: boolean) => void;
   setLogFile: (path: string | undefined) => void;
+  removeLogFile: () => void;
 }
 
 const fileLogger = {
   queue: [] as string[],
   stream: undefined as ReturnType<typeof createWriteStream> | undefined,
+  filepath: undefined as string | undefined,
   paused: false,
   append(...messages: string[]) {
     this.queue.push(...messages, '\n');
@@ -102,6 +104,15 @@ const fileLogger = {
     this.queue = [];
     this.stream?.end();
     this.stream = undefined;
+  },
+  remove(onError: LogFunction) {
+    this.disable();
+    if (this.filepath) {
+      rm(this.filepath, { force: true }, (err) => {
+        if (err) onError(err);
+      });
+      this.filepath = undefined;
+    }
   },
   pause() {
     if (this.stream && !this.paused) {
@@ -125,6 +136,7 @@ const fileLogger = {
         mkdirSync(path.dirname(filepath), { recursive: true });
 
         this.stream = createWriteStream(filepath, { flags: 'a' });
+        this.filepath = filepath;
         this.append = (...messages: string[]) => {
           this.stream?.write(
             messages
@@ -202,6 +214,9 @@ export const createLogger = (flags?: Flags, options?: Partial<Options>) => {
     setLogFile(path: string | undefined) {
       if (path) fileLogger.initialize(path, log('error'));
       else fileLogger.disable();
+    },
+    removeLogFile() {
+      fileLogger.remove(log('error'));
     },
     pause: () => {
       fileLogger.pause();

--- a/node-src/lib/parseArguments.ts
+++ b/node-src/lib/parseArguments.ts
@@ -63,7 +63,7 @@ export default function parseArguments(argv: string[]) {
       --no-interactive                 Don't ask interactive questions about your setup and don't overwrite output. Always true in non-TTY environments.
       --storybook-log-file [filepath]  Write Storybook build output to a file. Disable via --no-storybook-log-file. [storybook-build.log]
       --trace-changed [mode]           Print dependency trace for changed files to affected story files. Set to "expanded" to list individual modules. Requires --only-changed.
-      --upload-metadata                Upload Chromatic metadata files as part of the published Storybook. Includes diagnostics and log files, among others. This option enables --diagnostics-file, --log-file and --storybook-log-file, unless explicitly disabled via the 'no-' prefix. Defaults to enabled when TurboSnap bails.
+      --upload-metadata                Upload Chromatic metadata files as part of the published Storybook. Includes diagnostics and log files, among others. This option enables --diagnostics-file, --log-file and --storybook-log-file, unless explicitly disabled via the 'no-' prefix. Defaults to enabled when running with TurboSnap.
 
     Deprecated options
       --preserve-missing            Treat missing stories as unchanged rather than deleted when comparing to the baseline.

--- a/node-src/lib/parseArguments.ts
+++ b/node-src/lib/parseArguments.ts
@@ -63,7 +63,7 @@ export default function parseArguments(argv: string[]) {
       --no-interactive                 Don't ask interactive questions about your setup and don't overwrite output. Always true in non-TTY environments.
       --storybook-log-file [filepath]  Write Storybook build output to a file. Disable via --no-storybook-log-file. [storybook-build.log]
       --trace-changed [mode]           Print dependency trace for changed files to affected story files. Set to "expanded" to list individual modules. Requires --only-changed.
-      --upload-metadata                Upload Chromatic metadata files as part of the published Storybook. Includes diagnostics and log files, among others. This option enables --diagnostics-file, --log-file and --storybook-log-file, unless explicitly disabled via the 'no-' prefix.
+      --upload-metadata                Upload Chromatic metadata files as part of the published Storybook. Includes diagnostics and log files, among others. This option enables --diagnostics-file, --log-file and --storybook-log-file, unless explicitly disabled via the 'no-' prefix. Defaults to enabled when TurboSnap bails.
 
     Deprecated options
       --preserve-missing            Treat missing stories as unchanged rather than deleted when comparing to the baseline.

--- a/node-src/lib/testLogger.ts
+++ b/node-src/lib/testLogger.ts
@@ -20,6 +20,7 @@ export default class TestLogger implements Logger {
   setLevel: Mock;
   setInteractive: Mock;
   setLogFile: Mock;
+  removeLogFile: Mock;
   getLevel: Mock;
   pause: Mock;
   resume: Mock;
@@ -57,6 +58,7 @@ export default class TestLogger implements Logger {
     this.setLevel = vi.fn();
     this.setInteractive = vi.fn();
     this.setLogFile = vi.fn();
+    this.removeLogFile = vi.fn();
     this.getLevel = vi.fn();
     this.pause = vi.fn();
     this.resume = vi.fn();

--- a/node-src/lib/uploadMetadataFiles.test.ts
+++ b/node-src/lib/uploadMetadataFiles.test.ts
@@ -1,8 +1,13 @@
+import * as Sentry from '@sentry/node';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import TestLogger from './testLogger';
 import { uploadFiles } from './uploadFiles';
 import { uploadMetadataFiles } from './uploadMetadataFiles';
+
+vi.mock('@sentry/node', () => ({
+  captureException: vi.fn(),
+}));
 
 vi.mock('fs', () => ({
   stat: vi.fn().mockImplementation((_path, callback) => callback(null, { size: 100 })),
@@ -77,5 +82,35 @@ describe('uploadMetadataFiles', () => {
 
     expect(logPauseCallOrder).toBeLessThan(uploadFilesCallOrder);
     expect(logResumeCallOrder).toBeGreaterThan(uploadFilesCallOrder);
+  });
+
+  it('does not throw when the upload fails, reporting to Sentry and resuming the log', async () => {
+    vi.mocked(uploadFiles).mockRejectedValueOnce(new Error('network boom'));
+
+    const target = {
+      contentLength: 100,
+      filePath: 'chromatic.log',
+      formAction: 'https://s3.amazonaws.com',
+      formFields: {},
+      localPath: 'chromatic.log',
+    };
+    const ctx = {
+      ...baseContext,
+      options: { logFile: target.localPath },
+      announcedBuild: { id: '1' },
+      build: { storybookUrl: 'https://sample-storybook.dev-chromatic.com' },
+      client: {
+        runQuery: vi.fn().mockResolvedValue({
+          uploadMetadata: { info: { targets: [target] }, userErrors: [] },
+        }),
+      },
+    } as any;
+
+    await expect(uploadMetadataFiles(ctx)).resolves.toBeUndefined();
+
+    expect(Sentry.captureException).toHaveBeenCalledWith(expect.any(Error), {
+      fingerprint: ['UploadMetadataFilesError'],
+    });
+    expect(ctx.log.resume).toHaveBeenCalled();
   });
 });

--- a/node-src/lib/uploadMetadataFiles.ts
+++ b/node-src/lib/uploadMetadataFiles.ts
@@ -1,3 +1,4 @@
+import * as Sentry from '@sentry/node';
 import { stat, writeFileSync } from 'fs';
 import path from 'path';
 import { withFile } from 'tmp-promise';
@@ -25,51 +26,58 @@ export async function uploadMetadataFiles(ctx: Context) {
     return;
   }
 
-  return withPausedLog(ctx, async () => {
-    const metadataFiles = [
-      ctx.options.logFile,
-      ctx.options.diagnosticsFile,
-      ctx.options.storybookLogFile,
-      await findStorybookConfigFile(ctx.options.storybookConfigDir, /^main\.[jt]sx?$/).catch(
-        () => undefined
-      ),
-      await findStorybookConfigFile(ctx.options.storybookConfigDir, /^preview\.[jt]sx?$/).catch(
-        () => undefined
-      ),
-      ctx.fileInfo?.statsPath && (await trimStatsFile([ctx.fileInfo.statsPath])),
-    ].filter((m): m is string => !!m);
+  try {
+    return withPausedLog(ctx, async () => {
+      const metadataFiles = [
+        ctx.options.logFile,
+        ctx.options.diagnosticsFile,
+        ctx.options.storybookLogFile,
+        await findStorybookConfigFile(ctx.options.storybookConfigDir, /^main\.[jt]sx?$/).catch(
+          () => undefined
+        ),
+        await findStorybookConfigFile(ctx.options.storybookConfigDir, /^preview\.[jt]sx?$/).catch(
+          () => undefined
+        ),
+        ctx.fileInfo?.statsPath && (await trimStatsFile([ctx.fileInfo.statsPath])),
+      ].filter((m): m is string => !!m);
 
-    const unfilteredFiles = await Promise.all(
-      metadataFiles.map(async (localPath) => {
-        const contentLength = await fileSize(localPath);
-        const targetPath = `.chromatic/${path.basename(localPath)}`;
-        return contentLength && { contentLength, localPath, targetPath };
-      })
-    );
-    const files = unfilteredFiles
-      .filter((f): f is FileDesc => !!f)
-      .sort((a, b) => a.targetPath.localeCompare(b.targetPath, 'en', { numeric: true }));
+      const unfilteredFiles = await Promise.all(
+        metadataFiles.map(async (localPath) => {
+          const contentLength = await fileSize(localPath);
+          const targetPath = `.chromatic/${path.basename(localPath)}`;
+          return contentLength && { contentLength, localPath, targetPath };
+        })
+      );
+      const files = unfilteredFiles
+        .filter((f): f is FileDesc => !!f)
+        .sort((a, b) => a.targetPath.localeCompare(b.targetPath, 'en', { numeric: true }));
 
-    if (files.length === 0) {
-      ctx.log.warn('No metadata files found, skipping metadata upload.');
-      return;
-    }
+      if (files.length === 0) {
+        ctx.log.warn('No metadata files found, skipping metadata upload.');
+        return;
+      }
 
-    await withFile(async ({ path }) => {
-      const html = metadataHtml(ctx, files);
-      writeFileSync(path, html);
-      files.push({
-        contentLength: html.length,
-        localPath: path,
-        targetPath: '.chromatic/index.html',
+      await withFile(async ({ path }) => {
+        const html = metadataHtml(ctx, files);
+        writeFileSync(path, html);
+        files.push({
+          contentLength: html.length,
+          localPath: path,
+          targetPath: '.chromatic/index.html',
+        });
+
+        const directoryUrl = `${ctx.build.storybookUrl}.chromatic/`;
+        ctx.log.info(uploadingMetadata(directoryUrl, files));
+
+        await uploadMetadata(ctx, files);
       });
-
-      const directoryUrl = `${ctx.build.storybookUrl}.chromatic/`;
-      ctx.log.info(uploadingMetadata(directoryUrl, files));
-
-      await uploadMetadata(ctx, files);
     });
-  });
+  } catch (err) {
+    // Log the error but don't rethrow to fail upwards. This step is a best-effort stage and
+    // shouldn't impact the build pipeline.
+    ctx.log.debug('Failed to upload metadata files to Chromatic');
+    Sentry.captureException(err, { fingerprint: ['UploadMetadataFilesError'] });
+  }
 }
 
 /**

--- a/node-src/lib/uploadMetadataFiles.ts
+++ b/node-src/lib/uploadMetadataFiles.ts
@@ -27,7 +27,7 @@ export async function uploadMetadataFiles(ctx: Context) {
   }
 
   try {
-    return withPausedLog(ctx, async () => {
+    return await withPausedLog(ctx, async () => {
       const metadataFiles = [
         ctx.options.logFile,
         ctx.options.diagnosticsFile,

--- a/node-src/lib/uploadMetadataFiles.ts
+++ b/node-src/lib/uploadMetadataFiles.ts
@@ -75,7 +75,7 @@ export async function uploadMetadataFiles(ctx: Context) {
   } catch (err) {
     // Log the error but don't rethrow to fail upwards. This step is a best-effort stage and
     // shouldn't impact the build pipeline.
-    ctx.log.debug('Failed to upload metadata files to Chromatic');
+    ctx.log.debug('Failed to upload metadata files to Chromatic', err);
     Sentry.captureException(err, { fingerprint: ['UploadMetadataFilesError'] });
   }
 }

--- a/node-src/lib/writeChromaticDiagnostics.test.ts
+++ b/node-src/lib/writeChromaticDiagnostics.test.ts
@@ -1,10 +1,14 @@
-import { mkdirSync } from 'fs';
+import { mkdirSync, rmSync } from 'fs';
 import jsonfile from 'jsonfile';
 import path from 'path';
 import { describe, expect, it, vi } from 'vitest';
 
 import { createLogger } from './log';
-import { getDiagnostics, writeChromaticDiagnostics } from './writeChromaticDiagnostics';
+import {
+  getDiagnostics,
+  removeChromaticDiagnostics,
+  writeChromaticDiagnostics,
+} from './writeChromaticDiagnostics';
 
 vi.mock('jsonfile');
 vi.mock('fs');
@@ -50,5 +54,24 @@ describe('writeChromaticDiagnostics', () => {
       expect.any(Object),
       expect.any(Object)
     );
+  });
+});
+
+describe('removeChromaticDiagnostics', () => {
+  it('removes the configured diagnostics file', () => {
+    const ctx = {
+      log: createLogger(),
+      options: { diagnosticsFile: 'chromatic-diagnostics.json' },
+    };
+    removeChromaticDiagnostics(ctx as any);
+
+    expect(rmSync).toHaveBeenCalledWith('chromatic-diagnostics.json', { force: true });
+  });
+
+  it('does nothing when no diagnostics file is configured', () => {
+    const ctx = { log: createLogger(), options: {} };
+    removeChromaticDiagnostics(ctx as any);
+
+    expect(rmSync).not.toHaveBeenCalled();
   });
 });

--- a/node-src/lib/writeChromaticDiagnostics.ts
+++ b/node-src/lib/writeChromaticDiagnostics.ts
@@ -1,4 +1,4 @@
-import { mkdirSync } from 'fs';
+import { mkdirSync, rmSync } from 'fs';
 import jsonfile from 'jsonfile';
 import path from 'path';
 
@@ -24,6 +24,24 @@ export async function writeChromaticDiagnostics(ctx: Context) {
 
     await writeFile(ctx.options.diagnosticsFile, getDiagnostics(ctx), { spaces: 2 });
     ctx.log.info(wroteReport(ctx.options.diagnosticsFile, 'Chromatic diagnostics'));
+  } catch (error) {
+    ctx.log.error(error);
+  }
+}
+
+/**
+ * Remove the diagnostics file we wrote during the run. Used to clean up a diagnostics file that
+ * was enabled implicitly (e.g. for metadata upload) rather than requested by the user.
+ *
+ * @param ctx The context set when executing the CLI.
+ */
+export function removeChromaticDiagnostics(ctx: Context) {
+  if (!ctx.options.diagnosticsFile) {
+    return;
+  }
+
+  try {
+    rmSync(ctx.options.diagnosticsFile, { force: true });
   } catch (error) {
     ctx.log.error(error);
   }

--- a/node-src/share.test.ts
+++ b/node-src/share.test.ts
@@ -42,6 +42,17 @@ vi.mock('fs', async (importOriginal) => {
   const originalModule = (await importOriginal()) as any;
   return {
     ...originalModule,
+    // Return a fake stream so neither the file logger nor the Storybook build log writes a real
+    // file during tests.
+    createWriteStream: vi.fn(() => ({
+      on: (event: string, callback: () => void) => {
+        if (event === 'open') callback();
+      },
+      write: vi.fn(),
+      end: vi.fn(),
+      cork: vi.fn(),
+      uncork: vi.fn(),
+    })),
     mkdirSync: vi.fn(),
     readdirSync: vi.fn(() => ['iframe.html', 'index.html']),
     statSync: vi.fn((path: string) => {
@@ -226,5 +237,23 @@ describe('share()', () => {
     mockConfirmShare.mockRejectedValueOnce(new Error('Confirm failed'));
 
     await expect(share({ userToken: 'user-token' })).rejects.toThrow('S3 upload failed');
+  });
+
+  describe('log file', () => {
+    it('does not configure a log file by default', async () => {
+      await share({ userToken: 'user-token' });
+
+      expect(mockReserveShare).toHaveBeenCalledWith(
+        expect.objectContaining({ options: expect.objectContaining({ logFile: undefined }) })
+      );
+    });
+
+    it('uses the log file path provided by the caller', async () => {
+      await share({ userToken: 'user-token', logFile: 'custom.log' });
+
+      expect(mockReserveShare).toHaveBeenCalledWith(
+        expect.objectContaining({ options: expect.objectContaining({ logFile: 'custom.log' }) })
+      );
+    });
   });
 });

--- a/node-src/share.ts
+++ b/node-src/share.ts
@@ -20,6 +20,8 @@ export interface ShareOptions {
   onProgress?: (progress: number, total: number) => void;
   onError?: (error: Error) => void;
   abortSignal?: AbortSignal;
+  /** Path to write a debug log file. Disabled by default so share() leaves no file behind. */
+  logFile?: string;
 }
 
 export interface ShareOutput {
@@ -38,6 +40,7 @@ export interface ShareOutput {
  * @param shareOptions.onError Callback for errors. When provided, share() resolves instead of
  * rejecting.
  * @param shareOptions.abortSignal An AbortSignal to cancel the share operation.
+ * @param shareOptions.logFile Path to write a debug log file. Disabled by default.
  *
  * @returns An object with the share URL.
  */
@@ -106,7 +109,7 @@ async function reportShareStatus(ctx: Context, status: ConfirmShareStatus) {
 }
 
 async function setupShareContext(shareOptions: ShareOptions): Promise<Context> {
-  const { userToken, onProgress, abortSignal } = shareOptions;
+  const { userToken, onProgress, abortSignal, logFile } = shareOptions;
 
   const extraOptions: Partial<Options> = {
     userToken,
@@ -146,6 +149,7 @@ async function setupShareContext(shareOptions: ShareOptions): Promise<Context> {
   initialContext = await setupContext(initialContext);
   const ctx = initialContext as Context;
   ctx.options = getOptions(initialContext);
+  ctx.options.logFile = logFile;
   ctx.log.setLogFile(ctx.options.logFile);
   ctx.runtime = { forceRebuild: ctx.options.forceRebuild };
   return ctx;

--- a/node-src/types.ts
+++ b/node-src/types.ts
@@ -71,7 +71,10 @@ export interface Options extends Configuration {
 
   configFile?: Flags['configFile'];
   logFile?: Flags['logFile'];
-  /** Whether the log file should be kept after the run (true when a path was explicitly configured). */
+  /**
+   * Whether the log file should be kept after the run (true when a path was explicitly
+   * configured or --debug is set).
+   */
   persistLogFile?: boolean;
   logLevel?: Flags['logLevel'];
   logPrefix?: Flags['logPrefix'];
@@ -89,6 +92,11 @@ export interface Options extends Configuration {
   forceRebuild: boolean | string;
   debug: boolean;
   diagnosticsFile?: Flags['diagnosticsFile'];
+  /**
+   * Whether the diagnostics file should be kept after the run (true when a path was explicitly
+   * configured or --debug is set).
+   */
+  persistDiagnosticsFile?: boolean;
   fileHashing: Flags['fileHashing'];
   interactive: boolean;
   junitReport?: Flags['junitReport'];

--- a/node-src/types.ts
+++ b/node-src/types.ts
@@ -71,6 +71,8 @@ export interface Options extends Configuration {
 
   configFile?: Flags['configFile'];
   logFile?: Flags['logFile'];
+  /** Whether the log file should be kept after the run (true when a path was explicitly configured). */
+  persistLogFile?: boolean;
   logLevel?: Flags['logLevel'];
   logPrefix?: Flags['logPrefix'];
   onlyChanged: boolean | string;


### PR DESCRIPTION
We want to help with debugging TurboSnap bails without going back and forth with the customer too much because it's slow and a little annoying as a customer. This change automatically uploads the metadata files (mostly log files) to Chromatic for quicker debugging and a better support experience.

Note: You can opt out of this behavior by setting `--upload-metadata=false` or `--no-upload-metadata`.

List of changes in this PR:

1. Writes debug logs to `LOG_FILE` despite what the UI is showing
2. Writes `LOG_FILE` in case we need to upload for debugging (unless opted out)
3. Moves the question of "do you want me to add a `chromatic` script to your `package.json` since it makes more sense to happen at the end rather than before file uploads

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>17.7.0--canary.1400.28114016138.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@17.7.0--canary.1400.28114016138.0
  # or 
  yarn add chromatic@17.7.0--canary.1400.28114016138.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
