### PR TITLE
Show full trace path to bail file reason

### DIFF
--- a/node-src/lib/turbosnap/getDependentStoryFiles.test.ts
+++ b/node-src/lib/turbosnap/getDependentStoryFiles.test.ts
@@ -597,9 +597,63 @@ describe('getDependentStoryFiles', () => {
     expect(ctx.turboSnap.bailReason).toEqual({
       changedStorybookFiles: ['path/to/storybook-config/file.js'],
     });
+    expect(ctx.turboSnap.bailPath).toEqual(['src/styles.js', 'path/to/storybook-config/file.js']);
     expect(ctx.log.warn).toHaveBeenCalledWith(
       expect.stringContaining(
         chalk`Found a Storybook config change in {bold path/to/storybook-config/file.js}`
+      )
+    );
+    expect(ctx.log.warn).toHaveBeenCalledWith(
+      expect.stringContaining(
+        chalk`This was triggered by a change to {bold src/styles.js}, which is imported by {bold path/to/storybook-config/file.js}`
+      )
+    );
+  });
+
+  it('traces the full import chain when a deeply nested dependency of a config file changes', async () => {
+    const changedFiles = ['src/theme.js'];
+    const modules = [
+      {
+        id: './src/theme.js',
+        name: './src/theme.js',
+        reasons: [{ moduleName: './src/tokens.js' }],
+      },
+      {
+        id: './src/tokens.js',
+        name: './src/tokens.js',
+        reasons: [{ moduleName: './path/to/storybook-config/preview.js' }],
+      },
+      {
+        id: './path/to/storybook-config/preview.js',
+        name: './path/to/storybook-config/preview.js',
+        reasons: [{ moduleName: './path/to/storybook-config/generated-stories-entry.js' }],
+      },
+      {
+        id: CSF_GLOB,
+        name: CSF_GLOB,
+        reasons: [{ moduleName: './path/to/storybook-config/generated-stories-entry.js' }],
+      },
+    ];
+    const ctx = getContext({ configDir: 'path/to/storybook-config' });
+    const result = await getDependentStoryFiles(ctx, { modules }, statsPath, changedFiles);
+    expect(result).toBeUndefined();
+    expect(ctx.turboSnap.bailReason).toEqual({
+      changedStorybookFiles: ['path/to/storybook-config/preview.js'],
+    });
+    expect(ctx.turboSnap.bailPath).toEqual([
+      'src/theme.js',
+      'src/tokens.js',
+      'path/to/storybook-config/preview.js',
+    ]);
+    expect(ctx.log.warn).toHaveBeenCalledWith(
+      expect.stringContaining(
+        chalk`This was triggered by a change to {bold src/theme.js}, which is imported by {bold path/to/storybook-config/preview.js}`
+      )
+    );
+    // The full import chain is rendered, including the intermediate file (src/tokens.js).
+    expect(ctx.log.warn).toHaveBeenCalledWith(
+      expect.stringContaining(
+        chalk`{dim →} {bold src/theme.js}\n{dim →} {bold src/tokens.js}\n{dim →} {bold path/to/storybook-config/preview.js}`
       )
     );
   });

--- a/node-src/lib/turbosnap/getDependentStoryFiles.ts
+++ b/node-src/lib/turbosnap/getDependentStoryFiles.ts
@@ -263,7 +263,15 @@ export async function getDependentStoryFiles(
     };
   }
 
