### PR TITLE
Don't bail on irrelevant manifest parsing failures

### DIFF
--- a/node-src/lib/turbosnap/getPackageFilesInBuild.test.ts
+++ b/node-src/lib/turbosnap/getPackageFilesInBuild.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'vitest';
+
+import { Context, Stats } from '../../types';
+import { getPackageFilesInBuild } from './getPackageFilesInBuild';
+
+const makeContext = (rootPath: string, baseDirectory = ''): Context =>
+  ({
+    git: { rootPath },
+    storybook: { baseDir: baseDirectory },
+  }) as any;
+
+const makeStats = (names: string[]): Stats => ({
+  modules: names.map((name, index) => ({ id: index, name })),
+});
+
+describe('getPackageFilesInBuild', () => {
+  it('always considers a repository-root package file relevant', () => {
+    const ctx = makeContext('/repo');
+    const stats = makeStats(['./packages/app/src/Button.jsx']);
+
+    expect(getPackageFilesInBuild(ctx, stats, ['./package.json'])).toEqual(['./package.json']);
+    expect(getPackageFilesInBuild(ctx, stats, ['package.json'])).toEqual(['package.json']);
+  });
+
+  it('keeps package files whose directory contains a module in the build', () => {
+    const ctx = makeContext('/repo');
+    const stats = makeStats([
+      '/repo/packages/app/src/Button.jsx',
+      '/repo/packages/app/src/index.js',
+    ]);
+
+    expect(getPackageFilesInBuild(ctx, stats, ['packages/app/package.json'])).toEqual([
+      'packages/app/package.json',
+    ]);
+  });
+
+  it('drops package files whose directory has no module in the build', () => {
+    const ctx = makeContext('/repo');
+    const stats = makeStats(['/repo/packages/app/src/Button.jsx']);
+
+    expect(getPackageFilesInBuild(ctx, stats, ['packages/unrelated/package.json'])).toEqual([]);
+  });
+
+  it('does not treat a directory as relevant via a partial name match', () => {
+    const ctx = makeContext('/repo');
+    // `packages/app-utils` should not be matched by the `packages/app` package file.
+    const stats = makeStats(['/repo/packages/app-utils/src/index.js']);
+
+    expect(getPackageFilesInBuild(ctx, stats, ['packages/app/package.json'])).toEqual([]);
+  });
+
+  it('matches modules relative to the Storybook base directory', () => {
+    const ctx = makeContext('/repo', 'packages/app');
+    // Builder stats generated inside `packages/app` reference modules relative to that directory.
+    const stats = makeStats(['./src/Button.jsx']);
+
+    expect(getPackageFilesInBuild(ctx, stats, ['packages/app/package.json'])).toEqual([
+      'packages/app/package.json',
+    ]);
+  });
+
+  it('considers the constituent modules of concatenated modules', () => {
+    const ctx = makeContext('/repo');
+    const stats: Stats = {
+      modules: [
+        {
+          id: 0,
+          name: '/repo/packages/app/src/index.js + 2 modules',
+          modules: [{ name: '/repo/packages/app/src/Button.jsx' }],
+        },
+      ],
+    };
+
+    expect(getPackageFilesInBuild(ctx, stats, ['packages/app/package.json'])).toEqual([
+      'packages/app/package.json',
+    ]);
+  });
+
+  it('filters a mixed list of relevant and irrelevant package files', () => {
+    const ctx = makeContext('/repo');
+    const stats = makeStats(['/repo/packages/app/src/Button.jsx']);
+
+    expect(
+      getPackageFilesInBuild(ctx, stats, [
+        './package.json',
+        'packages/app/package.json',
+        'packages/unrelated/package.json',
+      ])
+    ).toEqual(['./package.json', 'packages/app/package.json']);
+  });
+});

