### PR TITLE
Migrate `snapshot` to Clack

### DIFF
--- a/node-src/index.ts
+++ b/node-src/index.ts
@@ -40,6 +40,7 @@ import { renderBuild } from './renderer/build';
 import { renderGitInfo } from './renderer/gitInfo';
 import { renderInitialize } from './renderer/initialize';
 import { renderPrepare } from './renderer/prepare';
+import { renderSnapshot } from './renderer/snapshot';
 import { renderStorybookInfo } from './renderer/storybookInfo';
 import { renderUpload } from './renderer/upload';
 import { renderVerify } from './renderer/verify';
@@ -357,6 +358,7 @@ async function runBuild(ctx: Context) {
       await renderPrepare(ctx);
       await renderUpload(ctx);
       await renderVerify(ctx);
+      await renderSnapshot(ctx);
       await new Listr(getTasks(ctx), options).run(ctx);
       ctx.log.debug('Tasks completed');
     } catch (err) {

--- a/node-src/renderer/engine/index.test.ts
+++ b/node-src/renderer/engine/index.test.ts
@@ -362,6 +362,36 @@ describe('runTask', () => {
       });
     });
 
+    it('writes a reported build onto ctx so the onTaskProgress snapshot is live', async () => {
+      const seen: Context[] = [];
+      const onTaskProgress = vi.fn((ctxSnapshot: Context) => seen.push(ctxSnapshot));
+      const ctx = fakeContext({
+        build: { number: 1 } as any,
+        options: { experimental_onTaskProgress: onTaskProgress } as any,
+      });
+      const { renderer } = recordingRenderer();
+
+      const polledBuild = { number: 1, status: 'IN_PROGRESS' } as any;
+      const config: TaskConfig<unknown, unknown> = {
+        name: 'snapshot',
+        title: 'Snapshotting',
+        transitions,
+        extractInput: () => ({}),
+        run: async (deps) => {
+          deps.report({
+            progress: { progress: 1, total: 5, unit: 'snapshots' },
+            build: polledBuild,
+          });
+          return { kind: 'continue', output: {} };
+        },
+      };
+
+      await runTask(ctx, config, renderer);
+
+      expect(ctx.build).toBe(polledBuild);
+      expect(seen[0].build).toBe(polledBuild);
+    });
+
     it('passes a numeric-only report through with no output', async () => {
       const ctx = fakeContext({ options: {} as any });
       const { renderer, calls } = recordingRenderer();

--- a/node-src/renderer/engine/index.ts
+++ b/node-src/renderer/engine/index.ts
@@ -109,6 +109,7 @@ export async function runTask<TInput, TOutput, TPartial = never>(
 function makeReporter(ctx: Context, renderer: TaskRenderer): TaskReporter {
   return (update) => {
     if (update.title !== undefined) ctx.title = update.title;
+    if (update.build !== undefined) ctx.build = update.build;
 
     renderer.update({
       title: ctx.title,

--- a/node-src/renderer/snapshot.test.ts
+++ b/node-src/renderer/snapshot.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+
+import TestLogger from '../lib/testLogger';
+import { renderSnapshot } from './snapshot';
+
+// `actualTestCount: 0` keeps the `pending` transition off the stats path (it needs only the count),
+// so these fixtures stay minimal. The snapshot task self-skips before touching anything else.
+const createContext = (overrides: any) =>
+  ({
+    client: { runQuery: () => undefined },
+    env: {},
+    log: new TestLogger(),
+    git: { matchesBranch: () => false },
+    build: { actualTestCount: 0 },
+    options: {},
+    ...overrides,
+  }) as any;
+
+describe('renderSnapshot skip frames', () => {
+  it('renders the dry-run frame and does not set an exit code', async () => {
+    const ctx = createContext({ options: { dryRun: true } });
+
+    await renderSnapshot(ctx);
+
+    expect(ctx.log.info).toHaveBeenCalledWith(expect.stringContaining('Skipped due to --dry-run'));
+    expect(ctx.exitCode).toBeUndefined();
+  });
+
+  it('renders the dry-run frame when ctx.build is undefined', async () => {
+    const ctx = createContext({ options: { dryRun: true }, build: undefined });
+
+    await expect(renderSnapshot(ctx)).resolves.toBeUndefined();
+
+    expect(ctx.log.info).toHaveBeenCalledWith(expect.stringContaining('Skipped due to --dry-run'));
+    expect(ctx.exitCode).toBeUndefined();
+  });
+
+  it('renders the publish-only skip frame when ctx.skipSnapshots is set', async () => {
+    const ctx = createContext({ skipSnapshots: true, isPublishOnly: true });
+
+    await renderSnapshot(ctx);
+
+    expect(ctx.log.info).toHaveBeenCalledWith(
+      expect.stringContaining('No UI tests or UI review enabled')
+    );
+    expect(ctx.exitCode).toBeUndefined();
+  });
+
+  it('renders the --exit-once-uploaded skip frame when ctx.skipSnapshots is set', async () => {
+    const ctx = createContext({ skipSnapshots: true });
+
+    await renderSnapshot(ctx);
+
+    expect(ctx.log.info).toHaveBeenCalledWith(
+      expect.stringContaining('Skipped due to --exit-once-uploaded')
+    );
+  });
+});

--- a/node-src/renderer/snapshot.ts
+++ b/node-src/renderer/snapshot.ts
@@ -1,0 +1,32 @@
+import { applySnapshotOutput, extractSnapshotInput, snapshotProject } from '../tasks/snapshot';
+import { Context } from '../types';
+import { dryRun, initial, pending, skipped, success } from '../ui/tasks/snapshot';
+import { runTask } from './engine';
+import { clackProgressBarRenderer } from './engine/clack/progressRenderer';
+import { getRenderer } from './engine/getRenderer';
+
+/**
+ * Render the snapshot task.
+ *
+ * @param ctx The CLI context.
+ */
+export async function renderSnapshot(ctx: Context): Promise<void> {
+  await runTask(
+    ctx,
+    {
+      name: 'snapshot',
+      title: initial(ctx).title,
+      transitions: {
+        pending,
+        success,
+        // Two self-skip reasons share the one `skipped` transition: an upstream verify decision
+        // (`ctx.skipSnapshots`: publish-only / --list / --exit-once-uploaded) vs. `--dry-run`.
+        skipped: (context: Context) => (context.skipSnapshots ? skipped(context) : dryRun(context)),
+      },
+      extractInput: extractSnapshotInput,
+      run: snapshotProject,
+      applyOutput: applySnapshotOutput,
+    },
+    getRenderer(ctx, clackProgressBarRenderer)
+  );
+}

--- a/node-src/tasks/index.ts
+++ b/node-src/tasks/index.ts
@@ -4,12 +4,13 @@ import { Context } from '../types';
 import prepareWorkspace from './prepareWorkspace';
 import report from './report';
 import restoreWorkspace from './restoreWorkspace';
-import snapshot from './snapshot';
 import uploadShare from './uploadShare';
 
 export const runShare = [uploadShare];
 
-export const runUploadBuild = [snapshot];
+// snapshot migrated to the Clack renderer (`renderSnapshot`, called directly in `index.ts`); only
+// the conditionally-appended `report` task may remain in this Listr block.
+export const runUploadBuild: ((ctx: Context) => Listr.ListrTask<Context>)[] = [];
 
 export const runPatchBuild = [prepareWorkspace, ...runUploadBuild, restoreWorkspace];
 

--- a/node-src/tasks/snapshot.test.ts
+++ b/node-src/tasks/snapshot.test.ts
@@ -8,7 +8,12 @@ import * as Sentry from '@sentry/node';
 import { describe, expect, it, vi } from 'vitest';
 
 import TestLogger from '../lib/testLogger';
-import { takeSnapshots } from './snapshot';
+import {
+  applySnapshotOutput,
+  extractSnapshotInput,
+  SnapshotOutput,
+  snapshotProject,
+} from './snapshot';
 
 vi.mock('@sentry/node', () => ({
   captureException: vi.fn(),
@@ -41,7 +46,20 @@ const createBaseTestContext = () => ({
 
 const mockWaitForBuildToComplete = vi.mocked(waitForBuildToComplete);
 
-describe('takeSnapshots', () => {
+// Project ctx into the (deps, input) seam the way `runTask` would, run the task body, then fold its
+// result back onto ctx so the legacy assertions (ctx.build, ctx.exitCode) keep holding.
+const runSnapshot = async (ctx: any) => {
+  const report = vi.fn();
+  const deps = { report, client: ctx.client, log: ctx.log, env: ctx.env, options: ctx.options };
+  const input = extractSnapshotInput(ctx);
+  const result = await snapshotProject(deps as any, input as any);
+  if (result.kind === 'continue') {
+    applySnapshotOutput(ctx, result.output);
+  }
+  return { result, report };
+};
+
+describe('snapshotProject', () => {
   it('waits for the build to complete and sets it on context', async () => {
     const build = {
       app: { repository: { provider: 'github' } },
@@ -49,17 +67,14 @@ describe('takeSnapshots', () => {
       features: {},
       reportToken: 'report-token',
     };
-    const ctx = {
-      ...createBaseTestContext(),
-      build,
-    } as any;
+    const ctx = { ...createBaseTestContext(), build } as any;
 
     ctx.client.runQuery.mockReturnValueOnce({ app: { build: { status: 'IN_PROGRESS' } } });
     ctx.client.runQuery.mockReturnValueOnce({
       app: { build: { changeCount: 0, status: 'PASSED', completedAt: 1 } },
     });
 
-    await takeSnapshots(ctx, {} as any);
+    await runSnapshot(ctx);
     expect(ctx.client.runQuery).toHaveBeenCalledWith(
       expect.stringMatching(/SnapshotBuildQuery/),
       { number: 1 },
@@ -72,18 +87,14 @@ describe('takeSnapshots', () => {
 
   it('sets exitCode to 1 when build has changes', async () => {
     const build = { app: { repository: { provider: 'github' } }, number: 1, features: {} };
-    const ctx = {
-      ...createBaseTestContext(),
-      build,
-      announcedBuild: build,
-    } as any;
+    const ctx = { ...createBaseTestContext(), build, announcedBuild: build } as any;
 
     ctx.client.runQuery.mockReturnValueOnce({ app: { build: { status: 'IN_PROGRESS' } } });
     ctx.client.runQuery.mockReturnValueOnce({
       app: { build: { changeCount: 2, status: 'PENDING', completedAt: 1 } },
     });
 
-    await takeSnapshots(ctx, {} as any);
+    await runSnapshot(ctx);
     expect(ctx.build).toEqual({ ...build, changeCount: 2, status: 'PENDING', completedAt: 1 });
     expect(ctx.exitCode).toBe(1);
   });
@@ -92,9 +103,7 @@ describe('takeSnapshots', () => {
     const build = { app: { repository: { provider: 'github' } }, number: 1, features: {} };
     const ctx = {
       ...createBaseTestContext(),
-      options: {
-        exitZeroOnChanges: 'true',
-      },
+      options: { exitZeroOnChanges: 'true' },
       build,
       announcedBuild: build,
     } as any;
@@ -104,48 +113,52 @@ describe('takeSnapshots', () => {
       app: { build: { changeCount: 2, status: 'PENDING', completedAt: 1 } },
     });
 
-    await takeSnapshots(ctx, {} as any);
+    await runSnapshot(ctx);
     expect(ctx.build).toEqual({ ...build, changeCount: 2, status: 'PENDING', completedAt: 1 });
     expect(ctx.exitCode).toBe(0);
   });
 
   it('sets exitCode to 2 when build is broken (capture error)', async () => {
     const build = { app: { repository: { provider: 'github' } }, number: 1, features: {} };
-    const ctx = {
-      ...createBaseTestContext(),
-      build,
-      announcedBuild: build,
-    } as any;
+    const ctx = { ...createBaseTestContext(), build, announcedBuild: build } as any;
 
     ctx.client.runQuery.mockReturnValueOnce({ app: { build: { status: 'IN_PROGRESS' } } });
     ctx.client.runQuery.mockReturnValueOnce({
       app: { build: { changeCount: 2, status: 'BROKEN', completedAt: 1 } },
     });
 
-    await takeSnapshots(ctx, {} as any);
+    await runSnapshot(ctx);
     expect(ctx.build).toEqual({ ...build, changeCount: 2, status: 'BROKEN', completedAt: 1 });
     expect(ctx.exitCode).toBe(2);
   });
 
   it('sets exitCode to 3 when build fails (system error)', async () => {
     const build = { app: { repository: { provider: 'github' } }, number: 1, features: {} };
-    const ctx = {
-      ...createBaseTestContext(),
-      build,
-      announcedBuild: build,
-    } as any;
+    const ctx = { ...createBaseTestContext(), build, announcedBuild: build } as any;
 
     ctx.client.runQuery.mockReturnValueOnce({ app: { build: { status: 'IN_PROGRESS' } } });
     ctx.client.runQuery.mockReturnValueOnce({
       app: { build: { changeCount: 2, status: 'FAILED', completedAt: 1 } },
     });
 
-    await takeSnapshots(ctx, {} as any);
+    await runSnapshot(ctx);
     expect(ctx.build).toEqual({ ...build, changeCount: 2, status: 'FAILED', completedAt: 1 });
     expect(ctx.exitCode).toBe(3);
   });
 
-  it('calls experimental_onTaskProgress with progress', async () => {
+  it('sets exitCode to 6 when build is canceled', async () => {
+    const build = { app: { repository: { provider: 'github' } }, number: 1, features: {} };
+    const ctx = { ...createBaseTestContext(), build, announcedBuild: build } as any;
+
+    ctx.client.runQuery.mockReturnValueOnce({
+      app: { build: { status: 'CANCELLED', completedAt: 1 } },
+    });
+
+    await runSnapshot(ctx);
+    expect(ctx.exitCode).toBe(6);
+  });
+
+  it('reports snapshot-count progress through deps.report', async () => {
     const build = {
       app: { repository: { provider: 'github' } },
       number: 1,
@@ -154,11 +167,7 @@ describe('takeSnapshots', () => {
       actualTestCount: 5,
       inProgressCount: 5,
     };
-    const ctx = {
-      ...createBaseTestContext(),
-      options: { experimental_onTaskProgress: vi.fn() },
-      build,
-    } as any;
+    const ctx = { ...createBaseTestContext(), build } as any;
 
     ctx.client.runQuery.mockReturnValueOnce({
       app: { build: { status: 'IN_PROGRESS', inProgressCount: 5 } },
@@ -170,43 +179,19 @@ describe('takeSnapshots', () => {
       app: { build: { changeCount: 0, status: 'PASSED', completedAt: 1, inProgressCount: 0 } },
     });
 
-    await takeSnapshots(ctx, {} as any);
+    const { report } = await runSnapshot(ctx);
 
-    expect(ctx.options.experimental_onTaskProgress).toHaveBeenCalledTimes(2);
-    expect(ctx.options.experimental_onTaskProgress).toHaveBeenCalledWith(expect.any(Object), {
-      progress: 1,
-      total: 5,
-      unit: 'snapshots',
-    });
-    expect(ctx.options.experimental_onTaskProgress).toHaveBeenCalledWith(expect.any(Object), {
-      progress: 3,
-      total: 5,
-      unit: 'snapshots',
-    });
-  });
-
-  it('calls waitForBuildToComplete with correct arguments', async () => {
-    const build = {
-      app: { repository: { provider: 'github' } },
-      number: 1,
-      features: {},
-      reportToken: 'report-token',
-      id: 'build-123',
-      actualTestCount: 0,
-    };
-    const ctx = {
-      ...createBaseTestContext(),
-      build,
-    } as any;
-
-    mockWaitForBuildToComplete.mockResolvedValue();
-    ctx.client.runQuery.mockReturnValueOnce({
-      app: { build: { changeCount: 0, status: 'PASSED', completedAt: 1 } },
-    });
-
-    await takeSnapshots(ctx, {} as any);
-
-    expect(mockWaitForBuildToComplete).not.toHaveBeenCalled();
+    expect(report).toHaveBeenCalledTimes(2);
+    expect(report).toHaveBeenCalledWith(
+      expect.objectContaining({ progress: { progress: 1, total: 5, unit: 'snapshots' } })
+    );
+    expect(report).toHaveBeenCalledWith(
+      expect.objectContaining({ progress: { progress: 3, total: 5, unit: 'snapshots' } })
+    );
+    // Each report carries the live polled build so the engine can keep ctx.build fresh mid-task.
+    expect(report).toHaveBeenCalledWith(
+      expect.objectContaining({ build: expect.objectContaining({ status: 'IN_PROGRESS' }) })
+    );
   });
 
   it('does not call waitForBuildToComplete if there are no tests', async () => {
@@ -216,19 +201,37 @@ describe('takeSnapshots', () => {
       features: {},
       reportToken: 'report-token',
       id: 'build-123',
-      actualTestCount: 1,
+      actualTestCount: 0,
     };
-    const ctx = {
-      ...createBaseTestContext(),
-      build,
-    } as any;
+    const ctx = { ...createBaseTestContext(), build } as any;
 
     mockWaitForBuildToComplete.mockResolvedValue();
     ctx.client.runQuery.mockReturnValueOnce({
       app: { build: { changeCount: 0, status: 'PASSED', completedAt: 1 } },
     });
 
-    await takeSnapshots(ctx, {} as any);
+    await runSnapshot(ctx);
+
+    expect(mockWaitForBuildToComplete).not.toHaveBeenCalled();
+  });
+
+  it('calls waitForBuildToComplete with correct arguments', async () => {
+    const build = {
+      app: { repository: { provider: 'github' } },
+      number: 1,
+      features: {},
+      reportToken: 'report-token',
+      id: 'build-123',
+      actualTestCount: 1,
+    };
+    const ctx = { ...createBaseTestContext(), build } as any;
+
+    mockWaitForBuildToComplete.mockResolvedValue();
+    ctx.client.runQuery.mockReturnValueOnce({
+      app: { build: { changeCount: 0, status: 'PASSED', completedAt: 1 } },
+    });
+
+    await runSnapshot(ctx);
 
     expect(mockWaitForBuildToComplete).toHaveBeenCalledWith({
       notifyServiceUrl: environment.CHROMATIC_NOTIFY_SERVICE_URL,
@@ -250,10 +253,7 @@ describe('takeSnapshots', () => {
       id: 'build-123',
       actualTestCount: 1,
     };
-    const ctx = {
-      ...createBaseTestContext(),
-      build,
-    } as any;
+    const ctx = { ...createBaseTestContext(), build } as any;
 
     const connectionError = new NotifyConnectionError('Failed to connect to notify service', 1006);
     mockWaitForBuildToComplete.mockRejectedValue(connectionError);
@@ -261,7 +261,7 @@ describe('takeSnapshots', () => {
       app: { build: { changeCount: 0, status: 'PASSED', completedAt: 1 } },
     });
 
-    await takeSnapshots(ctx, {} as any);
+    await runSnapshot(ctx);
 
     expect(ctx.log.debug).toHaveBeenCalledWith(
       'Failed to connect to notify service, falling back to polling: code: 1006, original error: undefined'
@@ -279,10 +279,7 @@ describe('takeSnapshots', () => {
       id: 'build-123',
       actualTestCount: 1,
     };
-    const ctx = {
-      ...createBaseTestContext(),
-      build,
-    } as any;
+    const ctx = { ...createBaseTestContext(), build } as any;
 
     const notifyError = new NotifyServiceError(
       'Connection failed',
@@ -295,7 +292,7 @@ describe('takeSnapshots', () => {
       app: { build: { changeCount: 0, status: 'PASSED', completedAt: 1 } },
     });
 
-    await takeSnapshots(ctx, {} as any);
+    await runSnapshot(ctx);
 
     expect(ctx.log.debug).toHaveBeenCalledWith(
       'Error getting updates from notify service: Connection failed code: 1001, reason: Going away, original error: Original error'
@@ -313,10 +310,7 @@ describe('takeSnapshots', () => {
       id: 'build-123',
       actualTestCount: 1,
     };
-    const ctx = {
-      ...createBaseTestContext(),
-      build,
-    } as any;
+    const ctx = { ...createBaseTestContext(), build } as any;
 
     const timeoutError = new NotifyServiceMessageTimeoutError(
       'Timed out waiting for message',
@@ -328,7 +322,7 @@ describe('takeSnapshots', () => {
       app: { build: { changeCount: 0, status: 'PASSED', completedAt: 1 } },
     });
 
-    await takeSnapshots(ctx, {} as any);
+    await runSnapshot(ctx);
 
     expect(ctx.log.debug).toHaveBeenCalledWith(
       'Timed out waiting for message from notify service, falling back to polling'
@@ -347,10 +341,7 @@ describe('takeSnapshots', () => {
       id: 'build-123',
       actualTestCount: 1,
     };
-    const ctx = {
-      ...createBaseTestContext(),
-      build,
-    } as any;
+    const ctx = { ...createBaseTestContext(), build } as any;
 
     const genericError = new Error('Generic connection error');
     mockWaitForBuildToComplete.mockRejectedValue(genericError);
@@ -358,7 +349,7 @@ describe('takeSnapshots', () => {
       app: { build: { changeCount: 0, status: 'PASSED', completedAt: 1 } },
     });
 
-    await takeSnapshots(ctx, {} as any);
+    await runSnapshot(ctx);
 
     expect(ctx.log.error).toHaveBeenCalledWith(
       'Unexpected error from notify service: Generic connection error'
@@ -376,10 +367,7 @@ describe('takeSnapshots', () => {
       id: 'build-123',
       actualTestCount: 1,
     };
-    const ctx = {
-      ...createBaseTestContext(),
-      build,
-    } as any;
+    const ctx = { ...createBaseTestContext(), build } as any;
 
     const authenticationError = new NotifyServiceAuthenticationError('Unauthorized request', 401);
     mockWaitForBuildToComplete.mockRejectedValue(authenticationError);
@@ -387,7 +375,7 @@ describe('takeSnapshots', () => {
       app: { build: { changeCount: 0, status: 'PASSED', completedAt: 1 } },
     });
 
-    await takeSnapshots(ctx, {} as any);
+    await runSnapshot(ctx);
 
     expect(ctx.log.debug).toHaveBeenCalledWith(
       'Error authenticating with notify service: 401 Unauthorized request'
@@ -396,7 +384,7 @@ describe('takeSnapshots', () => {
     expect(ctx.exitCode).toBe(0);
   });
 
-  it('calls experimental_onTaskProgress via waitForBuildToComplete progress callback', async () => {
+  it('reports progress via the waitForBuildToComplete progress callback', async () => {
     const build = {
       app: { repository: { provider: 'github' } },
       number: 1,
@@ -405,11 +393,7 @@ describe('takeSnapshots', () => {
       actualTestCount: 5,
       id: 'build-123',
     };
-    const ctx = {
-      ...createBaseTestContext(),
-      options: { experimental_onTaskProgress: vi.fn() },
-      build,
-    } as any;
+    const ctx = { ...createBaseTestContext(), build } as any;
 
     let progressCallback: any;
     mockWaitForBuildToComplete.mockImplementation(({ progressMessageCallback }) => {
@@ -420,22 +404,64 @@ describe('takeSnapshots', () => {
       app: { build: { changeCount: 0, status: 'PASSED', completedAt: 1 } },
     });
 
-    await takeSnapshots(ctx, {} as any);
+    const { report } = await runSnapshot(ctx);
 
     // Simulate progress messages through the callback
     progressCallback({ inProgressCount: 3, status: 'IN_PROGRESS' });
     progressCallback({ inProgressCount: 1, status: 'IN_PROGRESS' });
 
-    expect(ctx.options.experimental_onTaskProgress).toHaveBeenCalledTimes(2);
-    expect(ctx.options.experimental_onTaskProgress).toHaveBeenCalledWith(expect.any(Object), {
-      progress: 3, // actualTestCount (5) - inProgressCount (3) + 1 = 3
-      total: 5,
-      unit: 'snapshots',
-    });
-    expect(ctx.options.experimental_onTaskProgress).toHaveBeenCalledWith(expect.any(Object), {
-      progress: 5, // actualTestCount (5) - inProgressCount (1) + 1 = 5
-      total: 5,
-      unit: 'snapshots',
-    });
+    expect(report).toHaveBeenCalledWith(
+      expect.objectContaining({ progress: { progress: 3, total: 5, unit: 'snapshots' } })
+    );
+    expect(report).toHaveBeenCalledWith(
+      expect.objectContaining({ progress: { progress: 5, total: 5, unit: 'snapshots' } })
+    );
+  });
+
+  it('self-skips for --dry-run without polling', async () => {
+    const build = { app: {}, number: 1, features: {} };
+    const ctx = { ...createBaseTestContext(), options: { dryRun: true }, build } as any;
+
+    const { result } = await runSnapshot(ctx);
+
+    expect(result.kind).toBe('skip-self');
+    expect(ctx.client.runQuery).not.toHaveBeenCalled();
+    expect(ctx.exitCode).toBeUndefined();
+  });
+
+  it('self-skips when ctx.skipSnapshots is set without polling', async () => {
+    const build = { app: {}, number: 1, features: {} };
+    const ctx = { ...createBaseTestContext(), skipSnapshots: true, build } as any;
+
+    const { result } = await runSnapshot(ctx);
+
+    expect(result.kind).toBe('skip-self');
+    expect(ctx.client.runQuery).not.toHaveBeenCalled();
+  });
+});
+
+describe('applySnapshotOutput', () => {
+  it('sets the exit code, writes the build onto ctx, and logs the passed message', () => {
+    const build = { number: 1, changeCount: 0, webUrl: 'https://x' } as any;
+    const ctx = { log, options: {} } as any;
+    const output: SnapshotOutput = { exitCode: 0, userError: false, log: 'passed', build };
+
+    applySnapshotOutput(ctx, output);
+
+    expect(ctx.build).toBe(build);
+    expect(ctx.exitCode).toBe(0);
+    expect(ctx.log.info).toHaveBeenCalled();
+  });
+
+  it('sets the changes exit code as a user error and logs the changes message', () => {
+    const build = { number: 1, changeCount: 2, webUrl: 'https://x' } as any;
+    const ctx = { log, options: {} } as any;
+    const output: SnapshotOutput = { exitCode: 1, userError: true, log: 'changes', build };
+
+    applySnapshotOutput(ctx, output);
+
+    expect(ctx.exitCode).toBe(1);
+    expect(ctx.userError).toBe(true);
+    expect(ctx.log.error).toHaveBeenCalled();
   });
 });

--- a/node-src/tasks/snapshot.ts
+++ b/node-src/tasks/snapshot.ts
@@ -8,24 +8,13 @@ import waitForBuildToComplete, {
 import * as Sentry from '@sentry/node';
 
 import { exitCodes, setExitCode } from '../lib/setExitCode';
-import { createTask, transitionTo } from '../lib/tasks';
 import { delay, throttle } from '../lib/utilities';
-import { Context, Task } from '../types';
+import { Context, Deps, TaskResult } from '../types';
 import buildHasChanges from '../ui/messages/errors/buildHasChanges';
 import buildHasErrors from '../ui/messages/errors/buildHasErrors';
 import buildPassedMessage from '../ui/messages/info/buildPassed';
 import speedUpCI from '../ui/messages/info/speedUpCI';
-import {
-  buildBroken,
-  buildCanceled,
-  buildComplete,
-  buildFailed,
-  buildPassed,
-  dryRun,
-  initial,
-  pending,
-  skipped,
-} from '../ui/tasks/snapshot';
+import { pending } from '../ui/tasks/snapshot';
 
 const SnapshotBuildQuery = `
   query SnapshotBuildQuery($number: Int!) {
@@ -59,18 +48,59 @@ interface BuildQueryResult {
   };
 }
 
+// Discriminates which terminal message `applyOutput` logs once the exit code is set; the success
+// frame itself is chosen by `transitions.success` branching on the completed `ctx.build.status`.
+// `build` carries the polled-to-completion build back to `applyOutput`, which writes it onto
+// Context so the success transition reads the completed status.
+export interface SnapshotOutput {
+  exitCode: number;
+  userError: boolean;
+  log?: 'passed' | 'changes' | 'errors';
+  build: Context['build'];
+}
+
+export interface SnapshotInput {
+  build: Context['build'];
+  skipSnapshots?: boolean;
+  uploadedBytes?: number;
+  matchesBranch: Context['git']['matchesBranch'];
+  onlyStoryFiles?: Context['onlyStoryFiles'];
+}
+
+export type SnapshotDeps = Pick<Deps, 'client' | 'log' | 'env' | 'options' | 'report'>;
+
+/**
+ * Poll Chromatic until the published build finishes, reporting snapshot-count progress, then map the
+ * terminal build status to an exit code and the message the snapshot task should log.
+ *
+ * @param deps Narrow set of cross-cutting dependencies the task needs.
+ * @param input Per-pipeline-run input extracted from Context at the seam.
+ *
+ * @returns A TaskResult conveying the terminal exit code, or a self-skip for `--dry-run` / publish-only.
+ */
 // TODO: refactor this function
 // eslint-disable-next-line complexity
-export const takeSnapshots = async (ctx: Context, task: Task) => {
-  const { client, log, uploadedBytes } = ctx;
-  const { app, number, tests, testCount, actualTestCount, reportToken } = ctx.build;
+export async function snapshotProject(
+  deps: SnapshotDeps,
+  input: SnapshotInput
+): Promise<TaskResult<SnapshotOutput>> {
+  const { client, log, env, options } = deps;
+  const { skipSnapshots, uploadedBytes, matchesBranch, onlyStoryFiles } = input;
 
-  if (app.repository && uploadedBytes && !ctx.options.junitReport) {
+  if (skipSnapshots || options.dryRun) {
+    return { kind: 'skip-self' };
+  }
+
+  // Reassigned each poll; the progress reporter and the terminal switch read the latest value.
+  let build = input.build;
+  const { app, number, tests, testCount, actualTestCount, reportToken } = build;
+
+  if (app.repository && uploadedBytes && !options.junitReport) {
     log.info(speedUpCI(app.repository.provider));
   }
 
   const testLabels =
-    ctx.options.interactive &&
+    options.interactive &&
     testCount === actualTestCount &&
     tests?.map(({ spec, parameters, mode }) => {
       const testSuffixName = mode.name || `[${parameters.viewport}px]`;
@@ -80,14 +110,14 @@ export const takeSnapshots = async (ctx: Context, task: Task) => {
 
   const updateProgress = throttle(
     ({ cursor, label }) => {
-      task.output = pending(ctx, { cursor, label }).output;
-      ctx.options.experimental_onTaskProgress?.(
-        { ...ctx },
-        { progress: cursor, total: actualTestCount, unit: 'snapshots' }
-      );
+      deps.report({
+        output: pending({ build, options, onlyStoryFiles }, { cursor, label }).output,
+        progress: { progress: cursor, total: actualTestCount, unit: 'snapshots' },
+        build,
+      });
     },
     // Avoid spamming the logs with progress updates in non-interactive mode
-    ctx.options.interactive ? ctx.env.CHROMATIC_POLL_INTERVAL : ctx.env.CHROMATIC_OUTPUT_INTERVAL
+    options.interactive ? env.CHROMATIC_POLL_INTERVAL : env.CHROMATIC_OUTPUT_INTERVAL
   );
 
   const uiStateUpdater = (buildProgressData: BuildProgressMessage | Context['build']): void => {
@@ -100,85 +130,108 @@ export const takeSnapshots = async (ctx: Context, task: Task) => {
   };
 
   const getCompletedBuild = async (): Promise<Context['build']> => {
-    const options = { headers: { Authorization: `Bearer ${reportToken}` } };
-    const data = await client.runQuery<BuildQueryResult>(SnapshotBuildQuery, { number }, options);
-    ctx.build = { ...ctx.build, ...data.app.build };
+    const queryOptions = { headers: { Authorization: `Bearer ${reportToken}` } };
+    const data = await client.runQuery<BuildQueryResult>(
+      SnapshotBuildQuery,
+      { number },
+      queryOptions
+    );
+    build = { ...build, ...data.app.build };
 
-    if (ctx.build.completedAt) {
-      return ctx.build;
+    if (build.completedAt) {
+      return build;
     }
 
-    uiStateUpdater(ctx.build);
+    uiStateUpdater(build);
 
-    await delay(ctx.env.CHROMATIC_POLL_INTERVAL);
+    await delay(env.CHROMATIC_POLL_INTERVAL);
     return getCompletedBuild();
   };
 
   if (actualTestCount > 0) {
-    await waitForBuildToCompleteAndHandleErrors(ctx, uiStateUpdater, reportToken);
+    await waitForBuildToCompleteAndHandleErrors(deps, build.id, uiStateUpdater, reportToken);
   }
 
-  const build = await getCompletedBuild();
+  const completedBuild = await getCompletedBuild();
 
-  switch (build.status) {
+  switch (completedBuild.status) {
     case 'PASSED':
-      setExitCode(ctx, exitCodes.OK);
-      ctx.log.info(buildPassedMessage(ctx));
-      transitionTo(buildPassed, true)(ctx, task);
-      break;
+      return {
+        kind: 'continue',
+        output: { exitCode: exitCodes.OK, userError: false, log: 'passed', build: completedBuild },
+      };
 
     // They may have sneakily looked at the build while we were waiting
     case 'ACCEPTED':
     case 'PENDING':
     case 'DENIED': {
-      if (
-        build.autoAcceptChanges ||
+      const passed =
+        completedBuild.autoAcceptChanges ||
         // The boolean version of this check is handled by ctx.git.matchesBranch
-        ctx.options?.exitZeroOnChanges === 'true' ||
-        ctx.git.matchesBranch?.(ctx.options?.exitZeroOnChanges || false)
-      ) {
-        setExitCode(ctx, exitCodes.OK);
-        ctx.log.info(buildPassedMessage(ctx));
-      } else {
-        setExitCode(ctx, exitCodes.BUILD_HAS_CHANGES, true);
-        ctx.log.error(buildHasChanges(ctx));
-      }
-      transitionTo(buildComplete, true)(ctx, task);
-      break;
+        options?.exitZeroOnChanges === 'true' ||
+        matchesBranch?.(options?.exitZeroOnChanges || false);
+      return passed
+        ? {
+            kind: 'continue',
+            output: {
+              exitCode: exitCodes.OK,
+              userError: false,
+              log: 'passed',
+              build: completedBuild,
+            },
+          }
+        : {
+            kind: 'continue',
+            output: {
+              exitCode: exitCodes.BUILD_HAS_CHANGES,
+              userError: true,
+              log: 'changes',
+              build: completedBuild,
+            },
+          };
     }
 
     case 'BROKEN':
-      setExitCode(ctx, exitCodes.BUILD_HAS_ERRORS, true);
-      ctx.log.error(buildHasErrors(ctx));
-      transitionTo(buildBroken, true)(ctx, task);
-      break;
+      return {
+        kind: 'continue',
+        output: {
+          exitCode: exitCodes.BUILD_HAS_ERRORS,
+          userError: true,
+          log: 'errors',
+          build: completedBuild,
+        },
+      };
 
     case 'FAILED':
-      setExitCode(ctx, exitCodes.BUILD_FAILED, false);
-      transitionTo(buildFailed, true)(ctx, task);
-      break;
+      return {
+        kind: 'continue',
+        output: { exitCode: exitCodes.BUILD_FAILED, userError: false, build: completedBuild },
+      };
 
     case 'CANCELLED':
-      setExitCode(ctx, exitCodes.BUILD_WAS_CANCELED, true);
-      transitionTo(buildCanceled, true)(ctx, task);
-      break;
+      return {
+        kind: 'continue',
+        output: { exitCode: exitCodes.BUILD_WAS_CANCELED, userError: true, build: completedBuild },
+      };
 
     default:
-      throw new Error(`Unexpected build status: ${build.status}`);
+      throw new Error(`Unexpected build status: ${completedBuild.status}`);
   }
-};
+}
 
 async function waitForBuildToCompleteAndHandleErrors(
-  ctx: Context,
+  deps: Pick<Deps, 'env' | 'log'>,
+  buildId: string,
   uiStateUpdater: (buildProgressData: BuildProgressMessage | Context['build']) => void,
   reportToken: string | undefined
 ) {
+  const { env, log } = deps;
   try {
     await waitForBuildToComplete({
-      notifyServiceUrl: ctx.env.CHROMATIC_NOTIFY_SERVICE_URL,
-      buildId: ctx.build.id,
+      notifyServiceUrl: env.CHROMATIC_NOTIFY_SERVICE_URL,
+      buildId,
       progressMessageCallback: uiStateUpdater,
-      log: ctx.log,
+      log,
       headers: {
         Authorization: `Bearer ${reportToken}`,
       },
@@ -186,42 +239,46 @@ async function waitForBuildToCompleteAndHandleErrors(
   } catch (error) {
     Sentry.captureException(error);
     if (error instanceof NotifyConnectionError) {
-      ctx.log.debug(
+      log.debug(
         `Failed to connect to notify service, falling back to polling: code: ${error.statusCode}, original error: ${error.originalError?.message}`
       );
     } else if (error instanceof NotifyServiceMessageTimeoutError) {
-      ctx.log.debug('Timed out waiting for message from notify service, falling back to polling');
+      log.debug('Timed out waiting for message from notify service, falling back to polling');
     } else if (error instanceof NotifyServiceAuthenticationError) {
-      ctx.log.debug(
-        `Error authenticating with notify service: ${error.statusCode} ${error.message}`
-      );
+      log.debug(`Error authenticating with notify service: ${error.statusCode} ${error.message}`);
     } else if (error instanceof NotifyServiceError) {
-      ctx.log.debug(
+      log.debug(
         `Error getting updates from notify service: ${error.message} code: ${error.statusCode}, reason: ${error.reason}, original error: ${error.originalError?.message}`
       );
     } else {
-      ctx.log.error(`Unexpected error from notify service: ${error.message}`);
+      log.error(`Unexpected error from notify service: ${error.message}`);
     }
   }
 }
 
-/**
- * Sets up the Listr task for snapshotting the Storybook.
- *
- * @param ctx The context set when executing the CLI.
- *
- * @returns A Listr task.
- */
-export default function main(ctx: Context) {
-  return createTask({
-    name: 'snapshot',
-    title: initial(ctx).title,
-    skip: (ctx: Context) => {
-      if (ctx.skip) return true;
-      if (ctx.skipSnapshots) return skipped(ctx).output;
-      if (ctx.options.dryRun) return dryRun(ctx).output;
-      return false;
-    },
-    steps: [transitionTo(pending), takeSnapshots],
-  });
-}
+export const extractSnapshotInput = (ctx: Context): SnapshotInput => ({
+  build: ctx.build,
+  skipSnapshots: ctx.skipSnapshots,
+  uploadedBytes: ctx.uploadedBytes,
+  matchesBranch: ctx.git.matchesBranch,
+  onlyStoryFiles: ctx.onlyStoryFiles,
+});
+
+export const applySnapshotOutput = (ctx: Context, output: SnapshotOutput) => {
+  ctx.build = output.build;
+  setExitCode(ctx, output.exitCode, output.userError);
+
+  switch (output.log) {
+    case 'passed':
+      ctx.log.info(buildPassedMessage(ctx));
+      return;
+    case 'changes':
+      ctx.log.error(buildHasChanges(ctx));
+      return;
+    case 'errors':
+      ctx.log.error(buildHasErrors(ctx));
+      return;
+    default:
+      return;
+  }
+};

--- a/node-src/tasks/verify/index.ts
+++ b/node-src/tasks/verify/index.ts
@@ -18,6 +18,7 @@ export interface VerifyOutput {
   announcedBuild: Context['announcedBuild'];
   storybookUrl: string;
   build: Context['build'];
+  // TECHDEBT: if we add a third flag here, we should refactor to something more extensible
   isPublishOnly: boolean;
   skipSnapshots: boolean;
   limitExitCode?: { code: number; userError: boolean };
@@ -82,8 +83,8 @@ export const applyVerifyOutput = (ctx: Context, output: VerifyOutput) => {
   ctx.build = output.build;
   ctx.isPublishOnly = output.isPublishOnly;
 
-  // Replays the legacy setExitCode ordering: a limit code first, then OK overrides it when the
-  // build is publish-only / listed / exiting once uploaded.
+  // Ordering on the setExitCode calls matters: a limit code first, then OK overrides it when the
+  // build is publish-only / listed / exiting once uploaded. If we add a third case, refactor.
   if (output.limitExitCode) {
     setExitCode(ctx, output.limitExitCode.code, output.limitExitCode.userError);
   }

--- a/node-src/types.ts
+++ b/node-src/types.ts
@@ -501,6 +501,11 @@ export interface TaskUpdate {
   title?: string;
   output?: string;
   progress?: TaskProgress;
+  // A mid-task ctx mutation, not UI: `makeReporter` writes this onto `ctx.build` so the `{ ...ctx }`
+  // snapshot handed to `experimental_onTaskProgress` carries the live (polled) build. If we add more
+  // fields like this, refactor to a more extensible mid-task ctx-update channel rather than growing
+  // the UI-update payload with model-sync fields.
+  build?: Context['build'];
 }
 
 export type TaskReporter = (update: TaskUpdate) => void;

--- a/node-src/ui/tasks/snapshot.frames.ts
+++ b/node-src/ui/tasks/snapshot.frames.ts
@@ -1,0 +1,118 @@
+import { clackProgressBarRenderer } from '../../renderer/engine/clack/progressRenderer';
+import { captureTask } from '../../renderer/storybook/captureTask';
+import { Context, Task } from '../../types';
+import {
+  buildBroken,
+  buildCanceled,
+  buildComplete,
+  buildFailed,
+  buildPassed,
+  dryRun,
+  pending,
+  skipped,
+} from './snapshot';
+
+// Node-side scenarios for the snapshot task. The `?clack` Vite plugin runs this module in Node,
+// renders each export through the real Clack progress-bar renderer (snapshot reports discrete
+// snapshot-count progress), and hands the resulting ANSI strings to the browser story
+// (`snapshot.stories.ts`).
+
+const ctx = { options: {} } as any;
+
+const build = {
+  number: 42,
+  errorCount: 1,
+  changeCount: 2,
+  testCount: 10,
+  actualTestCount: 10,
+  actualCaptureCount: 20,
+  componentCount: 5,
+  specCount: 8,
+  features: { uiTests: true },
+};
+
+const now = 0;
+const startedAt = -123_456;
+
+const make = (state: Task, starting?: Task) =>
+  captureTask(state, starting, clackProgressBarRenderer);
+
+// The bar starts at 0% with a generic subtitle; the persistent header is the (cursor-independent)
+// pending title, which `succeed`/`fail` collapse into the completion line.
+const start = (context: Context) => pending(context);
+
+// A mid-run progress frame: the label carries the percent + counts (the renderer fills the bar from
+// `progress`, so the ascii bar prefix is gone), rendered as an update over the started bar.
+const progressFrame = (context: Context, cursor: number, label?: string) =>
+  make(
+    {
+      status: 'updating',
+      title: pending(context, { cursor, label }).title,
+      output: pending(context, { cursor, label }).output,
+      progress: { progress: cursor, total: context.build.actualTestCount, unit: 'snapshots' },
+    },
+    start(context)
+  );
+
+export const Pending = () =>
+  progressFrame({ ...ctx, build } as Context, 6, 'ComponentName › StoryName');
+
+export const PendingOnlyChanged = () =>
+  progressFrame(
+    { ...ctx, build: { ...build, actualTestCount: 8 }, onlyStoryFiles: [] } as Context,
+    6
+  );
+
+export const PendingOnlyStoryNames = () =>
+  progressFrame(
+    {
+      ...ctx,
+      build: { ...build, actualTestCount: 8 },
+      options: { ...ctx.options, onlyStoryNames: ['Pages/**'] },
+    } as Context,
+    6
+  );
+
+export const BuildPassed = () =>
+  make(buildPassed({ ...ctx, build, now, startedAt }), start({ ...ctx, build } as Context));
+
+export const BuildComplete = () =>
+  make(buildComplete({ ...ctx, build, now, startedAt }), start({ ...ctx, build } as Context));
+
+export const BuildAutoAccepted = () =>
+  make(
+    buildComplete({ ...ctx, build: { ...build, autoAcceptChanges: true }, now, startedAt }),
+    start({ ...ctx, build } as Context)
+  );
+
+// Broken/failed/canceled builds aren't pipeline-halting throws — they complete via `renderer.succeed`,
+// which renders a green completed frame (Listr did the same: it finished the task without throwing, so
+// the `status: 'error'` on these states only ever drove the old `task()` sim). Render them as success
+// frames here to match runtime; a distinct red-failure treatment is deferred to a follow-up PR.
+const completed = (state: Task) =>
+  make({ ...state, status: 'success' }, start({ ...ctx, build } as Context));
+
+export const BuildBroken = () => completed(buildBroken({ ...ctx, build, now, startedAt }));
+
+export const BuildFailed = () => completed(buildFailed({ ...ctx, build, now, startedAt }));
+
+export const BuildCanceled = () => completed(buildCanceled({ ...ctx, build, now, startedAt }));
+
+// --dry-run and the upstream skipSnapshots reasons all self-skip; runTask drives the skipped state
+// through `renderer.succeed`.
+export const DryRun = () => make(dryRun(ctx), start({ ...ctx, build } as Context));
+
+export const SkippedPublishOnly = () =>
+  make(skipped({ ...ctx, isPublishOnly: true }), start({ ...ctx, build } as Context));
+
+export const SkippedList = () =>
+  make(
+    skipped({ ...ctx, options: { ...ctx.options, list: true } }),
+    start({ ...ctx, build } as Context)
+  );
+
+export const SkippedExitOnceUploaded = () =>
+  make(
+    skipped({ ...ctx, options: { ...ctx.options, exitOnceUploaded: true } }),
+    start({ ...ctx, build } as Context)
+  );

--- a/node-src/ui/tasks/snapshot.stories.ts
+++ b/node-src/ui/tasks/snapshot.stories.ts
@@ -1,84 +1,19 @@
-import { exitCodes } from '../../lib/setExitCode';
-import task from '../components/task';
-import {
-  buildBroken,
-  buildCanceled,
-  buildComplete,
-  buildFailed,
-  buildPassed,
-  dryRun,
-  initial,
-  pending,
-  skipped,
-} from './snapshot';
+import frames from './snapshot.frames?clack';
 
 export default {
   title: 'CLI/Tasks/Snapshot',
-  decorators: [(storyFunction) => task(storyFunction())],
 };
 
-const build = {
-  number: 42,
-  errorCount: 1,
-  changeCount: 2,
-  testCount: 10,
-  actualTestCount: 10,
-  actualCaptureCount: 20,
-  componentCount: 5,
-  specCount: 8,
-  features: { uiTests: true },
-};
-const ctx = { options: {} } as any;
-
-const now = 0;
-const startedAt = -123_456;
-
-export const Initial = () => initial(ctx);
-
-export const DryRun = () => dryRun(ctx);
-
-export const Pending = () =>
-  pending({ ...ctx, build } as any, {
-    cursor: 6,
-    label: 'ComponentName › StoryName',
-  });
-
-export const PendingOnlyChanged = () =>
-  pending({ ...ctx, build: { ...build, actualTestCount: 8 }, onlyStoryFiles: [] } as any, {
-    cursor: 6,
-  });
-
-export const PendingOnlyStoryNames = () =>
-  pending(
-    {
-      ...ctx,
-      build: { ...build, actualTestCount: 8 },
-      options: { ...ctx.options, onlyStoryNames: ['Pages/**'] },
-    } as any,
-    { cursor: 6 }
-  );
-
-export const BuildPassed = () => buildPassed({ ...ctx, build, now, startedAt } as any);
-
-export const BuildComplete = () =>
-  buildComplete({ ...ctx, build, now, startedAt, exitCode: 1 } as any);
-
-export const BuildAutoAccepted = () =>
-  buildComplete({ ...ctx, build: { ...build, autoAcceptChanges: true }, now, startedAt } as any);
-
-export const BuildBroken = () =>
-  buildBroken({ ...ctx, build, now, startedAt, exitCode: exitCodes.BUILD_HAS_ERRORS } as any);
-
-export const BuildFailed = () =>
-  buildFailed({ ...ctx, build, now, startedAt, exitCode: exitCodes.BUILD_FAILED } as any);
-
-export const BuildCanceled = () =>
-  buildCanceled({ ...ctx, build, now, startedAt, exitCode: exitCodes.BUILD_WAS_CANCELED } as any);
-
-export const SkippedPublishOnly = () => skipped({ ...ctx, isPublishOnly: true } as any);
-
-export const SkippedList = () =>
-  skipped({ ...ctx, options: { ...ctx.options, list: true } } as any);
-
-export const SkippedExitOnceUploaded = () =>
-  skipped({ ...ctx, options: { ...ctx.optionns, exitOnceUploaded: true } } as any);
+export const Pending = () => frames.Pending;
+export const PendingOnlyChanged = () => frames.PendingOnlyChanged;
+export const PendingOnlyStoryNames = () => frames.PendingOnlyStoryNames;
+export const BuildPassed = () => frames.BuildPassed;
+export const BuildComplete = () => frames.BuildComplete;
+export const BuildAutoAccepted = () => frames.BuildAutoAccepted;
+export const BuildBroken = () => frames.BuildBroken;
+export const BuildFailed = () => frames.BuildFailed;
+export const BuildCanceled = () => frames.BuildCanceled;
+export const DryRun = () => frames.DryRun;
+export const SkippedPublishOnly = () => frames.SkippedPublishOnly;
+export const SkippedList = () => frames.SkippedList;
+export const SkippedExitOnceUploaded = () => frames.SkippedExitOnceUploaded;

--- a/node-src/ui/tasks/snapshot.ts
+++ b/node-src/ui/tasks/snapshot.ts
@@ -2,7 +2,6 @@ import pluralize from 'pluralize';
 
 import { isE2EBuild } from '../../lib/e2eUtils';
 import { getDuration } from '../../lib/tasks';
-import { progressBar } from '../../lib/utilities';
 import { Context } from '../../types';
 
 const testType = (ctx: Context) => (isE2EBuild(ctx.options) ? 'test suite' : 'stories');
@@ -45,9 +44,21 @@ export const stats = ({
 };
 
 // TODO: refactor this function
-// eslint-disable-next-line complexity
-export const pending = (ctx: Context, { cursor = 0, label = '' } = {}) => {
+/* eslint-disable complexity */
+export const pending = (
+  ctx: Pick<Context, 'build' | 'options' | 'onlyStoryFiles'>,
+  { cursor = 0, label = '' } = {}
+) => {
   const { build, options, onlyStoryFiles } = ctx;
+  // `runTask` renders this pending state before the task body runs, so it must survive skip paths
+  // that have no build yet — notably `--dry-run`, where `ctx.build` is undefined.
+  if (!build) {
+    return {
+      status: 'pending',
+      title: `Test your ${isE2EBuild(options) ? 'test suite' : 'stories'}`,
+      output: 'This may take a few minutes',
+    };
+  }
   if (build.actualTestCount === 0) {
     return {
       status: 'pending',
@@ -62,8 +73,11 @@ export const pending = (ctx: Context, { cursor = 0, label = '' } = {}) => {
     : '';
   const affected = onlyStoryFiles ? ' affected by recent changes' : '';
   const skipping = build.testCount > build.actualTestCount ? ` (skipping ${skips})` : '';
-  const percentage = Math.round((cursor / build.actualTestCount) * 100);
-  const counts = `${cursor}/${build.actualTestCount}`;
+  // The cursor is a 1-based "now capturing" index (`actualTestCount - inProgressCount + 1`), so it
+  // reaches `actualTestCount + 1` once nothing is in progress. Clamp it so the label never exceeds 100%.
+  const boundedCursor = Math.min(cursor, build.actualTestCount);
+  const percentage = Math.round((boundedCursor / build.actualTestCount) * 100);
+  const counts = `${boundedCursor}/${build.actualTestCount}`;
 
   let errs = '';
   if (build.errorCount) {
@@ -73,11 +87,10 @@ export const pending = (ctx: Context, { cursor = 0, label = '' } = {}) => {
   return {
     status: 'pending',
     title: `Running ${tests}${matching}${affected}${skipping}`,
-    output: cursor
-      ? `${progressBar(percentage)} ${counts} ${errs} ${label}`
-      : 'This may take a few minutes',
+    output: cursor ? `${percentage}% ${counts} ${errs} ${label}` : 'This may take a few minutes',
   };
 };
+/* eslint-enable complexity */
 
 export const buildPassed = (ctx: Context) => {
   const { snapshots, components, stories, e2eTests } = stats(ctx);
@@ -144,4 +157,22 @@ export const skipped = (ctx: Context) => {
       ? `No UI tests or UI review enabled`
       : `Skipped due to ${ctx.options.list ? '--list' : '--exit-once-uploaded'}`,
   };
+};
+
+// The snapshot task's terminal frame: `runTask` always drives the `continue` result through
+// `renderer.succeed`, so all five build outcomes (including the broken/failed/canceled ones, which
+// carry `status: 'error'` and render as red failure frames) branch from here on the completed status.
+export const success = (ctx: Context) => {
+  switch (ctx.build.status) {
+    case 'PASSED':
+      return buildPassed(ctx);
+    case 'BROKEN':
+      return buildBroken(ctx);
+    case 'FAILED':
+      return buildFailed(ctx);
+    case 'CANCELLED':
+      return buildCanceled(ctx);
+    default:
+      return buildComplete(ctx);
+  }
 };

--- a/node-src/ui/tasks/snapshotE2E.frames.ts
+++ b/node-src/ui/tasks/snapshotE2E.frames.ts
@@ -1,0 +1,109 @@
+import { clackProgressBarRenderer } from '../../renderer/engine/clack/progressRenderer';
+import { captureTask } from '../../renderer/storybook/captureTask';
+import { Context, Task } from '../../types';
+import {
+  buildBroken,
+  buildCanceled,
+  buildComplete,
+  buildFailed,
+  buildPassed,
+  dryRun,
+  pending,
+  skipped,
+} from './snapshot';
+
+// Node-side scenarios for the snapshot task on an E2E build. The `?clack` Vite plugin runs this
+// module in Node, renders each export through the real Clack progress-bar renderer, and hands the
+// resulting ANSI strings to the browser story (`snapshotE2E.stories.ts`).
+
+const ctx = { options: { playwright: true } } as any;
+
+const build = {
+  number: 42,
+  errorCount: 1,
+  changeCount: 2,
+  testCount: 10,
+  actualTestCount: 10,
+  actualCaptureCount: 20,
+  componentCount: 5,
+  specCount: 8,
+  features: { uiTests: true },
+};
+
+const now = 0;
+const startedAt = -123_456;
+
+const make = (state: Task, starting?: Task) =>
+  captureTask(state, starting, clackProgressBarRenderer);
+
+const start = (context: Context) => pending(context);
+
+const progressFrame = (context: Context, cursor: number, label?: string) =>
+  make(
+    {
+      status: 'updating',
+      title: pending(context, { cursor, label }).title,
+      output: pending(context, { cursor, label }).output,
+      progress: { progress: cursor, total: context.build.actualTestCount, unit: 'snapshots' },
+    },
+    start(context)
+  );
+
+export const Pending = () =>
+  progressFrame({ ...ctx, build } as Context, 6, 'Snapshot #1 w1280h720');
+
+export const PendingOnlyChanged = () =>
+  progressFrame(
+    { ...ctx, build: { ...build, actualTestCount: 8 }, onlyStoryFiles: [] } as Context,
+    6
+  );
+
+export const PendingOnlyStoryNames = () =>
+  progressFrame(
+    {
+      ...ctx,
+      build: { ...build, actualTestCount: 8 },
+      options: { ...ctx.options, onlyStoryNames: ['Pages/**'] },
+    } as Context,
+    6
+  );
+
+export const BuildPassed = () =>
+  make(buildPassed({ ...ctx, build, now, startedAt }), start({ ...ctx, build } as Context));
+
+export const BuildComplete = () =>
+  make(buildComplete({ ...ctx, build, now, startedAt }), start({ ...ctx, build } as Context));
+
+export const BuildAutoAccepted = () =>
+  make(
+    buildComplete({ ...ctx, build: { ...build, autoAcceptChanges: true }, now, startedAt }),
+    start({ ...ctx, build } as Context)
+  );
+
+// See snapshot.frames.ts: these complete via `renderer.succeed` (green), matching Listr; the red-frame
+// treatment is deferred to a follow-up PR.
+const completed = (state: Task) =>
+  make({ ...state, status: 'success' }, start({ ...ctx, build } as Context));
+
+export const BuildBroken = () => completed(buildBroken({ ...ctx, build, now, startedAt }));
+
+export const BuildFailed = () => completed(buildFailed({ ...ctx, build, now, startedAt }));
+
+export const BuildCanceled = () => completed(buildCanceled({ ...ctx, build, now, startedAt }));
+
+export const DryRun = () => make(dryRun(ctx), start({ ...ctx, build } as Context));
+
+export const SkippedPublishOnly = () =>
+  make(skipped({ ...ctx, isPublishOnly: true }), start({ ...ctx, build } as Context));
+
+export const SkippedList = () =>
+  make(
+    skipped({ ...ctx, options: { ...ctx.options, list: true } }),
+    start({ ...ctx, build } as Context)
+  );
+
+export const SkippedExitOnceUploaded = () =>
+  make(
+    skipped({ ...ctx, options: { ...ctx.options, exitOnceUploaded: true } }),
+    start({ ...ctx, build } as Context)
+  );

--- a/node-src/ui/tasks/snapshotE2E.stories.ts
+++ b/node-src/ui/tasks/snapshotE2E.stories.ts
@@ -1,84 +1,19 @@
-import { exitCodes } from '../../lib/setExitCode';
-import task from '../components/task';
-import {
-  buildBroken,
-  buildCanceled,
-  buildComplete,
-  buildFailed,
-  buildPassed,
-  dryRun,
-  initial,
-  pending,
-  skipped,
-} from './snapshot';
+import frames from './snapshotE2E.frames?clack';
 
 export default {
   title: 'CLI/Tasks/Snapshot/E2E',
-  decorators: [(storyFunction) => task(storyFunction())],
 };
 
-const build = {
-  number: 42,
-  errorCount: 1,
-  changeCount: 2,
-  testCount: 10,
-  actualTestCount: 10,
-  actualCaptureCount: 20,
-  componentCount: 5,
-  specCount: 8,
-  features: { uiTests: true },
-};
-const ctx = { options: { playwright: true } } as any;
-
-const now = 0;
-const startedAt = -123_456;
-
-export const Initial = () => initial(ctx);
-
-export const DryRun = () => dryRun(ctx);
-
-export const Pending = () =>
-  pending({ ...ctx, build } as any, {
-    cursor: 6,
-    label: 'Snapshot #1 w1280h720',
-  });
-
-export const PendingOnlyChanged = () =>
-  pending({ ...ctx, build: { ...build, actualTestCount: 8 }, onlyStoryFiles: [] } as any, {
-    cursor: 6,
-  });
-
-export const PendingOnlyStoryNames = () =>
-  pending(
-    {
-      ...ctx,
-      build: { ...build, actualTestCount: 8 },
-      options: { ...ctx.options, onlyStoryNames: ['Pages/**'] },
-    } as any,
-    { cursor: 6 }
-  );
-
-export const BuildPassed = () => buildPassed({ ...ctx, build, now, startedAt } as any);
-
-export const BuildComplete = () =>
-  buildComplete({ ...ctx, build, now, startedAt, exitCode: 1 } as any);
-
-export const BuildAutoAccepted = () =>
-  buildComplete({ ...ctx, build: { ...build, autoAcceptChanges: true }, now, startedAt } as any);
-
-export const BuildBroken = () =>
-  buildBroken({ ...ctx, build, now, startedAt, exitCode: exitCodes.BUILD_HAS_ERRORS } as any);
-
-export const BuildFailed = () =>
-  buildFailed({ ...ctx, build, now, startedAt, exitCode: exitCodes.BUILD_FAILED } as any);
-
-export const BuildCanceled = () =>
-  buildCanceled({ ...ctx, build, now, startedAt, exitCode: exitCodes.BUILD_WAS_CANCELED } as any);
-
-export const SkippedPublishOnly = () => skipped({ ...ctx, isPublishOnly: true } as any);
-
-export const SkippedList = () =>
-  skipped({ ...ctx, options: { ...ctx.options, list: true } } as any);
-
-export const SkippedExitOnceUploaded = () =>
-  skipped({ ...ctx, options: { ...ctx.options, exitOnceUploaded: true } } as any);
+export const Pending = () => frames.Pending;
+export const PendingOnlyChanged = () => frames.PendingOnlyChanged;
+export const PendingOnlyStoryNames = () => frames.PendingOnlyStoryNames;
+export const BuildPassed = () => frames.BuildPassed;
+export const BuildComplete = () => frames.BuildComplete;
+export const BuildAutoAccepted = () => frames.BuildAutoAccepted;
+export const BuildBroken = () => frames.BuildBroken;
+export const BuildFailed = () => frames.BuildFailed;
+export const BuildCanceled = () => frames.BuildCanceled;
+export const DryRun = () => frames.DryRun;
+export const SkippedPublishOnly = () => frames.SkippedPublishOnly;
+export const SkippedList = () => frames.SkippedList;
+export const SkippedExitOnceUploaded = () => frames.SkippedExitOnceUploaded;

--- a/node-src/ui/workflows/uploadBuild.stories.ts
+++ b/node-src/ui/workflows/uploadBuild.stories.ts
@@ -20,7 +20,13 @@ import {
   pending as initializePending,
   success as initializeSuccess,
 } from '../tasks/initialize';
-import * as snapshot from '../tasks/snapshot.stories';
+import {
+  buildComplete as snapshotBuildComplete,
+  buildPassed as snapshotBuildPassed,
+  initial as snapshotInitial,
+  pending as snapshotPending,
+  skipped as snapshotSkipped,
+} from '../tasks/snapshot';
 import {
   initial as storybookInfoInitial,
   pending as storybookInfoPending,
@@ -118,6 +124,50 @@ const verify = {
   Pending: () => verifyPending(buildContext),
   Published: () =>
     verifySuccess({ ...buildContext, isPublishOnly: true, build: verifiedBuild } as any),
+};
+
+// snapshot.stories now returns rendered ANSI strings (Clack capture), which the old task() path
+// can't consume, so rebuild the states the workflow needs from the raw task source.
+const snapshotBuild = {
+  number: 42,
+  errorCount: 1,
+  changeCount: 2,
+  testCount: 10,
+  actualTestCount: 10,
+  actualCaptureCount: 20,
+  componentCount: 5,
+  specCount: 8,
+  features: { uiTests: true },
+};
+const snapshot = {
+  Initial: () => snapshotInitial(buildContext),
+  Pending: () =>
+    snapshotPending({ ...buildContext, build: snapshotBuild } as any, {
+      cursor: 6,
+      label: 'ComponentName › StoryName',
+    }),
+  BuildPassed: () =>
+    snapshotBuildPassed({
+      ...buildContext,
+      build: snapshotBuild,
+      now: 0,
+      startedAt: -123_456,
+    } as any),
+  BuildComplete: () =>
+    snapshotBuildComplete({
+      ...buildContext,
+      build: snapshotBuild,
+      now: 0,
+      startedAt: -123_456,
+    } as any),
+  BuildAutoAccepted: () =>
+    snapshotBuildComplete({
+      ...buildContext,
+      build: { ...snapshotBuild, autoAcceptChanges: true },
+      now: 0,
+      startedAt: -123_456,
+    } as any),
+  SkippedPublishOnly: () => snapshotSkipped({ ...buildContext, isPublishOnly: true } as any),
 };
 
 export default {

--- a/node-src/ui/workflows/uploadBuildE2E.stories.ts
+++ b/node-src/ui/workflows/uploadBuildE2E.stories.ts
@@ -20,7 +20,13 @@ import {
   pending as initializePending,
   success as initializeSuccess,
 } from '../tasks/initialize';
-import * as snapshot from '../tasks/snapshotE2E.stories';
+import {
+  buildComplete as snapshotBuildComplete,
+  buildPassed as snapshotBuildPassed,
+  initial as snapshotInitial,
+  pending as snapshotPending,
+  skipped as snapshotSkipped,
+} from '../tasks/snapshot';
 import {
   initial as storybookInfoInitial,
   pending as storybookInfoPending,
@@ -119,6 +125,41 @@ const verify = {
   Initial: () => verifyInitial(ctx),
   Pending: () => verifyPending(ctx),
   Published: () => verifySuccess({ ...ctx, isPublishOnly: true, build: verifiedBuild } as any),
+};
+
+// snapshot.stories now returns rendered ANSI strings (Clack capture), which the old task() path
+// can't consume, so rebuild the states the workflow needs from the raw task source. The file-level
+// `ctx` (playwright) is forwarded by the `steps()` helper.
+const snapshotBuild = {
+  number: 42,
+  errorCount: 1,
+  changeCount: 2,
+  testCount: 10,
+  actualTestCount: 10,
+  actualCaptureCount: 20,
+  componentCount: 5,
+  specCount: 8,
+  features: { uiTests: true },
+};
+const snapshot = {
+  Initial: () => snapshotInitial(ctx),
+  Pending: () =>
+    snapshotPending({ ...ctx, build: snapshotBuild } as any, {
+      cursor: 6,
+      label: 'Snapshot #1 w1280h720',
+    }),
+  BuildPassed: () =>
+    snapshotBuildPassed({ ...ctx, build: snapshotBuild, now: 0, startedAt: -123_456 } as any),
+  BuildComplete: () =>
+    snapshotBuildComplete({ ...ctx, build: snapshotBuild, now: 0, startedAt: -123_456 } as any),
+  BuildAutoAccepted: () =>
+    snapshotBuildComplete({
+      ...ctx,
+      build: { ...snapshotBuild, autoAcceptChanges: true },
+      now: 0,
+      startedAt: -123_456,
+    } as any),
+  SkippedPublishOnly: () => snapshotSkipped({ ...ctx, isPublishOnly: true } as any),
 };
 
 export default {


### PR DESCRIPTION
# Description

This PR migrates the `snapshot` task to Clack.

# Manual QA

One happy path build. Full QA to come in the feature branch QA process.
<img width="1804" height="1066" alt="image" src="https://github.com/user-attachments/assets/0aad9057-3d14-4fb5-8b0e-6beab6d8414f" />

<img width="1582" height="1128" alt="image" src="https://github.com/user-attachments/assets/0790f151-a5ac-4835-a398-4835f38cb85f" />

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>18.0.1--canary.1410.28528471397.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@18.0.1--canary.1410.28528471397.0
  # or 
  yarn add chromatic@18.0.1--canary.1410.28528471397.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
