### PR TITLE
Only upload metadata files with a valid S3 path

### DIFF
--- a/node-src/index.test.ts
+++ b/node-src/index.test.ts
@@ -913,8 +913,14 @@ describe('diagnostics file cleanup', () => {
 });
 
 describe('shouldUploadMetadata', () => {
+  const publishedBuild = { storybookUrl: 'https://sample-storybook.dev-chromatic.com' };
+
   it('uploads when --upload-metadata is explicitly enabled', () => {
-    const ctx = { options: { uploadMetadata: true }, turboSnap: undefined } as any;
+    const ctx = {
+      options: { uploadMetadata: true },
+      turboSnap: undefined,
+      build: publishedBuild,
+    } as any;
     expect(shouldUploadMetadata(ctx)).toBe(true);
   });
 
@@ -922,27 +928,39 @@ describe('shouldUploadMetadata', () => {
     const ctx = {
       options: { uploadMetadata: false },
       turboSnap: {},
+      build: publishedBuild,
     } as any;
     expect(shouldUploadMetadata(ctx)).toBe(false);
   });
 
   it('uploads by default when TurboSnap is requested and the flag is unset', () => {
-    const ctx = { options: {}, turboSnap: {} } as any;
+    const ctx = { options: {}, turboSnap: {}, build: publishedBuild } as any;
     expect(shouldUploadMetadata(ctx)).toBe(true);
   });
 
   it('uploads by default when TurboSnap bailed and the flag is unset', () => {
-    const ctx = { options: {}, turboSnap: { bailReason: { rebuild: true } } } as any;
+    const ctx = {
+      options: {},
+      turboSnap: { bailReason: { rebuild: true } },
+      build: publishedBuild,
+    } as any;
     expect(shouldUploadMetadata(ctx)).toBe(true);
   });
 
   it('uploads by default when TurboSnap is unavailable and the flag is unset', () => {
-    const ctx = { options: {}, turboSnap: { unavailable: true } } as any;
+    const ctx = { options: {}, turboSnap: { unavailable: true }, build: publishedBuild } as any;
     expect(shouldUploadMetadata(ctx)).toBe(true);
   });
 
   it('does not upload by default when TurboSnap is disabled and the flag is unset', () => {
-    const ctx = { options: {}, turboSnap: undefined } as any;
+    const ctx = { options: {}, turboSnap: undefined, build: publishedBuild } as any;
+    expect(shouldUploadMetadata(ctx)).toBe(false);
+  });
+
+  it('does not upload for an unpublished build, even if --upload-metadata is enabled', () => {
+    // A build that never got published (e.g. `prepare` failed) doesn't have a storybookUrl, so
+    // there's no valid location to host the metadata files.
+    const ctx = { options: { uploadMetadata: true }, turboSnap: {}, build: { id: '1' } } as any;
     expect(shouldUploadMetadata(ctx)).toBe(false);
   });
 });

--- a/node-src/index.ts
+++ b/node-src/index.ts
@@ -267,6 +267,11 @@ function shouldWriteDiagnosticsFile(ctx: Context): boolean {
  * @returns True if metadata files should be uploaded.
  */
 export function shouldUploadMetadata(ctx: Context): boolean {
+  // Don't upload if we don't have a valid URL to S3
+  if (!ctx.build?.storybookUrl) {
+    return false;
+  }
+
   return ctx.options.uploadMetadata ?? isTurboSnapEnabled(ctx);
 }
 


### PR DESCRIPTION
If you attempt to run a build with TurboSnap on an existing Storybook artifact directory (`-d`) that doesn't have the required `preview-stats.json` file, it fails appropriately but then we attempt to upload the metadata files anyway to `undefined/.chromatc`.

Instead, we need to check that we have a valid hosted Storybook location in S3 before we attempt to upload.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>17.7.3--canary.1408.28253863185.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@17.7.3--canary.1408.28253863185.0
  # or 
  yarn add chromatic@17.7.3--canary.1408.28253863185.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