-  function shouldBail(moduleName: string) {
+  // Build the chain of files leading from the originally changed file (as it appears in
+  // `git diff`) to the Storybook config or static file that triggered the bail. The trace
+  // path holds the module IDs visited on the way here.
+  function buildBailPath(moduleName: string, tracePath: string[]): string[] {
+    const tracedNames = tracePath.flatMap((moduleId) => namesById.get(moduleId) ?? []);
+    return [...tracedNames, moduleName];
+  }
+
+  function shouldBail(moduleName: string, tracePath: string[] = []) {
     if (!ctx.turboSnap) ctx.turboSnap = {};
 
     // Check staticDirs before the Storybook config dir so static assets
@@ -271,11 +279,13 @@ export async function getDependentStoryFiles(
     // inside a configured staticDir) aren't mis-categorized as config changes.
     if (isStaticFile(moduleName)) {
       ctx.turboSnap.bailReason = { changedStaticFiles: files(moduleName) };
+      ctx.turboSnap.bailPath = buildBailPath(moduleName, tracePath);
       return true;
     }
 
     if (isStorybookFile(moduleName)) {
       ctx.turboSnap.bailReason = { changedStorybookFiles: files(moduleName) };
+      ctx.turboSnap.bailPath = buildBailPath(moduleName, tracePath);
       return true;
     }
     return false;
@@ -285,12 +295,12 @@ export async function getDependentStoryFiles(
   // eslint-disable-next-line complexity
   function traceName(name: string, tracePath: string[] = []) {
     if (ctx.turboSnap?.bailReason || isCsfGlob(name)) return;
-    if (shouldBail(name)) return;
+    if (shouldBail(name, tracePath)) return;
     const { id } = modulesByName.get(name) || {};
     // eslint-disable-next-line unicorn/no-null
     const normalizedName = namesById.get(id || null);
     if (!normalizedName) return;
-    if (shouldBail(normalizedName)) return;
+    if (shouldBail(normalizedName, tracePath)) return;
 
     if (!id || !reasonsById.get(id) || checkedIds[id]) return;
     // Queue this id for tracing

--- a/node-src/types.ts
+++ b/node-src/types.ts
@@ -557,6 +557,9 @@ export interface TurboSnap {
   modules?: string[];
   tracedFiles?: string[];
   tracedPaths?: Set<string>;
+  // The chain of files from the changed file (as it appears in `git diff`) to the Storybook
+  // config or static file that triggered the bail.
+  bailPath?: string[];
   changedDependencyNames?: Set<string>;
   changedManifestFiles?: Set<string>;
   affectedModuleIds?: Set<string | number>;

--- a/node-src/ui/messages/warnings/bailFile.stories.ts
+++ b/node-src/ui/messages/warnings/bailFile.stories.ts
@@ -33,6 +33,14 @@ export const BailTwoFiles = () =>
     },
   });
 
+export const BailStorybookFileImportedDependency = () =>
+  bailFile({
+    turboSnap: {
+      bailReason: { changedStorybookFiles: ['.storybook/preview.js'] },
+      bailPath: ['src/theme.js', 'src/tokens.js', '.storybook/preview.js'],
+    },
+  });
+
 export const BailThreeFiles = () =>
   bailFile({
     turboSnap: {

--- a/node-src/ui/messages/warnings/bailFile.ts
+++ b/node-src/ui/messages/warnings/bailFile.ts
@@ -33,9 +33,19 @@ export default ({ turboSnap }: { turboSnap: Context['turboSnap'] }) => {
       .map((f) => chalk.bold(f))
       .join(chalk`\n{dim →} `)}`;
 
+  // When the changed file isn't the bailed file itself but something it imports (directly or
+  // indirectly), show the import chain so it's obvious which file in the `git diff` led here.
+  let trace = '';
+  const bailPath = turboSnap?.bailPath;
+  if (bailPath && bailPath.length > 1) {
+    const [origin] = bailPath;
+    const chain = bailPath.map((f) => chalk`{dim →} {bold ${f}}`).join('\n');
+    trace = chalk`\nThis was triggered by a change to {bold ${origin}}, which is imported by {bold ${firstFile}}:\n${chain}`;
+  }
+
   return dedent(chalk`
     ${warning} {bold TurboSnap disabled due to file change}
-    Found a ${type} change in {bold ${firstFile}}${siblings}
+    Found a ${type} change in {bold ${firstFile}}${siblings}${trace}
     A full build is required because this file cannot be linked to any specific stories.
     ${info} Read more at ${link(docsUrl)}
   `);


### PR DESCRIPTION
We log the list of all the found between the baseline and head commits during a build run. Later, we use that to determine the behavior of TurboSnap. When you hit an import of `preview.js`, we bail and say `preview.js` changed but it's not in the list of changed files.

This change shows the changed file path from changed file to the file reason we're bailing TurboSnap so it's clear how we arrived at that conclusion.

### Before

```
⚠ TurboSnap disabled due to file change
Found a Storybook config change in .storybook/preview.js
A full build is required because this file cannot be linked to any specific stories.
ℹ Read more at https://www.chromatic.com/docs/turbosnap#how-it-works
```

### After

```
⚠ TurboSnap disabled due to file change
Found a Storybook config change in .storybook/preview.js
This was triggered by a change to src/hello.js, which is imported by .storybook/preview.js:
→ src/hello.js
→ .storybook/preview.js
A full build is required because this file cannot be linked to any specific stories.
ℹ Read more at https://www.chromatic.com/docs/turbosnap#how-it-works
```

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>17.6.1--canary.1401.28114021428.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@17.6.1--canary.1401.28114021428.0
  # or 
  yarn add chromatic@17.6.1--canary.1401.28114021428.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
