### PR TITLE
TurboSnap: Skipped -> Bypassed

### DIFF
--- a/node-src/ui/messages/info/turboSnapEnabled.ts
+++ b/node-src/ui/messages/info/turboSnapEnabled.ts
@@ -18,7 +18,7 @@ export default ({
       : 'snapshots';
     return dedent(chalk`
       ${success} {bold TurboSnap enabled}
-      Skipped capturing ${skipped} because no frontend files were changed.
+      Bypassed ${skipped} because no frontend files were changed.
     `);
   }
 


### PR DESCRIPTION
We're updating our verbiage from "Skipped" snapshots to "Bypassed" snapshots. Just a UI change to match the webapp!

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>18.2.0--canary.1419.29849780602.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@18.2.0--canary.1419.29849780602.0
  # or 
  yarn add chromatic@18.2.0--canary.1419.29849780602.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
