### PR TITLE
React Native: Parse build command from config file

### DIFF
--- a/node-src/tasks/build/buildReactNative.test.ts
+++ b/node-src/tasks/build/buildReactNative.test.ts
@@ -173,6 +173,24 @@ describe('buildArtifacts', () => {
     );
   });
 
+  it('splits androidBuildCommand into executable and arguments before spawning', async () => {
+    const ctx = {
+      ...baseContext,
+      announcedBuild: { browsers: ['android'] },
+      log: new TestLogger(),
+      options: { reactNative: { androidBuildCommand: 'yarn android -t remote -m release' } },
+      sourceDir: '/path/to/build',
+    } as any;
+    await buildArtifacts(ctx, task);
+    expect(execa).toHaveBeenCalledWith(
+      'yarn',
+      ['android', '-t', 'remote', '-m', 'release'],
+      expect.objectContaining({
+        env: expect.objectContaining({ CHROMATIC_ARTIFACT_DIRECTORY: '/path/to/build' }),
+      })
+    );
+  });
+
   it('ignores androidBuildArchitectures when androidBuildCommand is set and logs debug message', async () => {
     const log = new TestLogger();
     const ctx = {
@@ -209,6 +227,24 @@ describe('buildArtifacts', () => {
     expect(execa).toHaveBeenCalledWith(
       cmd,
       args,
+      expect.objectContaining({
+        env: expect.objectContaining({ CHROMATIC_ARTIFACT_DIRECTORY: '/path/to/build' }),
+      })
+    );
+  });
+
+  it('splits iosBuildCommand into executable and arguments before spawning', async () => {
+    const ctx = {
+      ...baseContext,
+      announcedBuild: { browsers: ['ios'] },
+      log: new TestLogger(),
+      options: { reactNative: { iosBuildCommand: 'yarn ios -t remote -m release' } },
+      sourceDir: '/path/to/build',
+    } as any;
+    await buildArtifacts(ctx, task);
+    expect(execa).toHaveBeenCalledWith(
+      'yarn',
+      ['ios', '-t', 'remote', '-m', 'release'],
       expect.objectContaining({
         env: expect.objectContaining({ CHROMATIC_ARTIFACT_DIRECTORY: '/path/to/build' }),
       })

--- a/node-src/tasks/build/buildReactNative.ts
+++ b/node-src/tasks/build/buildReactNative.ts
@@ -1,3 +1,4 @@
+import { parseCommandString } from 'execa';
 import { createReadStream, mkdirSync, type WriteStream } from 'fs';
 import path from 'path';
 import { createInterface } from 'readline';
@@ -35,9 +36,10 @@ async function readLastLines(filePath: string, lineCount: number): Promise<strin
 const runPlatformCommand = async (ctx: Context, command: string, logStream: WriteStream) => {
   ctx.log.debug('Running React Native build command:', command);
   try {
+    const [cmd, ...args] = parseCommandString(command);
     await execWithBuildEnvironment(
-      command,
-      [],
+      cmd,
+      args,
       { env: { CHROMATIC_ARTIFACT_DIRECTORY: ctx.sourceDir } },
       logStream
     );


### PR DESCRIPTION
When building React Native projects, we use the user's config option with a fallback default command. Unfortunately, we were passing the config command directly to `exec` instead of parsing so the shell was trying to run `yarn android ...` as a single command. That won't exist on the system so we just need to parse it! 🎉 

> [!Note]
> A customer has verified this canary on a real-world project.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>17.7.2--canary.1405.28193165845.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@17.7.2--canary.1405.28193165845.0
  # or 
  yarn add chromatic@17.7.2--canary.1405.28193165845.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
