### PR TITLE
Log untraced files and its matching glob

### DIFF
--- a/node-src/lib/turbosnap/getDependentStoryFiles.test.ts
+++ b/node-src/lib/turbosnap/getDependentStoryFiles.test.ts
@@ -838,6 +838,10 @@ describe('getDependentStoryFiles', () => {
     });
     const result = await getDependentStoryFiles(ctx, { modules }, statsPath, changedFiles);
     expect(result).toEqual({});
+    expect(ctx.untracedFiles).toEqual([
+      { filepath: 'src/stories/Button.jsx', glob: '**/stories/**' },
+      { filepath: 'src/stories/Page.jsx', glob: '**/stories/**' },
+    ]);
   });
 
   it.each(['./src/foo.js', './src/foo.js + 1 module', './src/foo.js + 2 modules'])(

--- a/node-src/lib/turbosnap/getDependentStoryFiles.ts
+++ b/node-src/lib/turbosnap/getDependentStoryFiles.ts
@@ -210,8 +210,9 @@ export async function getDependentStoryFiles(
 
   function untrace(filepath: string) {
     filepath = filepath.replace(/\s\+\s\d+\smodules?$/, ''); // strip ' + N modules' from the string before matching against `untraced`
-    if (untraced.some((glob) => matchesFile(glob, filepath))) {
-      ctx.untracedFiles?.push(filepath);
+    const matchedGlob = untraced.find((glob) => matchesFile(glob, filepath));
+    if (matchedGlob) {
+      ctx.untracedFiles?.push({ filepath, glob: matchedGlob });
       return false;
     }
     return true;

--- a/node-src/lib/utilities.test.ts
+++ b/node-src/lib/utilities.test.ts
@@ -1,6 +1,9 @@
+import chalk from 'chalk';
 import { describe, expect, it } from 'vitest';
 
-import { isPackageManifestFile, matchesFile } from './utilities';
+import { groupUntracedFilesByGlob, isPackageManifestFile, matchesFile } from './utilities';
+
+chalk.level = 0;
 
 describe('matchesFile', () => {
   it('matches file names', () => {
@@ -34,6 +37,32 @@ describe('matchesFile', () => {
 
   it('matches ./ prefix', () => {
     expect(matchesFile('src/*', './src/file.js')).toStrictEqual(true);
+  });
+});
+
+describe('groupUntracedFilesByGlob', () => {
+  it('groups files matched by the same glob together', () => {
+    const result = groupUntracedFilesByGlob([
+      { filepath: 'src/stories/Button.jsx', glob: '**/stories/**' },
+      { filepath: 'package.json', glob: '**/package.json' },
+      { filepath: 'src/stories/Page.jsx', glob: '**/stories/**' },
+    ]);
+    expect(result).toBe(
+      [
+        'Files matching **/stories/**:',
+        '→ src/stories/Button.jsx',
+        '→ src/stories/Page.jsx',
+        'Files matching **/package.json:',
+        '→ package.json',
+      ].join('\n')
+    );
+  });
+
+  it('lists a single matched file under its glob', () => {
+    const result = groupUntracedFilesByGlob([
+      { filepath: 'package.json', glob: '**/package.json' },
+    ]);
+    expect(result).toBe('Files matching **/package.json:\n→ package.json');
   });
 });
 

--- a/node-src/lib/utilities.ts
+++ b/node-src/lib/utilities.ts
@@ -1,4 +1,7 @@
+import chalk from 'chalk';
 import picomatch, { Matcher } from 'picomatch';
+
+import { Context } from '../types';
 
 export const lcfirst = (str: string) => `${str.charAt(0).toLowerCase()}${str.slice(1)}`;
 
@@ -51,6 +54,21 @@ const fileMatchers: Record<string, Matcher> = {};
 export const matchesFile = (glob: string, filepath: string) => {
   if (!fileMatchers[glob]) fileMatchers[glob] = picomatch(glob, { dot: true });
   return fileMatchers[glob](filepath.replace(/^\.\//, ''));
+};
+
+export const groupUntracedFilesByGlob = (untracedFiles: NonNullable<Context['untracedFiles']>) => {
+  const filesByGlob = new Map<string, string[]>();
+  for (const { filepath, glob } of untracedFiles) {
+    const files = filesByGlob.get(glob) ?? [];
+    files.push(filepath);
+    filesByGlob.set(glob, files);
+  }
+  return [...filesByGlob.entries()]
+    .map(
+      ([glob, files]) =>
+        chalk`Files matching {bold ${glob}}:\n{dim →} ${files.join(chalk`\n{dim →} `)}`
+    )
+    .join('\n');
 };
 
 export const isPackageManifestFile = (filePath: string) =>

--- a/node-src/tasks/prepare/traceChangedFiles.ts
+++ b/node-src/tasks/prepare/traceChangedFiles.ts
@@ -2,7 +2,7 @@ import * as turbosnap from '@cli/turbosnap';
 import semver from 'semver';
 
 import { transitionTo } from '../../lib/tasks';
-import { rewriteErrorMessage } from '../../lib/utilities';
+import { groupUntracedFilesByGlob, rewriteErrorMessage } from '../../lib/utilities';
 import { Context, Task } from '../../types';
 import missingStatsFile from '../../ui/messages/errors/missingStatsFile';
 import { bailed, traced, tracing } from '../../ui/tasks/prepare';
@@ -58,9 +58,9 @@ export async function traceChangedFiles(ctx: Context, task: Task) {
         }
         if (ctx.untracedFiles && ctx.untracedFiles.length > 0) {
           ctx.log.info(
-            `Encountered ${ctx.untracedFiles.length} untraced files:\n${ctx.untracedFiles
-              .map((f) => `  ${f}`)
-              .join('\n')}`
+            `Encountered ${ctx.untracedFiles.length} untraced files:\n${groupUntracedFilesByGlob(
+              ctx.untracedFiles
+            )}`
           );
         }
       }

--- a/node-src/types.ts
+++ b/node-src/types.ts
@@ -454,7 +454,7 @@ export interface Context {
   turboSnap?: TurboSnap;
   mergeBase?: string;
   onlyStoryFiles?: string[];
-  untracedFiles?: string[];
+  untracedFiles?: { filepath: string; glob: string }[];
   rebuildForBuildId?: string;
 }
 

--- a/node-src/ui/messages/info/tracedAffectedFiles.stories.ts
+++ b/node-src/ui/messages/info/tracedAffectedFiles.stories.ts
@@ -85,6 +85,25 @@ export const TracedAffectedFilesExpanded = () =>
     }
   );
 
+export const TracedAffectedFilesExpandedUntraced = () =>
+  tracedAffectedFiles(
+    {
+      options: { traceChanged: 'expanded' },
+      turboSnap: { rootPath, tracedPaths: new Set(tracedPaths) },
+      untracedFiles: [
+        { filepath: 'src/stories/Button.jsx', glob: '**/stories/**' },
+        { filepath: 'src/stories/Page.jsx', glob: '**/stories/**' },
+        { filepath: 'package.json', glob: '**/package.json' },
+      ],
+    } as any,
+    {
+      changedFiles: ['src/app/dashboard/index.ts'],
+      affectedModules,
+      modulesByName,
+      normalize: (f) => f,
+    }
+  );
+
 export const TracedAffectedFilesExpandedBailed = () =>
   tracedAffectedFiles(
     {

--- a/node-src/ui/messages/info/tracedAffectedFiles.ts
+++ b/node-src/ui/messages/info/tracedAffectedFiles.ts
@@ -1,6 +1,7 @@
 import chalk from 'chalk';
 import pluralize from 'pluralize';
 
+import { groupUntracedFilesByGlob } from '../../../lib/utilities';
 import { Context, Module, TurboSnap } from '../../../types';
 import { info } from '../../components/icons';
 
@@ -66,7 +67,7 @@ export default (
         ? `${chalk.magenta(
             `We detected some untraced files, this may affect your traced changes as 
     the untraced flag instructs TurboSnap to not trace dependencies for the files:`
-          )} \n  ${ctx.untracedFiles.join(',')}\n\n\n`
+          )} \n${groupUntracedFilesByGlob(ctx.untracedFiles)}\n\n\n`
         : '';
     directoryDebug = `${rootPath}${basePath}${storybookPath}${bailReason}${untracedNotice}${traceSuggestions}`;
   }


### PR DESCRIPTION
We're trying to add more context around the behavior of TurboSnap and part of that is being explicit about which files are untraced and which glob pattern they match. Then the user can simply look at the logs to figure out which files changed and which pattern they matched for quick debugging!

### Single glob
<img width="397" height="84" alt="Screenshot 2026-06-22 at 4 02 05 PM" src="https://github.com/user-attachments/assets/d32f59b4-dcd4-4cf4-9dab-d2ee208f6a3a" />

### Multiple globs
<img width="414" height="108" alt="Screenshot 2026-06-22 at 4 01 22 PM" src="https://github.com/user-attachments/assets/30b5a8ba-9561-435f-82ef-63b1a9b1212a" />

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>17.5.1--canary.1403.28045422834.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@17.5.1--canary.1403.28045422834.0
  # or 
  yarn add chromatic@17.5.1--canary.1403.28045422834.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
