### PR TITLE
Include ancestor build details on a fully TurboSnapped build

### DIFF
--- a/node-src/lib/upload.ts
+++ b/node-src/lib/upload.ts
@@ -46,6 +46,11 @@ const UploadBuildMutation = `
       build {
         id
         status
+        ancestorBuild {
+          status
+          webUrl
+          snapshotCount
+        }
       }
       userErrors {
         __typename
@@ -85,6 +90,11 @@ interface UploadBuildMutationResult {
     build?: {
       id: string;
       status: string;
+      ancestorBuild?: {
+        status: string;
+        webUrl: string;
+        snapshotCount: number;
+      };
     };
     userErrors: (
       | {
@@ -252,6 +262,7 @@ export async function uploadBuild(
           Sentry.captureException(err);
         });
 
+      ctx.ancestorBuild = uploadBuild.build.ancestorBuild;
       ctx.skip = true;
       return;
     }

--- a/node-src/lib/upload.ts
+++ b/node-src/lib/upload.ts
@@ -46,7 +46,7 @@ const UploadBuildMutation = `
       build {
         id
         status
-        ancestorBuild {
+        ancestorBuilds {
           status
           webUrl
           snapshotCount
@@ -90,11 +90,11 @@ interface UploadBuildMutationResult {
     build?: {
       id: string;
       status: string;
-      ancestorBuild?: {
+      ancestorBuilds?: {
         status: string;
         webUrl: string;
         snapshotCount: number;
-      };
+      }[];
     };
     userErrors: (
       | {
@@ -262,7 +262,8 @@ export async function uploadBuild(
           Sentry.captureException(err);
         });
 
-      ctx.ancestorBuild = uploadBuild.build.ancestorBuild;
+      // In this case, we should only have a single ancestor build
+      ctx.ancestorBuild = uploadBuild.build.ancestorBuilds?.[0];
       ctx.skip = true;
       return;
     }

--- a/node-src/tasks/upload.test.ts
+++ b/node-src/tasks/upload.test.ts
@@ -449,11 +449,13 @@ describe('uploadStorybook', () => {
         build: {
           id: '2',
           status: 'SKIPPED',
-          ancestorBuild: {
-            status: 'PASSED',
-            webUrl: 'https://www.chromatic.com/build?appId=abc&number=95',
-            snapshotCount: 54,
-          },
+          ancestorBuilds: [
+            {
+              status: 'PASSED',
+              webUrl: 'https://www.chromatic.com/build?appId=abc&number=95',
+              snapshotCount: 54,
+            },
+          ],
         },
         userErrors: [],
       },

--- a/node-src/tasks/upload.test.ts
+++ b/node-src/tasks/upload.test.ts
@@ -6,7 +6,8 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import makeZipFile from '../lib/compress';
 import TestLogger from '../lib/testLogger';
-import buildTurboSkipped from '../ui/messages/info/buildFullyTurboSnapped';
+import buildFullyTurboSnapped from '../ui/messages/info/buildFullyTurboSnapped';
+import turboSnapEnabled from '../ui/messages/info/turboSnapEnabled';
 import { finishUpload, uploadStorybook, waitForSentinels } from './upload';
 
 vi.mock('@sentry/node');
@@ -441,6 +442,48 @@ describe('uploadStorybook', () => {
     );
   });
 
+  it('captures the ancestor build details when the build is SKIPPED', async () => {
+    const client = { runQuery: vi.fn() };
+    client.runQuery.mockResolvedValue({
+      uploadBuild: {
+        build: {
+          id: '2',
+          status: 'SKIPPED',
+          ancestorBuild: {
+            status: 'PASSED',
+            webUrl: 'https://www.chromatic.com/build?appId=abc&number=95',
+            snapshotCount: 54,
+          },
+        },
+        userErrors: [],
+      },
+    });
+
+    const fileInfo = {
+      lengths: [{ knownAs: 'index.html', contentLength: 42 }],
+      paths: ['index.html'],
+      total: 42,
+    };
+    const ctx = {
+      client,
+      env: environment,
+      log,
+      http,
+      sourceDir: '/static/',
+      options: {},
+      fileInfo,
+      announcedBuild: { id: '1' },
+      onlyStoryFiles: [],
+    } as any;
+    await uploadStorybook(ctx, {} as any);
+
+    expect(ctx.ancestorBuild).toEqual({
+      status: 'PASSED',
+      webUrl: 'https://www.chromatic.com/build?appId=abc&number=95',
+      snapshotCount: 54,
+    });
+  });
+
   it('still skips and reports to Sentry when preparing the skipped build fails', async () => {
     const error = new Error('prepare failed');
     const client = { runQuery: vi.fn() };
@@ -528,23 +571,24 @@ describe('uploadStorybook', () => {
   });
 
   describe('finishUpload', () => {
-    it('logs the build skipped message and skips the task when the build is SKIPPED', () => {
+    it('logs the skipped-build messages and skips the task when the build is SKIPPED', () => {
       const ctx = { skip: true, log, options: {} } as any;
       const task = { skip: vi.fn() } as any;
 
       finishUpload(ctx, task);
 
-      expect(log.info).toHaveBeenCalledWith(buildTurboSkipped());
+      expect(log.info).toHaveBeenCalledWith(turboSnapEnabled(ctx));
+      expect(log.info).toHaveBeenCalledWith(buildFullyTurboSnapped(ctx));
       expect(task.skip).toHaveBeenCalledWith('');
     });
 
-    it('does not log the build skipped message when the build was uploaded', () => {
+    it('does not log the skipped-build messages when the build was uploaded', () => {
       const ctx = { skip: false, log, options: {} } as any;
       const task = { skip: vi.fn() } as any;
 
       finishUpload(ctx, task);
 
-      expect(log.info).not.toHaveBeenCalledWith(buildTurboSkipped());
+      expect(log.info).not.toHaveBeenCalledWith(buildFullyTurboSnapped(ctx));
       expect(task.skip).not.toHaveBeenCalled();
     });
   });

--- a/node-src/tasks/upload.ts
+++ b/node-src/tasks/upload.ts
@@ -7,7 +7,8 @@ import { throttle } from '../lib/utilities';
 import { waitForSentinel } from '../lib/waitForSentinel';
 import { Context, FileDesc, Task } from '../types';
 import sentinelFileErrors from '../ui/messages/errors/sentinelFileErrors';
-import buildTurboSkipped from '../ui/messages/info/buildFullyTurboSnapped';
+import buildFullyTurboSnapped from '../ui/messages/info/buildFullyTurboSnapped';
+import turboSnapEnabled from '../ui/messages/info/turboSnapEnabled';
 import deduplicationFailed from '../ui/messages/warnings/deduplicationFailed';
 import {
   dryRun,
@@ -105,7 +106,8 @@ export const waitForSentinels = async (ctx: Context, task: Task) => {
 export const finishUpload = (ctx: Context, task: Task) => {
   // The build may have been marked SKIPPED from the backend detecting no changes from TurboSnap.
   if (ctx.skip) {
-    ctx.log.info(buildTurboSkipped());
+    ctx.log.info(turboSnapEnabled(ctx));
+    ctx.log.info(buildFullyTurboSnapped(ctx));
 
     // Render as ↓ [skipped] rather than a ✔ checkmark to make it look like we never entered this step.
     setOutput('')(ctx, task); // Clear the "Starting publish" output so no subtitle shows

--- a/node-src/types.ts
+++ b/node-src/types.ts
@@ -462,6 +462,11 @@ export interface Context {
   uploadedBytes?: number;
   uploadedFiles?: number;
   turboSnap?: TurboSnap;
+  ancestorBuild?: {
+    status: string;
+    webUrl: string;
+    snapshotCount: number;
+  };
   mergeBase?: string;
   onlyStoryFiles?: string[];
   untracedFiles?: { filepath: string; glob: string }[];

--- a/node-src/ui/messages/info/buildFullyTurboSnapped.stories.ts
+++ b/node-src/ui/messages/info/buildFullyTurboSnapped.stories.ts
@@ -1,7 +1,26 @@
-import buildfullyTurboSnapped from './buildFullyTurboSnapped';
+import buildFullyTurboSnapped from './buildFullyTurboSnapped';
 
 export default {
   title: 'CLI/Messages/Info',
 };
 
-export const BuildFullyTurboSnapped = () => buildfullyTurboSnapped();
+const ancestorBuild = {
+  status: 'PENDING',
+  webUrl: 'https://www.chromatic.com/build?appId=abc123&number=95',
+  snapshotCount: 54,
+};
+
+export const BuildFullyTurboSnappedAncestorPending = () =>
+  buildFullyTurboSnapped({ ancestorBuild } as any);
+
+export const BuildFullyTurboSnappedAncestorPassed = () =>
+  buildFullyTurboSnapped({ ancestorBuild: { ...ancestorBuild, status: 'PASSED' } } as any);
+
+export const BuildFullyTurboSnappedAncestorAccepted = () =>
+  buildFullyTurboSnapped({ ancestorBuild: { ...ancestorBuild, status: 'ACCEPTED' } } as any);
+
+export const BuildFullyTurboSnappedAncestorDenied = () =>
+  buildFullyTurboSnapped({ ancestorBuild: { ...ancestorBuild, status: 'DENIED' } } as any);
+
+export const BuildFullyTurboSnappedAncestorOther = () =>
+  buildFullyTurboSnapped({ ancestorBuild: { ...ancestorBuild, status: 'BROKEN' } } as any);

--- a/node-src/ui/messages/info/buildFullyTurboSnapped.stories.ts
+++ b/node-src/ui/messages/info/buildFullyTurboSnapped.stories.ts
@@ -1,7 +1,8 @@
 import buildFullyTurboSnapped from './buildFullyTurboSnapped';
+import turboSnapEnabled from './turboSnapEnabled';
 
 export default {
-  title: 'CLI/Messages/Info',
+  title: 'CLI/Messages/Info/Build Skipped',
 };
 
 const ancestorBuild = {
@@ -10,17 +11,23 @@ const ancestorBuild = {
   snapshotCount: 54,
 };
 
-export const BuildFullyTurboSnappedAncestorPending = () =>
-  buildFullyTurboSnapped({ ancestorBuild } as any);
+// When a build is skipped, the CLI prints turboSnapEnabled() and buildFullyTurboSnapped()
+// back-to-back (see tasks/upload.ts finishUpload), so we render them together here.
+const buildSkipped = (ctx: any) => {
+  const skipContext = { ...ctx, skip: true };
+  return `${turboSnapEnabled(skipContext)}\n\n${buildFullyTurboSnapped(skipContext)}`;
+};
 
-export const BuildFullyTurboSnappedAncestorPassed = () =>
-  buildFullyTurboSnapped({ ancestorBuild: { ...ancestorBuild, status: 'PASSED' } } as any);
+export const BuildSkippedAncestorPending = () => buildSkipped({ ancestorBuild });
 
-export const BuildFullyTurboSnappedAncestorAccepted = () =>
-  buildFullyTurboSnapped({ ancestorBuild: { ...ancestorBuild, status: 'ACCEPTED' } } as any);
+export const BuildSkippedAncestorPassed = () =>
+  buildSkipped({ ancestorBuild: { ...ancestorBuild, status: 'PASSED' } });
 
-export const BuildFullyTurboSnappedAncestorDenied = () =>
-  buildFullyTurboSnapped({ ancestorBuild: { ...ancestorBuild, status: 'DENIED' } } as any);
+export const BuildSkippedAncestorAccepted = () =>
+  buildSkipped({ ancestorBuild: { ...ancestorBuild, status: 'ACCEPTED' } });
 
-export const BuildFullyTurboSnappedAncestorOther = () =>
-  buildFullyTurboSnapped({ ancestorBuild: { ...ancestorBuild, status: 'BROKEN' } } as any);
+export const BuildSkippedAncestorDenied = () =>
+  buildSkipped({ ancestorBuild: { ...ancestorBuild, status: 'DENIED' } });
+
+export const BuildSkippedAncestorOther = () =>
+  buildSkipped({ ancestorBuild: { ...ancestorBuild, status: 'BROKEN' } });

--- a/node-src/ui/messages/info/buildFullyTurboSnapped.ts
+++ b/node-src/ui/messages/info/buildFullyTurboSnapped.ts
@@ -1,9 +1,30 @@
 import chalk from 'chalk';
 import { dedent } from 'ts-dedent';
 
-import { info } from '../../components/icons';
+import { Context } from '../../../types';
+import { info, success } from '../../components/icons';
+import link from '../../components/link';
 
-export default () =>
-  dedent(chalk`
-    ${info} No frontend files were changed, so TurboSnap skipped taking any snapshots. This build will not be displayed in Chromatic.
-  `);
+const ancestorStatusMessages: Record<string, string> = {
+  PENDING:
+    'The pending status will be carried over from the most recent ancestor build that has unreviewed changes.',
+  PASSED: 'The passed status will be carried over from the most recent ancestor build.',
+  ACCEPTED: 'The accepted status will be carried over from the most recent ancestor build.',
+  DENIED: 'The denied status will be carried over from the most recent ancestor build.',
+};
+
+export default ({ ancestorBuild }: Pick<Context, 'ancestorBuild'>) => {
+  const lines = [
+    chalk`${success} {bold This build was skipped and will not be displayed in Chromatic.}`,
+  ];
+
+  const statusMessage = ancestorBuild && ancestorStatusMessages[ancestorBuild.status];
+  if (ancestorBuild && statusMessage) {
+    lines.push(
+      statusMessage,
+      `${info} View ancestor build details at ${link(ancestorBuild.webUrl)}`
+    );
+  }
+
+  return `${dedent(chalk`${lines.join('\n')}`)}\n`;
+};

--- a/node-src/ui/messages/info/turboSnapEnabled.stories.ts
+++ b/node-src/ui/messages/info/turboSnapEnabled.stories.ts
@@ -12,3 +12,14 @@ export const TurboSnapEnabled = (args: any) => turboSnapEnabled(args);
 
 export const TurboSnapEnabledInteractive = (args: any) =>
   turboSnapEnabled({ ...args, options: { interactive: true } });
+
+export const TurboSnapEnabledSkipped = (args: any) =>
+  turboSnapEnabled({
+    ...args,
+    skip: true,
+    ancestorBuild: {
+      status: 'PASSED',
+      webUrl: 'https://www.chromatic.com/build?appId=abc&number=95',
+      snapshotCount: 54,
+    },
+  });

--- a/node-src/ui/messages/info/turboSnapEnabled.stories.ts
+++ b/node-src/ui/messages/info/turboSnapEnabled.stories.ts
@@ -12,14 +12,3 @@ export const TurboSnapEnabled = (args: any) => turboSnapEnabled(args);
 
 export const TurboSnapEnabledInteractive = (args: any) =>
   turboSnapEnabled({ ...args, options: { interactive: true } });
-
-export const TurboSnapEnabledSkipped = (args: any) =>
-  turboSnapEnabled({
-    ...args,
-    skip: true,
-    ancestorBuild: {
-      status: 'PASSED',
-      webUrl: 'https://www.chromatic.com/build?appId=abc&number=95',
-      snapshotCount: 54,
-    },
-  });

--- a/node-src/ui/messages/info/turboSnapEnabled.ts
+++ b/node-src/ui/messages/info/turboSnapEnabled.ts
@@ -8,17 +8,29 @@ import { success } from '../../components/icons';
 export default ({
   build,
   options,
+  skip,
   skipSnapshots,
-}: Pick<Context, 'build' | 'options' | 'skipSnapshots'>) => {
+  ancestorBuild,
+}: Pick<Context, 'build' | 'options' | 'skip' | 'skipSnapshots' | 'ancestorBuild'>) => {
+  if (skip) {
+    const skipped = ancestorBuild
+      ? pluralize('snapshot', ancestorBuild.snapshotCount, true)
+      : 'snapshots';
+    return dedent(chalk`
+      ${success} {bold TurboSnap enabled}
+      Skipped capturing ${skipped} because no frontend files were changed.
+    `);
+  }
+
   const captures = pluralize('snapshot', build.actualCaptureCount, true);
-  const skips = pluralize('snapshot', build.inheritedCaptureCount, true);
+  const turboSnaps = pluralize('TurboSnap', build.inheritedCaptureCount, true);
   return !options.interactive || skipSnapshots
     ? dedent(chalk`
       ${success} {bold TurboSnap enabled}
-      Capturing ${captures} and skipping ${skips}.
+      Capturing ${captures}, copying ${turboSnaps}.
     `)
     : dedent(chalk`
       ${success} {bold TurboSnap enabled}
-      Captured ${captures} and skipped ${skips}.
+      Captured ${captures}, copied ${turboSnaps}.
     `);
 };


### PR DESCRIPTION
This PR brings in the UI design of fully TurboSnapped builds (an extension of https://github.com/chromaui/chromatic-cli/pull/1394). It gets the single ancestor build and prints the information associated with it because a fully TurboSnapped build won't have a proper build within Chromatic.

Example:
<img width="770" height="420" alt="image" src="https://github.com/user-attachments/assets/4e5db54d-0f06-4f98-95f2-be2ae8933098" />

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>17.9.0--canary.1406.28385391607.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@17.9.0--canary.1406.28385391607.0
  # or 
  yarn add chromatic@17.9.0--canary.1406.28385391607.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
