### PR TITLE
Reorganize TurboSnap to return results instead of mutating `ctx`

### DIFF
--- a/node-src/lib/turbosnap/errors.ts
+++ b/node-src/lib/turbosnap/errors.ts
@@ -108,6 +108,16 @@ const NETWORK_ERROR_CODES = new Set([
 ]);
 
 /**
+ * Error thrown when no CSF globs were found in the stats file.
+ */
+export class NoCSFGlobsError extends Error {
+  constructor() {
+    super('Did not find any CSF globs in preview-stats.json');
+    this.name = 'NoCSFGlobsError';
+  }
+}
+
+/**
  * Determine whether an unknown thrown value represents a transport-layer network failure.
  * Recognizes `HTTPClientError`, `FetchError`-shaped errors, and Node-style errors carrying a
  * known DNS/connection error code (`ENOTFOUND`, `ECONNREFUSED`, `ECONNRESET`, `ETIMEDOUT`,

--- a/node-src/lib/turbosnap/errors.ts
+++ b/node-src/lib/turbosnap/errors.ts
@@ -108,16 +108,6 @@ const NETWORK_ERROR_CODES = new Set([
 ]);
 
 /**
- * Error thrown when no CSF globs were found in the stats file.
- */
-export class NoCSFGlobsError extends Error {
-  constructor() {
-    super('Did not find any CSF globs in preview-stats.json');
-    this.name = 'NoCSFGlobsError';
-  }
-}
-
-/**
  * Determine whether an unknown thrown value represents a transport-layer network failure.
  * Recognizes `HTTPClientError`, `FetchError`-shaped errors, and Node-style errors carrying a
  * known DNS/connection error code (`ENOTFOUND`, `ECONNREFUSED`, `ECONNRESET`, `ETIMEDOUT`,

--- a/node-src/lib/turbosnap/getDependentStoryFiles.test.ts
+++ b/node-src/lib/turbosnap/getDependentStoryFiles.test.ts
@@ -4,6 +4,7 @@ import { afterEach, describe, expect, it } from 'vitest';
 
 import { Context } from '../../types';
 import TestLogger from '../testLogger';
+import { NoCSFGlobsError } from './errors';
 import { getDependentStoryFiles, normalizePath } from './getDependentStoryFiles';
 
 const CSF_GLOB = String.raw`./src sync ^\.\/(?:(?!\.)(?=.)[^/]*?\.stories\.js)$`;
@@ -52,7 +53,7 @@ describe('getDependentStoryFiles', () => {
     ];
     const ctx = getContext();
     const result = await getDependentStoryFiles(ctx, { modules }, statsPath, changedFiles);
-    expect(result).toEqual({
+    expect(result.affectedModules).toEqual({
       './src/foo.stories.js': ['src/foo.stories.js'],
     });
   });
@@ -73,7 +74,7 @@ describe('getDependentStoryFiles', () => {
     ];
     const ctx = getContext();
     const result = await getDependentStoryFiles(ctx, { modules }, statsPath, changedFiles);
-    expect(result).toEqual({
+    expect(result.affectedModules).toEqual({
       './src/foo.stories.js': ['src/foo.stories.js'],
     });
   });
@@ -94,7 +95,7 @@ describe('getDependentStoryFiles', () => {
     ];
     const ctx = getContext({ storybookBaseDir: 'path/to/project' });
     const result = await getDependentStoryFiles(ctx, { modules }, statsPath, changedFiles);
-    expect(result).toEqual({
+    expect(result.affectedModules).toEqual({
       './src/foo.stories.js': ['path/to/project/src/foo.stories.js'],
     });
   });
@@ -115,7 +116,7 @@ describe('getDependentStoryFiles', () => {
     ];
     const ctx = getContext();
     const result = await getDependentStoryFiles(ctx, { modules }, statsPath, changedFiles);
-    expect(result).toEqual({
+    expect(result.affectedModules).toEqual({
       './src/foo.stories.js': ['src/foo.stories.js'],
     });
   });
@@ -136,7 +137,7 @@ describe('getDependentStoryFiles', () => {
     ];
     const ctx = getContext();
     const result = await getDependentStoryFiles(ctx, { modules }, statsPath, changedFiles);
-    expect(result).toEqual({
+    expect(result.affectedModules).toEqual({
       './src/foo.stories.js': ['src/foo.stories.js'],
     });
   });
@@ -160,7 +161,7 @@ describe('getDependentStoryFiles', () => {
     ];
     const ctx = getContext();
     const result = await getDependentStoryFiles(ctx, { modules }, statsPath, changedFiles);
-    expect(result).toEqual({
+    expect(result.affectedModules).toEqual({
       './src/foo.stories.js': ['src/foo.stories.js'],
     });
   });
@@ -195,7 +196,7 @@ describe('getDependentStoryFiles', () => {
     ];
     const ctx = getContext();
     const result = await getDependentStoryFiles(ctx, { modules }, statsPath, changedFiles);
-    expect(result).toEqual({
+    expect(result.affectedModules).toEqual({
       './src/foo.stories.js': ['src/foo.stories.js'],
     });
   });
@@ -221,7 +222,7 @@ describe('getDependentStoryFiles', () => {
     ];
     const ctx = getContext();
     const result = await getDependentStoryFiles(ctx, { modules }, statsPath, changedFiles);
-    expect(result).toEqual({
+    expect(result.affectedModules).toEqual({
       './src/foo.stories.js': ['src/foo.stories.js'],
     });
   });
@@ -253,7 +254,7 @@ describe('getDependentStoryFiles', () => {
     ];
     const ctx = getContext();
     const result = await getDependentStoryFiles(ctx, { modules }, statsPath, changedFiles);
-    expect(result).toEqual({
+    expect(result.affectedModules).toEqual({
       './src/foo.stories.ts': ['src/foo.stories.ts'],
     });
   });
@@ -275,7 +276,7 @@ describe('getDependentStoryFiles', () => {
     ];
     const ctx = getContext();
     const result = await getDependentStoryFiles(ctx, { modules }, statsPath, changedFiles);
-    expect(result).toEqual({
+    expect(result.affectedModules).toEqual({
       './src/foo.stories.js': ['src/foo.stories.js', 'src/foo.js'],
     });
   });
@@ -308,7 +309,7 @@ describe('getDependentStoryFiles', () => {
       changedFiles,
       changedDependencies
     );
-    expect(result).toEqual({
+    expect(result.affectedModules).toEqual({
       './src/foo.stories.js': ['src/foo.stories.js'],
     });
   });
@@ -334,7 +335,7 @@ describe('getDependentStoryFiles', () => {
     ];
     const ctx = getContext({ storybookBaseDir: 'services/webapp' });
     const result = await getDependentStoryFiles(ctx, { modules }, statsPath, changedFiles);
-    expect(result).toEqual({
+    expect(result.affectedModules).toEqual({
       './src/foo.stories.js': ['services/webapp/src/foo.stories.js'],
     });
   });
@@ -362,7 +363,7 @@ describe('getDependentStoryFiles', () => {
     ];
     const ctx = getContext();
     const result = await getDependentStoryFiles(ctx, { modules }, statsPath, changedFiles);
-    expect(result).toEqual({
+    expect(result.affectedModules).toEqual({
       '/path/to/project/src/foo.stories.js': ['src/foo.stories.js'],
     });
   });
@@ -390,7 +391,7 @@ describe('getDependentStoryFiles', () => {
     ];
     const ctx = getContext({ storybookBaseDir: 'packages/storybook' });
     const result = await getDependentStoryFiles(ctx, { modules }, statsPath, changedFiles);
-    expect(result).toEqual({
+    expect(result.affectedModules).toEqual({
       '/path/to/project/packages/webapp/src/foo.stories.js': ['packages/webapp/src/foo.stories.js'],
     });
   });
@@ -405,9 +406,13 @@ describe('getDependentStoryFiles', () => {
       },
     ];
     const ctx = getContext({ configDir: 'path/to/storybook-config' });
-    await expect(() =>
-      getDependentStoryFiles(ctx, { modules }, statsPath, changedFiles)
-    ).rejects.toEqual(new Error('Did not find any CSF globs in preview-stats.json'));
+    let err;
+    try {
+      await getDependentStoryFiles(ctx, { modules }, statsPath, changedFiles);
+    } catch (error) {
+      err = error;
+    }
+    expect(err).toBeInstanceOf(NoCSFGlobsError);
   });
 
   it('does not bail on changed global file', async () => {
@@ -432,10 +437,10 @@ describe('getDependentStoryFiles', () => {
     ];
     const ctx = getContext();
     const result = await getDependentStoryFiles(ctx, { modules }, statsPath, changedFiles);
-    expect(result).toEqual({
+    expect(result.affectedModules).toEqual({
       './src/foo.stories.js': ['src/foo.stories.js'],
     });
-    expect(ctx.turboSnap.bailReason).toBeUndefined();
+    expect(result.turboSnap.bailReason).toBeUndefined();
   });
 
   it('only runs tests for stories affected by dependency changes', async () => {
@@ -466,8 +471,8 @@ describe('getDependentStoryFiles', () => {
       changedFiles,
       changedDependencies
     );
-    expect(ctx.turboSnap.bailReason).toBeUndefined();
-    expect(result).toEqual({
+    expect(result.turboSnap.bailReason).toBeUndefined();
+    expect(result.affectedModules).toEqual({
       './src/foo.stories.js': ['src/foo.stories.js'],
     });
   });
@@ -495,8 +500,8 @@ describe('getDependentStoryFiles', () => {
       git: { ...rawContext.git, changedPackageManifests: ['src/package.json'] },
     };
     const result = await getDependentStoryFiles(ctx, { modules }, statsPath, changedFiles);
-    expect(ctx.turboSnap.bailReason).toBeUndefined();
-    expect(result).toEqual({
+    expect(result.turboSnap.bailReason).toBeUndefined();
+    expect(result.affectedModules).toEqual({
       './src/foo.stories.js': ['src/foo.stories.js'],
     });
   });
@@ -517,8 +522,8 @@ describe('getDependentStoryFiles', () => {
     ];
     const ctx = getContext({ configDir: 'path/to/storybook-config' });
     const result = await getDependentStoryFiles(ctx, { modules }, statsPath, changedFiles);
-    expect(result).toBeUndefined();
-    expect(ctx.turboSnap.bailReason).toEqual({
+    expect(result.affectedModules).toBeUndefined();
+    expect(result.turboSnap.bailReason).toEqual({
       changedStorybookFiles: ['path/to/storybook-config/file.js'],
     });
     expect(ctx.log.warn).toHaveBeenCalledWith(
@@ -544,8 +549,8 @@ describe('getDependentStoryFiles', () => {
     ];
     const ctx = getContext();
     const result = await getDependentStoryFiles(ctx, { modules }, statsPath, changedFiles);
-    expect(ctx.turboSnap.bailReason).toBeUndefined();
-    expect(result).toEqual({
+    expect(result.turboSnap.bailReason).toBeUndefined();
+    expect(result.affectedModules).toEqual({
       './src/foo.stories.js': ['src/foo.stories.js'],
     });
   });
@@ -566,8 +571,8 @@ describe('getDependentStoryFiles', () => {
     ];
     const ctx = getContext({ configDir: 'path/to/storybook-config' });
     const result = await getDependentStoryFiles(ctx, { modules }, statsPath, changedFiles);
-    expect(result).toBeUndefined();
-    expect(ctx.turboSnap.bailReason).toEqual({
+    expect(result.affectedModules).toBeUndefined();
+    expect(result.turboSnap.bailReason).toEqual({
       changedStorybookFiles: ['path/to/storybook-config/preview.js'],
     });
     expect(ctx.log.warn).toHaveBeenCalledWith(
@@ -593,11 +598,14 @@ describe('getDependentStoryFiles', () => {
     ];
     const ctx = getContext({ configDir: 'path/to/storybook-config' });
     const result = await getDependentStoryFiles(ctx, { modules }, statsPath, changedFiles);
-    expect(result).toBeUndefined();
-    expect(ctx.turboSnap.bailReason).toEqual({
+    expect(result.affectedModules).toBeUndefined();
+    expect(result.turboSnap.bailReason).toEqual({
       changedStorybookFiles: ['path/to/storybook-config/file.js'],
     });
-    expect(ctx.turboSnap.bailPath).toEqual(['src/styles.js', 'path/to/storybook-config/file.js']);
+    expect(result.turboSnap.bailPath).toEqual([
+      'src/styles.js',
+      'path/to/storybook-config/file.js',
+    ]);
     expect(ctx.log.warn).toHaveBeenCalledWith(
       expect.stringContaining(
         chalk`Found a Storybook config change in {bold path/to/storybook-config/file.js}`
@@ -636,11 +644,11 @@ describe('getDependentStoryFiles', () => {
     ];
     const ctx = getContext({ configDir: 'path/to/storybook-config' });
     const result = await getDependentStoryFiles(ctx, { modules }, statsPath, changedFiles);
-    expect(result).toBeUndefined();
-    expect(ctx.turboSnap.bailReason).toEqual({
+    expect(result.affectedModules).toBeUndefined();
+    expect(result.turboSnap.bailReason).toEqual({
       changedStorybookFiles: ['path/to/storybook-config/preview.js'],
     });
-    expect(ctx.turboSnap.bailPath).toEqual([
+    expect(result.turboSnap.bailPath).toEqual([
       'src/theme.js',
       'src/tokens.js',
       'path/to/storybook-config/preview.js',
@@ -675,8 +683,8 @@ describe('getDependentStoryFiles', () => {
     ];
     const ctx = getContext({ configDir: 'path/to/storybook-config' });
     const result = await getDependentStoryFiles(ctx, { modules }, statsPath, changedFiles);
-    expect(result).toBeUndefined();
-    expect(ctx.turboSnap.bailReason).toEqual({
+    expect(result.affectedModules).toBeUndefined();
+    expect(result.turboSnap.bailReason).toEqual({
       changedStorybookFiles: ['path/to/storybook-config/file.js', 'src/styles.js'],
     });
     expect(ctx.log.warn).toHaveBeenCalledWith(
@@ -702,8 +710,8 @@ describe('getDependentStoryFiles', () => {
     ];
     const ctx = getContext({ staticDir: ['path/to/statics'] });
     const result = await getDependentStoryFiles(ctx, { modules }, statsPath, changedFiles);
-    expect(result).toBeUndefined();
-    expect(ctx.turboSnap.bailReason).toEqual({
+    expect(result.affectedModules).toBeUndefined();
+    expect(result.turboSnap.bailReason).toEqual({
       changedStaticFiles: ['path/to/statics/image.png'],
     });
     expect(ctx.log.warn).toHaveBeenCalledWith(
@@ -730,8 +738,8 @@ describe('getDependentStoryFiles', () => {
     ];
     const ctx = getContext({ staticDir: ['.storybook/static'] });
     const result = await getDependentStoryFiles(ctx, { modules }, statsPath, changedFiles);
-    expect(result).toBeUndefined();
-    expect(ctx.turboSnap.bailReason).toEqual({
+    expect(result.affectedModules).toBeUndefined();
+    expect(result.turboSnap.bailReason).toEqual({
       changedStaticFiles: ['.storybook/static/foo.js'],
     });
     expect(ctx.log.warn).toHaveBeenCalledWith(
@@ -755,8 +763,8 @@ describe('getDependentStoryFiles', () => {
     ];
     const ctx = getContext();
     const result = await getDependentStoryFiles(ctx, { modules }, statsPath, changedFiles);
-    expect(result).toBeUndefined();
-    expect(ctx.turboSnap.bailReason).toEqual({
+    expect(result.affectedModules).toBeUndefined();
+    expect(result.turboSnap.bailReason).toEqual({
       changedStorybookFiles: ['.storybook/static/foo.js'],
     });
     expect(ctx.log.warn).toHaveBeenCalledWith(
@@ -837,8 +845,8 @@ describe('getDependentStoryFiles', () => {
       untraced: ['**/stories/**'],
     });
     const result = await getDependentStoryFiles(ctx, { modules }, statsPath, changedFiles);
-    expect(result).toEqual({});
-    expect(ctx.untracedFiles).toEqual([
+    expect(result.affectedModules).toEqual({});
+    expect(result.untracedFiles).toEqual([
       { filepath: 'src/stories/Button.jsx', glob: '**/stories/**' },
       { filepath: 'src/stories/Page.jsx', glob: '**/stories/**' },
     ]);
@@ -875,8 +883,8 @@ describe('getDependentStoryFiles', () => {
         untraced: ['**/foo.js'],
       });
       const result = await getDependentStoryFiles(ctx, { modules }, statsPath, changedFiles);