--- a/node-src/lib/turbosnap/getPackageFilesInBuild.ts
+++ b/node-src/lib/turbosnap/getPackageFilesInBuild.ts
@@ -1,0 +1,50 @@
+import path from 'path';
+
+import { Context, Stats } from '../../types';
+import { normalizePath } from './getDependentStoryFiles';
+
+// Strip a leading `./` so paths line up with the (git root relative) module paths in the stats.
+const stripRelativePrefix = (filepath: string) => filepath.replace(/^\.\//, '');
+
+/**
+ * Given a list of changed package metadata files (manifests and/or lockfiles) which we could not
+ * resolve to a concrete set of dependency changes, determine which of them are actually relevant
+ * to the Storybook build.
+ *
+ * A package file is considered relevant if the build includes at least one module located within
+ * the package file's directory. A package file at the repository root governs the entire project,
+ * so it is always considered relevant. This lets us avoid bailing the whole build for an unrelated
+ * (e.g. newly added) `package.json` belonging to a monorepo package that isn't part of Storybook.
+ *
+ * @param ctx The context set when executing the CLI.
+ * @param stats The stats file information from the project's builder (Webpack, for example).
+ * @param packageFiles The changed package metadata files we couldn't resolve to dependency changes.
+ *
+ * @returns The subset of `packageFiles` whose directory contains at least one module in the build.
+ */
+export const getPackageFilesInBuild = (
+  ctx: Context,
+  stats: Stats,
+  packageFiles: string[]
+): string[] => {
+  const { rootPath = '' } = ctx.git || {};
+  const { baseDir: baseDirectory = '' } = ctx.storybook || {};
+
+  // Collect the git-root-relative path of every module in the build, including the constituent
+  // modules of any concatenated (e.g. ModuleConcatenation) modules.
+  const buildModulePaths = stats.modules.flatMap((module_) => [
+    normalizePath(module_.name, rootPath, baseDirectory),
+    ...(module_.modules?.map((m) => normalizePath(m.name, rootPath, baseDirectory)) || []),
+  ]);
+
+  return packageFiles.filter((file) => {
+    const directory = path.posix.dirname(stripRelativePrefix(file));
+    // A package file at the repository root governs the whole project, so always treat it as relevant.
+    if (directory === '.' || directory === '') {
+      return true;
+    }
+
+    const prefix = `${directory}/`;
+    return buildModulePaths.some((modulePath) => modulePath.startsWith(prefix));
+  });
+};

--- a/node-src/lib/turbosnap/index.test.ts
+++ b/node-src/lib/turbosnap/index.test.ts
@@ -14,6 +14,7 @@ import {
 import { findChangedDependencies as findChangedDependenciesDep } from './findChangedDependencies';
 import { findChangedPackageFiles as findChangedPackageFilesDep } from './findChangedPackageFiles';
 import { getDependentStoryFiles as getDependentStoryFilesDep } from './getDependentStoryFiles';
+import { getPackageFilesInBuild as getPackageFilesInBuildDep } from './getPackageFilesInBuild';
 
 vi.mock('@sentry/node', () => ({
   captureException: vi.fn(() => 'sentry-event-id'),
@@ -28,6 +29,7 @@ vi.mock('./findChangedDependencies', async (importOriginal) => {
 });
 vi.mock('./findChangedPackageFiles');
 vi.mock('./getDependentStoryFiles');
+vi.mock('./getPackageFilesInBuild');
 vi.mock('./classifyBailRootCause');
 vi.mock('../../tasks/readStatsFile', () => ({
   readStatsFile: () =>
@@ -44,6 +46,7 @@ vi.mock('../../tasks/readStatsFile', () => ({
 const getDependentStoryFiles = vi.mocked(getDependentStoryFilesDep);
 const findChangedPackageFiles = vi.mocked(findChangedPackageFilesDep);
 const findChangedDependencies = vi.mocked(findChangedDependenciesDep);
+const getPackageFilesInBuild = vi.mocked(getPackageFilesInBuildDep);
 const classifyTagsFromError = vi.mocked(classifyTagsFromErrorDep);
 const accessMock = vi.mocked(access);
 const captureException = vi.mocked(Sentry.captureException);
@@ -145,6 +148,7 @@ describe('traceChangedFiles', () => {
     it(`bails on package.json changes and tags bailReason as ${name}`, async () => {
       findChangedDependencies.mockRejectedValue(error);
       findChangedPackageFiles.mockResolvedValue(['./package.json']);
+      getPackageFilesInBuild.mockReturnValue(['./package.json']);
       classifyTagsFromError.mockImplementation(async (_deps, err) =>
         err instanceof BaselineCheckoutFailedError
           ? { baseline_failure_kind: 'baselineManifestMoved' }
@@ -242,6 +246,37 @@ describe('traceChangedFiles', () => {
     expect(ctx.turboSnap.bailReason).toBeUndefined();
     expect(onlyStoryFiles).toStrictEqual(deps);
     expect(findChangedPackageFiles).toHaveBeenCalledWith(ctx, packageMetadataChanges);
+  });
+
+  it('does not bail when changed package files are not part of the Storybook build', async () => {
+    const deps = { 123: ['./example.stories.js'] };
+    findChangedDependencies.mockRejectedValue(new BaselineCheckoutFailedError('abc:package.json'));
+    findChangedPackageFiles.mockResolvedValue(['packages/unrelated/package.json']);
+    // The changed package.json lives in a monorepo package that isn't part of the build.
+    getPackageFilesInBuild.mockReturnValue([]);
+    getDependentStoryFiles.mockResolvedValue(deps);
+
+    const packageMetadataChanges = [
+      { changedFiles: ['packages/unrelated/package.json'], commit: 'abcdef' },
+    ];
+    const ctx = {
+      env: environment,
+      log,
+      http,
+      options: {},
+      sourceDir: '/static/',
+      fileInfo: { statsPath: '/static/preview-stats.json' },
+      git: {
+        changedFiles: ['./example.js', 'packages/unrelated/package.json'],
+        packageMetadataChanges,
+      },
+      turboSnap: {},
+    } as any;
+    const onlyStoryFiles = await traceChangedFiles(ctx);
+
+    expect(ctx.turboSnap.bailReason).toBeUndefined();
+    expect(onlyStoryFiles).toStrictEqual(deps);
+    expect(captureException).not.toHaveBeenCalled();
   });
 
   it('does not set bailReason or capture to Sentry when findChangedDependencies fails but findChangedPackageFiles is empty', async () => {

--- a/node-src/lib/turbosnap/index.ts
+++ b/node-src/lib/turbosnap/index.ts
@@ -11,8 +11,9 @@ import { classifyTagsFromError } from './classifyBailRootCause';
 import { findChangedDependencies } from './findChangedDependencies';
 import { findChangedPackageFiles } from './findChangedPackageFiles';
 import { getDependentStoryFiles } from './getDependentStoryFiles';
+import { getPackageFilesInBuild } from './getPackageFilesInBuild';
 
-// eslint-disable-next-line complexity
+// eslint-disable-next-line complexity, max-statements
 export const traceChangedFiles = async (ctx: Context) => {
   if (!ctx.turboSnap || ctx.turboSnap.unavailable) return;
   if (!ctx.git.changedFiles) return;
@@ -33,6 +34,11 @@ export const traceChangedFiles = async (ctx: Context) => {
   let changedDependencyNames: void | string[] = [];
   let pendingError: unknown;
   let pendingPatch: Partial<ChangedPackageFilesBailReason> | undefined;
+  // Package files whose dependency changes we couldn't resolve from the lockfiles. We don't bail on
+  // these immediately because a changed (or newly added) package.json may belong to a monorepo
+  // package that isn't part of the Storybook build. Instead we defer the decision until we've read
+  // the stats file, then only bail if one of these files is actually relevant to the build.
+  let unresolvedPackageFiles: string[] = [];
   if (packageMetadataChanges?.length) {
     changedDependencyNames = await findChangedDependencies(ctx).catch((err) => {
       pendingError = err;
@@ -52,33 +58,44 @@ export const traceChangedFiles = async (ctx: Context) => {
       }
     } else {
       ctx.log.warn(`Could not retrieve dependency changes from lockfiles; checking package.json`);
-
-      const changedPackageFiles = await findChangedPackageFiles(ctx, packageMetadataChanges);
-      if (changedPackageFiles.length > 0) {
-        // Capture original error from findChangedDependencies at the actual bail site. There could
-        // be times when findChangedDependencies fails but our fallback works. In those cases, we
-        // don't want to capture an error since we were able to recover and didn't bail.
-        if (pendingPatch && pendingError) {
-          pendingPatch.sentryEventId = captureBailException(pendingError, {
-            bailSubreason: pendingPatch.bailSubreason,
-            bailPath: 'findChangedDependencies',
-            additionalTags: await classifyTagsFromError(ctx, pendingError),
-          });
-        }
-
-        ctx.turboSnap.bailReason = {
-          changedPackageFiles,
-          ...pendingPatch,
-        };
-        ctx.log.warn(bailFile({ turboSnap: ctx.turboSnap }));
-        return;
-      }
+      unresolvedPackageFiles = await findChangedPackageFiles(ctx, packageMetadataChanges);
     }
   }
 
   const stats = await readStatsFile(statsPath);
 
   await checkStorybookBaseDirectory(ctx, stats);
+
+  if (unresolvedPackageFiles.length > 0) {
+    // Only bail on package files that actually map to modules included in the Storybook build.
+    // Unrelated package files (e.g. an added package.json in a sibling monorepo package) are
+    // ignored so they don't take down the whole build.
+    const changedPackageFiles = getPackageFilesInBuild(ctx, stats, unresolvedPackageFiles);
+    if (changedPackageFiles.length > 0) {
+      // Capture original error from findChangedDependencies at the actual bail site. There could
+      // be times when findChangedDependencies fails but our fallback works. In those cases, we
+      // don't want to capture an error since we were able to recover and didn't bail.
+      if (pendingPatch && pendingError) {
+        pendingPatch.sentryEventId = captureBailException(pendingError, {
+          bailSubreason: pendingPatch.bailSubreason,
+          bailPath: 'findChangedDependencies',
+          additionalTags: await classifyTagsFromError(ctx, pendingError),
+        });
+      }
+
+      ctx.turboSnap.bailReason = {
+        changedPackageFiles,
+        ...pendingPatch,
+      };
+      ctx.log.warn(bailFile({ turboSnap: ctx.turboSnap }));
+      return;
+    }
+
+    ctx.log.debug(
+      { unresolvedPackageFiles },
+      'Ignoring changed package files that are not part of the Storybook build'
+    );
+  }
 
   return await getDependentStoryFiles(
     ctx,


### PR DESCRIPTION
One unfortunate discovery is that we bail on any promise rejection when trying to parse _any_ manifest pair (`package.json` and lock file) in the repository. This tends to cause issues in monorepos where things update frequently.

The main scenario I tested was simply adding a new package into my test monorepo. I didn't add it to the Storybook or anything. TurboSnap bailed immediately because it attempt to checkout the baseline version of the new package's `package.json` and it failed because it didn't exist in the baseline.

To fix this, we can simply ignore any manifest pairs that are irrelevant to the Storybook. I considered a couple ways to accomplish this:

1. Flipping the `preview-stats.json` read and the manifest parsing but the changes were more substantial than I cared for (especially if we're looking at replacing this entire algorithmanyway)
2. (This PR) Ensuring the manifests exist in the baseline then bailing on any that don't have a baseline but appear in the Storybook build output

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>17.7.2--canary.1407.28198929320.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@17.7.2--canary.1407.28198929320.0
  # or 
  yarn add chromatic@17.7.2--canary.1407.28198929320.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
