### PR TITLE
Fix silent error swallowing early in CLI invocation

### DIFF
--- a/bin-src/main.ts
+++ b/bin-src/main.ts
@@ -3,6 +3,7 @@ import '../node-src/errorMonitoring';
 import * as Sentry from '@sentry/node';
 
 import { run } from '../node-src';
+import { exitCodes } from '../node-src/lib/setExitCode';
 
 /**
  * The main entrypoint for the CLI.
@@ -15,6 +16,8 @@ export async function main(argv: string[]) {
     process.exitCode = code;
   } catch (err) {
     Sentry.captureException(err);
+    console.error(err instanceof Error ? err.message : err);
+    process.exitCode = exitCodes.UNKNOWN_ERROR;
   } finally {
     await Sentry.flush(2500);
     process.exit();


### PR DESCRIPTION
# Description

Errors thrown before the task pipeline starts (e.g. meow's flag validation when a flag like `--force-rebuild` is passed twice) were caught in `bin-src/main.ts`, sent to Sentry, and then silently discarded — the argless `process.exit()` in the `finally` block exited with code 0 and no output, making failures look like success.

The catch block now prints the error message to stderr and sets `process.exitCode` to `UNKNOWN_ERROR` (255). Sentry capture is unchanged.

# Manual QA

<img width="1222" height="110" alt="CleanShot 2026-07-02 at 13 30 48@2x" src="https://github.com/user-attachments/assets/f3500cbd-263a-41ef-9a12-3b1400e91043" />

Confirmed happy path still works too.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>18.0.2--canary.1413.28609989297.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@18.0.2--canary.1413.28609989297.0
  # or 
  yarn add chromatic@18.0.2--canary.1413.28609989297.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
