### PR TITLE
Migrate `prepare` to Clack

### DIFF
--- a/node-src/index.ts
+++ b/node-src/index.ts
@@ -36,6 +36,7 @@ import { renderAuth } from './renderer/auth';
 import { renderBuild } from './renderer/build';
 import { renderGitInfo } from './renderer/gitInfo';
 import { renderInitialize } from './renderer/initialize';
+import { renderPrepare } from './renderer/prepare';
 import { renderStorybookInfo } from './renderer/storybookInfo';
 import getTasks from './tasks';
 import { Context, Flags, Options } from './types';
@@ -296,6 +297,7 @@ async function runBuild(ctx: Context) {
       await renderStorybookInfo(ctx);
       await renderInitialize(ctx);
       await renderBuild(ctx);
+      await renderPrepare(ctx);
       await new Listr(getTasks(ctx), options).run(ctx);
       ctx.log.debug('Tasks completed');
     } catch (err) {

--- a/node-src/renderer/prepare.ts
+++ b/node-src/renderer/prepare.ts
@@ -1,0 +1,26 @@
+import { applyPrepareOutput, extractPrepareInput, prepareProject } from '../tasks/prepare';
+import { Context } from '../types';
+import { initial, success, validating } from '../ui/tasks/prepare';
+import { runTask } from './engine';
+import { clackTaskLogRenderer } from './engine/clack/taskLogRenderer';
+import { getRenderer } from './engine/getRenderer';
+
+/**
+ * Render the prepare task.
+ *
+ * @param ctx The CLI context.
+ */
+export async function renderPrepare(ctx: Context): Promise<void> {
+  await runTask(
+    ctx,
+    {
+      name: 'prepare',
+      title: initial(ctx).title,
+      transitions: { pending: validating, success },
+      extractInput: extractPrepareInput,
+      run: prepareProject,
+      applyOutput: applyPrepareOutput,
+    },
+    getRenderer(ctx, clackTaskLogRenderer)
+  );
+}

--- a/node-src/renderer/prepare.ts
+++ b/node-src/renderer/prepare.ts
@@ -1,7 +1,7 @@
 import { applyPrepareOutput, extractPrepareInput, prepareProject } from '../tasks/prepare';
 import { Context } from '../types';
 import { initial, success, validating } from '../ui/tasks/prepare';
-import { runTask } from './engine';
+import { fallbackFailureState, runTask } from './engine';
 import { clackTaskLogRenderer } from './engine/clack/taskLogRenderer';
 import { getRenderer } from './engine/getRenderer';
 
@@ -16,7 +16,17 @@ export async function renderPrepare(ctx: Context): Promise<void> {
     {
       name: 'prepare',
       title: initial(ctx).title,
-      transitions: { pending: validating, success },
+      transitions: {
+        pending: validating,
+        success,
+        failure: (context: Context, error: Error) =>
+          fallbackFailureState(
+            context.isReactNativeApp
+              ? 'Prepare your built React Native Storybook'
+              : validating(context).title,
+            error
+          ),
+      },
       extractInput: extractPrepareInput,
       run: prepareProject,
       applyOutput: applyPrepareOutput,

--- a/node-src/share.ts
+++ b/node-src/share.ts
@@ -11,6 +11,7 @@ import NonTTYRenderer from './lib/nonTTYRenderer';
 import parseArguments from './lib/parseArguments';
 import { confirmShare, ConfirmShareStatus, reserveShare } from './lib/share';
 import { renderBuild } from './renderer/build';
+import { renderPrepare } from './renderer/prepare';
 import { runShare } from './tasks';
 import { Context, Options } from './types';
 import { endActivity } from './ui/components/activity';
@@ -161,6 +162,7 @@ async function runShareTasks(ctx: Context): Promise<void> {
 
   try {
     await renderBuild(ctx);
+    await renderPrepare(ctx);
     await new Listr(
       runShare.map((task) => task(ctx)),
       listrOptions

--- a/node-src/tasks/index.ts
+++ b/node-src/tasks/index.ts
@@ -1,7 +1,6 @@
 import Listr from 'listr';
 
 import { Context } from '../types';
-import prepare from './prepare';
 import prepareWorkspace from './prepareWorkspace';
 import report from './report';
 import restoreWorkspace from './restoreWorkspace';
@@ -10,9 +9,9 @@ import upload from './upload';
 import uploadShare from './uploadShare';
 import verify from './verify';
 
-export const runShare = [prepare, uploadShare];
+export const runShare = [uploadShare];
 
-export const runUploadBuild = [prepare, upload, verify, snapshot];
+export const runUploadBuild = [upload, verify, snapshot];
 
 export const runPatchBuild = [prepareWorkspace, ...runUploadBuild, restoreWorkspace];
 

--- a/node-src/tasks/prepare/calculateFileHashes.test.ts
+++ b/node-src/tasks/prepare/calculateFileHashes.test.ts
@@ -10,7 +10,6 @@ vi.mock('../../lib/getFileHashes', () => ({
 
 const environment = { CHROMATIC_RETRIES: 2, CHROMATIC_OUTPUT_INTERVAL: 0 };
 const log = new TestLogger();
-const http = { fetch: vi.fn() };
 
 afterEach(() => {
   vi.restoreAllMocks();
@@ -18,30 +17,33 @@ afterEach(() => {
 });
 
 describe('calculateFileHashes', () => {
-  it('sets hashes on context.fileInfo', async () => {
-    const fileInfo = {
-      lengths: [
-        { knownAs: 'iframe.html', contentLength: 42 },
-        { knownAs: 'index.html', contentLength: 42 },
-      ],
-      paths: ['iframe.html', 'index.html'],
-      total: 84,
-    };
-    const ctx = {
-      env: environment,
-      log,
-      http,
-      sourceDir: '/static/',
-      options: { fileHashing: true },
-      fileInfo,
-      announcedBuild: { id: '1' },
-    } as any;
+  const fileInfo = {
+    lengths: [
+      { knownAs: 'iframe.html', contentLength: 42 },
+      { knownAs: 'index.html', contentLength: 42 },
+    ],
+    paths: ['iframe.html', 'index.html'],
+    total: 84,
+  };
 
-    await calculateFileHashes(ctx, {} as any);
+  it('returns hashes for the file paths', async () => {
+    const { hashes } = await calculateFileHashes(
+      { log, env: environment, options: { fileHashing: true }, report: vi.fn() } as any,
+      { fileInfo: fileInfo as any, sourceDir: '/static/' }
+    );
 
-    expect(ctx.fileInfo.hashes).toMatchObject({
+    expect(hashes).toMatchObject({
       'iframe.html': 'hash',
       'index.html': 'hash',
     });
+  });
+
+  it('returns nothing when file hashing is disabled', async () => {
+    const { hashes } = await calculateFileHashes(
+      { log, env: environment, options: { fileHashing: false }, report: vi.fn() } as any,
+      { fileInfo: fileInfo as any, sourceDir: '/static/' }
+    );
+
+    expect(hashes).toBeUndefined();
   });
 });

--- a/node-src/tasks/prepare/calculateFileHashes.ts
+++ b/node-src/tasks/prepare/calculateFileHashes.ts
@@ -1,34 +1,47 @@
 import { getFileHashes } from '../../lib/getFileHashes';
-import { transitionTo } from '../../lib/tasks';
-import { Context, Task } from '../../types';
-import { hashing, invalid } from '../../ui/tasks/prepare';
+import { Context, Deps } from '../../types';
+import { hashing } from '../../ui/tasks/prepare';
+
+type CalculateFileHashesDeps = Pick<Deps, 'log' | 'options' | 'env' | 'report'>;
+
+export interface CalculateFileHashesInput {
+  fileInfo: NonNullable<Context['fileInfo']>;
+  sourceDir: string;
+}
+
+export interface CalculateFileHashesOutput {
+  hashes?: NonNullable<Context['fileInfo']>['hashes'];
+}
 
 /**
  * Calculates file hashes for all files to be uploaded.
  * File hashes are used for deduplication and integrity checking during upload.
- * Skips calculation if file hashing is disabled or the task is being skipped.
+ * Skips calculation if file hashing is disabled.
  *
- * @param ctx - The CLI context containing file info and options
- * @param task - The current Listr task for UI updates
+ * @param deps - Logger, options, environment and the mid-task reporter.
+ * @param input - The validated file info and source directory.
+ *
+ * @returns The calculated hashes, or none when hashing is disabled or fails.
  */
-export async function calculateFileHashes(ctx: Context, task: Task) {
-  if (ctx.skip || !ctx.options.fileHashing) return;
-  transitionTo(hashing)(ctx, task);
+export async function calculateFileHashes(
+  deps: CalculateFileHashesDeps,
+  input: CalculateFileHashesInput
+): Promise<CalculateFileHashesOutput> {
+  if (!deps.options.fileHashing) return {};
+  deps.report(hashing({ options: deps.options }));
 
   try {
-    if (!ctx.fileInfo) {
-      throw new Error(invalid(ctx).output);
-    }
-
     const start = Date.now();
-    ctx.fileInfo.hashes = await getFileHashes(
-      ctx.fileInfo.paths,
-      ctx.sourceDir,
-      ctx.env.CHROMATIC_HASH_CONCURRENCY
+    const hashes = await getFileHashes(
+      input.fileInfo.paths,
+      input.sourceDir,
+      deps.env.CHROMATIC_HASH_CONCURRENCY
     );
-    ctx.log.debug(`Calculated file hashes in ${Date.now() - start}ms`);
+    deps.log.debug(`Calculated file hashes in ${Date.now() - start}ms`);
+    return { hashes };
   } catch (err) {
-    ctx.log.warn('Failed to calculate file hashes');
-    ctx.log.debug(err);
+    deps.log.warn('Failed to calculate file hashes');
+    deps.log.debug(err);
+    return {};
   }
 }

--- a/node-src/tasks/prepare/index.ts
+++ b/node-src/tasks/prepare/index.ts
@@ -1,79 +1,72 @@
-import { createTask, transitionTo } from '../../lib/tasks';
-import { Context } from '../../types';
-import { initial, success, validating } from '../../ui/tasks/prepare';
+import { Context, Deps, TaskResult } from '../../types';
 import { calculateFileHashes } from './calculateFileHashes';
 import { traceChangedFiles } from './traceChangedFiles';
 import { validateAndroidArtifact } from './validateAndroidArtifact';
 import { validateFiles } from './validateFiles';
 
-/**
- * Sets up the Listr task for preparing the built storybook for upload to Chromatic.
- *
- * @param ctx The context set when executing the CLI.
- *
- * @returns A Listr task.
- */
-export default function main(ctx: Context) {
-  return createTask({
-    name: 'prepare',
-    title: initial(ctx).title,
-    skip: (ctx: Context) => {
-      return !!ctx.skip;
-    },
-    steps: [
-      transitionTo(validating),
-      async (ctx: Context) => {
-        const { fileInfo, sourceDir } = await validateFiles(
-          { log: ctx.log, options: ctx.options, packageJson: ctx.packageJson },
-          {
-            isReactNativeApp: !!ctx.isReactNativeApp,
-            sourceDir: ctx.sourceDir,
-            buildLogFile: ctx.buildLogFile,
-            browsers: ctx.announcedBuild?.browsers,
-          }
-        );
-        ctx.fileInfo = fileInfo;
-        ctx.sourceDir = sourceDir;
-      },
-      async (ctx: Context) => {
-        await validateAndroidArtifact({
-          sourceDir: ctx.sourceDir,
-          browsers: ctx.announcedBuild?.browsers,
-        });
-      },
-      async (ctx: Context) => {
-        const { onlyStoryFiles } = await traceChangedFiles(
-          { log: ctx.log, options: ctx.options, report: () => {} },
-          {
-            turboSnapContext: {
-              log: ctx.log,
-              options: ctx.options,
-              env: ctx.env,
-              storybook: ctx.storybook,
-              git: ctx.git,
-              turboSnap: ctx.turboSnap,
-              fileInfo: ctx.fileInfo,
-              untracedFiles: ctx.untracedFiles,
-            },
-          }
-        );
-        if (onlyStoryFiles) {
-          ctx.onlyStoryFiles = onlyStoryFiles;
-        }
-      },
-      async (ctx: Context) => {
-        if (!ctx.fileInfo) {
-          return;
-        }
-        const { hashes } = await calculateFileHashes(
-          { log: ctx.log, options: ctx.options, env: ctx.env, report: () => {} },
-          { fileInfo: ctx.fileInfo, sourceDir: ctx.sourceDir }
-        );
-        if (hashes) {
-          ctx.fileInfo.hashes = hashes;
-        }
-      },
-      transitionTo(success, true),
-    ],
-  });
+export interface PrepareInput {
+  isReactNativeApp: boolean;
+  sourceDir: string;
+  buildLogFile?: string;
+  browsers?: string[];
+  // Context threaded for the still-ctx-coupled TurboSnap subsystem (see traceChangedFiles).
+  turboSnapContext: Context;
 }
+
+export interface PrepareOutput {
+  fileInfo: NonNullable<Context['fileInfo']>;
+  sourceDir: string;
+  onlyStoryFiles?: string[];
+}
+
+/**
+ * Validate the built Storybook (or E2E/React Native) artifacts, trace which specs are affected by
+ * recent changes via TurboSnap, and hash the files for deduplicated upload.
+ *
+ * @param deps Narrow set of cross-cutting dependencies the task needs.
+ * @param input Per-pipeline-run input extracted from Context at the seam.
+ *
+ * @returns A TaskResult conveying the validated file info, source directory and affected specs.
+ */
+export async function prepareProject(
+  deps: Deps,
+  input: PrepareInput
+): Promise<TaskResult<PrepareOutput>> {
+  const { fileInfo, sourceDir } = await validateFiles(deps, {
+    isReactNativeApp: input.isReactNativeApp,
+    sourceDir: input.sourceDir,
+    buildLogFile: input.buildLogFile,
+    browsers: input.browsers,
+  });
+
+  await validateAndroidArtifact({ sourceDir, browsers: input.browsers });
+
+  // TurboSnap reads the freshly-validated stats file; validateFiles may have corrected the directory.
+  input.turboSnapContext.fileInfo = fileInfo;
+  const { onlyStoryFiles } = await traceChangedFiles(deps, {
+    turboSnapContext: input.turboSnapContext,
+  });
+
+  const { hashes } = await calculateFileHashes(deps, { fileInfo, sourceDir });
+  if (hashes) {
+    fileInfo.hashes = hashes;
+  }
+
+  return { kind: 'continue', output: { fileInfo, sourceDir, onlyStoryFiles } };
+}
+
+export const extractPrepareInput = (ctx: Context): PrepareInput => ({
+  isReactNativeApp: !!ctx.isReactNativeApp,
+  sourceDir: ctx.sourceDir,
+  buildLogFile: ctx.buildLogFile,
+  browsers: ctx.announcedBuild?.browsers,
+  turboSnapContext: ctx,
+});
+
+export const applyPrepareOutput = (ctx: Context, output: PrepareOutput) => {
+  ctx.fileInfo = output.fileInfo;
+  ctx.sourceDir = output.sourceDir;
+  if (output.onlyStoryFiles) {
+    ctx.onlyStoryFiles = output.onlyStoryFiles;
+  }
+};

--- a/node-src/tasks/prepare/index.ts
+++ b/node-src/tasks/prepare/index.ts
@@ -41,7 +41,26 @@ export default function main(ctx: Context) {
           browsers: ctx.announcedBuild?.browsers,
         });
       },
-      traceChangedFiles,
+      async (ctx: Context) => {
+        const { onlyStoryFiles } = await traceChangedFiles(
+          { log: ctx.log, options: ctx.options, report: () => {} },
+          {
+            turboSnapContext: {
+              log: ctx.log,
+              options: ctx.options,
+              env: ctx.env,
+              storybook: ctx.storybook,
+              git: ctx.git,
+              turboSnap: ctx.turboSnap,
+              fileInfo: ctx.fileInfo,
+              untracedFiles: ctx.untracedFiles,
+            },
+          }
+        );
+        if (onlyStoryFiles) {
+          ctx.onlyStoryFiles = onlyStoryFiles;
+        }
+      },
       calculateFileHashes,
       transitionTo(success, true),
     ],

--- a/node-src/tasks/prepare/index.ts
+++ b/node-src/tasks/prepare/index.ts
@@ -22,7 +22,19 @@ export default function main(ctx: Context) {
     },
     steps: [
       transitionTo(validating),
-      validateFiles,
+      async (ctx: Context) => {
+        const { fileInfo, sourceDir } = await validateFiles(
+          { log: ctx.log, options: ctx.options, packageJson: ctx.packageJson },
+          {
+            isReactNativeApp: !!ctx.isReactNativeApp,
+            sourceDir: ctx.sourceDir,
+            buildLogFile: ctx.buildLogFile,
+            browsers: ctx.announcedBuild?.browsers,
+          }
+        );
+        ctx.fileInfo = fileInfo;
+        ctx.sourceDir = sourceDir;
+      },
       validateAndroidArtifact,
       traceChangedFiles,
       calculateFileHashes,

--- a/node-src/tasks/prepare/index.ts
+++ b/node-src/tasks/prepare/index.ts
@@ -61,7 +61,18 @@ export default function main(ctx: Context) {
           ctx.onlyStoryFiles = onlyStoryFiles;
         }
       },
-      calculateFileHashes,
+      async (ctx: Context) => {
+        if (!ctx.fileInfo) {
+          return;
+        }
+        const { hashes } = await calculateFileHashes(
+          { log: ctx.log, options: ctx.options, env: ctx.env, report: () => {} },
+          { fileInfo: ctx.fileInfo, sourceDir: ctx.sourceDir }
+        );
+        if (hashes) {
+          ctx.fileInfo.hashes = hashes;
+        }
+      },
       transitionTo(success, true),
     ],
   });

--- a/node-src/tasks/prepare/index.ts
+++ b/node-src/tasks/prepare/index.ts
@@ -35,7 +35,12 @@ export default function main(ctx: Context) {
         ctx.fileInfo = fileInfo;
         ctx.sourceDir = sourceDir;
       },
-      validateAndroidArtifact,
+      async (ctx: Context) => {
+        await validateAndroidArtifact({
+          sourceDir: ctx.sourceDir,
+          browsers: ctx.announcedBuild?.browsers,
+        });
+      },
       traceChangedFiles,
       calculateFileHashes,
       transitionTo(success, true),

--- a/node-src/tasks/prepare/traceChangedFiles.test.ts
+++ b/node-src/tasks/prepare/traceChangedFiles.test.ts
@@ -24,7 +24,18 @@ const accessMock = vi.mocked(access);
 
 const environment = { CHROMATIC_RETRIES: 2, CHROMATIC_OUTPUT_INTERVAL: 0 };
 const log = new TestLogger();
-const http = { fetch: vi.fn() };
+
+const deps = () => ({ log, options: {}, report: vi.fn() }) as any;
+
+const turboSnapContext = () =>
+  ({
+    env: environment,
+    log,
+    options: {},
+    fileInfo: { statsPath: '/static/preview-stats.json' },
+    git: { changedFiles: ['./example.js'] },
+    turboSnap: {},
+  }) as any;
 
 afterEach(() => {
   vi.restoreAllMocks();
@@ -36,27 +47,17 @@ describe('traceChangedFiles', () => {
     accessMock.mockImplementation((_path, callback) => Promise.resolve(callback(null)));
   });
 
-  it('sets onlyStoryFiles on context', async () => {
-    const deps = { 123: ['./example.stories.js'] };
-    traceChangedFilesTurbosnap.mockResolvedValue(deps);
+  it('returns onlyStoryFiles', async () => {
+    const traced = { 123: ['./example.stories.js'] };
+    traceChangedFilesTurbosnap.mockResolvedValue(traced);
 
-    const ctx = {
-      env: environment,
-      log,
-      http,
-      options: {},
-      sourceDir: '/static/',
-      fileInfo: { statsPath: '/static/preview-stats.json' },
-      git: { changedFiles: ['./example.js'] },
-      turboSnap: {},
-    } as any;
-    await traceChangedFiles(ctx, {} as any);
+    const result = await traceChangedFiles(deps(), { turboSnapContext: turboSnapContext() });
 
-    expect(ctx.onlyStoryFiles).toStrictEqual(Object.keys(deps));
+    expect(result.onlyStoryFiles).toStrictEqual(Object.keys(traced));
   });
 
-  it('escapes special characters on context', async () => {
-    const deps = {
+  it('escapes special characters', async () => {
+    const traced = {
       './$example-new.stories.js': ['./$example-new.stories.js'],
       './+example-new.stories.js': ['./+example-new.stories.js'],
       './example-(new).stories.js': ['./example-(new).stories.js'],
@@ -65,21 +66,11 @@ describe('traceChangedFiles', () => {
         '[./example/[account]/[id]/[unit]/language/example.stories.tsx]',
       ],
     };
-    traceChangedFilesTurbosnap.mockResolvedValue(deps);
+    traceChangedFilesTurbosnap.mockResolvedValue(traced);
 
-    const ctx = {
-      env: environment,
-      log,
-      http,
-      options: {},
-      sourceDir: '/static/',
-      fileInfo: { statsPath: '/static/preview-stats.json' },
-      git: { changedFiles: ['./example.js'] },
-      turboSnap: {},
-    } as any;
-    await traceChangedFiles(ctx, {} as any);
+    const result = await traceChangedFiles(deps(), { turboSnapContext: turboSnapContext() });
 
-    expect(ctx.onlyStoryFiles).toStrictEqual([
+    expect(result.onlyStoryFiles).toStrictEqual([
       String.raw`./\$example-new.stories.js`,
       String.raw`./\+example-new.stories.js`,
       String.raw`./example-\(new\).stories.js`,

--- a/node-src/tasks/prepare/traceChangedFiles.ts
+++ b/node-src/tasks/prepare/traceChangedFiles.ts
@@ -1,9 +1,8 @@
 import * as turbosnap from '@cli/turbosnap';
 import semver from 'semver';
 
-import { transitionTo } from '../../lib/tasks';
 import { rewriteErrorMessage } from '../../lib/utilities';
-import { Context, Task } from '../../types';
+import { Context, Deps } from '../../types';
 import missingStatsFile from '../../ui/messages/errors/missingStatsFile';
 import { bailed, traced, tracing } from '../../ui/tasks/prepare';
 
@@ -11,20 +10,40 @@ import { bailed, traced, tracing } from '../../ui/tasks/prepare';
 // because they are used as special characters in picomatch
 const SPECIAL_CHARS_REGEXP = /([$()*+?[\]^])/g;
 
+type TraceChangedFilesDeps = Pick<Deps, 'log' | 'options' | 'report'>;
+
+export interface TraceChangedFilesInput {
+  // The TurboSnap lib still reads and mutates `Context` directly. This is a deliberate escape hatch,
+  // as refactoring the whole `lib/turbosnap` tree to `(deps, input)` is a large lift. We should
+  // revisit it, but for now `lib/turbosnap.traceChangedFiles` still takes a Context.
+  turboSnapContext: Context;
+}
+
+export interface TraceChangedFilesOutput {
+  onlyStoryFiles?: string[];
+}
+
 /**
  * Traces which story files are affected by recent changes using TurboSnap.
  * Analyzes changed files to determine which stories need to be tested.
  *
- * @param ctx - The CLI context containing git info and TurboSnap configuration
- * @param task - The current Listr task for UI updates
+ * @param deps - Logger, options and the mid-task reporter.
+ * @param input - The CLI context the TurboSnap lib reads and mutates.
+ *
+ * @returns The affected story files, or none when TurboSnap is unavailable or bailed.
  *
  * @throws {Error} if stats file is missing or tracing fails
  */
 // TODO: refactor this function
 // eslint-disable-next-line complexity
-export async function traceChangedFiles(ctx: Context, task: Task) {
-  if (!ctx.turboSnap || ctx.turboSnap.unavailable) return;
-  if (!ctx.git.changedFiles) return;
+export async function traceChangedFiles(
+  deps: TraceChangedFilesDeps,
+  input: TraceChangedFilesInput
+): Promise<TraceChangedFilesOutput> {
+  const ctx = input.turboSnapContext;
+
+  if (!ctx.turboSnap || ctx.turboSnap.unavailable) return {};
+  if (!ctx.git.changedFiles) return {};
   if (!ctx.fileInfo?.statsPath) {
     // If we don't know the SB version, we should assume we don't support `--stats-json`
     const nonLegacyStatsSupported =
@@ -35,7 +54,7 @@ export async function traceChangedFiles(ctx: Context, task: Task) {
     throw new Error(missingStatsFile({ legacy: !nonLegacyStatsSupported }));
   }
 
-  transitionTo(tracing)(ctx, task);
+  deps.report(tracing({ git: ctx.git, options: deps.options }));
 
   const { statsPath } = ctx.fileInfo;
   const { changedFiles } = ctx.git;
@@ -44,33 +63,35 @@ export async function traceChangedFiles(ctx: Context, task: Task) {
     const onlyStoryFiles = await turbosnap.traceChangedFiles(ctx);
     if (onlyStoryFiles) {
       // Escape special characters in the filename so it does not conflict with picomatch
-      ctx.onlyStoryFiles = Object.keys(onlyStoryFiles).map((key) =>
+      const escaped = Object.keys(onlyStoryFiles).map((key) =>
         key.replaceAll(SPECIAL_CHARS_REGEXP, String.raw`\$1`)
       );
 
-      if (!ctx.options.interactive) {
-        if (!ctx.options.traceChanged) {
-          ctx.log.info(
+      if (!deps.options.interactive) {
+        if (!deps.options.traceChanged) {
+          deps.log.info(
             `Found affected story files:\n${Object.entries(onlyStoryFiles)
               .flatMap(([id, files]) => files.map((f) => `  ${f} [${id}]`))
               .join('\n')}`
           );
         }
         if (ctx.untracedFiles && ctx.untracedFiles.length > 0) {
-          ctx.log.info(
+          deps.log.info(
             `Encountered ${ctx.untracedFiles.length} untraced files:\n${ctx.untracedFiles
               .map((f) => `  ${f}`)
               .join('\n')}`
           );
         }
       }
-      transitionTo(traced)(ctx, task);
-    } else {
-      transitionTo(bailed)(ctx, task);
+      deps.report(traced({ options: deps.options, onlyStoryFiles: escaped }));
+      return { onlyStoryFiles: escaped };
     }
+
+    deps.report(bailed({ turboSnap: ctx.turboSnap }));
+    return {};
   } catch (err) {
-    if (!ctx.options.interactive) {
-      ctx.log.info('Failed to retrieve dependent story files', { statsPath, changedFiles, err });
+    if (!deps.options.interactive) {
+      deps.log.info('Failed to retrieve dependent story files', { statsPath, changedFiles, err });
     }
     throw rewriteErrorMessage(err, `Could not retrieve dependent story files.\n${err.message}`);
   }

--- a/node-src/tasks/prepare/validateAndroidArtifact.test.ts
+++ b/node-src/tasks/prepare/validateAndroidArtifact.test.ts
@@ -1,30 +1,18 @@
 import AdmZip from 'adm-zip';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import TestLogger from '../../lib/testLogger';
 import { validateAndroidArtifact } from './validateAndroidArtifact';
 
 vi.mock('adm-zip', () => ({ default: vi.fn() }));
 
 const AdmZipMock = vi.mocked(AdmZip);
 
-const environment = { CHROMATIC_RETRIES: 2, CHROMATIC_OUTPUT_INTERVAL: 0 };
-const log = new TestLogger();
-const http = { fetch: vi.fn() };
-
 afterEach(() => {
   vi.restoreAllMocks();
   vi.resetAllMocks();
 });
 
-const makeContext = (browsers: string[]) =>
-  ({
-    env: environment,
-    log,
-    http,
-    sourceDir: '/static/',
-    announcedBuild: { browsers },
-  }) as any;
+const input = (browsers: string[]) => ({ sourceDir: '/static/', browsers });
 
 const mockEntries = (entryNames: string[]) => {
   const entries = entryNames.map((entryName) => ({ entryName }));
@@ -35,36 +23,35 @@ const mockEntries = (entryNames: string[]) => {
 
 describe('validateAndroidArtifact', () => {
   it('skips when android is not in browsers', async () => {
-    const ctx = makeContext(['ios']);
-    await expect(validateAndroidArtifact(ctx)).resolves.toBeUndefined();
+    await expect(validateAndroidArtifact(input(['ios']))).resolves.toBeUndefined();
     expect(AdmZipMock).not.toHaveBeenCalled();
   });
 
   it('passes when APK has no lib/ entries', async () => {
     mockEntries(['AndroidManifest.xml', 'classes.dex']);
-    await expect(validateAndroidArtifact(makeContext(['android']))).resolves.toBeUndefined();
+    await expect(validateAndroidArtifact(input(['android']))).resolves.toBeUndefined();
   });
 
   it('passes when APK has only lib/x86_64/ entries', async () => {
     mockEntries(['lib/x86_64/libnative.so']);
-    await expect(validateAndroidArtifact(makeContext(['android']))).resolves.toBeUndefined();
+    await expect(validateAndroidArtifact(input(['android']))).resolves.toBeUndefined();
   });
 
   it('passes when APK has lib/x86_64/ alongside other ABIs', async () => {
     mockEntries(['lib/x86_64/libnative.so', 'lib/arm64-v8a/libnative.so']);
-    await expect(validateAndroidArtifact(makeContext(['android']))).resolves.toBeUndefined();
+    await expect(validateAndroidArtifact(input(['android']))).resolves.toBeUndefined();
   });
 
   it('throws when APK has only ARM ABI entries', async () => {
     mockEntries(['lib/armeabi-v7a/libnative.so']);
-    await expect(validateAndroidArtifact(makeContext(['android']))).rejects.toThrow(
+    await expect(validateAndroidArtifact(input(['android']))).rejects.toThrow(
       'Your storybook.apk contains native libraries but does not include x86_64 support. Chromatic only supports x86_64.'
     );
   });
 
   it('throws when APK has multiple ARM ABIs but no x86_64', async () => {
     mockEntries(['lib/armeabi-v7a/libnative.so', 'lib/arm64-v8a/libnative.so']);
-    await expect(validateAndroidArtifact(makeContext(['android']))).rejects.toThrow(
+    await expect(validateAndroidArtifact(input(['android']))).rejects.toThrow(
       'Your storybook.apk contains native libraries but does not include x86_64 support. Chromatic only supports x86_64.'
     );
   });

--- a/node-src/tasks/prepare/validateAndroidArtifact.ts
+++ b/node-src/tasks/prepare/validateAndroidArtifact.ts
@@ -1,21 +1,25 @@
 import AdmZip from 'adm-zip';
 import path from 'path';
 
-import { Context } from '../../types';
 import { invalidAndroidArtifact } from '../../ui/tasks/prepare';
+
+export interface ValidateAndroidArtifactInput {
+  sourceDir: string;
+  browsers?: string[];
+}
 
 /**
  * Validates that the Android APK artifact contains x86_64 native libraries if it contains
  * any native libraries at all. Chromatic only supports x86_64 Android emulators.
  *
- * @param ctx - The CLI context containing source directory and build info
+ * @param input - The source directory and the build's enabled browsers.
  *
  * @throws {Error} if the APK contains native libraries without x86_64 support
  */
-export async function validateAndroidArtifact(ctx: Context) {
-  if (!ctx.announcedBuild?.browsers?.includes('android')) return;
+export async function validateAndroidArtifact(input: ValidateAndroidArtifactInput) {
+  if (!input.browsers?.includes('android')) return;
 
-  const apkPath = path.join(ctx.sourceDir, 'storybook.apk');
+  const apkPath = path.join(input.sourceDir, 'storybook.apk');
   const zip = new AdmZip(apkPath);
   const entries = zip.getEntries();
 
@@ -28,6 +32,6 @@ export async function validateAndroidArtifact(ctx: Context) {
   }
 
   if (abiDirectories.size > 0 && !abiDirectories.has('x86_64')) {
-    throw new Error(invalidAndroidArtifact(ctx).output);
+    throw new Error(invalidAndroidArtifact().output);
   }
 }

--- a/node-src/tasks/prepare/validateFiles.test.ts
+++ b/node-src/tasks/prepare/validateFiles.test.ts
@@ -10,9 +10,9 @@ const readdirSyncMock = vi.mocked(readdirSync);
 const readFileSyncMock = vi.mocked(readFileSync);
 const statSyncMock = vi.mocked(statSync);
 
-const environment = { CHROMATIC_RETRIES: 2, CHROMATIC_OUTPUT_INTERVAL: 0 };
 const log = new TestLogger();
-const http = { fetch: vi.fn() };
+
+const deps = () => ({ log, options: {}, packageJson: {} }) as any;
 
 afterEach(() => {
   vi.restoreAllMocks();
@@ -20,14 +20,16 @@ afterEach(() => {
 });
 
 describe('validateFiles', () => {
-  it('sets fileInfo on context', async () => {
+  it('returns fileInfo for a valid Storybook build', async () => {
     readdirSyncMock.mockReturnValue(['iframe.html', 'index.html'] as any);
     statSyncMock.mockReturnValue({ isDirectory: () => false, size: 42 } as any);
 
-    const ctx = { env: environment, log, http, sourceDir: '/static/' } as any;
-    await validateFiles(ctx);
+    const { fileInfo } = await validateFiles(deps(), {
+      isReactNativeApp: false,
+      sourceDir: '/static/',
+    });
 
-    expect(ctx.fileInfo).toEqual(
+    expect(fileInfo).toEqual(
       expect.objectContaining({
         lengths: [
           { contentLength: 42, knownAs: 'iframe.html', pathname: 'iframe.html' },
@@ -43,16 +45,18 @@ describe('validateFiles', () => {
     readdirSyncMock.mockReturnValue(['iframe.html'] as any);
     statSyncMock.mockReturnValue({ isDirectory: () => false, size: 42 } as any);
 
-    const ctx = { env: environment, log, http, options: {}, sourceDir: '/static/' } as any;
-    await expect(validateFiles(ctx)).rejects.toThrow('Invalid Storybook build at /static/');
+    await expect(
+      validateFiles(deps(), { isReactNativeApp: false, sourceDir: '/static/' })
+    ).rejects.toThrow('Invalid Storybook build at /static/');
   });
 
   it("throws when iframe.html doesn't exist", async () => {
     readdirSyncMock.mockReturnValue(['index.html'] as any);
     statSyncMock.mockReturnValue({ isDirectory: () => false, size: 42 } as any);
 
-    const ctx = { env: environment, log, http, options: {}, sourceDir: '/static/' } as any;
-    await expect(validateFiles(ctx)).rejects.toThrow('Invalid Storybook build at /static/');
+    await expect(
+      validateFiles(deps(), { isReactNativeApp: false, sourceDir: '/static/' })
+    ).rejects.toThrow('Invalid Storybook build at /static/');
   });
 
   it('does not include the .chromatic directory in the file list', async () => {
@@ -69,10 +73,12 @@ describe('validateFiles', () => {
       return { isDirectory: () => false, size: 42 } as any;
     });
 
-    const ctx = { env: environment, log, http, sourceDir: '.' } as any;
-    await validateFiles(ctx);
+    const { fileInfo } = await validateFiles(deps(), {
+      isReactNativeApp: false,
+      sourceDir: '.',
+    });
 
-    expect(ctx.fileInfo).toEqual(
+    expect(fileInfo).toEqual(
       expect.objectContaining({
         lengths: [
           { contentLength: 42, knownAs: 'iframe.html', pathname: 'iframe.html' },
@@ -91,20 +97,15 @@ describe('validateFiles', () => {
       statSyncMock.mockReturnValue({ isDirectory: () => false, size: 42 } as any);
       readFileSyncMock.mockReturnValue('info => Output directory: /var/storybook-static');
 
-      const ctx = {
-        env: environment,
-        log,
-        http,
+      const { fileInfo, sourceDir } = await validateFiles(deps(), {
+        isReactNativeApp: false,
         sourceDir: '/static/',
         buildLogFile: 'build-storybook.log',
-        options: {},
-        packageJson: {},
-      } as any;
-      await validateFiles(ctx);
+      });
 
       expect(log.warn).toHaveBeenCalledWith(expect.stringContaining('Unexpected build directory'));
-      expect(ctx.sourceDir).toBe('/var/storybook-static');
-      expect(ctx.fileInfo).toEqual(
+      expect(sourceDir).toBe('/var/storybook-static');
+      expect(fileInfo).toEqual(
         expect.objectContaining({
           lengths: [
             { contentLength: 42, knownAs: 'iframe.html', pathname: 'iframe.html' },
@@ -120,26 +121,21 @@ describe('validateFiles', () => {
       readdirSyncMock.mockReturnValueOnce([]);
       readdirSyncMock.mockReturnValueOnce(['iframe.html', 'index.html'] as any);
       statSyncMock.mockReturnValue({ isDirectory: () => false, size: 42 } as any);
-      readFileSyncMock.mockReturnValue(`\u001B[32m◇\u001B[39m  Output directory:
-\u001B[90m│\u001B[39m  /var/storybook-static
-\u001B[90m│\u001B[39m
-\u001B[90m└\u001B[39m  Storybook build completed successfully
+      readFileSyncMock.mockReturnValue(`[32m◇[39m  Output directory:
+[90m│[39m  /var/storybook-static
+[90m│[39m
+[90m└[39m  Storybook build completed successfully
 `);
 
-      const ctx = {
-        env: environment,
-        log,
-        http,
+      const { fileInfo, sourceDir } = await validateFiles(deps(), {
+        isReactNativeApp: false,
         sourceDir: '/static/',
         buildLogFile: 'build-storybook.log',
-        options: {},
-        packageJson: {},
-      } as any;
-      await validateFiles(ctx);
+      });
 
       expect(log.warn).toHaveBeenCalledWith(expect.stringContaining('Unexpected build directory'));
-      expect(ctx.sourceDir).toBe('/var/storybook-static');
-      expect(ctx.fileInfo).toEqual(
+      expect(sourceDir).toBe('/var/storybook-static');
+      expect(fileInfo).toEqual(
         expect.objectContaining({
           lengths: [
             { contentLength: 42, knownAs: 'iframe.html', pathname: 'iframe.html' },
@@ -161,36 +157,27 @@ describe('validateFiles', () => {
       ] as any);
       statSyncMock.mockReturnValue({ isDirectory: () => false, size: 42 } as any);
 
-      const ctx = {
-        env: environment,
-        log,
-        http,
-        options: {},
-        sourceDir: '/static/',
-        isReactNativeApp: true,
-        announcedBuild: { browsers: [] },
-      } as any;
-      await expect(validateFiles(ctx)).rejects.toThrow(
-        'Invalid React Native Storybook build in directory /static'
-      );
+      await expect(
+        validateFiles(deps(), {
+          isReactNativeApp: true,
+          sourceDir: '/static/',
+          browsers: [],
+        })
+      ).rejects.toThrow('Invalid React Native Storybook build in directory /static');
     });
 
     describe('Android devices', () => {
-      it('sets fileInfo on context with valid React Native build', async () => {
+      it('returns fileInfo for a valid React Native build', async () => {
         readdirSyncMock.mockReturnValue(['storybook.apk', 'manifest.json'] as any);
         statSyncMock.mockReturnValue({ isDirectory: () => false, size: 42 } as any);
 
-        const ctx = {
-          env: environment,
-          log,
-          http,
-          sourceDir: '/static/',
+        const { fileInfo } = await validateFiles(deps(), {
           isReactNativeApp: true,
-          announcedBuild: { browsers: ['android'] },
-        } as any;
-        await validateFiles(ctx);
+          sourceDir: '/static/',
+          browsers: ['android'],
+        });
 
-        expect(ctx.fileInfo).toEqual(
+        expect(fileInfo).toEqual(
           expect.objectContaining({
             lengths: [
               { contentLength: 42, knownAs: 'storybook.apk', pathname: 'storybook.apk' },
@@ -206,16 +193,13 @@ describe('validateFiles', () => {
         readdirSyncMock.mockReturnValue(['storybook.apk'] as any);
         statSyncMock.mockReturnValue({ isDirectory: () => false, size: 42 } as any);
 
-        const ctx = {
-          env: environment,
-          log,
-          http,
-          options: {},
-          sourceDir: '/static/',
-          isReactNativeApp: true,
-          announcedBuild: { browsers: ['android'] },
-        } as any;
-        await expect(validateFiles(ctx)).rejects.toThrow(
+        await expect(
+          validateFiles(deps(), {
+            isReactNativeApp: true,
+            sourceDir: '/static/',
+            browsers: ['android'],
+          })
+        ).rejects.toThrow(
           `Missing files:
   → manifest.json
 
@@ -227,16 +211,13 @@ Invalid React Native Storybook build in directory /static`
         readdirSyncMock.mockReturnValue(['manifest.json'] as any);
         statSyncMock.mockReturnValue({ isDirectory: () => false, size: 42 } as any);
 
-        const ctx = {
-          env: environment,
-          log,
-          http,
-          options: {},
-          sourceDir: '/static/',
-          isReactNativeApp: true,
-          announcedBuild: { browsers: ['android'] },
-        } as any;
-        await expect(validateFiles(ctx)).rejects.toThrow(
+        await expect(
+          validateFiles(deps(), {
+            isReactNativeApp: true,
+            sourceDir: '/static/',
+            browsers: ['android'],
+          })
+        ).rejects.toThrow(
           `→ This build is missing the storybook.apk file required for React Native Storybook for Android.
   Please ensure that the file is present in the output directory and named correctly before running the CLI.
 
@@ -246,21 +227,17 @@ Invalid React Native Storybook build in directory /static`
     });
 
     describe('iOS devices', () => {
-      it('sets fileInfo on context with valid React Native build', async () => {
+      it('returns fileInfo for a valid React Native build', async () => {
         readdirSyncMock.mockReturnValue(['storybook.app/modules.json', 'manifest.json'] as any);
         statSyncMock.mockReturnValue({ isDirectory: () => false, size: 42 } as any);
 
-        const ctx = {
-          env: environment,
-          log,
-          http,
-          sourceDir: '/static/',
+        const { fileInfo } = await validateFiles(deps(), {
           isReactNativeApp: true,
-          announcedBuild: { browsers: ['ios'] },
-        } as any;
-        await validateFiles(ctx);
+          sourceDir: '/static/',
+          browsers: ['ios'],
+        });
 
-        expect(ctx.fileInfo).toEqual(
+        expect(fileInfo).toEqual(
           expect.objectContaining({
             lengths: [
               {
@@ -280,16 +257,13 @@ Invalid React Native Storybook build in directory /static`
         readdirSyncMock.mockReturnValue(['storybook.app/modules.json'] as any);
         statSyncMock.mockReturnValue({ isDirectory: () => false, size: 42 } as any);
 
-        const ctx = {
-          env: environment,
-          log,
-          http,
-          options: {},
-          sourceDir: '/static/',
-          isReactNativeApp: true,
-          announcedBuild: { browsers: ['ios'] },
-        } as any;
-        await expect(validateFiles(ctx)).rejects.toThrow(
+        await expect(
+          validateFiles(deps(), {
+            isReactNativeApp: true,
+            sourceDir: '/static/',
+            browsers: ['ios'],
+          })
+        ).rejects.toThrow(
           `Missing files:
   → manifest.json
 
@@ -301,16 +275,13 @@ Invalid React Native Storybook build in directory /static`
         readdirSyncMock.mockReturnValue(['manifest.json'] as any);
         statSyncMock.mockReturnValue({ isDirectory: () => false, size: 42 } as any);
 
-        const ctx = {
-          env: environment,
-          log,
-          http,
-          options: {},
-          sourceDir: '/static/',
-          isReactNativeApp: true,
-          announcedBuild: { browsers: ['ios'] },
-        } as any;
-        await expect(validateFiles(ctx)).rejects.toThrow(
+        await expect(
+          validateFiles(deps(), {
+            isReactNativeApp: true,
+            sourceDir: '/static/',
+            browsers: ['ios'],
+          })
+        ).rejects.toThrow(
           `→ This build is missing the storybook.app file required for React Native Storybook for iOS.
   Please ensure that the file is present in the output directory and named correctly before running the CLI.
 
@@ -324,16 +295,13 @@ Invalid React Native Storybook build in directory /static`
         readdirSyncMock.mockReturnValue(['manifest.json'] as any);
         statSyncMock.mockReturnValue({ isDirectory: () => false, size: 42 } as any);
 
-        const ctx = {
-          env: environment,
-          log,
-          http,
-          options: {},
-          sourceDir: '/static/',
-          isReactNativeApp: true,
-          announcedBuild: { browsers: ['android', 'ios'] },
-        } as any;
-        await expect(validateFiles(ctx)).rejects.toThrow(
+        await expect(
+          validateFiles(deps(), {
+            isReactNativeApp: true,
+            sourceDir: '/static/',
+            browsers: ['android', 'ios'],
+          })
+        ).rejects.toThrow(
           `→ This build is missing the storybook.app (iOS) and storybook.apk (Android) files required for React Native Storybook.
   Please ensure that the files are present in the output directory and named correctly before running the CLI.
 

--- a/node-src/tasks/prepare/validateFiles.ts
+++ b/node-src/tasks/prepare/validateFiles.ts
@@ -3,9 +3,23 @@ import path from 'path';
 import { stripVTControlCharacters } from 'util';
 
 import { posix } from '../../lib/posix';
-import { Context } from '../../types';
+import { Context, Deps } from '../../types';
 import deviatingOutputDirectory from '../../ui/messages/warnings/deviatingOutputDirectory';
 import { invalid, invalidReactNative } from '../../ui/tasks/prepare';
+
+type ValidateFilesDeps = Pick<Deps, 'log' | 'options' | 'packageJson'>;
+
+export interface ValidateFilesInput {
+  isReactNativeApp: boolean;
+  sourceDir: string;
+  buildLogFile?: string;
+  browsers?: string[];
+}
+
+export interface ValidateFilesOutput {
+  fileInfo: NonNullable<Context['fileInfo']>;
+  sourceDir: string;
+}
 
 /**
  * Represents a file path specification with its content length.
@@ -21,13 +35,19 @@ interface PathSpec {
  * paths will be like iframe.html rather than storybook-static/iframe.html).
  * Excludes the .chromatic directory which is reserved for internal use.
  *
- * @param ctx - The CLI context for logging
+ * @param deps - The narrowed dependencies (logger, options) for error messaging
  * @param rootDirectory - The root directory to scan
+ * @param buildLogFile - The build log file path, surfaced in the failure message
  * @param dirname - The current subdirectory being scanned (relative to rootDirectory)
  *
  * @returns Array of path specifications with pathname and content length
  */
-function getPathSpecsInDirectory(ctx: Context, rootDirectory: string, dirname = '.'): PathSpec[] {
+function getPathSpecsInDirectory(
+  deps: Pick<Deps, 'log' | 'options'>,
+  rootDirectory: string,
+  buildLogFile: string | undefined,
+  dirname = '.'
+): PathSpec[] {
   // .chromatic is a special directory reserved for internal use and should not be uploaded
   if (dirname === '.chromatic') {
     return [];
@@ -38,12 +58,14 @@ function getPathSpecsInDirectory(ctx: Context, rootDirectory: string, dirname = 
       const pathname = path.join(dirname, p);
       const stats = statSync(path.join(rootDirectory, pathname));
       return stats.isDirectory()
-        ? getPathSpecsInDirectory(ctx, rootDirectory, pathname)
+        ? getPathSpecsInDirectory(deps, rootDirectory, buildLogFile, pathname)
         : [{ pathname, contentLength: stats.size }];
     });
   } catch (err) {
-    ctx.log.debug(err);
-    throw new Error(invalid({ ...ctx, sourceDir: rootDirectory }, err).output);
+    deps.log.debug(err);
+    throw new Error(
+      invalid({ sourceDir: rootDirectory, buildLogFile, options: deps.options }, err).output
+    );
   }
 }
 
@@ -81,13 +103,18 @@ function getOutputDirectory(buildLog: string) {
  * Analyzes a directory to extract file information needed for upload.
  * Processes all files to calculate total size, collect paths, and locate stats files.
  *
- * @param ctx - The CLI context for logging
+ * @param deps - The narrowed dependencies (logger, options) for error messaging
  * @param sourceDirectory - The directory to analyze
+ * @param buildLogFile - The build log file path, surfaced in the failure message
  *
  * @returns Object containing file lengths, paths, stats path, and total size
  */
-function getFileInfo(ctx: Context, sourceDirectory: string) {
-  const lengths = getPathSpecsInDirectory(ctx, sourceDirectory).map((o) => ({
+function getFileInfo(
+  deps: Pick<Deps, 'log' | 'options'>,
+  sourceDirectory: string,
+  buildLogFile: string | undefined
+) {
+  const lengths = getPathSpecsInDirectory(deps, sourceDirectory, buildLogFile).map((o) => ({
     ...o,
     knownAs: posix(o.pathname),
   }));
@@ -164,36 +191,50 @@ const isValidReactNativeStorybook = (
  * If validation fails and a build log is available, attempts to find the
  * correct output directory from the log and retries validation.
  *
- * @param ctx - The CLI context containing source directory and build log info
+ * @param deps - The narrowed dependencies (logger, options, package manifest)
+ * @param input - Source directory, build type and build log info
+ *
+ * @returns The validated file info and the (possibly corrected) source directory
  *
  * @throws {Error} if no valid Storybook build is found
  */
-export async function validateFiles(ctx: Context) {
-  const validator = ctx.isReactNativeApp ? isValidReactNativeStorybook : isValidStorybook;
-  const browsers = ctx.announcedBuild?.browsers;
+export async function validateFiles(
+  deps: ValidateFilesDeps,
+  input: ValidateFilesInput
+): Promise<ValidateFilesOutput> {
+  const validator = input.isReactNativeApp ? isValidReactNativeStorybook : isValidStorybook;
+  const { browsers, buildLogFile } = input;
+  let { sourceDir } = input;
 
-  ctx.fileInfo = getFileInfo(ctx, ctx.sourceDir);
+  let fileInfo = getFileInfo(deps, sourceDir, buildLogFile);
 
-  if (!validator(ctx.fileInfo, browsers).valid && ctx.buildLogFile) {
+  if (!validator(fileInfo, browsers).valid && buildLogFile) {
     try {
-      const buildLog = readFileSync(ctx.buildLogFile, 'utf8');
+      const buildLog = readFileSync(buildLogFile, 'utf8');
       const outputDirectory = getOutputDirectory(buildLog);
-      if (outputDirectory && outputDirectory !== ctx.sourceDir) {
-        ctx.log.warn(deviatingOutputDirectory(ctx, outputDirectory));
-        ctx.sourceDir = outputDirectory;
-        ctx.fileInfo = getFileInfo(ctx, ctx.sourceDir);
+      if (outputDirectory && outputDirectory !== sourceDir) {
+        deps.log.warn(
+          deviatingOutputDirectory(
+            { sourceDir, options: deps.options, packageJson: deps.packageJson },
+            outputDirectory
+          )
+        );
+        sourceDir = outputDirectory;
+        fileInfo = getFileInfo(deps, sourceDir, buildLogFile);
       }
     } catch (err) {
-      ctx.log.debug(err);
+      deps.log.debug(err);
     }
   }
 
-  const validatorResult = validator(ctx.fileInfo, browsers);
+  const validatorResult = validator(fileInfo, browsers);
   if (!validatorResult.valid) {
     throw new Error(
-      ctx.isReactNativeApp
-        ? invalidReactNative(ctx, validatorResult.missingFiles).output
-        : invalid(ctx).output
+      input.isReactNativeApp
+        ? invalidReactNative({ sourceDir }, validatorResult.missingFiles).output
+        : invalid({ sourceDir, buildLogFile, options: deps.options }).output
     );
   }
+
+  return { fileInfo, sourceDir };
 }

--- a/node-src/ui/tasks/prepare.frames.ts
+++ b/node-src/ui/tasks/prepare.frames.ts
@@ -22,26 +22,29 @@ const sourceDirectory =
   '/var/folders/h3/ff9kk23958l99z2qbzfjdlxc0000gn/T/chromatic-20036LMP9FAlLEjpu';
 const buildLogFile = '/var/folders/h3/ff9kk23958l99z2qbzfjdlxc0000gn/T/build-storybook.log';
 
-// prepare registers no `failure` transition, so a thrown validation error renders the engine's
-// fallback failure state, built from the pending (validating) title and the error message.
+// prepare's `failure` transition forks on `ctx.isReactNativeApp`, passing an RN-specific or generic
+// title to the engine's fallback failure state (the error body is logged, not shown in the frame).
 const failure = (output: string) =>
   captureTask(fallbackFailureState(validating(ctx).title, new Error(output)));
+
+const rnFailure = (output: string) =>
+  captureTask(fallbackFailureState('Prepare your built React Native Storybook', new Error(output)));
 
 export const Validating = () => captureTask(validating(ctx));
 
 export const Invalid = () =>
   failure(invalid({ ...ctx, sourceDir: sourceDirectory, buildLogFile }).output);
 
-export const InvalidAndroidArtifact = () => failure(invalidAndroidArtifact().output);
+export const InvalidAndroidArtifact = () => rnFailure(invalidAndroidArtifact().output);
 
 export const InvalidReactNativeAndroidMissing = () =>
-  failure(invalidReactNative({ sourceDir: sourceDirectory }, ['storybook.apk']).output);
+  rnFailure(invalidReactNative({ sourceDir: sourceDirectory }, ['storybook.apk']).output);
 
 export const InvalidReactNativeIosMissing = () =>
-  failure(invalidReactNative({ sourceDir: sourceDirectory }, ['storybook.app']).output);
+  rnFailure(invalidReactNative({ sourceDir: sourceDirectory }, ['storybook.app']).output);
 
 export const InvalidReactNativeBothMissing = () =>
-  failure(
+  rnFailure(
     invalidReactNative({ sourceDir: sourceDirectory }, ['storybook.apk', 'storybook.app']).output
   );
 

--- a/node-src/ui/tasks/prepare.frames.ts
+++ b/node-src/ui/tasks/prepare.frames.ts
@@ -1,0 +1,84 @@
+import { fallbackFailureState } from '../../renderer/engine';
+import { captureTask } from '../../renderer/storybook/captureTask';
+import {
+  bailed,
+  hashing,
+  invalid,
+  invalidAndroidArtifact,
+  invalidReactNative,
+  success,
+  traced,
+  tracing,
+  validating,
+} from './prepare';
+
+// Node-side scenarios for the prepare task. The `?clack` Vite plugin runs this module in Node,
+// renders each export through the real Clack renderer, and hands the resulting ANSI strings to the
+// browser story (`prepare.stories.ts`).
+
+const ctx = { options: {} } as any;
+
+const sourceDirectory =
+  '/var/folders/h3/ff9kk23958l99z2qbzfjdlxc0000gn/T/chromatic-20036LMP9FAlLEjpu';
+const buildLogFile = '/var/folders/h3/ff9kk23958l99z2qbzfjdlxc0000gn/T/build-storybook.log';
+
+// prepare registers no `failure` transition, so a thrown validation error renders the engine's
+// fallback failure state, built from the pending (validating) title and the error message.
+const failure = (output: string) =>
+  captureTask(fallbackFailureState(validating(ctx).title, new Error(output)));
+
+export const Validating = () => captureTask(validating(ctx));
+
+export const Invalid = () =>
+  failure(invalid({ ...ctx, sourceDir: sourceDirectory, buildLogFile }).output);
+
+export const InvalidAndroidArtifact = () => failure(invalidAndroidArtifact().output);
+
+export const InvalidReactNativeAndroidMissing = () =>
+  failure(invalidReactNative({ sourceDir: sourceDirectory }, ['storybook.apk']).output);
+
+export const InvalidReactNativeIosMissing = () =>
+  failure(invalidReactNative({ sourceDir: sourceDirectory }, ['storybook.app']).output);
+
+export const InvalidReactNativeBothMissing = () =>
+  failure(
+    invalidReactNative({ sourceDir: sourceDirectory }, ['storybook.apk', 'storybook.app']).output
+  );
+
+export const Tracing = () =>
+  captureTask(
+    tracing({ git: { changedFiles: Array.from({ length: 3 }) }, options: {} } as any),
+    validating(ctx)
+  );
+
+export const BailedPackageFile = () =>
+  captureTask(
+    bailed({ turboSnap: { bailReason: { changedPackageFiles: ['package.json'] } } } as any),
+    validating(ctx)
+  );
+
+export const BailedLockfile = () =>
+  captureTask(
+    bailed({ turboSnap: { bailReason: { changedPackageFiles: ['yarn.lock'] } } } as any),
+    validating(ctx)
+  );
+
+export const BailedSiblings = () =>
+  captureTask(
+    bailed({
+      turboSnap: {
+        bailReason: { changedStorybookFiles: ['.storybook/preview.js', '.storybook/otherfile.js'] },
+      },
+    } as any),
+    validating(ctx)
+  );
+
+export const Traced = () =>
+  captureTask(
+    traced({ options: {}, onlyStoryFiles: Array.from({ length: 5 }) } as any),
+    validating(ctx)
+  );
+
+export const Hashing = () => captureTask(hashing(ctx), validating(ctx));
+
+export const Success = () => captureTask(success(ctx));

--- a/node-src/ui/tasks/prepare.stories.ts
+++ b/node-src/ui/tasks/prepare.stories.ts
@@ -1,71 +1,19 @@
-import task from '../components/task';
-import {
-  bailed,
-  hashing,
-  initial,
-  invalid,
-  invalidAndroidArtifact,
-  invalidReactNative,
-  success,
-  traced,
-  tracing,
-  validating,
-} from './prepare';
+import frames from './prepare.frames?clack';
 
 export default {
   title: 'CLI/Tasks/Prepare',
-  decorators: [(storyFunction: any) => task(storyFunction())],
 };
 
-const ctx = { options: {} } as any;
-
-export const Initial = () => initial(ctx);
-
-export const Validating = () => validating(ctx);
-
-export const Invalid = () =>
-  invalid({
-    ...ctx,
-    sourceDir: '/var/folders/h3/ff9kk23958l99z2qbzfjdlxc0000gn/T/chromatic-20036LMP9FAlLEjpu',
-    buildLogFile: '/var/folders/h3/ff9kk23958l99z2qbzfjdlxc0000gn/T/build-storybook.log',
-  } as any);
-
-const reactNativeContext = {
-  ...ctx,
-  sourceDir: '/var/folders/h3/ff9kk23958l99z2qbzfjdlxc0000gn/T/chromatic-20036LMP9FAlLEjpu',
-  buildLogFile: '/var/folders/h3/ff9kk23958l99z2qbzfjdlxc0000gn/T/build-storybook.log',
-};
-
-export const InvalidAndroidArtifact = () => invalidAndroidArtifact(ctx);
-
-export const InvalidReactNativeAndroidMissing = () =>
-  invalidReactNative(reactNativeContext as any, ['storybook.apk']);
-
-export const InvalidReactNativeIosMissing = () =>
-  invalidReactNative(reactNativeContext as any, ['storybook.app']);
-
-export const InvalidReactNativeBothMissing = () =>
-  invalidReactNative(reactNativeContext as any, ['storybook.apk', 'storybook.app']);
-
-export const Tracing = () =>
-  tracing({ ...ctx, git: { changedFiles: Array.from({ length: 3 }) } } as any);
-
-export const BailedPackageFile = () =>
-  bailed({ ...ctx, turboSnap: { bailReason: { changedPackageFiles: ['package.json'] } } } as any);
-
-export const BailedLockfile = () =>
-  bailed({ ...ctx, turboSnap: { bailReason: { changedPackageFiles: ['yarn.lock'] } } } as any);
-
-export const BailedSiblings = () =>
-  bailed({
-    ...ctx,
-    turboSnap: {
-      bailReason: { changedStorybookFiles: ['.storybook/preview.js', '.storybook/otherfile.js'] },
-    },
-  } as any);
-
-export const Traced = () => traced({ ...ctx, onlyStoryFiles: Array.from({ length: 5 }) } as any);
-
-export const Hashing = () => hashing(ctx);
-
-export const Success = () => success(ctx);
+export const Validating = () => frames.Validating;
+export const Invalid = () => frames.Invalid;
+export const InvalidAndroidArtifact = () => frames.InvalidAndroidArtifact;
+export const InvalidReactNativeAndroidMissing = () => frames.InvalidReactNativeAndroidMissing;
+export const InvalidReactNativeIosMissing = () => frames.InvalidReactNativeIosMissing;
+export const InvalidReactNativeBothMissing = () => frames.InvalidReactNativeBothMissing;
+export const Tracing = () => frames.Tracing;
+export const BailedPackageFile = () => frames.BailedPackageFile;
+export const BailedLockfile = () => frames.BailedLockfile;
+export const BailedSiblings = () => frames.BailedSiblings;
+export const Traced = () => frames.Traced;
+export const Hashing = () => frames.Hashing;
+export const Success = () => frames.Success;

--- a/node-src/ui/tasks/prepare.ts
+++ b/node-src/ui/tasks/prepare.ts
@@ -91,7 +91,7 @@ export const invalidReactNative = (
   };
 };
 
-export const tracing = (ctx: Context) => {
+export const tracing = (ctx: Pick<Context, 'git' | 'options'>) => {
   const files = pluralize('file', ctx.git.changedFiles?.length, true);
   const testType = isE2EBuild(ctx.options) ? 'test' : 'story';
 
@@ -102,7 +102,7 @@ export const tracing = (ctx: Context) => {
   };
 };
 
-export const bailed = (ctx: Context) => {
+export const bailed = (ctx: Pick<Context, 'turboSnap'>) => {
   const { changedPackageFiles, changedStorybookFiles, changedStaticFiles } =
     ctx.turboSnap?.bailReason || {};
   const changedFiles = changedPackageFiles || changedStorybookFiles || changedStaticFiles;
@@ -126,7 +126,7 @@ export const bailed = (ctx: Context) => {
   };
 };
 
-export const traced = (ctx: Context) => {
+export const traced = (ctx: Pick<Context, 'options' | 'onlyStoryFiles'>) => {
   const testType = isE2EBuild(ctx.options) ? 'test' : 'story';
   const files = pluralize(`${testType} file`, ctx.onlyStoryFiles?.length, true);
 

--- a/node-src/ui/tasks/prepare.ts
+++ b/node-src/ui/tasks/prepare.ts
@@ -96,7 +96,7 @@ export const tracing = (ctx: Pick<Context, 'git' | 'options'>) => {
   const testType = isE2EBuild(ctx.options) ? 'test' : 'story';
 
   return {
-    status: 'pending',
+    status: 'updating',
     title: `Retrieving ${testType} files affected by recent changes`,
     output: `Traversing dependencies for ${files} that changed since the last build`,
   };
@@ -120,7 +120,7 @@ export const bailed = (ctx: Pick<Context, 'turboSnap'>) => {
   if (otherFiles.length === 1) output += ' or its sibling';
   if (otherFiles.length > 1) output += ` or one of its ${siblings}`;
   return {
-    status: 'pending',
+    status: 'updating',
     title: 'TurboSnap disabled',
     output,
   };
@@ -131,14 +131,14 @@ export const traced = (ctx: Pick<Context, 'options' | 'onlyStoryFiles'>) => {
   const files = pluralize(`${testType} file`, ctx.onlyStoryFiles?.length, true);
 
   return {
-    status: 'pending',
+    status: 'updating',
     title: `Retrieved ${testType} files affected by recent changes`,
     output: `Found ${files} affected by recent changes`,
   };
 };
 
 export const hashing = (ctx: Pick<Context, 'options'>) => ({
-  status: 'pending',
+  status: 'updating',
   title: `Prepare your built ${buildType(ctx)}`,
   output: `Calculating file hashes`,
 });

--- a/node-src/ui/tasks/prepare.ts
+++ b/node-src/ui/tasks/prepare.ts
@@ -31,7 +31,7 @@ export const invalid = (
   };
 };
 
-export const invalidAndroidArtifact = (_ctx: Context) => ({
+export const invalidAndroidArtifact = (_ctx?: Context) => ({
   status: 'error',
   title: 'Preparing your built React Native Storybook',
   output:

--- a/node-src/ui/tasks/prepare.ts
+++ b/node-src/ui/tasks/prepare.ts
@@ -137,7 +137,7 @@ export const traced = (ctx: Pick<Context, 'options' | 'onlyStoryFiles'>) => {
   };
 };
 
-export const hashing = (ctx: Context) => ({
+export const hashing = (ctx: Pick<Context, 'options'>) => ({
   status: 'pending',
   title: `Prepare your built ${buildType(ctx)}`,
   output: `Calculating file hashes`,

--- a/node-src/ui/tasks/prepare.ts
+++ b/node-src/ui/tasks/prepare.ts
@@ -17,7 +17,10 @@ export const validating = (ctx: Context) => ({
   output: `Validating ${buildType(ctx)} files`,
 });
 
-export const invalid = (ctx: Context, error?: Error) => {
+export const invalid = (
+  ctx: Pick<Context, 'sourceDir' | 'buildLogFile' | 'options'>,
+  error?: Error
+) => {
   let output = `Invalid ${buildType(ctx)} build at ${ctx.sourceDir}`;
   if (ctx.buildLogFile) output += ' (check the build log)';
   if (error) output += `: ${error.message}`;
@@ -35,7 +38,10 @@ export const invalidAndroidArtifact = (_ctx: Context) => ({
     'Your storybook.apk contains native libraries but does not include x86_64 support. Chromatic only supports x86_64.',
 });
 
-export const invalidReactNative = (ctx: Context, missingFiles: string[] = []) => {
+export const invalidReactNative = (
+  ctx: Pick<Context, 'sourceDir'>,
+  missingFiles: string[] = []
+) => {
   const lines: string[] = [];
 
   if (missingFiles.length > 0) {

--- a/node-src/ui/tasks/prepareE2E.frames.ts
+++ b/node-src/ui/tasks/prepareE2E.frames.ts
@@ -1,0 +1,60 @@
+import { fallbackFailureState } from '../../renderer/engine';
+import { captureTask } from '../../renderer/storybook/captureTask';
+import { bailed, hashing, invalid, success, traced, tracing, validating } from './prepare';
+
+// Node-side scenarios for the prepare task on an E2E (Playwright) build. The `?clack` Vite plugin
+// renders each export through the real Clack renderer for the browser story (`prepareE2E.stories.ts`).
+
+const ctx = { options: { playwright: true } } as any;
+
+const sourceDirectory =
+  '/var/folders/h3/ff9kk23958l99z2qbzfjdlxc0000gn/T/chromatic-20036LMP9FAlLEjpu';
+const buildLogFile = '/var/folders/h3/ff9kk23958l99z2qbzfjdlxc0000gn/T/build-storybook.log';
+
+export const Validating = () => captureTask(validating(ctx));
+
+export const Invalid = () =>
+  captureTask(
+    fallbackFailureState(
+      validating(ctx).title,
+      new Error(invalid({ ...ctx, sourceDir: sourceDirectory, buildLogFile }).output)
+    )
+  );
+
+export const Tracing = () =>
+  captureTask(
+    tracing({ git: { changedFiles: Array.from({ length: 3 }) }, options: ctx.options } as any),
+    validating(ctx)
+  );
+
+export const BailedPackageFile = () =>
+  captureTask(
+    bailed({ turboSnap: { bailReason: { changedPackageFiles: ['package.json'] } } } as any),
+    validating(ctx)
+  );
+
+export const BailedLockfile = () =>
+  captureTask(
+    bailed({ turboSnap: { bailReason: { changedPackageFiles: ['yarn.lock'] } } } as any),
+    validating(ctx)
+  );
+
+export const BailedSiblings = () =>
+  captureTask(
+    bailed({
+      turboSnap: {
+        bailReason: { changedStorybookFiles: ['.storybook/preview.js', '.storybook/otherfile.js'] },
+      },
+    } as any),
+    validating(ctx)
+  );
+
+export const Traced = () =>
+  captureTask(
+    traced({ options: ctx.options, onlyStoryFiles: Array.from({ length: 5 }) } as any),
+    validating(ctx)
+  );
+
+export const Hashing = () => captureTask(hashing(ctx), validating(ctx));
+
+export const Success = () => captureTask(success(ctx));

--- a/node-src/ui/tasks/prepareE2E.stories.ts
+++ b/node-src/ui/tasks/prepareE2E.stories.ts
@@ -1,46 +1,15 @@
-import task from '../components/task';
-import { bailed, hashing, invalid, success, traced, tracing, validating } from './prepare';
+import frames from './prepareE2E.frames?clack';
 
 export default {
   title: 'CLI/Tasks/Prepare/E2E',
-  decorators: [(storyFunction: any) => task(storyFunction())],
 };
 
-const ctx = { options: { playwright: true } } as any;
-
-export const Validating = () => validating(ctx);
-
-export const Invalid = () =>
-  invalid({
-    ...ctx,
-    sourceDir: '/var/folders/h3/ff9kk23958l99z2qbzfjdlxc0000gn/T/chromatic-20036LMP9FAlLEjpu',
-    buildLogFile: '/var/folders/h3/ff9kk23958l99z2qbzfjdlxc0000gn/T/build-storybook.log',
-  } as any);
-
-export const Tracing = () =>
-  tracing({ ...ctx, git: { changedFiles: Array.from({ length: 3 }) } } as any);
-
-export const BailedPackageFile = () =>
-  bailed({ ...ctx, turboSnap: { bailReason: { changedPackageFiles: ['package.json'] } } } as any);
-
-export const BailedLockfile = () =>
-  bailed({ ...ctx, turboSnap: { bailReason: { changedPackageFiles: ['yarn.lock'] } } } as any);
-
-export const BailedSiblings = () =>
-  bailed({
-    ...ctx,
-    turboSnap: {
-      bailReason: { changedStorybookFiles: ['.storybook/preview.js', '.storybook/otherfile.js'] },
-    },
-  } as any);
-
-export const Traced = () => traced({ ...ctx, onlyStoryFiles: Array.from({ length: 5 }) } as any);
-
-export const Hashing = () => hashing(ctx);
-
-export const Success = () =>
-  success({
-    ...ctx,
-    now: 0,
-    startedAt: -54_321,
-  } as any);
+export const Validating = () => frames.Validating;
+export const Invalid = () => frames.Invalid;
+export const Tracing = () => frames.Tracing;
+export const BailedPackageFile = () => frames.BailedPackageFile;
+export const BailedLockfile = () => frames.BailedLockfile;
+export const BailedSiblings = () => frames.BailedSiblings;
+export const Traced = () => frames.Traced;
+export const Hashing = () => frames.Hashing;
+export const Success = () => frames.Success;

--- a/node-src/ui/tasks/utilities.ts
+++ b/node-src/ui/tasks/utilities.ts
@@ -1,7 +1,7 @@
 import { isE2EBuild } from '../../lib/e2eUtils';
 import { Context } from '../../types';
 
-export const buildType = (ctx: Context) => {
+export const buildType = (ctx: Pick<Context, 'options'>) => {
   if (isE2EBuild(ctx.options)) return 'test suite';
   return 'Storybook';
 };


### PR DESCRIPTION
# Description

This PR migrates the `prepare` task to Clack. This is a legacy task, so, like `build` before it, it first migrates the task and related helper functions to the extract input, run, apply output pattern. For this task, I decided to violate the principle of keeping `Context` out of business logic because this task is where turbosnap happens. Refactoring the entire `lib/turbosnap` tree to no longer touch `Context` would be a large lift, so in the interest of moving faster, I decided to pass `Context` into `traceChangedFiles`. Potential upcoming work refactoring the turbosnap feature also nudges us in this direction.

> [!NOTE]
> Worth calling out: the failure state for React Native now says `Prepare your built Storybook failed` rather than `Preparing your built React Native Storybook failed`. As always, the detailed error is below the task UI. Adding that `React Native` bit is doable, but it's a bit of additional forking I didn't feel was worth it. But I can add it in if reviewers disagree.

# Manual QA

## Storybook

**Build 1:** happy path.
<img width="1768" height="962" alt="CleanShot 2026-06-23 at 11 50 55@2x" src="https://github.com/user-attachments/assets/320eac95-b605-44aa-8181-c5a193510935" />

**Build 2:** failure path by manually pointing at an empty directory.
<img width="1606" height="930" alt="CleanShot 2026-06-23 at 11 52 17@2x" src="https://github.com/user-attachments/assets/d34ef092-af26-48e6-82e6-31af50cad70c" />

## React Native

**Build 1:** happy path.
<img width="920" height="930" alt="CleanShot 2026-06-23 at 12 39 21@2x" src="https://github.com/user-attachments/assets/b8a60c30-2f53-4aec-9a82-24a38687dc97" />

**Build 2:** failure path by pointing at a source directory without a `storybook.app`.
<img width="1766" height="964" alt="CleanShot 2026-06-23 at 12 40 54@2x" src="https://github.com/user-attachments/assets/c4d4ec8c-244c-4b9c-9250-9c594c734e2f" />

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>18.0.1--canary.1402.28528483744.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@18.0.1--canary.1402.28528483744.0
  # or 
  yarn add chromatic@18.0.1--canary.1402.28528483744.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
