### PR TITLE
Update upload task to log ancestor build details

### DIFF
--- a/node-src/lib/upload.ts
+++ b/node-src/lib/upload.ts
@@ -46,6 +46,11 @@ const UploadBuildMutation = `
       build {
         id
         status
+        ancestorBuilds {
+          status
+          webUrl
+          snapshotCount
+        }
       }
       userErrors {
         __typename
@@ -85,6 +90,11 @@ interface UploadBuildMutationResult {
     build?: {
       id: string;
       status: string;
+      ancestorBuilds?: {
+        status: string;
+        webUrl: string;
+        snapshotCount: number;
+      }[];
     };
     userErrors: (
       | {
@@ -145,6 +155,11 @@ export interface UploadBuildResult {
   uploadedBytes: number;
   uploadedFiles: number;
   skippedByTurboSnap?: boolean;
+  ancestorBuild?: {
+    status: string;
+    webUrl: string;
+    snapshotCount: number;
+  };
 }
 
 /**
@@ -259,7 +274,14 @@ export async function uploadBuild(
           Sentry.captureException(err);
         });
 
-      return { sentinelUrls, uploadedBytes, uploadedFiles, skippedByTurboSnap: true };
+      return {
+        sentinelUrls,
+        uploadedBytes,
+        uploadedFiles,
+        skippedByTurboSnap: true,
+        // In this case, we should only have a single ancestor build.
+        ancestorBuild: uploadBuild.build.ancestorBuilds?.[0],
+      };
     }
 
     sentinelUrls.push(...(uploadBuild.info?.sentinelUrls || []));

--- a/node-src/tasks/upload.test.ts
+++ b/node-src/tasks/upload.test.ts
@@ -6,7 +6,8 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import makeZipFile from '../lib/compress';
 import TestLogger from '../lib/testLogger';
-import buildTurboSkipped from '../ui/messages/info/buildFullyTurboSnapped';
+import buildFullyTurboSnapped from '../ui/messages/info/buildFullyTurboSnapped';
+import turboSnapEnabled from '../ui/messages/info/turboSnapEnabled';
 import { applyUploadOutput, extractUploadInput, uploadProject } from './upload';
 
 vi.mock('@sentry/node');
@@ -387,8 +388,42 @@ describe('uploadProject', () => {
       } as any;
       const result = await runUpload(ctx);
 
-      expect(result).toEqual({ kind: 'skip', reason: buildTurboSkipped() });
+      expect(result).toEqual({ kind: 'skip' });
       expect(http.fetch).not.toHaveBeenCalled();
+    });
+
+    it('logs the TurboSnap skip messages with ancestor build details when SKIPPED', async () => {
+      const skipLogger = new TestLogger();
+      const ancestorBuild = {
+        status: 'PASSED',
+        webUrl: 'https://www.chromatic.com/build?appId=abc&number=95',
+        snapshotCount: 54,
+      };
+      const client = { runQuery: vi.fn() };
+      client.runQuery.mockResolvedValue({
+        uploadBuild: {
+          build: { id: '2', status: 'SKIPPED', ancestorBuilds: [ancestorBuild] },
+          userErrors: [],
+        },
+      });
+
+      const ctx = {
+        client,
+        env: environment,
+        log: skipLogger,
+        http,
+        sourceDir: '/static/',
+        options: {},
+        fileInfo,
+        announcedBuild: { id: '1' },
+        onlyStoryFiles: [],
+      } as any;
+      await uploadProject({ log: skipLogger, report: vi.fn() } as any, extractUploadInput(ctx));
+
+      expect(skipLogger.info).toHaveBeenCalledWith(
+        turboSnapEnabled({ ...ctx, skip: true, ancestorBuild })
+      );
+      expect(skipLogger.info).toHaveBeenCalledWith(buildFullyTurboSnapped({ ancestorBuild }));
     });
 
     it('prepares the skipped build so stats carry over from its ancestor', async () => {
@@ -441,7 +476,7 @@ describe('uploadProject', () => {
       } as any;
       const result = await runUpload(ctx);
 
-      expect(result).toEqual({ kind: 'skip', reason: buildTurboSkipped() });
+      expect(result).toEqual({ kind: 'skip' });
       expect(skipLogger.error).toHaveBeenCalledWith(
         expect.stringContaining('Failed to prepare skipped build 2'),
         error

--- a/node-src/tasks/upload.ts
+++ b/node-src/tasks/upload.ts
@@ -4,7 +4,8 @@ import { uploadBuild } from '../lib/upload';
 import { throttle } from '../lib/utilities';
 import { waitForSentinel } from '../lib/waitForSentinel';
 import { Context, Deps, FileDesc, TaskResult } from '../types';
-import buildTurboSkipped from '../ui/messages/info/buildFullyTurboSnapped';
+import buildFullyTurboSnapped from '../ui/messages/info/buildFullyTurboSnapped';
+import turboSnapEnabled from '../ui/messages/info/turboSnapEnabled';
 import deduplicationFailed from '../ui/messages/warnings/deduplicationFailed';
 import { failed, finalizing, invalid, uploading } from '../ui/tasks/upload';
 
@@ -20,6 +21,7 @@ export interface UploadOutput {
   uploadedBytes: number;
   uploadedFiles: number;
   skippedByTurboSnap?: boolean;
+  ancestorBuild?: Context['ancestorBuild'];
 }
 
 const buildFileList = (ctx: Context, withHashes: boolean): FileDesc[] => {
@@ -43,10 +45,8 @@ const uploadAndWaitForSentinels = async (
   ctx: Context,
   files: FileDesc[]
 ): Promise<UploadOutput> => {
-  const { sentinelUrls, uploadedBytes, uploadedFiles, skippedByTurboSnap } = await uploadBuild(
-    ctx,
-    files,
-    {
+  const { sentinelUrls, uploadedBytes, uploadedFiles, skippedByTurboSnap, ancestorBuild } =
+    await uploadBuild(ctx, files, {
       onProgress: throttle(
         (progress, total) => {
           const percentage = Math.round((progress / total) * 100);
@@ -61,12 +61,11 @@ const uploadAndWaitForSentinels = async (
       onError: (error: Error, path?: string) => {
         throw path === error.message ? new Error(failed(ctx, { path }).output) : error;
       },
-    }
-  );
+    });
 
   // A TurboSnap-skipped build uploads nothing and has no sentinels to wait for.
   if (skippedByTurboSnap || sentinelUrls.length === 0) {
-    return { sentinelUrls, uploadedBytes, uploadedFiles, skippedByTurboSnap };
+    return { sentinelUrls, uploadedBytes, uploadedFiles, skippedByTurboSnap, ancestorBuild };
   }
 
   deps.report({ output: finalizing(ctx).output });
@@ -82,6 +81,19 @@ const uploadAndWaitForSentinels = async (
   await Promise.all(Object.values(sentinels).map((sentinel) => waitForSentinel(ctx, sentinel)));
 
   return { sentinelUrls, uploadedBytes, uploadedFiles };
+};
+
+// A fully-TurboSnapped build halts the pipeline (kind:'skip'). The upload frame renders bare; the
+// two TurboSnap success messages are logged here so they flush as free-standing blocks below the
+// task frames (verify/snapshot never run to log them themselves).
+const skipTurboSnapped = (
+  deps: Deps,
+  ctx: Context,
+  ancestorBuild: UploadOutput['ancestorBuild']
+): TaskResult<UploadOutput> => {
+  deps.log.info(turboSnapEnabled({ ...ctx, skip: true, ancestorBuild }));
+  deps.log.info(buildFullyTurboSnapped({ ancestorBuild }));
+  return { kind: 'skip' };
 };
 
 /**
@@ -105,7 +117,7 @@ export async function uploadProject(
   try {
     const output = await uploadAndWaitForSentinels(deps, ctx, buildFileList(ctx, true));
     if (output.skippedByTurboSnap) {
-      return { kind: 'skip', reason: buildTurboSkipped() };
+      return skipTurboSnapped(deps, ctx, output.ancestorBuild);
     }
     return { kind: 'continue', output };
   } catch {
@@ -114,7 +126,7 @@ export async function uploadProject(
     // results are discarded simply by running again.
     const output = await uploadAndWaitForSentinels(deps, ctx, buildFileList(ctx, false));
     if (output.skippedByTurboSnap) {
-      return { kind: 'skip', reason: buildTurboSkipped() };
+      return skipTurboSnapped(deps, ctx, output.ancestorBuild);
     }
     return { kind: 'continue', output };
   }

--- a/node-src/types.ts
+++ b/node-src/types.ts
@@ -467,6 +467,11 @@ export interface Context {
   sentinelUrls?: string[];
   uploadedBytes?: number;
   uploadedFiles?: number;
+  ancestorBuild?: {
+    status: string;
+    webUrl: string;
+    snapshotCount: number;
+  };
   turboSnap?: TurboSnap;
   mergeBase?: string;
   onlyStoryFiles?: string[];

--- a/node-src/ui/messages/info/buildFullyTurboSnapped.stories.ts
+++ b/node-src/ui/messages/info/buildFullyTurboSnapped.stories.ts
@@ -1,7 +1,33 @@
-import buildfullyTurboSnapped from './buildFullyTurboSnapped';
+import buildFullyTurboSnapped from './buildFullyTurboSnapped';
+import turboSnapEnabled from './turboSnapEnabled';
 
 export default {
-  title: 'CLI/Messages/Info',
+  title: 'CLI/Messages/Info/Build Skipped',
 };
 
-export const BuildFullyTurboSnapped = () => buildfullyTurboSnapped();
+const ancestorBuild = {
+  status: 'PENDING',
+  webUrl: 'https://www.chromatic.com/build?appId=abc123&number=95',
+  snapshotCount: 54,
+};
+
+// When a build is skipped, the CLI logs turboSnapEnabled() and buildFullyTurboSnapped() back-to-back
+// (see `skipTurboSnapped` in tasks/upload.ts), so we render them together here.
+const buildSkipped = (ctx: any) => {
+  const skipContext = { ...ctx, skip: true };
+  return `${turboSnapEnabled(skipContext)}\n\n${buildFullyTurboSnapped(skipContext)}`;
+};
+
+export const BuildSkippedAncestorPending = () => buildSkipped({ ancestorBuild });
+
+export const BuildSkippedAncestorPassed = () =>
+  buildSkipped({ ancestorBuild: { ...ancestorBuild, status: 'PASSED' } });
+
+export const BuildSkippedAncestorAccepted = () =>
+  buildSkipped({ ancestorBuild: { ...ancestorBuild, status: 'ACCEPTED' } });
+
+export const BuildSkippedAncestorDenied = () =>
+  buildSkipped({ ancestorBuild: { ...ancestorBuild, status: 'DENIED' } });
+
+export const BuildSkippedAncestorOther = () =>
+  buildSkipped({ ancestorBuild: { ...ancestorBuild, status: 'BROKEN' } });

--- a/node-src/ui/messages/info/buildFullyTurboSnapped.ts
+++ b/node-src/ui/messages/info/buildFullyTurboSnapped.ts
@@ -1,6 +1,30 @@
+import chalk from 'chalk';
 import { dedent } from 'ts-dedent';
 
-export default () =>
-  dedent`
-    No frontend files were changed, so TurboSnap skipped taking any snapshots. This build will not be displayed in Chromatic.
-  `;
+import { Context } from '../../../types';
+import { info, success } from '../../components/icons';
+import link from '../../components/link';
+
+const ancestorStatusMessages: Record<string, string> = {
+  PENDING:
+    'The pending status will be carried over from the most recent ancestor build that has unreviewed changes.',
+  PASSED: 'The passed status will be carried over from the most recent ancestor build.',
+  ACCEPTED: 'The accepted status will be carried over from the most recent ancestor build.',
+  DENIED: 'The denied status will be carried over from the most recent ancestor build.',
+};
+
+export default ({ ancestorBuild }: Pick<Context, 'ancestorBuild'>) => {
+  const lines = [
+    chalk`${success} {bold This build was skipped and will not be displayed in Chromatic.}`,
+  ];
+
+  const statusMessage = ancestorBuild && ancestorStatusMessages[ancestorBuild.status];
+  if (ancestorBuild && statusMessage) {
+    lines.push(
+      statusMessage,
+      `${info} View ancestor build details at ${link(ancestorBuild.webUrl)}`
+    );
+  }
+
+  return `${dedent(chalk`${lines.join('\n')}`)}\n`;
+};

--- a/node-src/ui/messages/info/turboSnapEnabled.ts
+++ b/node-src/ui/messages/info/turboSnapEnabled.ts
@@ -8,17 +8,29 @@ import { success } from '../../components/icons';
 export default ({
   build,
   options,
+  skip,
   skipSnapshots,
-}: Pick<Context, 'build' | 'options' | 'skipSnapshots'>) => {
+  ancestorBuild,
+}: Pick<Context, 'build' | 'options' | 'skip' | 'skipSnapshots' | 'ancestorBuild'>) => {
+  if (skip) {
+    const skipped = ancestorBuild
+      ? pluralize('snapshot', ancestorBuild.snapshotCount, true)
+      : 'snapshots';
+    return dedent(chalk`
+      ${success} {bold TurboSnap enabled}
+      Skipped capturing ${skipped} because no frontend files were changed.
+    `);
+  }
+
   const captures = pluralize('snapshot', build.actualCaptureCount, true);
-  const skips = pluralize('snapshot', build.inheritedCaptureCount, true);
+  const turboSnaps = pluralize('TurboSnap', build.inheritedCaptureCount, true);
   return !options.interactive || skipSnapshots
     ? dedent(chalk`
       ${success} {bold TurboSnap enabled}