-      expect(ctx.turboSnap.bailReason).toBeUndefined();
-      expect(result).toEqual({});
+      expect(result.turboSnap.bailReason).toBeUndefined();
+      expect(result.affectedModules).toEqual({});
     }
   );
 
@@ -914,8 +922,8 @@ describe('getDependentStoryFiles', () => {
       untraced: ['**/(package**.json|yarn.lock|pnpm-lock.yaml)'],
     });
     const result = await getDependentStoryFiles(ctx, { modules }, statsPath, changedFiles);
-    expect(ctx.turboSnap.bailReason).toBeUndefined();
-    expect(result).toEqual({
+    expect(result.turboSnap.bailReason).toBeUndefined();
+    expect(result.affectedModules).toEqual({
       './src/foo.stories.js': ['src/foo.stories.js'],
     });
   });
@@ -963,8 +971,8 @@ describe('getDependentStoryFiles', () => {
       untraced: ['**/decorator.jsx'],
     });
     const result = await getDependentStoryFiles(ctx, { modules }, statsPath, changedFiles);
-    expect(ctx.turboSnap.bailReason).toBeUndefined();
-    expect(result).toEqual({
+    expect(result.turboSnap.bailReason).toBeUndefined();
+    expect(result.affectedModules).toEqual({
       './src/foo.stories.js': ['src/foo.stories.js'],
     });
   });
@@ -1020,8 +1028,8 @@ describe('getDependentStoryFiles', () => {
       untraced: ['**/decorator.jsx'],
     });
     const result = await getDependentStoryFiles(ctx, { modules }, statsPath, changedFiles);
-    expect(ctx.turboSnap.bailReason).toBeUndefined();
-    expect(result).toEqual({
+    expect(result.turboSnap.bailReason).toBeUndefined();
+    expect(result.affectedModules).toEqual({
       './src/foo.stories.js': ['src/foo.stories.js'],
     });
   });
@@ -1053,8 +1061,8 @@ describe('getDependentStoryFiles', () => {
       changedFiles,
       changedDependencies
     );
-    expect(result).toBeUndefined();
-    expect(ctx.turboSnap.bailReason).toEqual({
+    expect(result.affectedModules).toBeUndefined();
+    expect(result.turboSnap.bailReason).toEqual({
       changedPackageFiles: ['package.json'],
       bailSubreason: 'nodeModulesMissingInStats',
     });
@@ -1080,8 +1088,14 @@ describe('getDependentStoryFiles', () => {
       ...rawContext,
       git: { ...rawContext.git, changedFiles: ['package.json'] },
     };
-    await getDependentStoryFiles(ctx, { modules }, statsPath, changedFiles, changedDependencies);
-    expect(ctx.turboSnap.bailReason?.bailSubreason).toBeUndefined();
+    const result = await getDependentStoryFiles(
+      ctx,
+      { modules },
+      statsPath,
+      changedFiles,
+      changedDependencies
+    );
+    expect(result.turboSnap.bailReason).toBeUndefined();
   });
 });
 

--- a/node-src/lib/turbosnap/getDependentStoryFiles.test.ts
+++ b/node-src/lib/turbosnap/getDependentStoryFiles.test.ts
@@ -4,7 +4,6 @@ import { afterEach, describe, expect, it } from 'vitest';
 
 import { Context } from '../../types';
 import TestLogger from '../testLogger';
-import { NoCSFGlobsError } from './errors';
 import { getDependentStoryFiles, normalizePath } from './getDependentStoryFiles';
 
 const CSF_GLOB = String.raw`./src sync ^\.\/(?:(?!\.)(?=.)[^/]*?\.stories\.js)$`;
