### PR TITLE
Migrate `verify` to Clack

### DIFF
--- a/node-src/index.ts
+++ b/node-src/index.ts
@@ -42,6 +42,7 @@ import { renderInitialize } from './renderer/initialize';
 import { renderPrepare } from './renderer/prepare';
 import { renderStorybookInfo } from './renderer/storybookInfo';
 import { renderUpload } from './renderer/upload';
+import { renderVerify } from './renderer/verify';
 import getTasks from './tasks';
 import { Context, Flags, Options } from './types';
 import { endActivity } from './ui/components/activity';
@@ -355,6 +356,7 @@ async function runBuild(ctx: Context) {
       await renderBuild(ctx);
       await renderPrepare(ctx);
       await renderUpload(ctx);
+      await renderVerify(ctx);
       await new Listr(getTasks(ctx), options).run(ctx);
       ctx.log.debug('Tasks completed');
     } catch (err) {

--- a/node-src/renderer/verify.ts
+++ b/node-src/renderer/verify.ts
@@ -1,0 +1,30 @@
+import { applyVerifyOutput, extractVerifyInput, verifyProject } from '../tasks/verify';
+import { Context } from '../types';
+import { dryRun, initial, pending, success } from '../ui/tasks/verify';
+import { runTask } from './engine';
+import { clackSpinnerRenderer } from './engine/clack/spinnerRenderer';
+import { getRenderer } from './engine/getRenderer';
+
+/**
+ * Render the verify task.
+ *
+ * @param ctx The CLI context.
+ */
+export async function renderVerify(ctx: Context): Promise<void> {
+  await runTask(
+    ctx,
+    {
+      name: 'verify',
+      title: initial(ctx).title,
+      transitions: {
+        pending,
+        success,
+        skipped: dryRun,
+      },
+      extractInput: extractVerifyInput,
+      run: verifyProject,
+      applyOutput: applyVerifyOutput,
+    },
+    getRenderer(ctx, clackSpinnerRenderer)
+  );
+}

--- a/node-src/tasks/index.ts
+++ b/node-src/tasks/index.ts
@@ -6,11 +6,10 @@ import report from './report';
 import restoreWorkspace from './restoreWorkspace';
 import snapshot from './snapshot';
 import uploadShare from './uploadShare';
-import verify from './verify';
 
 export const runShare = [uploadShare];
 
-export const runUploadBuild = [verify, snapshot];
+export const runUploadBuild = [snapshot];
 
 export const runPatchBuild = [prepareWorkspace, ...runUploadBuild, restoreWorkspace];
 

--- a/node-src/tasks/verify/index.test.ts
+++ b/node-src/tasks/verify/index.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { exitCodes } from '../../lib/setExitCode';
+import { applyVerifyOutput, verifyProject } from './index';
+
+vi.mock('./publishBuild');
+vi.mock('./verifyBuild');
+
+const baseOutput = {
+  announcedBuild: { number: 1 },
+  storybookUrl: 'https://chromatic.com/build',
+  build: { number: 1 },
+  isPublishOnly: false,
+  skipSnapshots: false,
+} as any;
+
+describe('applyVerifyOutput', () => {
+  it('applies build metadata to context', () => {
+    const ctx = {} as any;
+    applyVerifyOutput(ctx, baseOutput);
+    expect(ctx.announcedBuild).toEqual({ number: 1 });
+    expect(ctx.storybookUrl).toBe('https://chromatic.com/build');
+    expect(ctx.build).toEqual({ number: 1 });
+    expect(ctx.isPublishOnly).toBe(false);
+    expect(ctx.skipSnapshots).toBe(undefined);
+    expect(ctx.exitCode).toBe(undefined);
+  });
+
+  it('applies a limit exit code', () => {
+    const ctx = {} as any;
+    applyVerifyOutput(ctx, {
+      ...baseOutput,
+      limitExitCode: { code: exitCodes.ACCOUNT_QUOTA_REACHED, userError: true },
+    });
+    expect(ctx.exitCode).toBe(exitCodes.ACCOUNT_QUOTA_REACHED);
+    expect(ctx.userError).toBe(true);
+  });
+
+  it('sets OK and skipSnapshots, overriding a limit exit code', () => {
+    const ctx = {} as any;
+    applyVerifyOutput(ctx, {
+      ...baseOutput,
+      skipSnapshots: true,
+      limitExitCode: { code: exitCodes.ACCOUNT_QUOTA_REACHED, userError: true },
+    });
+    expect(ctx.skipSnapshots).toBe(true);
+    expect(ctx.exitCode).toBe(exitCodes.OK);
+  });
+});
+
+describe('verifyProject', () => {
+  it('skips itself on a dry run without publishing', async () => {
+    const result = await verifyProject({ options: { dryRun: true } } as any, {} as any);
+    expect(result).toEqual({ kind: 'skip-self' });
+  });
+});

--- a/node-src/tasks/verify/index.ts
+++ b/node-src/tasks/verify/index.ts
@@ -1,26 +1,94 @@
-import { createTask, transitionTo } from '../../lib/tasks';
-import { Context } from '../../types';
-import { endActivity, startActivity } from '../../ui/components/activity';
-import { dryRun, initial, pending } from '../../ui/tasks/verify';
+import { exitCodes, setExitCode } from '../../lib/setExitCode';
+import { Context, Deps, TaskResult } from '../../types';
 import { publishBuild } from './publishBuild';
 import { verifyBuild } from './verifyBuild';
 
-/**
- * Sets up the Listr task for verifying the uploaded Storybook.
- *
- * @param ctx The context set when executing the CLI.
- *
- * @returns A Listr task.
- */
-export default function main(ctx: Context) {
-  return createTask({
-    name: 'verify',
-    title: initial(ctx).title,
-    skip: (ctx: Context) => {
-      if (ctx.skip) return true;
-      if (ctx.options.dryRun) return dryRun(ctx).output;
-      return false;
-    },
-    steps: [transitionTo(pending), startActivity, publishBuild, verifyBuild, endActivity],
-  });
+export interface VerifyInput {
+  announcedBuild: Context['announcedBuild'];
+  build: Context['build'];
+  replacementBuildIds?: Context['git']['replacementBuildIds'];
+  options: Context['options'];
+  onlyStoryFiles?: string[];
+  matchesBranch?: Context['git']['matchesBranch'];
+  turboSnap?: Context['turboSnap'];
+  isReactNativeApp?: boolean;
 }
+
+export interface VerifyOutput {
+  announcedBuild: Context['announcedBuild'];
+  storybookUrl: string;
+  build: Context['build'];
+  isPublishOnly: boolean;
+  skipSnapshots: boolean;
+  limitExitCode?: { code: number; userError: boolean };
+}
+
+/**
+ * Publish the uploaded build and wait for Chromatic to verify it has started, surfacing build
+ * metadata (component/spec counts, TurboSnap status, limits) for the snapshot task that follows.
+ *
+ * @param deps Narrow set of cross-cutting dependencies the task needs.
+ * @param input Per-pipeline-run input extracted from Context at the seam.
+ *
+ * @returns A TaskResult conveying the verified build, or a self-skip for `--dry-run`.
+ */
+export async function verifyProject(
+  deps: Deps,
+  input: VerifyInput
+): Promise<TaskResult<VerifyOutput>> {
+  if (deps.options.dryRun) {
+    return { kind: 'skip-self' };
+  }
+
+  const { announcedBuild, storybookUrl } = await publishBuild(deps, {
+    announcedBuild: input.announcedBuild,
+    options: input.options,
+    replacementBuildIds: input.replacementBuildIds,
+    onlyStoryFiles: input.onlyStoryFiles,
+    turboSnap: input.turboSnap,
+  });
+
+  const { build, isPublishOnly, skipSnapshots, limitExitCode } = await verifyBuild(deps, {
+    announcedBuild,
+    build: input.build,
+    storybookUrl,
+    options: input.options,
+    onlyStoryFiles: input.onlyStoryFiles,
+    matchesBranch: input.matchesBranch,
+    turboSnap: input.turboSnap,
+    isReactNativeApp: input.isReactNativeApp,
+  });
+
+  return {
+    kind: 'continue',
+    output: { announcedBuild, storybookUrl, build, isPublishOnly, skipSnapshots, limitExitCode },
+  };
+}
+
+export const extractVerifyInput = (ctx: Context): VerifyInput => ({
+  announcedBuild: ctx.announcedBuild,
+  build: ctx.build,
+  replacementBuildIds: ctx.git.replacementBuildIds,
+  options: ctx.options,
+  onlyStoryFiles: ctx.onlyStoryFiles,
+  matchesBranch: ctx.git.matchesBranch,
+  turboSnap: ctx.turboSnap,
+  isReactNativeApp: ctx.isReactNativeApp,
+});
+
+export const applyVerifyOutput = (ctx: Context, output: VerifyOutput) => {
+  ctx.announcedBuild = output.announcedBuild;
+  ctx.storybookUrl = output.storybookUrl;
+  ctx.build = output.build;
+  ctx.isPublishOnly = output.isPublishOnly;
+
+  // Replays the legacy setExitCode ordering: a limit code first, then OK overrides it when the
+  // build is publish-only / listed / exiting once uploaded.
+  if (output.limitExitCode) {
+    setExitCode(ctx, output.limitExitCode.code, output.limitExitCode.userError);
+  }
+  if (output.skipSnapshots) {
+    setExitCode(ctx, exitCodes.OK);
+    ctx.skipSnapshots = true;
+  }
+};

--- a/node-src/tasks/verify/publishBuild.test.ts
+++ b/node-src/tasks/verify/publishBuild.test.ts
@@ -3,41 +3,25 @@ import { describe, expect, it, vi } from 'vitest';
 import TestLogger from '../../lib/testLogger';
 import { publishBuild } from './publishBuild';
 
-const environment = {
-  CHROMATIC_POLL_INTERVAL: 10,
-  CHROMATIC_UPGRADE_TIMEOUT: 100,
-  STORYBOOK_VERIFY_TIMEOUT: 20,
-};
 const log = new TestLogger();
-const http = { fetch: vi.fn() };
+
+const buildDeps = (client: { runQuery: ReturnType<typeof vi.fn> }) => ({ log, client }) as any;
 
 describe('publishBuild', () => {
-  it('updates the build on the index and updates context', async () => {
+  it('publishes the build and returns the merged announced build', async () => {
     const announcedBuild = { number: 1, status: 'ANNOUNCED', reportToken: 'report-token' };
     const publishedBuild = { status: 'PUBLISHED' };
     const client = { runQuery: vi.fn() };
     client.runQuery.mockReturnValue({ publishBuild: publishedBuild });
 
-    const ctx = {
-      env: environment,
-      log,
-      http,
-      client,
-      announcedBuild,
-      git: {},
-      sourceDir: '/static/',
-      buildLogFile: 'build-storybook.log',
-      options: {},
-      packageJson: {},
-    } as any;
-    await publishBuild(ctx);
+    const result = await publishBuild(buildDeps(client), { announcedBuild, options: {} } as any);
 
     expect(client.runQuery).toHaveBeenCalledWith(
       expect.stringMatching(/PublishBuildMutation/),
       { input: { turboSnapStatus: 'UNUSED' } },
       { headers: { Authorization: `Bearer report-token` }, retries: 3 }
     );
-    expect(ctx.announcedBuild).toEqual({ ...announcedBuild, ...publishedBuild });
+    expect(result.announcedBuild).toEqual({ ...announcedBuild, ...publishedBuild });
   });
 
   it('forwards turboSnapBailReason with merged detail fields in the publishBuild input', async () => {
@@ -54,20 +38,11 @@ describe('publishBuild', () => {
       sentryEventId: 'sentry-event-id',
     };
 
-    const ctx = {
-      env: environment,
-      log,
-      http,
-      client,
+    await publishBuild(buildDeps(client), {
       announcedBuild,
-      git: {},
-      sourceDir: '/static/',
-      buildLogFile: 'build-storybook.log',
       options: {},
-      packageJson: {},
       turboSnap: { bailReason },
-    } as any;
-    await publishBuild(ctx);
+    } as any);
 
     expect(client.runQuery).toHaveBeenCalledWith(
       expect.stringMatching(/PublishBuildMutation/),

--- a/node-src/tasks/verify/publishBuild.ts
+++ b/node-src/tasks/verify/publishBuild.ts
@@ -1,5 +1,5 @@
-import { exitCodes, setExitCode } from '../../lib/setExitCode';
-import { Context, TurboSnapStatus } from '../../types';
+import { exitCodes, TaskFailure } from '../../lib/setExitCode';
+import { Context, Deps, TurboSnapStatus } from '../../types';
 import { publishFailed } from '../../ui/tasks/verify';
 
 const PublishBuildMutation = `
@@ -19,11 +19,27 @@ interface PublishBuildMutationResult {
   };
 }
 
-export const publishBuild = async (ctx: Context) => {
-  const { turboSnap } = ctx;
-  const { id, reportToken } = ctx.announcedBuild;
-  const { replacementBuildIds } = ctx.git;
-  const { onlyStoryNames, onlyStoryFiles = ctx.onlyStoryFiles } = ctx.options;
+export interface PublishBuildInput {
+  announcedBuild: Context['announcedBuild'];
+  options: Context['options'];
+  replacementBuildIds?: Context['git']['replacementBuildIds'];
+  onlyStoryFiles?: string[];
+  turboSnap?: Context['turboSnap'];
+}
+
+export interface PublishBuildResult {
+  announcedBuild: Context['announcedBuild'];
+  storybookUrl: string;
+}
+
+export const publishBuild = async (
+  deps: Deps,
+  input: PublishBuildInput
+): Promise<PublishBuildResult> => {
+  const { client } = deps;
+  const { announcedBuild, replacementBuildIds, turboSnap } = input;
+  const { id, reportToken } = announcedBuild;
+  const { onlyStoryNames, onlyStoryFiles = input.onlyStoryFiles } = input.options;
 
   let turboSnapBailReason;
   let turboSnapStatus: TurboSnapStatus = 'UNUSED';
@@ -32,7 +48,7 @@ export const publishBuild = async (ctx: Context) => {
     turboSnapStatus = turboSnap.bailReason ? 'BAILED' : 'APPLIED';
   }
 
-  const { publishBuild: publishedBuild } = await ctx.client.runQuery<PublishBuildMutationResult>(
+  const { publishBuild: publishedBuild } = await client.runQuery<PublishBuildMutationResult>(
     PublishBuildMutation,
     {
       id,
@@ -49,12 +65,13 @@ export const publishBuild = async (ctx: Context) => {
     { headers: { Authorization: `Bearer ${reportToken}` }, retries: 3 }
   );
 
-  ctx.announcedBuild = { ...ctx.announcedBuild, ...publishedBuild };
-  ctx.storybookUrl = publishedBuild.storybookUrl;
-
   // Queueing the extract may have failed
   if (publishedBuild.status === 'FAILED') {
-    setExitCode(ctx, exitCodes.BUILD_FAILED, false);
-    throw new Error(publishFailed(ctx).output);
+    throw new TaskFailure(publishFailed(input).output, { exitCode: exitCodes.BUILD_FAILED });
   }
+
+  return {
+    announcedBuild: { ...announcedBuild, ...publishedBuild },
+    storybookUrl: publishedBuild.storybookUrl,
+  };
 };

--- a/node-src/tasks/verify/verifyBuild.test.ts
+++ b/node-src/tasks/verify/verifyBuild.test.ts
@@ -11,18 +11,16 @@ const environment = {
 };
 const log = new TestLogger();
 
-describe('verifyBuild', () => {
-  const defaultContext = {
-    env: environment,
-    log,
-    options: {},
-    environment: ':environment',
-    git: { version: 'whatever', matchesBranch: () => false },
-    pkg: { version: '1.0.0' },
-    storybook: { version: '2.0.0', addons: [] },
-    announcedBuild: { number: 1, reportToken: 'report-token' },
-  };
+const buildDeps = (client: { runQuery: ReturnType<typeof vi.fn> }) =>
+  ({ client, env: environment, log, report: vi.fn() }) as any;
 
+const defaultInput = {
+  options: {},
+  matchesBranch: () => false,
+  announcedBuild: { number: 1, reportToken: 'report-token' },
+} as any;
+
+describe('verifyBuild', () => {
   it('waits for the build to start', async () => {
     const build = {
       status: 'IN_PROGRESS',
@@ -38,8 +36,7 @@ describe('verifyBuild', () => {
       .mockReturnValueOnce({ app: { build: publishedBuild } })
       .mockReturnValue({ app: { build } });
 
-    const ctx = { client, ...defaultContext } as any;
-    await verifyBuild(ctx, {} as any);
+    const result = await verifyBuild(buildDeps(client), defaultInput);
 
     expect(client.runQuery).toHaveBeenNthCalledWith(
       1,
@@ -66,9 +63,9 @@ describe('verifyBuild', () => {
       { headers: { Authorization: `Bearer report-token` } }
     );
     expect(client.runQuery).toHaveBeenCalledTimes(4);
-    expect(ctx.build).toMatchObject(build);
-    expect(ctx.exitCode).toBe(undefined);
-    expect(ctx.skipSnapshots).toBe(undefined);
+    expect(result.build).toMatchObject(build);
+    expect(result.limitExitCode).toBe(undefined);
+    expect(result.skipSnapshots).toBe(false);
   });
 
   it('times out if build takes too long to start', async () => {
@@ -82,10 +79,9 @@ describe('verifyBuild', () => {
     const client = { runQuery: vi.fn() };
     client.runQuery.mockReturnValue({ app: { build: publishedBuild } });
 
-    const ctx = { client, ...defaultContext } as any;
-    await expect(verifyBuild(ctx, {} as any)).rejects.toThrow('Build verification timed out');
-
-    expect(ctx.exitCode).toBe(exitCodes.VERIFICATION_TIMEOUT);
+    const error = await verifyBuild(buildDeps(client), defaultInput).catch((error_) => error_);
+    expect(error.message).toBe('Build verification timed out');
+    expect(error.exitCode).toBe(exitCodes.VERIFICATION_TIMEOUT);
   });
 
   it('waits for upgrade builds before starting verification timeout', async () => {
@@ -111,11 +107,10 @@ describe('verifyBuild', () => {
       .mockReturnValueOnce({ app: { build: { ...publishedBuild, upgradeBuilds: completed } } })
       .mockReturnValue({ app: { build } });
 
-    const ctx = { client, ...defaultContext } as any;
-    await verifyBuild(ctx, {} as any);
+    const result = await verifyBuild(buildDeps(client), defaultInput);
 
-    expect(ctx.build).toMatchObject(build);
-    expect(ctx.exitCode).toBe(undefined);
+    expect(result.build).toMatchObject(build);
+    expect(result.limitExitCode).toBe(undefined);
   });
 
   it('times out if upgrade builds take too long to complete', async () => {
@@ -130,13 +125,12 @@ describe('verifyBuild', () => {
     const client = { runQuery: vi.fn() };
     client.runQuery.mockReturnValue({ app: { build: publishedBuild } });
 
-    const ctx = { client, ...defaultContext } as any;
-    await expect(verifyBuild(ctx, {} as any)).rejects.toThrow(
+    await expect(verifyBuild(buildDeps(client), defaultInput)).rejects.toThrow(
       'Timed out waiting for upgrade builds to complete'
     );
   });
 
-  it('sets exitCode to 5 if build was limited', async () => {
+  it('reports a limit exit code of 5 if build was limited', async () => {
     const client = { runQuery: vi.fn() };
     client.runQuery.mockReturnValue({
       app: {
@@ -152,12 +146,11 @@ describe('verifyBuild', () => {
       },
     });
 
-    const ctx = { client, ...defaultContext } as any;
-    await verifyBuild(ctx, {} as any);
-    expect(ctx.exitCode).toBe(5);
+    const result = await verifyBuild(buildDeps(client), defaultInput);
+    expect(result.limitExitCode?.code).toBe(exitCodes.BUILD_WAS_LIMITED);
   });
 
-  it('sets exitCode to 11 if snapshot quota was reached', async () => {
+  it('reports a limit exit code of 11 if snapshot quota was reached', async () => {
     const client = { runQuery: vi.fn() };
     client.runQuery.mockReturnValue({
       app: {
@@ -173,12 +166,11 @@ describe('verifyBuild', () => {
       },
     });
 
-    const ctx = { client, ...defaultContext } as any;
-    await verifyBuild(ctx, {} as any);
-    expect(ctx.exitCode).toBe(11);
+    const result = await verifyBuild(buildDeps(client), defaultInput);
+    expect(result.limitExitCode?.code).toBe(exitCodes.ACCOUNT_QUOTA_REACHED);
   });
 
-  it('sets exitCode to 12 if payment is required', async () => {
+  it('reports a limit exit code of 12 if payment is required', async () => {
     const client = { runQuery: vi.fn() };
     client.runQuery.mockReturnValue({
       app: {
@@ -194,12 +186,11 @@ describe('verifyBuild', () => {
       },
     });
 
-    const ctx = { client, ...defaultContext } as any;
-    await verifyBuild(ctx, {} as any);
-    expect(ctx.exitCode).toBe(12);
+    const result = await verifyBuild(buildDeps(client), defaultInput);
+    expect(result.limitExitCode?.code).toBe(exitCodes.ACCOUNT_PAYMENT_REQUIRED);
   });
 
-  it('sets exitCode to 0 and skips snapshotting for publish-only builds', async () => {
+  it('skips snapshotting for publish-only builds', async () => {
     const client = { runQuery: vi.fn() };
     client.runQuery.mockReturnValue({
       app: {
@@ -215,9 +206,8 @@ describe('verifyBuild', () => {
       },
     });
 
-    const ctx = { client, ...defaultContext } as any;
-    await verifyBuild(ctx, {} as any);
-    expect(ctx.exitCode).toBe(0);
-    expect(ctx.skipSnapshots).toBe(true);
+    const result = await verifyBuild(buildDeps(client), defaultInput);
+    expect(result.isPublishOnly).toBe(true);
+    expect(result.skipSnapshots).toBe(true);
   });
 });

--- a/node-src/tasks/verify/verifyBuild.ts
+++ b/node-src/tasks/verify/verifyBuild.ts
@@ -1,7 +1,6 @@
-import { exitCodes, setExitCode } from '../../lib/setExitCode';
-import { transitionTo } from '../../lib/tasks';
+import { exitCodes, TaskFailure } from '../../lib/setExitCode';
 import { delay } from '../../lib/utilities';
-import { Context, Task } from '../../types';
+import { Context, Deps } from '../../types';
 import brokenStorybook from '../../ui/messages/errors/brokenStorybook';
 import listingStories from '../../ui/messages/info/listingStories';
 import storybookPublished from '../../ui/messages/info/storybookPublished';
@@ -10,13 +9,7 @@ import buildLimited from '../../ui/messages/warnings/buildLimited';
 import paymentRequired from '../../ui/messages/warnings/paymentRequired';
 import snapshotQuotaReached from '../../ui/messages/warnings/snapshotQuotaReached';
 import turboSnapUnavailable from '../../ui/messages/warnings/turboSnapUnavailable';
-import {
-  awaitingUpgrades,
-  publishFailed,
-  runOnlyFiles,
-  runOnlyNames,
-  success,
-} from '../../ui/tasks/verify';
+import { awaitingUpgrades, publishFailed, runOnlyFiles, runOnlyNames } from '../../ui/tasks/verify';
 
 const StartedBuildQuery = `
   query StartedBuildQuery($number: Int!) {
@@ -112,51 +105,77 @@ interface VerifyBuildQueryResult {
   };
 }
 
+export interface VerifyBuildInput {
+  announcedBuild: Context['announcedBuild'];
+  build: Context['build'];
+  storybookUrl?: string;
+  options: Context['options'];
+  onlyStoryFiles?: string[];
+  matchesBranch?: Context['git']['matchesBranch'];
+  turboSnap?: Context['turboSnap'];
+  isReactNativeApp?: boolean;
+}
+
+export interface VerifyBuildResult {
+  build: Context['build'];
+  isPublishOnly: boolean;
+  skipSnapshots: boolean;
+  // A non-throwing exit code set when the build was limited (quota/payment/other), applied to ctx
+  // in `applyVerifyOutput`. `run` has no ctx to call `setExitCode` directly.
+  limitExitCode?: { code: number; userError: boolean };
+}
+
 // TODO: refactor this function
-// eslint-disable-next-line complexity, max-statements
-export const verifyBuild = async (ctx: Context, task: Task) => {
-  const { client } = ctx;
-  const { list, onlyStoryNames, onlyStoryFiles = ctx.onlyStoryFiles } = ctx.options;
-  const { matchesBranch } = ctx.git;
+/* eslint-disable complexity, max-statements */
+export const verifyBuild = async (
+  deps: Deps,
+  input: VerifyBuildInput
+): Promise<VerifyBuildResult> => {
+  const { client, env, log, report } = deps;
+  const { announcedBuild, storybookUrl, turboSnap, matchesBranch } = input;
+  const { list, onlyStoryNames, onlyStoryFiles = input.onlyStoryFiles } = input.options;
 
   // It's not possible to set both --only-changed and --only-story-files and/or --only-story-names
   // onlyStoryFiles may be passed directly, or calculated via --only-changed
   if (onlyStoryFiles) {
-    transitionTo(runOnlyFiles)(ctx, task);
+    report(runOnlyFiles(input));
   }
   if (onlyStoryNames) {
-    transitionTo(runOnlyNames)(ctx, task);
+    report(runOnlyNames(input));
   }
 
+  let build = input.build;
   let timeoutStart = Date.now();
   const waitForBuildToStart = async () => {
-    const { storybookUrl } = ctx;
-    const { number, reportToken } = ctx.announcedBuild;
+    const { number, reportToken } = announcedBuild;
     const variables = { number };
     const options = { headers: { Authorization: `Bearer ${reportToken}` } };
 
     const {
-      app: { build },
+      app: { build: startedInfo },
     } = await client.runQuery<StartedBuildQueryResult>(StartedBuildQuery, variables, options);
 
-    if (build.failureReason) {
-      ctx.log.warn(brokenStorybook(ctx, { failureReason: build.failureReason, storybookUrl }));
-      setExitCode(ctx, exitCodes.STORYBOOK_BROKEN, true);
-      throw new Error(publishFailed(ctx).output);
+    if (startedInfo.failureReason) {
+      log.warn(brokenStorybook(input, { failureReason: startedInfo.failureReason, storybookUrl }));
+      throw new TaskFailure(publishFailed(input).output, {
+        exitCode: exitCodes.STORYBOOK_BROKEN,
+        userError: true,
+      });
     }
 
-    if (!build.startedAt) {
+    if (!startedInfo.startedAt) {
       // Upgrade builds can take a long time to complete, so we can't apply a hard timeout yet,
       // instead we only timeout on the actual build verification, after upgrades are complete.
-      if (build.upgradeBuilds?.some((upgrade) => !upgrade.completedAt)) {
-        task.output = awaitingUpgrades(ctx, build.upgradeBuilds).output;
-        timeoutStart = Date.now() + ctx.env.CHROMATIC_POLL_INTERVAL;
-      } else if (Date.now() - timeoutStart > ctx.env.STORYBOOK_VERIFY_TIMEOUT) {
-        setExitCode(ctx, exitCodes.VERIFICATION_TIMEOUT);
-        throw new Error('Build verification timed out');
+      if (startedInfo.upgradeBuilds?.some((upgrade) => !upgrade.completedAt)) {
+        report({ output: awaitingUpgrades(input, startedInfo.upgradeBuilds).output });
+        timeoutStart = Date.now() + env.CHROMATIC_POLL_INTERVAL;
+      } else if (Date.now() - timeoutStart > env.STORYBOOK_VERIFY_TIMEOUT) {
+        throw new TaskFailure('Build verification timed out', {
+          exitCode: exitCodes.VERIFICATION_TIMEOUT,
+        });
       }
 
-      await delay(ctx.env.CHROMATIC_POLL_INTERVAL);
+      await delay(env.CHROMATIC_POLL_INTERVAL);
       await waitForBuildToStart();
       return;
     }
@@ -164,7 +183,7 @@ export const verifyBuild = async (ctx: Context, task: Task) => {
     const {
       app: { build: startedBuild },
     } = await client.runQuery<VerifyBuildQueryResult>(VerifyBuildQuery, variables, options);
-    ctx.build = { ...ctx.announcedBuild, ...ctx.build, ...startedBuild };
+    build = { ...announcedBuild, ...build, ...startedBuild };
   };
 
   await Promise.race([
@@ -172,49 +191,61 @@ export const verifyBuild = async (ctx: Context, task: Task) => {
     new Promise((_, reject) =>
       setTimeout(
         reject,
-        ctx.env.CHROMATIC_UPGRADE_TIMEOUT,
+        env.CHROMATIC_UPGRADE_TIMEOUT,
         new Error('Timed out waiting for upgrade builds to complete')
       )
     ),
   ]);
 
-  ctx.isPublishOnly = !ctx.build.features?.uiReview && !ctx.build.features?.uiTests;
+  const isPublishOnly = !build.features?.uiReview && !build.features?.uiTests;
 
-  if (list && ctx.build.tests) {
-    ctx.log.info(listingStories(ctx.build.tests));
+  if (list && build.tests) {
+    log.info(listingStories(build.tests));
   }
 
-  if (ctx.turboSnap) {
-    if (ctx.turboSnap.unavailable) {
-      ctx.log.warn(turboSnapUnavailable(ctx));
-    } else if (ctx.build.turboSnapEnabled) {
-      ctx.log.info(turboSnapEnabled(ctx));
+  if (turboSnap) {
+    if (turboSnap.unavailable) {
+      log.warn(turboSnapUnavailable({ build }));
+    } else if (build.turboSnapEnabled) {
+      log.info(turboSnapEnabled({ build, options: input.options }));
     }
   }
 
-  if (ctx.build.wasLimited) {
-    const { account } = ctx.build.app;
+  let limitExitCode: VerifyBuildResult['limitExitCode'];
+  if (build.wasLimited) {
+    const { account } = build.app;
     if (account?.exceededThreshold) {
-      ctx.log.warn(snapshotQuotaReached(account));
-      setExitCode(ctx, exitCodes.ACCOUNT_QUOTA_REACHED, true);
+      log.warn(snapshotQuotaReached(account));
+      limitExitCode = { code: exitCodes.ACCOUNT_QUOTA_REACHED, userError: true };
     } else if (account?.paymentRequired) {
-      ctx.log.warn(paymentRequired(account));
-      setExitCode(ctx, exitCodes.ACCOUNT_PAYMENT_REQUIRED, true);
+      log.warn(paymentRequired(account));
+      limitExitCode = { code: exitCodes.ACCOUNT_PAYMENT_REQUIRED, userError: true };
     } else {
       // Future proofing for reasons we aren't aware of
-      if (account) ctx.log.warn(buildLimited(account));
-      setExitCode(ctx, exitCodes.BUILD_WAS_LIMITED, true);
+      if (account) {
+        log.warn(buildLimited(account));
+      }
+      limitExitCode = { code: exitCodes.BUILD_WAS_LIMITED, userError: true };
     }
   }
 
-  if (ctx.build && ctx.storybookUrl) {
-    ctx.log.info(storybookPublished(ctx));
+  if (build && storybookUrl) {
+    log.info(
+      storybookPublished({
+        storybookUrl,
+        build,
+        options: input.options,
+        isReactNativeApp: input.isReactNativeApp,
+      })
+    );
   }
 
-  transitionTo(success, true)(ctx, task);
+  const skipSnapshots = !!(
+    list ||
+    isPublishOnly ||
+    matchesBranch?.(input.options.exitOnceUploaded)
+  );
 
-  if (list || ctx.isPublishOnly || matchesBranch?.(ctx.options.exitOnceUploaded)) {
-    setExitCode(ctx, exitCodes.OK);
-    ctx.skipSnapshots = true;
-  }
+  return { build, isPublishOnly, skipSnapshots, limitExitCode };
 };
+/* eslint-enable complexity, max-statements */

--- a/node-src/ui/messages/errors/brokenStorybook.ts
+++ b/node-src/ui/messages/errors/brokenStorybook.ts
@@ -5,7 +5,7 @@ import { Context } from '../../../types';
 import { error } from '../../components/icons';
 import link from '../../components/link';
 
-export default (ctx: Context, { failureReason, storybookUrl }) => {
+export default (ctx: Pick<Context, 'isReactNativeApp'>, { failureReason, storybookUrl }) => {
   const visitStorybookLine = ctx.isReactNativeApp
     ? ''
     : `\n    Visit your published Storybook at ${link(storybookUrl)}`;

--- a/node-src/ui/messages/info/storybookPublished.ts
+++ b/node-src/ui/messages/info/storybookPublished.ts
@@ -8,7 +8,7 @@ import link from '../../components/link';
 import { stats } from '../../tasks/snapshot';
 import { buildType, capitalize } from '../../tasks/utilities';
 
-export default (ctx: Context) => {
+export default (ctx: Pick<Context, 'storybookUrl' | 'build' | 'options' | 'isReactNativeApp'>) => {
   if (!ctx.storybookUrl) {
     throw new Error('No Storybook URL provided');
   }

--- a/node-src/ui/tasks/verify.frames.ts
+++ b/node-src/ui/tasks/verify.frames.ts
@@ -1,0 +1,70 @@
+/* eslint-disable unicorn/no-null -- GraphQL returns `null` if a value doesn't exist */
+import { fallbackFailureState } from '../../renderer/engine';
+import { clackSpinnerRenderer } from '../../renderer/engine/clack/spinnerRenderer';
+import { captureTask } from '../../renderer/storybook/captureTask';
+import { Task } from '../../types';
+import {
+  awaitingUpgrades,
+  dryRun,
+  pending,
+  publishFailed,
+  runOnlyFiles,
+  runOnlyNames,
+  success,
+} from './verify';
+
+// Node-side scenarios for the verify task. The `?clack` Vite plugin runs this module in Node,
+// renders each export through the real Clack spinner renderer (verify wires the spinner while it
+// polls for the build to start), and hands the ANSI strings to the browser story
+// (`verify.stories.ts`).
+
+const ctx = { options: {} } as any;
+
+const build = {
+  number: 42,
+  webUrl: 'https://www.chromatic.com/build?appId=59c59bd0183bd100364e1d57&number=42',
+  app: { setupUrl: 'https://www.chromatic.com/setup?appId=59c59bd0183bd100364e1d57' },
+};
+
+const make = (state: Task, starting?: Task) => captureTask(state, starting, clackSpinnerRenderer);
+
+// verify reports mid-run progress (partial-build filters, awaiting upgrade builds) via `deps.report`,
+// so those render as updates over the started spinner.
+const update = (output: string) =>
+  make({ status: 'updating', title: pending(ctx).title, output }, pending(ctx));
+
+export const Pending = () => make(pending(ctx));
+
+export const RunOnlyChangedFiles = () =>
+  update(
+    runOnlyFiles({ ...ctx, onlyStoryFiles: Array.from({ length: 12 }), options: {} } as any).output
+  );
+
+export const RunOnlyFiles = () =>
+  update(
+    runOnlyFiles({ ...ctx, options: { onlyStoryFiles: ['./src/**/*.stories.js'] } } as any).output
+  );
+
+export const RunOnlyNames = () =>
+  update(runOnlyNames({ ...ctx, options: { onlyStoryNames: ['MyComponent/**'] } } as any).output);
+
+export const AwaitingUpgrades = () =>
+  update(awaitingUpgrades(ctx, [{ completedAt: 123 }, { completedAt: null }]).output);
+
+export const Started = () => make(success({ ...ctx, build } as any), pending(ctx));
+
+export const Published = () =>
+  make(success({ ...ctx, isPublishOnly: true, build } as any), pending(ctx));
+
+export const ContinueSetup = () =>
+  make(success({ ...ctx, isOnboarding: true, build } as any), pending(ctx));
+
+export const DryRun = () => make(dryRun(ctx), pending(ctx));
+
+// verify registers no `failure` transition, so failures render the engine's fallback failure state
+// (built from the pending title); the thrown error body goes to the log file, not the frame.
+export const Failed = () =>
+  make(
+    fallbackFailureState(pending(ctx).title, new Error(publishFailed(ctx).output)),
+    pending(ctx)
+  );

--- a/node-src/ui/tasks/verify.stories.ts
+++ b/node-src/ui/tasks/verify.stories.ts
@@ -1,67 +1,14 @@
-/* eslint-disable unicorn/no-null -- GraphQL returns `null` if a value doesn't exist */
-import task from '../components/task';
-import {
-  awaitingUpgrades,
-  dryRun,
-  failed,
-  initial,
-  pending,
-  publishFailed,
-  runOnlyFiles,
-  runOnlyNames,
-  success,
-} from './verify';
+import frames from './verify.frames?clack';
 
-export default {
-  title: 'CLI/Tasks/Verify',
-  decorators: [(storyFunction: any) => task(storyFunction())],
-};
+export default { title: 'CLI/Tasks/Verify' };
 
-const build = {
-  number: 42,
-  webUrl: 'https://www.chromatic.com/build?appId=59c59bd0183bd100364e1d57&number=42',
-  app: { setupUrl: 'https://www.chromatic.com/setup?appId=59c59bd0183bd100364e1d57' },
-};
-
-const ctx = { options: {} } as any;
-
-export const Initial = () => initial(ctx);
-
-export const DryRun = () => dryRun(ctx);
-
-export const Pending = () => pending(ctx);
-
-export const PublishFailed = () => publishFailed(ctx);
-
-export const RunOnlyChangedFiles = () =>
-  runOnlyFiles({
-    ...ctx,
-    onlyStoryFiles: Array.from({ length: 12 }),
-    options: {},
-  } as any);
-
-export const RunOnlyFiles = () =>
-  runOnlyFiles({
-    ...ctx,
-    options: { ...ctx.options, onlyStoryFiles: ['./src/**/*.stories.js'] },
-  } as any);
-
-export const RunOnlyNames = () =>
-  runOnlyNames({
-    ...ctx,
-    options: { ...ctx.options, onlyStoryNames: ['MyComponent/**'] },
-  } as any);
-
-export const AwaitingUpgrades = () =>
-  awaitingUpgrades(ctx, [{ completedAt: 123 }, { completedAt: null }]);
-
-export const Started = () => success({ ...ctx, build } as any);
-
-export const Published = () => success({ ...ctx, isPublishOnly: true, build } as any);
-
-export const ContinueSetup = () => success({ ...ctx, isOnboarding: true, build } as any);
-
-export const NoStories = () => failed({ ...ctx, options: {} } as any);
-
-export const NoMatches = () =>
-  failed({ ...ctx, options: { ...ctx.options, onlyStoryNames: ['MyComponent/MyStory'] } } as any);
+export const Pending = () => frames.Pending;
+export const RunOnlyChangedFiles = () => frames.RunOnlyChangedFiles;
+export const RunOnlyFiles = () => frames.RunOnlyFiles;
+export const RunOnlyNames = () => frames.RunOnlyNames;
+export const AwaitingUpgrades = () => frames.AwaitingUpgrades;
+export const Started = () => frames.Started;
+export const Published = () => frames.Published;
+export const ContinueSetup = () => frames.ContinueSetup;
+export const DryRun = () => frames.DryRun;
+export const Failed = () => frames.Failed;

--- a/node-src/ui/tasks/verify.ts
+++ b/node-src/ui/tasks/verify.ts
@@ -71,15 +71,3 @@ export const success = (ctx: Context) => ({
     ? `Continue setup at ${ctx.build.app.setupUrl}`
     : `View build details at ${ctx.build.webUrl}`,
 });
-
-export const failed = (ctx: Context) => {
-  const testType = isE2EBuild(ctx.options) ? 'tests' : 'stories';
-
-  return {
-    status: 'error',
-    title: `Verifying your ${buildType(ctx)}`,
-    output: ctx.options.onlyStoryNames
-      ? `Cannot run a build with no ${testType}. Change or omit the --only-story-names predicate.`
-      : `Cannot run a build with no ${testType}. Please add some ${testType}!`,
-  };
-};

--- a/node-src/ui/tasks/verify.ts
+++ b/node-src/ui/tasks/verify.ts
@@ -21,13 +21,13 @@ export const pending = (ctx: Context) => ({
   output: 'This may take a few minutes',
 });
 
-export const publishFailed = (ctx: Context) => ({
+export const publishFailed = (ctx: Pick<Context, 'options'>) => ({
   status: 'error',
   title: `Verifying your ${buildType(ctx)}`,
   output: 'Failed to publish build',
 });
 
-export const runOnlyFiles = (ctx: Context) => ({
+export const runOnlyFiles = (ctx: Pick<Context, 'options' | 'onlyStoryFiles'>) => ({
   status: 'pending',
   title: 'Starting partial build',
   output: ctx.options.onlyStoryFiles
@@ -37,7 +37,7 @@ export const runOnlyFiles = (ctx: Context) => ({
     : `Snapshots will be limited to ${ctx.onlyStoryFiles?.length} story files affected by recent changes`,
 });
 
-export const runOnlyNames = (ctx: Context) => {
+export const runOnlyNames = (ctx: Pick<Context, 'options'>) => {
   const testType = isE2EBuild(ctx.options) ? 'tests' : 'stories';
 
   return {
@@ -50,7 +50,7 @@ export const runOnlyNames = (ctx: Context) => {
 };
 
 export const awaitingUpgrades = (
-  ctx: Context,
+  ctx: Pick<Context, 'options'>,
   upgradeBuilds: { completedAt?: number | null }[]
 ) => {
   const pending = upgradeBuilds.filter((upgrade) => !upgrade.completedAt).length;

--- a/node-src/ui/tasks/verifyE2E.frames.ts
+++ b/node-src/ui/tasks/verifyE2E.frames.ts
@@ -1,0 +1,74 @@
+/* eslint-disable unicorn/no-null -- GraphQL returns `null` if a value doesn't exist */
+import { fallbackFailureState } from '../../renderer/engine';
+import { clackSpinnerRenderer } from '../../renderer/engine/clack/spinnerRenderer';
+import { captureTask } from '../../renderer/storybook/captureTask';
+import { Task } from '../../types';
+import {
+  awaitingUpgrades,
+  dryRun,
+  pending,
+  publishFailed,
+  runOnlyFiles,
+  runOnlyNames,
+  success,
+} from './verify';
+
+// Node-side scenarios for the verify task on an E2E project, where the task reports on the "test
+// suite" rather than "Storybook". Same state functions as `verify.frames.ts`, different `ctx.options`.
+
+const ctx = { options: { playwright: true } } as any;
+
+const build = {
+  number: 42,
+  webUrl: 'https://www.chromatic.com/build?appId=59c59bd0183bd100364e1d57&number=42',
+  app: { setupUrl: 'https://www.chromatic.com/setup?appId=59c59bd0183bd100364e1d57' },
+};
+
+const make = (state: Task, starting?: Task) => captureTask(state, starting, clackSpinnerRenderer);
+
+const update = (output: string) =>
+  make({ status: 'updating', title: pending(ctx).title, output }, pending(ctx));
+
+export const Pending = () => make(pending(ctx));
+
+export const RunOnlyChangedFiles = () =>
+  update(
+    runOnlyFiles({
+      ...ctx,
+      onlyStoryFiles: Array.from({ length: 12 }),
+      options: ctx.options,
+    } as any).output
+  );
+
+export const RunOnlyFiles = () =>
+  update(
+    runOnlyFiles({
+      ...ctx,
+      options: { ...ctx.options, onlyStoryFiles: ['./src/**/*.stories.js'] },
+    } as any).output
+  );
+
+export const RunOnlyNames = () =>
+  update(
+    runOnlyNames({ ...ctx, options: { ...ctx.options, onlyStoryNames: ['MyComponent/**'] } } as any)
+      .output
+  );
+
+export const AwaitingUpgrades = () =>
+  update(awaitingUpgrades(ctx, [{ completedAt: 123 }, { completedAt: null }]).output);
+
+export const Started = () => make(success({ ...ctx, build } as any), pending(ctx));
+
+export const Published = () =>
+  make(success({ ...ctx, isPublishOnly: true, build } as any), pending(ctx));
+
+export const ContinueSetup = () =>
+  make(success({ ...ctx, isOnboarding: true, build } as any), pending(ctx));
+
+export const DryRun = () => make(dryRun(ctx), pending(ctx));
+
+export const Failed = () =>
+  make(
+    fallbackFailureState(pending(ctx).title, new Error(publishFailed(ctx).output)),
+    pending(ctx)
+  );

--- a/node-src/ui/tasks/verifyE2E.stories.ts
+++ b/node-src/ui/tasks/verifyE2E.stories.ts
@@ -1,67 +1,14 @@
-/* eslint-disable unicorn/no-null -- GraphQL returns `null` if a value doesn't exist */
-import task from '../components/task';
-import {
-  awaitingUpgrades,
-  dryRun,
-  failed,
-  initial,
-  pending,
-  publishFailed,
-  runOnlyFiles,
-  runOnlyNames,
-  success,
-} from './verify';
+import frames from './verifyE2E.frames?clack';
 
-export default {
-  title: 'CLI/Tasks/Verify/E2E',
-  decorators: [(storyFunction: any) => task(storyFunction())],
-};
+export default { title: 'CLI/Tasks/Verify/E2E' };
 
-const build = {
-  number: 42,
-  webUrl: 'https://www.chromatic.com/build?appId=59c59bd0183bd100364e1d57&number=42',
-  app: { setupUrl: 'https://www.chromatic.com/setup?appId=59c59bd0183bd100364e1d57' },
-};
-
-const ctx = { options: { playwright: true } } as any;
-
-export const Initial = () => initial(ctx);
-
-export const DryRun = () => dryRun(ctx);
-
-export const Pending = () => pending(ctx);
-
-export const PublishFailed = () => publishFailed(ctx);
-
-export const RunOnlyChangedFiles = () =>
-  runOnlyFiles({
-    ...ctx,
-    onlyStoryFiles: Array.from({ length: 12 }),
-    options: {},
-  } as any);
-
-export const RunOnlyFiles = () =>
-  runOnlyFiles({
-    ...ctx,
-    options: { ...ctx.options, onlyStoryFiles: ['./src/**/*.stories.js'] },
-  } as any);
-
-export const RunOnlyNames = () =>
-  runOnlyNames({
-    ...ctx,
-    options: { ...ctx.options, onlyStoryNames: ['MyComponent/**'] },
-  } as any);
-
-export const AwaitingUpgrades = () =>
-  awaitingUpgrades(ctx, [{ completedAt: 123 }, { completedAt: null }]);
-
-export const Started = () => success({ ...ctx, build } as any);
-
-export const Published = () => success({ ...ctx, isPublishOnly: true, build } as any);
-
-export const ContinueSetup = () => success({ ...ctx, isOnboarding: true, build } as any);
-
-export const NoStories = () => failed(ctx);
-
-export const NoMatches = () =>
-  failed({ ...ctx, options: { ...ctx.options, onlyStoryNames: ['MyComponent/MyStory'] } } as any);
+export const Pending = () => frames.Pending;
+export const RunOnlyChangedFiles = () => frames.RunOnlyChangedFiles;
+export const RunOnlyFiles = () => frames.RunOnlyFiles;
+export const RunOnlyNames = () => frames.RunOnlyNames;
+export const AwaitingUpgrades = () => frames.AwaitingUpgrades;
+export const Started = () => frames.Started;
+export const Published = () => frames.Published;
+export const ContinueSetup = () => frames.ContinueSetup;
+export const DryRun = () => frames.DryRun;
+export const Failed = () => frames.Failed;

--- a/node-src/ui/workflows/uploadBuild.stories.ts
+++ b/node-src/ui/workflows/uploadBuild.stories.ts
@@ -31,7 +31,11 @@ import {
   success as uploadSuccess,
   uploading as uploadUploading,
 } from '../tasks/upload';
-import * as verify from '../tasks/verify.stories';
+import {
+  initial as verifyInitial,
+  pending as verifyPending,
+  success as verifySuccess,
+} from '../tasks/verify';
 
 const steps = (...steps) => steps.map((step) => task(step())).join('\n');
 
@@ -100,6 +104,20 @@ const upload = {
       uploadedFiles: 42,
       fileInfo: { paths: { length: 42 } },
     } as any),
+};
+
+// verify.stories now returns rendered ANSI strings (Clack capture), which the old task() path can't
+// consume, so rebuild the states the workflow needs from the raw task source.
+const verifiedBuild = {
+  number: 42,
+  webUrl: 'https://www.chromatic.com/build?appId=59c59bd0183bd100364e1d57&number=42',
+  app: { setupUrl: 'https://www.chromatic.com/setup?appId=59c59bd0183bd100364e1d57' },
+};
+const verify = {
+  Initial: () => verifyInitial(buildContext),
+  Pending: () => verifyPending(buildContext),
+  Published: () =>
+    verifySuccess({ ...buildContext, isPublishOnly: true, build: verifiedBuild } as any),
 };
 
 export default {

--- a/node-src/ui/workflows/uploadBuildE2E.stories.ts
+++ b/node-src/ui/workflows/uploadBuildE2E.stories.ts
@@ -31,7 +31,11 @@ import {
   success as uploadSuccess,
   uploading as uploadUploading,
 } from '../tasks/upload';
-import * as verify from '../tasks/verifyE2E.stories';
+import {
+  initial as verifyInitial,
+  pending as verifyPending,
+  success as verifySuccess,
+} from '../tasks/verify';
 
 const ctx = { options: { playwright: true } } as any;
 const steps = (...steps) => steps.map((step) => task(step(ctx))).join('\n');
@@ -101,6 +105,20 @@ const upload = {
       uploadedFiles: 42,
       fileInfo: { paths: { length: 42 } },
     } as any),
+};
+
+// verify.stories now returns rendered ANSI strings (Clack capture), which the old task() path can't
+// consume, so rebuild the states the workflow needs from the raw task source. The file-level `ctx`
+// (playwright) is forwarded by the `steps()` helper.
+const verifiedBuild = {
+  number: 42,
+  webUrl: 'https://www.chromatic.com/build?appId=59c59bd0183bd100364e1d57&number=42',
+  app: { setupUrl: 'https://www.chromatic.com/setup?appId=59c59bd0183bd100364e1d57' },
+};
+const verify = {
+  Initial: () => verifyInitial(ctx),
+  Pending: () => verifyPending(ctx),
+  Published: () => verifySuccess({ ...ctx, isPublishOnly: true, build: verifiedBuild } as any),
 };
 
 export default {


### PR DESCRIPTION
# Description

This PR migrates the `verify` task to render with a Clack spinner renderer.

# Manual QA

Confirmed happy path:
<img width="1476" height="1224" alt="CleanShot 2026-06-29 at 09 45 08@2x" src="https://github.com/user-attachments/assets/1dcee6f6-05ba-491a-85e7-9b317bc4d6e2" />

AI-driven QA for other paths (full human-driven QA will happen on the feature branch before merging to main):
[pr-1409-verify-clack-qa.md](https://github.com/user-attachments/files/29467930/pr-1409-verify-clack-qa.md)

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>18.0.1--canary.1409.28528472802.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@18.0.1--canary.1409.28528472802.0
  # or 
  yarn add chromatic@18.0.1--canary.1409.28528472802.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