-      Capturing ${captures} and skipping ${skips}.
+      Capturing ${captures}, copying ${turboSnaps}.
     `)
     : dedent(chalk`
       ${success} {bold TurboSnap enabled}
-      Captured ${captures} and skipped ${skips}.
+      Captured ${captures}, copied ${turboSnaps}.
     `);
 };

--- a/node-src/ui/tasks/upload.frames.ts
+++ b/node-src/ui/tasks/upload.frames.ts
@@ -2,7 +2,6 @@ import { fallbackFailureState } from '../../renderer/engine';
 import { clackProgressBarRenderer } from '../../renderer/engine/clack/progressRenderer';
 import { captureTask } from '../../renderer/storybook/captureTask';
 import { Task } from '../../types';
-import buildTurboSkipped from '../messages/info/buildFullyTurboSnapped';
 import { dryRun, failed, finalizing, invalid, starting, success, uploading } from './upload';
 
 // Node-side scenarios for the upload task. The `?clack` Vite plugin runs this module in Node,
@@ -68,10 +67,10 @@ export const SuccessNoFiles = () =>
 // --dry-run self-skips; runTask drives the skipped state through `renderer.succeed`.
 export const DryRun = () => make(dryRun(ctx), pending);
 
-// The backend marked the build fully TurboSnapped (kind:'skip'); the engine renders the pending
-// title with the skip reason as output through `renderer.succeed`.
-export const TurboSkipped = () =>
-  make({ status: 'skipped', title: pending.title, output: buildTurboSkipped() }, pending);
+// The backend marked the build fully TurboSnapped (kind:'skip'); the upload frame renders bare (the
+// engine passes no reason). The TurboSnap success messages render as separate Info messages (see
+// `messages/info/buildFullyTurboSnapped.stories.ts`), logged from the task and flushed below.
+export const TurboSkipped = () => make({ status: 'skipped', title: pending.title }, pending);
 
 // upload's `failure` transition forks on `ctx.isReactNativeApp`, passing an RN-specific or generic
 // title to the engine's fallback failure state (the error body is logged, not shown in the frame).


### PR DESCRIPTION
# Description

This PR adds the changes introduced in #1406 to the Clack-migrated `upload` task. The referenced PR adds some additional UI when turboskipping a build. This PR adds that same UI to the Clack version of this task.

Dealing with merge conflicts when rebasing the clack feature branch on main has been really messy in the past, so I decided to just recreate the logic from the referenced PR here and then just accept my versions of the touched files when I rebase on main.

# Manual QA

UI looks more or less the same as the screenshot from the mentioned PR:
<img width="1702" height="1100" alt="image" src="https://github.com/user-attachments/assets/335a5ba1-f87d-4116-ada2-98a5f6613833" />

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>18.0.1--canary.1411.28528473303.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@18.0.1--canary.1411.28528473303.0
  # or 
  yarn add chromatic@18.0.1--canary.1411.28528473303.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