@@ -412,7 +411,8 @@ describe('getDependentStoryFiles', () => {
     } catch (error) {
       err = error;
     }
-    expect(err).toBeInstanceOf(NoCSFGlobsError);
+    expect(err).toBeDefined();
+    expect(err.message).toContain('Did not find any CSF globs in preview-stats.json');
   });
 
   it('does not bail on changed global file', async () => {

--- a/node-src/lib/turbosnap/getDependentStoryFiles.test.ts
+++ b/node-src/lib/turbosnap/getDependentStoryFiles.test.ts
@@ -52,8 +52,11 @@ describe('getDependentStoryFiles', () => {
     ];
     const ctx = getContext();
     const result = await getDependentStoryFiles(ctx, { modules }, statsPath, changedFiles);
-    expect(result.affectedModules).toEqual({
-      './src/foo.stories.js': ['src/foo.stories.js'],
+    expect(result).toMatchObject({
+      status: 'traced',
+      onlyStoryFiles: {
+        './src/foo.stories.js': ['src/foo.stories.js'],
+      },
     });
   });
 
@@ -73,8 +76,11 @@ describe('getDependentStoryFiles', () => {
     ];
     const ctx = getContext();
     const result = await getDependentStoryFiles(ctx, { modules }, statsPath, changedFiles);
-    expect(result.affectedModules).toEqual({
-      './src/foo.stories.js': ['src/foo.stories.js'],
+    expect(result).toMatchObject({
+      status: 'traced',
+      onlyStoryFiles: {
+        './src/foo.stories.js': ['src/foo.stories.js'],
+      },
     });
   });
 
@@ -94,8 +100,11 @@ describe('getDependentStoryFiles', () => {
     ];
     const ctx = getContext({ storybookBaseDir: 'path/to/project' });
     const result = await getDependentStoryFiles(ctx, { modules }, statsPath, changedFiles);
-    expect(result.affectedModules).toEqual({
-      './src/foo.stories.js': ['path/to/project/src/foo.stories.js'],
+    expect(result).toMatchObject({
+      status: 'traced',
+      onlyStoryFiles: {
+        './src/foo.stories.js': ['path/to/project/src/foo.stories.js'],
+      },
     });
   });
 
@@ -115,8 +124,11 @@ describe('getDependentStoryFiles', () => {
     ];
     const ctx = getContext();
     const result = await getDependentStoryFiles(ctx, { modules }, statsPath, changedFiles);
-    expect(result.affectedModules).toEqual({
-      './src/foo.stories.js': ['src/foo.stories.js'],
+    expect(result).toMatchObject({
+      status: 'traced',
+      onlyStoryFiles: {
+        './src/foo.stories.js': ['src/foo.stories.js'],
+      },
     });
   });
 
@@ -136,8 +148,11 @@ describe('getDependentStoryFiles', () => {
     ];
     const ctx = getContext();
     const result = await getDependentStoryFiles(ctx, { modules }, statsPath, changedFiles);
-    expect(result.affectedModules).toEqual({
-      './src/foo.stories.js': ['src/foo.stories.js'],
+    expect(result).toMatchObject({
+      status: 'traced',
+      onlyStoryFiles: {
+        './src/foo.stories.js': ['src/foo.stories.js'],
+      },
     });
   });
 
@@ -160,8 +175,11 @@ describe('getDependentStoryFiles', () => {
     ];
     const ctx = getContext();
     const result = await getDependentStoryFiles(ctx, { modules }, statsPath, changedFiles);
-    expect(result.affectedModules).toEqual({
-      './src/foo.stories.js': ['src/foo.stories.js'],
+    expect(result).toMatchObject({
+      status: 'traced',
+      onlyStoryFiles: {
+        './src/foo.stories.js': ['src/foo.stories.js'],
+      },
     });
   });
 
@@ -195,8 +213,11 @@ describe('getDependentStoryFiles', () => {
     ];
     const ctx = getContext();
     const result = await getDependentStoryFiles(ctx, { modules }, statsPath, changedFiles);
-    expect(result.affectedModules).toEqual({
-      './src/foo.stories.js': ['src/foo.stories.js'],
+    expect(result).toMatchObject({
+      status: 'traced',
+      onlyStoryFiles: {
+        './src/foo.stories.js': ['src/foo.stories.js'],
+      },
     });
   });
 
@@ -221,8 +242,11 @@ describe('getDependentStoryFiles', () => {
     ];
     const ctx = getContext();
     const result = await getDependentStoryFiles(ctx, { modules }, statsPath, changedFiles);
-    expect(result.affectedModules).toEqual({
-      './src/foo.stories.js': ['src/foo.stories.js'],
+    expect(result).toMatchObject({
+      status: 'traced',
+      onlyStoryFiles: {
+        './src/foo.stories.js': ['src/foo.stories.js'],
+      },
     });
   });
 
@@ -253,8 +277,11 @@ describe('getDependentStoryFiles', () => {
     ];
     const ctx = getContext();
     const result = await getDependentStoryFiles(ctx, { modules }, statsPath, changedFiles);
-    expect(result.affectedModules).toEqual({
-      './src/foo.stories.ts': ['src/foo.stories.ts'],
+    expect(result).toMatchObject({
+      status: 'traced',
+      onlyStoryFiles: {
+        './src/foo.stories.ts': ['src/foo.stories.ts'],
+      },
     });
   });
 
@@ -275,8 +302,11 @@ describe('getDependentStoryFiles', () => {
     ];
     const ctx = getContext();
     const result = await getDependentStoryFiles(ctx, { modules }, statsPath, changedFiles);
-    expect(result.affectedModules).toEqual({
-      './src/foo.stories.js': ['src/foo.stories.js', 'src/foo.js'],
+    expect(result).toMatchObject({
+      status: 'traced',
+      onlyStoryFiles: {
+        './src/foo.stories.js': ['src/foo.stories.js', 'src/foo.js'],
+      },
     });
   });
 
@@ -308,8 +338,11 @@ describe('getDependentStoryFiles', () => {
       changedFiles,
       changedDependencies
     );
-    expect(result.affectedModules).toEqual({
-      './src/foo.stories.js': ['src/foo.stories.js'],
+    expect(result).toMatchObject({
+      status: 'traced',
+      onlyStoryFiles: {
+        './src/foo.stories.js': ['src/foo.stories.js'],
+      },
     });
   });
 
@@ -334,8 +367,11 @@ describe('getDependentStoryFiles', () => {
     ];
     const ctx = getContext({ storybookBaseDir: 'services/webapp' });
     const result = await getDependentStoryFiles(ctx, { modules }, statsPath, changedFiles);
-    expect(result.affectedModules).toEqual({
-      './src/foo.stories.js': ['services/webapp/src/foo.stories.js'],
+    expect(result).toMatchObject({
+      status: 'traced',
+      onlyStoryFiles: {
+        './src/foo.stories.js': ['services/webapp/src/foo.stories.js'],
+      },
     });
   });
 
@@ -362,8 +398,11 @@ describe('getDependentStoryFiles', () => {
     ];
     const ctx = getContext();
     const result = await getDependentStoryFiles(ctx, { modules }, statsPath, changedFiles);
-    expect(result.affectedModules).toEqual({
-      '/path/to/project/src/foo.stories.js': ['src/foo.stories.js'],
+    expect(result).toMatchObject({
+      status: 'traced',
+      onlyStoryFiles: {
+        '/path/to/project/src/foo.stories.js': ['src/foo.stories.js'],
+      },
     });
   });
 
@@ -390,8 +429,13 @@ describe('getDependentStoryFiles', () => {
     ];
     const ctx = getContext({ storybookBaseDir: 'packages/storybook' });
     const result = await getDependentStoryFiles(ctx, { modules }, statsPath, changedFiles);
-    expect(result.affectedModules).toEqual({
-      '/path/to/project/packages/webapp/src/foo.stories.js': ['packages/webapp/src/foo.stories.js'],
+    expect(result).toMatchObject({
+      status: 'traced',
+      onlyStoryFiles: {
+        '/path/to/project/packages/webapp/src/foo.stories.js': [
+          'packages/webapp/src/foo.stories.js',
+        ],
+      },
     });
   });
 
@@ -437,8 +481,11 @@ describe('getDependentStoryFiles', () => {
     ];
     const ctx = getContext();
     const result = await getDependentStoryFiles(ctx, { modules }, statsPath, changedFiles);
-    expect(result.affectedModules).toEqual({
-      './src/foo.stories.js': ['src/foo.stories.js'],
+    expect(result).toMatchObject({
+      status: 'traced',
+      onlyStoryFiles: {
+        './src/foo.stories.js': ['src/foo.stories.js'],
+      },
     });
     expect(result.turboSnap.bailReason).toBeUndefined();
   });
@@ -472,8 +519,11 @@ describe('getDependentStoryFiles', () => {
       changedDependencies
     );
     expect(result.turboSnap.bailReason).toBeUndefined();
-    expect(result.affectedModules).toEqual({
-      './src/foo.stories.js': ['src/foo.stories.js'],
+    expect(result).toMatchObject({
+      status: 'traced',
+      onlyStoryFiles: {
+        './src/foo.stories.js': ['src/foo.stories.js'],
+      },
     });
   });
 
@@ -501,8 +551,11 @@ describe('getDependentStoryFiles', () => {
     };
     const result = await getDependentStoryFiles(ctx, { modules }, statsPath, changedFiles);
     expect(result.turboSnap.bailReason).toBeUndefined();
-    expect(result.affectedModules).toEqual({
-      './src/foo.stories.js': ['src/foo.stories.js'],
+    expect(result).toMatchObject({
+      status: 'traced',
+      onlyStoryFiles: {
+        './src/foo.stories.js': ['src/foo.stories.js'],
+      },
     });
   });
 
@@ -522,7 +575,7 @@ describe('getDependentStoryFiles', () => {
     ];
     const ctx = getContext({ configDir: 'path/to/storybook-config' });
     const result = await getDependentStoryFiles(ctx, { modules }, statsPath, changedFiles);
-    expect(result.affectedModules).toBeUndefined();
+    expect(result.status).toBe('bailed');
     expect(result.turboSnap.bailReason).toEqual({
       changedStorybookFiles: ['path/to/storybook-config/file.js'],
     });
@@ -550,8 +603,11 @@ describe('getDependentStoryFiles', () => {
     const ctx = getContext();
     const result = await getDependentStoryFiles(ctx, { modules }, statsPath, changedFiles);
     expect(result.turboSnap.bailReason).toBeUndefined();
-    expect(result.affectedModules).toEqual({
-      './src/foo.stories.js': ['src/foo.stories.js'],
+    expect(result).toMatchObject({
+      status: 'traced',
+      onlyStoryFiles: {
+        './src/foo.stories.js': ['src/foo.stories.js'],
+      },
     });
   });
 
@@ -571,7 +627,7 @@ describe('getDependentStoryFiles', () => {
     ];
     const ctx = getContext({ configDir: 'path/to/storybook-config' });
     const result = await getDependentStoryFiles(ctx, { modules }, statsPath, changedFiles);
-    expect(result.affectedModules).toBeUndefined();
+    expect(result.status).toBe('bailed');
     expect(result.turboSnap.bailReason).toEqual({
       changedStorybookFiles: ['path/to/storybook-config/preview.js'],
     });
@@ -598,7 +654,7 @@ describe('getDependentStoryFiles', () => {
     ];
     const ctx = getContext({ configDir: 'path/to/storybook-config' });
     const result = await getDependentStoryFiles(ctx, { modules }, statsPath, changedFiles);
-    expect(result.affectedModules).toBeUndefined();
+    expect(result.status).toBe('bailed');
     expect(result.turboSnap.bailReason).toEqual({
       changedStorybookFiles: ['path/to/storybook-config/file.js'],
     });
@@ -644,7 +700,7 @@ describe('getDependentStoryFiles', () => {
     ];
     const ctx = getContext({ configDir: 'path/to/storybook-config' });
     const result = await getDependentStoryFiles(ctx, { modules }, statsPath, changedFiles);
-    expect(result.affectedModules).toBeUndefined();
+    expect(result.status).toBe('bailed');
     expect(result.turboSnap.bailReason).toEqual({
       changedStorybookFiles: ['path/to/storybook-config/preview.js'],
     });
@@ -683,7 +739,7 @@ describe('getDependentStoryFiles', () => {
     ];
     const ctx = getContext({ configDir: 'path/to/storybook-config' });
     const result = await getDependentStoryFiles(ctx, { modules }, statsPath, changedFiles);
-    expect(result.affectedModules).toBeUndefined();
+    expect(result.status).toBe('bailed');
     expect(result.turboSnap.bailReason).toEqual({
       changedStorybookFiles: ['path/to/storybook-config/file.js', 'src/styles.js'],
     });
@@ -710,7 +766,7 @@ describe('getDependentStoryFiles', () => {
     ];
     const ctx = getContext({ staticDir: ['path/to/statics'] });
     const result = await getDependentStoryFiles(ctx, { modules }, statsPath, changedFiles);
-    expect(result.affectedModules).toBeUndefined();
+    expect(result.status).toBe('bailed');
     expect(result.turboSnap.bailReason).toEqual({
       changedStaticFiles: ['path/to/statics/image.png'],
     });
@@ -738,7 +794,7 @@ describe('getDependentStoryFiles', () => {
     ];
     const ctx = getContext({ staticDir: ['.storybook/static'] });
     const result = await getDependentStoryFiles(ctx, { modules }, statsPath, changedFiles);
-    expect(result.affectedModules).toBeUndefined();
+    expect(result.status).toBe('bailed');
     expect(result.turboSnap.bailReason).toEqual({
       changedStaticFiles: ['.storybook/static/foo.js'],
     });
@@ -763,7 +819,7 @@ describe('getDependentStoryFiles', () => {
     ];
     const ctx = getContext();
     const result = await getDependentStoryFiles(ctx, { modules }, statsPath, changedFiles);
-    expect(result.affectedModules).toBeUndefined();
+    expect(result.status).toBe('bailed');
     expect(result.turboSnap.bailReason).toEqual({
       changedStorybookFiles: ['.storybook/static/foo.js'],
     });
@@ -845,11 +901,14 @@ describe('getDependentStoryFiles', () => {
       untraced: ['**/stories/**'],
     });
     const result = await getDependentStoryFiles(ctx, { modules }, statsPath, changedFiles);
-    expect(result.affectedModules).toEqual({});
-    expect(result.untracedFiles).toEqual([
-      { filepath: 'src/stories/Button.jsx', glob: '**/stories/**' },
-      { filepath: 'src/stories/Page.jsx', glob: '**/stories/**' },
-    ]);
+    expect(result).toMatchObject({
+      status: 'traced',
+      onlyStoryFiles: {},
+      untracedFiles: [
+        { filepath: 'src/stories/Button.jsx', glob: '**/stories/**' },
+        { filepath: 'src/stories/Page.jsx', glob: '**/stories/**' },
+      ],
+    });
   });
 
   it.each(['./src/foo.js', './src/foo.js + 1 module', './src/foo.js + 2 modules'])(
@@ -883,8 +942,11 @@ describe('getDependentStoryFiles', () => {
         untraced: ['**/foo.js'],
       });
       const result = await getDependentStoryFiles(ctx, { modules }, statsPath, changedFiles);
+      expect(result).toMatchObject({
+        status: 'traced',
+        onlyStoryFiles: {},
+      });
       expect(result.turboSnap.bailReason).toBeUndefined();
-      expect(result.affectedModules).toEqual({});
     }
   );
 
@@ -923,8 +985,11 @@ describe('getDependentStoryFiles', () => {
     });
     const result = await getDependentStoryFiles(ctx, { modules }, statsPath, changedFiles);
     expect(result.turboSnap.bailReason).toBeUndefined();
-    expect(result.affectedModules).toEqual({
-      './src/foo.stories.js': ['src/foo.stories.js'],
+    expect(result).toMatchObject({
+      status: 'traced',
+      onlyStoryFiles: {
+        './src/foo.stories.js': ['src/foo.stories.js'],
+      },
     });
   });
 
@@ -972,8 +1037,11 @@ describe('getDependentStoryFiles', () => {
     });
     const result = await getDependentStoryFiles(ctx, { modules }, statsPath, changedFiles);
     expect(result.turboSnap.bailReason).toBeUndefined();
-    expect(result.affectedModules).toEqual({
-      './src/foo.stories.js': ['src/foo.stories.js'],
+    expect(result).toMatchObject({
+      status: 'traced',
+      onlyStoryFiles: {
+        './src/foo.stories.js': ['src/foo.stories.js'],
+      },
     });
   });
   it('does not bail on changed dependency in dynamic import of untraced config file', async () => {
@@ -1029,8 +1097,11 @@ describe('getDependentStoryFiles', () => {
     });
     const result = await getDependentStoryFiles(ctx, { modules }, statsPath, changedFiles);
     expect(result.turboSnap.bailReason).toBeUndefined();
-    expect(result.affectedModules).toEqual({
-      './src/foo.stories.js': ['src/foo.stories.js'],
+    expect(result).toMatchObject({
+      status: 'traced',
+      onlyStoryFiles: {
+        './src/foo.stories.js': ['src/foo.stories.js'],
+      },
     });
   });
 
@@ -1061,7 +1132,7 @@ describe('getDependentStoryFiles', () => {
       changedFiles,
       changedDependencies
     );
-    expect(result.affectedModules).toBeUndefined();
+    expect(result.status).toBe('bailed');
     expect(result.turboSnap.bailReason).toEqual({
       changedPackageFiles: ['package.json'],
       bailSubreason: 'nodeModulesMissingInStats',

--- a/node-src/lib/turbosnap/getDependentStoryFiles.ts
+++ b/node-src/lib/turbosnap/getDependentStoryFiles.ts
@@ -6,7 +6,6 @@ import tracedAffectedFiles from '../../ui/messages/info/tracedAffectedFiles';
 import bailFile from '../../ui/messages/warnings/bailFile';
 import { posix } from '../posix';
 import { isPackageManifestFile, matchesFile } from '../utilities';
-import { NoCSFGlobsError } from './errors';
 import { SUPPORTED_LOCK_FILES } from './findChangedDependencies';
 
 type FilePath = string;
@@ -211,7 +210,7 @@ export async function getDependentStoryFiles(
         entryFile,
       })
     );
-    throw new NoCSFGlobsError();
+    throw new Error('Did not find any CSF globs in preview-stats.json');
   }
 
   const isCsfGlob = (name: NormalizedName) => csfGlobsByName.has(name);

--- a/node-src/lib/turbosnap/getDependentStoryFiles.ts
+++ b/node-src/lib/turbosnap/getDependentStoryFiles.ts
@@ -1,11 +1,12 @@
 import path from 'path';
 
-import { Context, Module, Reason, Stats } from '../../types';
+import { Context, Module, Reason, Stats, TurboSnap, UntracedFile } from '../../types';
 import noCSFGlobs from '../../ui/messages/errors/noCSFGlobs';
 import tracedAffectedFiles from '../../ui/messages/info/tracedAffectedFiles';
 import bailFile from '../../ui/messages/warnings/bailFile';
 import { posix } from '../posix';
 import { isPackageManifestFile, matchesFile } from '../utilities';
+import { NoCSFGlobsError } from './errors';
 import { SUPPORTED_LOCK_FILES } from './findChangedDependencies';
 
 type FilePath = string;
@@ -52,9 +53,19 @@ export function normalizePath(posixPath: string, rootPath: string, baseDirectory
 }
 
 /**
- * This traverses the webpack module stats to retrieve a set of CSF files that somehow trace back to
- * the changed git files. The result is a map of Module ID => file path. In the end we'll only send
- * the Module IDs to Chromatic, the file paths are only for logging purposes.
+ * The affected story files plus the TurboSnap trace state and untraced files; `affectedModules`
+ * is absent when TurboSnap bailed.
+ */
+export interface DependentStoryFilesResult {
+  affectedModules?: Record<string, string[]>;
+  turboSnap: TurboSnap;
+  untracedFiles: UntracedFile[];
+}
+
+/**
+ * Traverses the webpack module stats to retrieve a set of CSF files that somehow trace back to
+ * the changed git files. The result is a map of Module ID => file path. In the end we'll only
+ * send the Module IDs to Chromatic, the file paths are only for logging purposes.
  *
  * @param ctx The context set when executing the CLI.
  * @param stats The stats file information from the project's builder (Webpack, for example).
@@ -63,7 +74,8 @@ export function normalizePath(posixPath: string, rootPath: string, baseDirectory
  * @param changedFiles A list of changed files.
  * @param changedDependencies A list of changed dependencies.
  *
- * @returns Any story files that are impacted by the list of changed files and dependencies.
+ * @returns The affected story files plus the TurboSnap trace state and untraced files;
+ * `affectedModules` is absent when TurboSnap bailed.
  */
 // TODO: refactor this function
 // eslint-disable-next-line complexity, max-statements
@@ -73,7 +85,7 @@ export async function getDependentStoryFiles(
   statsPath: string,
   changedFiles: string[],
   changedDependencies: string[] = []
-) {
+): Promise<DependentStoryFilesResult> {
   const { rootPath } = ctx.git || {};
   if (!rootPath) {
     throw new Error('Failed to determine repository root');
@@ -199,20 +211,20 @@ export async function getDependentStoryFiles(
         entryFile,
       })
     );
-    throw new Error('Did not find any CSF globs in preview-stats.json');
+    throw new NoCSFGlobsError();
   }
 
   const isCsfGlob = (name: NormalizedName) => csfGlobsByName.has(name);
   const isStaticFile = (name: string) =>
     staticDirectories.some((directory) => name && name.startsWith(`${directory}/`));
 
-  ctx.untracedFiles = [];
+  const untracedFiles: UntracedFile[] = [];
 
   function untrace(filepath: string) {
     filepath = filepath.replace(/\s\+\s\d+\smodules?$/, ''); // strip ' + N modules' from the string before matching against `untraced`
     const matchedGlob = untraced.find((glob) => matchesFile(glob, filepath));
     if (matchedGlob) {
-      ctx.untracedFiles?.push({ filepath, glob: matchedGlob });
+      untracedFiles.push({ filepath, glob: matchedGlob });
       return false;
     }
     return true;
@@ -237,7 +249,8 @@ export async function getDependentStoryFiles(
   const checkedIds = {};
   const toCheck: TraceToCheck[] = [];
 
-  ctx.turboSnap = {
+  const turboSnap: TurboSnap = {
+    ...ctx.turboSnap,
     rootPath,
     baseDir: baseDirectory,
     storybookDir: storybookDirectory,
@@ -255,7 +268,7 @@ export async function getDependentStoryFiles(
   if (nodeModules.size === 0 && changedDependencies.length > 0) {
     // If we didn't find any node_modules in the stats file, it's probably incomplete and we can't
     // trace changed dependencies, so we bail just in case.
-    ctx.turboSnap.bailReason = {
+    turboSnap.bailReason = {
       changedPackageFiles: [
         ...(ctx.git.changedFiles?.filter((file) => isPackageManifestFile(file)) || []),
         ...changedPackageLockFiles,
@@ -273,20 +286,18 @@ export async function getDependentStoryFiles(
   }
 
   function shouldBail(moduleName: string, tracePath: string[] = []) {
-    if (!ctx.turboSnap) ctx.turboSnap = {};
-
     // Check staticDirs before the Storybook config dir so static assets
     // nested under `.storybook/` (e.g. an MSW-generated mockServiceWorker.js
     // inside a configured staticDir) aren't mis-categorized as config changes.
     if (isStaticFile(moduleName)) {
-      ctx.turboSnap.bailReason = { changedStaticFiles: files(moduleName) };
-      ctx.turboSnap.bailPath = buildBailPath(moduleName, tracePath);
+      turboSnap.bailReason = { changedStaticFiles: files(moduleName) };
+      turboSnap.bailPath = buildBailPath(moduleName, tracePath);
       return true;
     }
 
     if (isStorybookFile(moduleName)) {
-      ctx.turboSnap.bailReason = { changedStorybookFiles: files(moduleName) };
-      ctx.turboSnap.bailPath = buildBailPath(moduleName, tracePath);
+      turboSnap.bailReason = { changedStorybookFiles: files(moduleName) };
+      turboSnap.bailPath = buildBailPath(moduleName, tracePath);
       return true;
     }
     return false;
@@ -295,7 +306,7 @@ export async function getDependentStoryFiles(
   // TODO: refactor this function
   // eslint-disable-next-line complexity
   function traceName(name: string, tracePath: string[] = []) {
-    if (ctx.turboSnap?.bailReason || isCsfGlob(name)) return;
+    if (turboSnap.bailReason || isCsfGlob(name)) return;
     if (shouldBail(name, tracePath)) return;
     const { id } = modulesByName.get(name) || {};
     // eslint-disable-next-line unicorn/no-null
@@ -351,20 +362,23 @@ export async function getDependentStoryFiles(
 
   if (ctx.options.traceChanged) {
     ctx.log.info(
-      tracedAffectedFiles(ctx, {
-        changedFiles,
-        affectedModules,
-        modulesByName: Object.fromEntries(modulesByName),
-        normalize,
-      })
+      tracedAffectedFiles(
+        { ...ctx, turboSnap, untracedFiles },
+        {
+          changedFiles,
+          affectedModules,
+          modulesByName: Object.fromEntries(modulesByName),
+          normalize,
+        }
+      )
     );
     ctx.log.info('');
   }
 
-  if (ctx.turboSnap.bailReason) {
-    ctx.log.warn(bailFile({ turboSnap: ctx.turboSnap }));
-    return;
+  if (turboSnap.bailReason) {
+    ctx.log.warn(bailFile({ turboSnap }));
+    return { turboSnap, untracedFiles };
   }
 
-  return affectedModules;
+  return { affectedModules, turboSnap, untracedFiles };
 }

--- a/node-src/lib/turbosnap/getDependentStoryFiles.ts
+++ b/node-src/lib/turbosnap/getDependentStoryFiles.ts
@@ -246,7 +246,6 @@ export async function getDependentStoryFiles(
   const toCheck: TraceToCheck[] = [];
 
   const turboSnap: TurboSnap = {
-    ...ctx.turboSnap,
     rootPath,
     baseDir: baseDirectory,
     storybookDir: storybookDirectory,

--- a/node-src/lib/turbosnap/getDependentStoryFiles.ts
+++ b/node-src/lib/turbosnap/getDependentStoryFiles.ts
@@ -7,6 +7,7 @@ import bailFile from '../../ui/messages/warnings/bailFile';
 import { posix } from '../posix';
 import { isPackageManifestFile, matchesFile } from '../utilities';
 import { SUPPORTED_LOCK_FILES } from './findChangedDependencies';
+import { TraceChangedFilesResult } from './types';
 
 type FilePath = string;
 type NormalizedName = string;
@@ -52,14 +53,10 @@ export function normalizePath(posixPath: string, rootPath: string, baseDirectory
 }
 
 /**
- * The affected story files plus the TurboSnap trace state and untraced files; `affectedModules`
- * is absent when TurboSnap bailed.
+ * The result of tracing story files: either `bailed` or `traced`. This never skips since it's
+ * handled by the caller.
  */
-export interface DependentStoryFilesResult {
-  affectedModules?: Record<string, string[]>;
-  turboSnap: TurboSnap;
-  untracedFiles: UntracedFile[];
-}
+export type DependentStoryFilesResult = Exclude<TraceChangedFilesResult, { status: 'skipped' }>;
 
 /**
  * Traverses the webpack module stats to retrieve a set of CSF files that somehow trace back to
@@ -73,8 +70,8 @@ export interface DependentStoryFilesResult {
  * @param changedFiles A list of changed files.
  * @param changedDependencies A list of changed dependencies.
  *
- * @returns The affected story files plus the TurboSnap trace state and untraced files;
- * `affectedModules` is absent when TurboSnap bailed.
+ * @returns `bailed` when TurboSnap gave up, or `traced` with the affected story files in
+ * `onlyStoryFiles`.
  */
 // TODO: refactor this function
 // eslint-disable-next-line complexity, max-statements
@@ -376,8 +373,8 @@ export async function getDependentStoryFiles(
 
   if (turboSnap.bailReason) {
     ctx.log.warn(bailFile({ turboSnap }));
-    return { turboSnap, untracedFiles };
+    return { status: 'bailed', turboSnap };
   }
 
-  return { affectedModules, turboSnap, untracedFiles };
+  return { status: 'traced', onlyStoryFiles: affectedModules, turboSnap, untracedFiles };
 }

--- a/node-src/lib/turbosnap/index.test.ts
+++ b/node-src/lib/turbosnap/index.test.ts
@@ -175,11 +175,12 @@ describe('traceChangedFiles', () => {
       } as any;
       const result = await traceChangedFiles(ctx);
 
-      // Putting this in an if statement to avoid TS errors about type shape
-      if (result.status !== 'bailed') {
-        throw new Error(`Expected result.status to be 'bailed', but got '${result.status}'`);
-      }
-      expect(result.turboSnap.bailReason).toEqual(expectedBailReason);
+      expect(result).toMatchObject({
+        status: 'bailed',
+        turboSnap: {
+          bailReason: expectedBailReason,
+        },
+      });
       expect(captureException).toHaveBeenCalledTimes(1);
       expect(captureException).toHaveBeenCalledWith(error, {
         tags: {
@@ -215,11 +216,10 @@ describe('traceChangedFiles', () => {
     } as any;
     const result = await traceChangedFiles(ctx);
 
-    // Putting this in an if statement to avoid TS errors about type shape
-    if (result.status !== 'traced') {
-      throw new Error(`Expected result.status to be 'traced', but got '${result.status}'`);
-    }
-    expect(result.changedDependencyNames).toEqual(['moment']);
+    expect(result).toMatchObject({
+      status: 'traced',
+      changedDependencyNames: ['moment'],
+    });
     expect(ctx.git.changedDependencyNames).toBeUndefined();
   });
 
@@ -281,12 +281,11 @@ describe('traceChangedFiles', () => {
     } as any;
     const result = await traceChangedFiles(ctx);
 
-    // Putting this in an if statement to avoid TS errors about type shape
-    if (result.status !== 'traced') {
-      throw new Error(`Expected result.status to be 'traced', but got '${result.status}'`);
-    }
-    expect(result.onlyStoryFiles).toStrictEqual(deps);
-    expect(result.turboSnap.bailReason).toBeUndefined();
+    expect(result).toMatchObject({
+      status: 'traced',
+      onlyStoryFiles: deps,
+      turboSnap: {}, // checking there is no bailReason set
+    });
     expect(findChangedPackageFiles).toHaveBeenCalledWith(ctx, packageMetadataChanges);
   });
 
@@ -314,11 +313,10 @@ describe('traceChangedFiles', () => {
     } as any;
     const result = await traceChangedFiles(ctx);
 
-    // Putting this in an if statement to avoid TS errors about type shape
-    if (result.status !== 'traced') {
-      throw new Error(`Expected result.status to be 'traced', but got '${result.status}'`);
-    }
-    expect(result.turboSnap.bailReason).toBeUndefined();
+    expect(result).toMatchObject({
+      status: 'traced',
+      turboSnap: {}, // checking there is no bailReason set
+    });
     expect(captureException).not.toHaveBeenCalled();
   });
 

--- a/node-src/lib/turbosnap/index.test.ts
+++ b/node-src/lib/turbosnap/index.test.ts
@@ -63,7 +63,11 @@ beforeEach(() => {
 describe('traceChangedFiles', () => {
   it('does not run package dependency analysis if there are no metadata changes', async () => {
     const deps = { 123: ['./example.stories.js'] };
-    getDependentStoryFiles.mockResolvedValue(deps);
+    getDependentStoryFiles.mockResolvedValue({
+      affectedModules: deps,
+      turboSnap: {},
+      untracedFiles: [],
+    });
 
     const ctx = {
       env: environment,
@@ -75,9 +79,15 @@ describe('traceChangedFiles', () => {
       git: { changedFiles: ['./example.js'] },
       turboSnap: {},
     } as any;
-    const onlyStoryFiles = await traceChangedFiles(ctx);
+    const result = await traceChangedFiles(ctx);
 
-    expect(onlyStoryFiles).toStrictEqual(deps);
+    expect(result).toStrictEqual({
+      status: 'traced',
+      onlyStoryFiles: deps,
+      turboSnap: {},
+      changedDependencyNames: undefined,
+      untracedFiles: [],
+    });
     expect(findChangedDependencies).not.toHaveBeenCalled();
     expect(findChangedPackageFiles).not.toHaveBeenCalled();
   });
@@ -162,9 +172,13 @@ describe('traceChangedFiles', () => {
         git: { changedFiles: ['./example.js', './package.json'], packageMetadataChanges },
         turboSnap: {},
       } as any;
-      await traceChangedFiles(ctx);
+      const result = await traceChangedFiles(ctx);
 
-      expect(ctx.turboSnap.bailReason).toEqual(expectedBailReason);
+      // Putting this in an if statement to avoid TS errors about type shape
+      if (result.status !== 'bailed') {
+        throw new Error(`Expected result.status to be 'bailed', but got '${result.status}'`);
+      }
+      expect(result.turboSnap.bailReason).toEqual(expectedBailReason);
       expect(captureException).toHaveBeenCalledTimes(1);
       expect(captureException).toHaveBeenCalledWith(error, {
         tags: {
@@ -177,9 +191,14 @@ describe('traceChangedFiles', () => {
     });
   }
 
-  it('stores dependency changes', async () => {
+  it('returns dependency changes', async () => {
     findChangedDependencies.mockResolvedValue(['moment']);
     findChangedPackageFiles.mockResolvedValue([]);
+    getDependentStoryFiles.mockResolvedValue({
+      affectedModules: {},
+      turboSnap: {},
+      untracedFiles: [],
+    });
 
     const packageMetadataChanges = [{ changedFiles: ['./package.json'], commit: 'abcdef' }];
     const ctx = {
@@ -192,16 +211,25 @@ describe('traceChangedFiles', () => {
       git: { changedFiles: ['./example.js', './package.json'], packageMetadataChanges },
       turboSnap: {},
     } as any;
-    await traceChangedFiles(ctx);
+    const result = await traceChangedFiles(ctx);
 
-    expect(ctx.git.changedDependencyNames).toEqual(['moment']);
+    // Putting this in an if statement to avoid TS errors about type shape
+    if (result.status !== 'traced') {
+      throw new Error(`Expected result.status to be 'traced', but got '${result.status}'`);
+    }
+    expect(result.changedDependencyNames).toEqual(['moment']);
+    expect(ctx.git.changedDependencyNames).toBeUndefined();
   });
 
   it('throws an error if storybookBaseDir is incorrect', async () => {
     const deps = { 123: ['./example.stories.js'] };
     findChangedDependencies.mockResolvedValue([]);
     findChangedPackageFiles.mockResolvedValue([]);
-    getDependentStoryFiles.mockResolvedValue(deps);
+    getDependentStoryFiles.mockResolvedValue({
+      affectedModules: deps,
+      turboSnap: {},
+      untracedFiles: [],
+    });
     accessMock.mockImplementation((_path, callback) =>
       Promise.resolve(callback(new Error('some error')))
     );
@@ -216,7 +244,13 @@ describe('traceChangedFiles', () => {
       git: { changedFiles: ['./example.js'] },
       turboSnap: {},
     } as any;
-    await expect(traceChangedFiles(ctx)).rejects.toThrow();
+    let err;
+    try {
+      await traceChangedFiles(ctx);
+    } catch (error) {
+      err = error;
+    }
+    expect(err).toBeTruthy();
     expect(ctx.exitCode).toBe(exitCodes.INVALID_OPTIONS);
   });
 
@@ -224,7 +258,11 @@ describe('traceChangedFiles', () => {
     const deps = { 123: ['./example.stories.js'] };
     findChangedDependencies.mockRejectedValue(new Error('no lockfile'));
     findChangedPackageFiles.mockResolvedValue([]); // no dependency changes
-    getDependentStoryFiles.mockResolvedValue(deps);
+    getDependentStoryFiles.mockResolvedValue({
+      affectedModules: deps,
+      turboSnap: {},
+      untracedFiles: [],
+    });
 
     const packageMetadataChanges = [{ changedFiles: ['./package.json'], commit: 'abcdef' }];
     const ctx = {
@@ -237,10 +275,14 @@ describe('traceChangedFiles', () => {
       git: { changedFiles: ['./example.js', './package.json'], packageMetadataChanges },
       turboSnap: {},
     } as any;
-    const onlyStoryFiles = await traceChangedFiles(ctx);
+    const result = await traceChangedFiles(ctx);
 
-    expect(ctx.turboSnap.bailReason).toBeUndefined();
-    expect(onlyStoryFiles).toStrictEqual(deps);
+    // Putting this in an if statement to avoid TS errors about type shape
+    if (result.status !== 'traced') {
+      throw new Error(`Expected result.status to be 'traced', but got '${result.status}'`);
+    }
+    expect(result.onlyStoryFiles).toStrictEqual(deps);
+    expect(result.turboSnap.bailReason).toBeUndefined();
     expect(findChangedPackageFiles).toHaveBeenCalledWith(ctx, packageMetadataChanges);
   });
 
@@ -248,7 +290,11 @@ describe('traceChangedFiles', () => {
     const error = new LockFileSizeExceededError('/tmp/x', 999);
     findChangedDependencies.mockRejectedValue(error);
     findChangedPackageFiles.mockResolvedValue([]);
-    getDependentStoryFiles.mockResolvedValue({});
+    getDependentStoryFiles.mockResolvedValue({
+      affectedModules: {},
+      turboSnap: {},
+      untracedFiles: [],
+    });
 
     const packageMetadataChanges = [{ changedFiles: ['./package.json'], commit: 'abcdef' }];
     const ctx = {
@@ -261,9 +307,13 @@ describe('traceChangedFiles', () => {
       git: { changedFiles: ['./example.js', './package.json'], packageMetadataChanges },
       turboSnap: {},
     } as any;
-    await traceChangedFiles(ctx);
+    const result = await traceChangedFiles(ctx);
 
-    expect(ctx.turboSnap.bailReason).toBeUndefined();
+    // Putting this in an if statement to avoid TS errors about type shape
+    if (result.status !== 'traced') {
+      throw new Error(`Expected result.status to be 'traced', but got '${result.status}'`);
+    }
+    expect(result.turboSnap.bailReason).toBeUndefined();
     expect(captureException).not.toHaveBeenCalled();
   });
 
@@ -279,7 +329,51 @@ describe('traceChangedFiles', () => {
       turboSnap: {},
     } as any;
 
-    await expect(traceChangedFiles(ctx)).rejects.toThrow();
-    expect(ctx.turboSnap.bailReason).toEqual({ missingStatsFile: true });
+    let err;
+    try {
+      await traceChangedFiles(ctx);
+    } catch (error) {
+      err = error;
+    }
+    expect(err.message).toContain('TurboSnap requires a stats file, but none was found');
+    expect(ctx.turboSnap.bailReason).toBeUndefined();
+  });
+
+  it('returns skipped when TurboSnap is unavailable', async () => {
+    const ctx = {
+      env: environment,
+      log,
+      http,
+      options: {},
+      git: {},
+      turboSnap: { unavailable: true },
+    } as any;
+
+    const result = await traceChangedFiles(ctx);
+
+    expect(result).toStrictEqual({ status: 'skipped' });
+  });
+
+  it('bails without mutating ctx when package files changed', async () => {
+    findChangedDependencies.mockRejectedValue(new Error('no lockfile'));
+    findChangedPackageFiles.mockResolvedValue(['./package.json']);
+
+    const packageMetadataChanges = [{ changedFiles: ['./package.json'], commit: 'abcdef' }];
+    const ctx = {
+      env: environment,
+      log,
+      http,
+      options: {},
+      sourceDir: '/static/',
+      fileInfo: { statsPath: '/static/preview-stats.json' },
+      git: { changedFiles: ['./example.js', './package.json'], packageMetadataChanges },
+      turboSnap: {},
+    } as any;
+
+    const result = await traceChangedFiles(ctx);
+
+    expect(result.status).toBe('bailed');
+    expect(ctx.turboSnap.bailReason).toBeUndefined();
+    expect(ctx.git.changedDependencyNames).toBeUndefined();
   });
 });

--- a/node-src/lib/turbosnap/index.test.ts
+++ b/node-src/lib/turbosnap/index.test.ts
@@ -64,7 +64,8 @@ describe('traceChangedFiles', () => {
   it('does not run package dependency analysis if there are no metadata changes', async () => {
     const deps = { 123: ['./example.stories.js'] };
     getDependentStoryFiles.mockResolvedValue({
-      affectedModules: deps,
+      status: 'traced',
+      onlyStoryFiles: deps,
       turboSnap: {},
       untracedFiles: [],
     });
@@ -195,7 +196,8 @@ describe('traceChangedFiles', () => {
     findChangedDependencies.mockResolvedValue(['moment']);
     findChangedPackageFiles.mockResolvedValue([]);
     getDependentStoryFiles.mockResolvedValue({
-      affectedModules: {},
+      status: 'traced',
+      onlyStoryFiles: {},
       turboSnap: {},
       untracedFiles: [],
     });
@@ -226,7 +228,8 @@ describe('traceChangedFiles', () => {
     findChangedDependencies.mockResolvedValue([]);
     findChangedPackageFiles.mockResolvedValue([]);
     getDependentStoryFiles.mockResolvedValue({
-      affectedModules: deps,
+      status: 'traced',
+      onlyStoryFiles: deps,
       turboSnap: {},
       untracedFiles: [],
     });
@@ -259,7 +262,8 @@ describe('traceChangedFiles', () => {
     findChangedDependencies.mockRejectedValue(new Error('no lockfile'));
     findChangedPackageFiles.mockResolvedValue([]); // no dependency changes
     getDependentStoryFiles.mockResolvedValue({
-      affectedModules: deps,
+      status: 'traced',
+      onlyStoryFiles: deps,
       turboSnap: {},
       untracedFiles: [],
     });
@@ -291,7 +295,8 @@ describe('traceChangedFiles', () => {
     findChangedDependencies.mockRejectedValue(error);
     findChangedPackageFiles.mockResolvedValue([]);
     getDependentStoryFiles.mockResolvedValue({
-      affectedModules: {},
+      status: 'traced',
+      onlyStoryFiles: {},
       turboSnap: {},
       untracedFiles: [],
     });

--- a/node-src/lib/turbosnap/index.test.ts
+++ b/node-src/lib/turbosnap/index.test.ts
@@ -335,7 +335,7 @@ describe('traceChangedFiles', () => {
     } catch (error) {
       err = error;
     }
-    expect(err.message).toContain('TurboSnap requires a stats file, but none was found');
+    expect(err.message).toContain('TurboSnap requires a stats file');
     expect(ctx.turboSnap.bailReason).toBeUndefined();
   });
 

--- a/node-src/lib/turbosnap/index.ts
+++ b/node-src/lib/turbosnap/index.ts
@@ -122,7 +122,6 @@ export async function traceChangedFiles(ctx: Context): Promise<TraceChangedFiles
   };
 }
 
-export { NoCSFGlobsError } from './errors';
 export { findChangedDependencies } from './findChangedDependencies';
 export { findChangedPackageFiles } from './findChangedPackageFiles';
 export { getDependentStoryFiles } from './getDependentStoryFiles';

--- a/node-src/lib/turbosnap/index.ts
+++ b/node-src/lib/turbosnap/index.ts
@@ -13,7 +13,7 @@ import { findChangedPackageFiles } from './findChangedPackageFiles';
 import { getDependentStoryFiles } from './getDependentStoryFiles';
 
 export type TraceChangedFilesResult =
-  | { status: 'skipped' } // turboSnap unavailable / no changed files
+  | { status: 'skipped' } // turboSnap unavailable / no changed files from `git diff`
   | {
       status: 'bailed';
       turboSnap: TurboSnap;

--- a/node-src/lib/turbosnap/index.ts
+++ b/node-src/lib/turbosnap/index.ts
@@ -1,7 +1,7 @@
 import semver from 'semver';
 
 import { readStatsFile } from '../../tasks/readStatsFile';
-import { ChangedPackageFilesBailReason, Context } from '../../types';
+import { ChangedPackageFilesBailReason, Context, TurboSnap, UntracedFile } from '../../types';
 import missingStatsFile from '../../ui/messages/errors/missingStatsFile';
 import bailFile from '../../ui/messages/warnings/bailFile';
 import { checkStorybookBaseDirectory } from '../checkStorybookBaseDirectory';
@@ -12,25 +12,48 @@ import { findChangedDependencies } from './findChangedDependencies';
 import { findChangedPackageFiles } from './findChangedPackageFiles';
 import { getDependentStoryFiles } from './getDependentStoryFiles';
 
+export type TraceChangedFilesResult =
+  | { status: 'skipped' } // turboSnap unavailable / no changed files
+  | {
+      status: 'bailed';
+      turboSnap: TurboSnap;
+      changedDependencyNames?: string[];
+      untracedFiles?: UntracedFile[]; // present when the bail happened mid-trace
+    }
+  | {
+      status: 'traced';
+      onlyStoryFiles: Record<string, string[]>;
+      turboSnap: TurboSnap;
+      changedDependencyNames?: string[];
+      untracedFiles: UntracedFile[];
+    };
+
+/**
+ * Determines which story files are affected by the changed git files, bailing out of TurboSnap
+ * when necessary.
+ *
+ * @param ctx The context set when executing the CLI.
+ *
+ * @returns The trace result: skipped, bailed, or traced with the affected story files.
+ */
 // eslint-disable-next-line complexity
-export const traceChangedFiles = async (ctx: Context) => {
-  if (!ctx.turboSnap || ctx.turboSnap.unavailable) return;
-  if (!ctx.git.changedFiles) return;
+export async function traceChangedFiles(ctx: Context): Promise<TraceChangedFilesResult> {
+  if (!ctx.turboSnap || ctx.turboSnap.unavailable) return { status: 'skipped' };
+  if (!ctx.git.changedFiles) return { status: 'skipped' };
   if (!ctx.fileInfo?.statsPath) {
     // If we don't know the SB version, we should assume we don't support `--stats-json`
     const nonLegacyStatsSupported =
       ctx.storybook?.version &&
       semver.gte(semver.coerce(ctx.storybook.version) || '0.0.0', '8.0.0');
 
-    ctx.turboSnap.bailReason = { missingStatsFile: true };
     throw new Error(missingStatsFile({ legacy: !nonLegacyStatsSupported }));
   }
 
   const { statsPath } = ctx.fileInfo;
   const { changedFiles, packageMetadataChanges } = ctx.git;
 
-  // eslint-disable-next-line @typescript-eslint/no-invalid-void-type
-  let changedDependencyNames: void | string[] = [];
+  // Only set when lockfile analysis ran and succeeded; an empty array means "no changes found".
+  let changedDependencyNames: string[] | undefined;
   let pendingError: unknown;
   let pendingPatch: Partial<ChangedPackageFilesBailReason> | undefined;
   if (packageMetadataChanges?.length) {
@@ -40,9 +63,9 @@ export const traceChangedFiles = async (ctx: Context) => {
 
       const { name, message, stack, code } = err;
       ctx.log.debug({ name, message, stack, code });
+      return undefined;
     });
     if (changedDependencyNames) {
-      ctx.git.changedDependencyNames = changedDependencyNames;
       if (!ctx.options.interactive) {
         const list =
           changedDependencyNames.length > 0
@@ -66,12 +89,12 @@ export const traceChangedFiles = async (ctx: Context) => {
           });
         }
 
-        ctx.turboSnap.bailReason = {
-          changedPackageFiles,
-          ...pendingPatch,
+        const turboSnap: TurboSnap = {
+          ...ctx.turboSnap,
+          bailReason: { changedPackageFiles, ...pendingPatch },
         };
-        ctx.log.warn(bailFile({ turboSnap: ctx.turboSnap }));
-        return;
+        ctx.log.warn(bailFile({ turboSnap }));
+        return { status: 'bailed', turboSnap };
       }
     }
   }
@@ -80,15 +103,28 @@ export const traceChangedFiles = async (ctx: Context) => {
 
   await checkStorybookBaseDirectory(ctx, stats);
 
-  return await getDependentStoryFiles(
+  const { affectedModules, turboSnap, untracedFiles } = await getDependentStoryFiles(
     ctx,
     stats,
     statsPath,
     changedFiles,
     changedDependencyNames || []
   );
-};
 
+  if (!affectedModules) {
+    return { status: 'bailed', turboSnap, changedDependencyNames, untracedFiles };
+  }
+
+  return {
+    status: 'traced',
+    onlyStoryFiles: affectedModules,
+    turboSnap,
+    changedDependencyNames,
+    untracedFiles,
+  };
+}
+
+export { NoCSFGlobsError } from './errors';
 export { findChangedDependencies } from './findChangedDependencies';
 export { findChangedPackageFiles } from './findChangedPackageFiles';
 export { getDependentStoryFiles } from './getDependentStoryFiles';

--- a/node-src/lib/turbosnap/index.ts
+++ b/node-src/lib/turbosnap/index.ts
@@ -88,7 +88,7 @@ export async function traceChangedFiles(ctx: Context): Promise<TraceChangedFiles
 
   await checkStorybookBaseDirectory(ctx, stats);
 
-  const { affectedModules, turboSnap, untracedFiles } = await getDependentStoryFiles(
+  const result = await getDependentStoryFiles(
     ctx,
     stats,
     statsPath,
@@ -96,17 +96,11 @@ export async function traceChangedFiles(ctx: Context): Promise<TraceChangedFiles
     changedDependencyNames || []
   );
 
-  if (!affectedModules) {
-    return { status: 'bailed', turboSnap };
+  if (result.status === 'bailed') {
+    return result;
   }
 
-  return {
-    status: 'traced',
-    onlyStoryFiles: affectedModules,
-    turboSnap,
-    changedDependencyNames,
-    untracedFiles,
-  };
+  return { ...result, changedDependencyNames };
 }
 
 export { findChangedDependencies } from './findChangedDependencies';

--- a/node-src/lib/turbosnap/index.ts
+++ b/node-src/lib/turbosnap/index.ts
@@ -17,8 +17,6 @@ export type TraceChangedFilesResult =
   | {
       status: 'bailed';
       turboSnap: TurboSnap;
-      changedDependencyNames?: string[];
-      untracedFiles?: UntracedFile[]; // present when the bail happened mid-trace
     }
   | {
       status: 'traced';
@@ -112,7 +110,7 @@ export async function traceChangedFiles(ctx: Context): Promise<TraceChangedFiles
   );
 
   if (!affectedModules) {
-    return { status: 'bailed', turboSnap, changedDependencyNames, untracedFiles };
+    return { status: 'bailed', turboSnap };
   }
 
   return {

--- a/node-src/lib/turbosnap/index.ts
+++ b/node-src/lib/turbosnap/index.ts
@@ -1,7 +1,7 @@
 import semver from 'semver';
 
 import { readStatsFile } from '../../tasks/readStatsFile';
-import { ChangedPackageFilesBailReason, Context, TurboSnap, UntracedFile } from '../../types';
+import { ChangedPackageFilesBailReason, Context, TurboSnap } from '../../types';
 import missingStatsFile from '../../ui/messages/errors/missingStatsFile';
 import bailFile from '../../ui/messages/warnings/bailFile';
 import { checkStorybookBaseDirectory } from '../checkStorybookBaseDirectory';
@@ -11,20 +11,7 @@ import { classifyTagsFromError } from './classifyBailRootCause';
 import { findChangedDependencies } from './findChangedDependencies';
 import { findChangedPackageFiles } from './findChangedPackageFiles';
 import { getDependentStoryFiles } from './getDependentStoryFiles';
-
-export type TraceChangedFilesResult =
-  | { status: 'skipped' } // turboSnap unavailable / no changed files from `git diff`
-  | {
-      status: 'bailed';
-      turboSnap: TurboSnap;
-    }
-  | {
-      status: 'traced';
-      onlyStoryFiles: Record<string, string[]>;
-      turboSnap: TurboSnap;
-      changedDependencyNames?: string[];
-      untracedFiles: UntracedFile[];
-    };
+import { TraceChangedFilesResult } from './types';
 
 /**
  * Determines which story files are affected by the changed git files, bailing out of TurboSnap

--- a/node-src/lib/turbosnap/types.ts
+++ b/node-src/lib/turbosnap/types.ts
@@ -1,0 +1,15 @@
+import { TurboSnap, UntracedFile } from '../../types';
+
+export type TraceChangedFilesResult =
+  | { status: 'skipped' } // turboSnap unavailable / no changed files from `git diff`
+  | {
+      status: 'bailed';
+      turboSnap: TurboSnap;
+    }
+  | {
+      status: 'traced';
+      onlyStoryFiles: Record<string, string[]>;
+      turboSnap: TurboSnap;
+      changedDependencyNames?: string[];
+      untracedFiles: UntracedFile[];
+    };

--- a/node-src/tasks/prepare/index.ts
+++ b/node-src/tasks/prepare/index.ts
@@ -10,7 +10,7 @@ export interface PrepareInput {
   buildLogFile?: string;
   browsers?: string[];
   // Context threaded for the TurboSnap subsystem, which reads it; trace results are applied back
-  // onto it in traceChangedFiles.
+  // onto it in ./traceChangedFiles.
   turboSnapContext: Context;
 }
 

--- a/node-src/tasks/prepare/index.ts
+++ b/node-src/tasks/prepare/index.ts
@@ -9,7 +9,8 @@ export interface PrepareInput {
   sourceDir: string;
   buildLogFile?: string;
   browsers?: string[];
-  // Context threaded for the still-ctx-coupled TurboSnap subsystem (see traceChangedFiles).
+  // Context threaded for the TurboSnap subsystem, which reads it; trace results are applied back
+  // onto it in traceChangedFiles.
   turboSnapContext: Context;
 }
 

--- a/node-src/tasks/prepare/traceChangedFiles.test.ts
+++ b/node-src/tasks/prepare/traceChangedFiles.test.ts
@@ -49,7 +49,12 @@ describe('traceChangedFiles', () => {
 
   it('returns onlyStoryFiles', async () => {
     const traced = { 123: ['./example.stories.js'] };
-    traceChangedFilesTurbosnap.mockResolvedValue(traced);
+    traceChangedFilesTurbosnap.mockResolvedValue({
+      status: 'traced',
+      onlyStoryFiles: traced,
+      turboSnap: {},
+      untracedFiles: [],
+    });
 
     const result = await traceChangedFiles(deps(), { turboSnapContext: turboSnapContext() });
 
@@ -66,7 +71,12 @@ describe('traceChangedFiles', () => {
         '[./example/[account]/[id]/[unit]/language/example.stories.tsx]',
       ],
     };
-    traceChangedFilesTurbosnap.mockResolvedValue(traced);
+    traceChangedFilesTurbosnap.mockResolvedValue({
+      status: 'traced',
+      onlyStoryFiles: traced,
+      turboSnap: {},
+      untracedFiles: [],
+    });
 
     const result = await traceChangedFiles(deps(), { turboSnapContext: turboSnapContext() });
 
@@ -77,5 +87,52 @@ describe('traceChangedFiles', () => {
       String.raw`./example\[\[lang=language\]\].stories.js`,
       String.raw`\[./example/\[account\]/\[id\]/\[unit\]/language/example.stories.tsx\]`,
     ]);
+  });
+
+  it('applies the trace result to the context', async () => {
+    const ctx = turboSnapContext();
+    traceChangedFilesTurbosnap.mockResolvedValue({
+      status: 'traced',
+      onlyStoryFiles: { 123: ['./example.stories.js'] },
+      turboSnap: { rootPath: '/repo' },
+      changedDependencyNames: ['moment'],
+      untracedFiles: [{ filepath: './skipped.js', glob: '*.js' }],
+    });
+
+    await traceChangedFiles(deps(), { turboSnapContext: ctx });
+
+    expect(ctx.turboSnap).toEqual({ rootPath: '/repo' });
+    expect(ctx.git.changedDependencyNames).toEqual(['moment']);
+    expect(ctx.untracedFiles).toEqual([{ filepath: './skipped.js', glob: '*.js' }]);
+  });
+
+  it('applies a bailed result to the context and reports the bail', async () => {
+    const ctx = turboSnapContext();
+    const d = deps();
+    const turboSnap = { bailReason: { changedPackageFiles: ['./package.json'] } };
+    traceChangedFilesTurbosnap.mockResolvedValue({ status: 'bailed', turboSnap });
+
+    const result = await traceChangedFiles(d, { turboSnapContext: ctx });
+
+    expect(result).toEqual({});
+    expect(ctx.turboSnap).toEqual(turboSnap);
+    expect(d.report).toHaveBeenCalledWith(expect.objectContaining({ title: 'TurboSnap disabled' }));
+  });
+
+  it('rethrows the missing stats file error unwrapped', async () => {
+    const ctx = turboSnapContext();
+    const missingStatsError = new Error('stats file not found');
+    traceChangedFilesTurbosnap.mockRejectedValue(missingStatsError);
+
+    let err;
+    try {
+      await traceChangedFiles(deps(), { turboSnapContext: ctx });
+    } catch (error) {
+      err = error;
+    }
+
+    expect(err).toBe(missingStatsError);
+    expect(ctx.turboSnap.bailReason).toBeUndefined();
+    expect(err.message).not.toContain('Could not retrieve dependent story files');
   });
 });

--- a/node-src/tasks/prepare/traceChangedFiles.test.ts
+++ b/node-src/tasks/prepare/traceChangedFiles.test.ts
@@ -119,7 +119,7 @@ describe('traceChangedFiles', () => {
     expect(d.report).toHaveBeenCalledWith(expect.objectContaining({ title: 'TurboSnap disabled' }));
   });
 
-  it('rethrows the missing stats file error unwrapped', async () => {
+  it('wraps the missing stats file error without recording a bail reason', async () => {
     const ctx = turboSnapContext();
     const missingStatsError = new Error('stats file not found');
     traceChangedFilesTurbosnap.mockRejectedValue(missingStatsError);
@@ -131,8 +131,7 @@ describe('traceChangedFiles', () => {
       err = error;
     }
 
-    expect(err).toBe(missingStatsError);
     expect(ctx.turboSnap.bailReason).toBeUndefined();
-    expect(err.message).not.toContain('Could not retrieve dependent story files');
+    expect(err.message).toBe('Could not retrieve dependent story files.\nstats file not found');
   });
 });

--- a/node-src/tasks/prepare/traceChangedFiles.ts
+++ b/node-src/tasks/prepare/traceChangedFiles.ts
@@ -50,16 +50,15 @@ export async function traceChangedFiles(
     }
 
     ctx.turboSnap = result.turboSnap;
-    if (result.changedDependencyNames) {
-      ctx.git.changedDependencyNames = result.changedDependencyNames;
-    }
-    if (result.untracedFiles) {
-      ctx.untracedFiles = result.untracedFiles;
-    }
 
     if (result.status === 'bailed') {
       deps.report(bailed({ turboSnap: result.turboSnap }));
       return {};
+    }
+
+    ctx.untracedFiles = result.untracedFiles;
+    if (result.changedDependencyNames) {
+      ctx.git.changedDependencyNames = result.changedDependencyNames;
     }
 
     // Escape special characters in the filename so it does not conflict with picomatch

--- a/node-src/tasks/prepare/traceChangedFiles.ts
+++ b/node-src/tasks/prepare/traceChangedFiles.ts
@@ -1,9 +1,8 @@
 import * as turbosnap from '@cli/turbosnap';
-import semver from 'semver';
+import { MissingStatsFileError } from '@cli/turbosnap';
 
 import { groupUntracedFilesByGlob, rewriteErrorMessage } from '../../lib/utilities';
 import { Context, Deps } from '../../types';
-import missingStatsFile from '../../ui/messages/errors/missingStatsFile';
 import { bailed, traced, tracing } from '../../ui/tasks/prepare';
 
 // These are the special characters that need to be escaped in the filename
@@ -12,9 +11,8 @@ const SPECIAL_CHARS_REGEXP = /([$()*+?[\]^])/g;
 type TraceChangedFilesDeps = Pick<Deps, 'log' | 'options' | 'report'>;
 
 export interface TraceChangedFilesInput {
-  // The TurboSnap lib still reads and mutates `Context` directly. This is a deliberate escape hatch,
-  // as refactoring the whole `lib/turbosnap` tree to `(deps, input)` is a large lift. We should
-  // revisit it, but for now `lib/turbosnap.traceChangedFiles` still takes a Context.
+  // The TurboSnap lib still reads `Context` (options, git, log), but no longer mutates it; this
+  // function is the single place trace results get written back onto the context.
   turboSnapContext: Context;
 }
 
@@ -27,14 +25,14 @@ export interface TraceChangedFilesOutput {
  * Analyzes changed files to determine which stories need to be tested.
  *
  * @param deps - Logger, options, and the mid-task reporter.
- * @param input - The CLI context the TurboSnap lib reads and mutates.
+ * @param input - The CLI context the TurboSnap lib reads; trace results are written back to it.
  *
  * @returns The affected story files, or none when TurboSnap is unavailable or bailed.
  *
  * @throws {Error} if stats file is missing or tracing fails
  */
 // TODO: refactor this function
-// eslint-disable-next-line complexity
+// eslint-disable-next-line max-statements, complexity
 export async function traceChangedFiles(
   deps: TraceChangedFilesDeps,
   input: TraceChangedFilesInput
@@ -43,53 +41,55 @@ export async function traceChangedFiles(
 
   if (!ctx.turboSnap || ctx.turboSnap.unavailable) return {};
   if (!ctx.git.changedFiles) return {};
-  if (!ctx.fileInfo?.statsPath) {
-    // If we don't know the SB version, we should assume we don't support `--stats-json`
-    const nonLegacyStatsSupported =
-      ctx.storybook?.version &&
-      semver.gte(semver.coerce(ctx.storybook.version) || '0.0.0', '8.0.0');
-
-    ctx.turboSnap.bailReason = { missingStatsFile: true };
-    throw new Error(missingStatsFile({ legacy: !nonLegacyStatsSupported }));
-  }
 
   deps.report(tracing({ git: ctx.git, options: deps.options }));
 
-  const { statsPath } = ctx.fileInfo;
-  const { changedFiles } = ctx.git;
-
   try {
-    const onlyStoryFiles = await turbosnap.traceChangedFiles(ctx);
-    if (onlyStoryFiles) {
-      // Escape special characters in the filename so it does not conflict with picomatch
-      const escaped = Object.keys(onlyStoryFiles).map((key) =>
-        key.replaceAll(SPECIAL_CHARS_REGEXP, String.raw`\$1`)
-      );
-
-      if (!deps.options.interactive) {
-        if (!deps.options.traceChanged) {
-          deps.log.info(
-            `Found affected story files:\n${Object.entries(onlyStoryFiles)
-              .flatMap(([id, files]) => files.map((f) => `  ${f} [${id}]`))
-              .join('\n')}`
-          );
-        }
-        if (ctx.untracedFiles && ctx.untracedFiles.length > 0) {
-          deps.log.info(
-            `Encountered ${ctx.untracedFiles.length} untraced files:\n${groupUntracedFilesByGlob(
-              ctx.untracedFiles
-            )}`
-          );
-        }
-      }
-      deps.report(traced({ options: deps.options, onlyStoryFiles: escaped }));
-      return { onlyStoryFiles: escaped };
+    const result = await turbosnap.traceChangedFiles(ctx);
+    if (result.status === 'skipped') {
+      return {};
     }
 
-    deps.report(bailed({ turboSnap: ctx.turboSnap }));
-    return {};
+    ctx.turboSnap = result.turboSnap;
+    if (result.changedDependencyNames) {
+      ctx.git.changedDependencyNames = result.changedDependencyNames;
+    }
+    if (result.untracedFiles) {
+      ctx.untracedFiles = result.untracedFiles;
+    }
+
+    if (result.status === 'bailed') {
+      deps.report(bailed({ turboSnap: result.turboSnap }));
+      return {};
+    }
+
+    // Escape special characters in the filename so it does not conflict with picomatch
+    const escaped = Object.keys(result.onlyStoryFiles).map((key) =>
+      key.replaceAll(SPECIAL_CHARS_REGEXP, String.raw`\$1`)
+    );
+
+    if (!deps.options.interactive) {
+      if (!deps.options.traceChanged) {
+        deps.log.info(
+          `Found affected story files:\n${Object.entries(result.onlyStoryFiles)
+            .flatMap(([id, files]) => files.map((f) => `  ${f} [${id}]`))
+            .join('\n')}`
+        );
+      }
+      if (result.untracedFiles.length > 0) {
+        deps.log.info(
+          `Encountered ${result.untracedFiles.length} untraced files:\n${groupUntracedFilesByGlob(
+            result.untracedFiles
+          )}`
+        );
+      }
+    }
+    deps.report(traced({ options: deps.options, onlyStoryFiles: escaped }));
+    return { onlyStoryFiles: escaped };
   } catch (err) {
     if (!deps.options.interactive) {
+      const { statsPath } = ctx.fileInfo ?? {};
+      const { changedFiles } = ctx.git;
       deps.log.info('Failed to retrieve dependent story files', { statsPath, changedFiles, err });
     }
     throw rewriteErrorMessage(err, `Could not retrieve dependent story files.\n${err.message}`);

--- a/node-src/tasks/prepare/traceChangedFiles.ts
+++ b/node-src/tasks/prepare/traceChangedFiles.ts
@@ -1,5 +1,4 @@
 import * as turbosnap from '@cli/turbosnap';
-import { MissingStatsFileError } from '@cli/turbosnap';
 
 import { groupUntracedFilesByGlob, rewriteErrorMessage } from '../../lib/utilities';
 import { Context, Deps } from '../../types';
@@ -32,7 +31,7 @@ export interface TraceChangedFilesOutput {
  * @throws {Error} if stats file is missing or tracing fails
  */
 // TODO: refactor this function
-// eslint-disable-next-line max-statements, complexity
+// eslint-disable-next-line complexity
 export async function traceChangedFiles(
   deps: TraceChangedFilesDeps,
   input: TraceChangedFilesInput

--- a/node-src/types.ts
+++ b/node-src/types.ts
@@ -549,7 +549,6 @@ interface TurboSnapBailReasonBase {
   changedStorybookFiles?: string[];
   changedStaticFiles?: string[];
   changedExternalFiles?: string[];
-  missingStatsFile?: true;
   noAncestorBuild?: true;
   rebuild?: true;
 }

--- a/node-src/types.ts
+++ b/node-src/types.ts
@@ -475,7 +475,7 @@ export interface Context {
   turboSnap?: TurboSnap;
   mergeBase?: string;
   onlyStoryFiles?: string[];
-  untracedFiles?: { filepath: string; glob: string }[];
+  untracedFiles?: UntracedFile[];
   rebuildForBuildId?: string;
 }
 
@@ -597,6 +597,11 @@ export type TurboSnapBailReason =
       changedPackageFiles?: never;
       invalidChangedFiles?: never;
     });
+
+export interface UntracedFile {
+  filepath: string;
+  glob: string;
+}
 
 export interface TurboSnap {
   unavailable?: boolean;

--- a/node-src/ui/messages/errors/missingStatsFile.ts
+++ b/node-src/ui/messages/errors/missingStatsFile.ts
@@ -5,7 +5,7 @@ import { error } from '../../components/icons';
 
 export default ({ legacy }: { legacy: boolean }) =>
   dedent(chalk`
-    ${error} {bold TurboSnap disabled due to missing stats file}
+    ${error} {bold TurboSnap requires a stats file}
     Did not find {bold preview-stats.json} in your built Storybook.
     Make sure you pass {bold ${
       legacy ? `--webpack-stats-json` : `--stats-json`


### PR DESCRIPTION
TurboSnap can be hard to reason about because we read and mutate a massive context object throughout the trace. This PR focuses on pulling out the mutations so we return TurboSnap results instead. Doing this will make it easier to reason about and extend later.

I also did some clean up on the missing stats file bail because it actually just fails the build.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>18.1.1--canary.1417.29849782362.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@18.1.1--canary.1417.29849782362.0
  # or 
  yarn add chromatic@18.1.1--canary.1417.29849782362.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
