### PR TITLE
Support more `.storybook/main` config structures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ node_modules
 !.yarn/versions
 
 storybook-static
+!node-src/__mocks__/**/storybook-static/
 test-storybook
 chromatic-build-*.xml
 chromatic-diagnostics.json

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -24,6 +24,8 @@ export default [
       'storybook-out/**',
       'coverage/**',
       'smoke-tests/**',
+      // Storybook config fixtures: intentionally a mix of module formats, so linting them is noise.
+      'node-src/__mocks__/storybookMainConfig/**',
     ],
   },
   // eslint core + overrides

--- a/node-src/__mocks__/storybookMainConfig/builder-js-esm/.storybook/main.js
+++ b/node-src/__mocks__/storybookMainConfig/builder-js-esm/.storybook/main.js
@@ -1,0 +1,1 @@
+export default { framework: { name: '@storybook/react-vite' } };

--- a/node-src/__mocks__/storybookMainConfig/builder-js-esm/package.json
+++ b/node-src/__mocks__/storybookMainConfig/builder-js-esm/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "fixture-builder-js-esm",
+  "type": "module"
+}

--- a/node-src/__mocks__/storybookMainConfig/cjs/.storybook/main.cjs
+++ b/node-src/__mocks__/storybookMainConfig/cjs/.storybook/main.cjs
@@ -1,0 +1,1 @@
+module.exports = { staticDirs: ['./static', '../public'] };

--- a/node-src/__mocks__/storybookMainConfig/cjs/package.json
+++ b/node-src/__mocks__/storybookMainConfig/cjs/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "fixture-cjs"
+}

--- a/node-src/__mocks__/storybookMainConfig/cjs/storybook-static/project.json
+++ b/node-src/__mocks__/storybookMainConfig/cjs/storybook-static/project.json
@@ -1,0 +1,66 @@
+{
+  "generatedAt": 1717341501873,
+  "builder": {
+    "name": "webpack4"
+  },
+  "hasCustomBabel": false,
+  "hasCustomWebpack": true,
+  "hasStaticDirs": true,
+  "hasStorybookEslint": false,
+  "refCount": 0,
+  "monorepo": "Turborepo",
+  "packageManager": {
+    "type": "yarn",
+    "version": "1.22.19"
+  },
+  "features": {
+    "postcss": false,
+    "interactionsDebugger": true,
+    "warnOnLegacyHierarchySeparator": false
+  },
+  "storybookVersion": "6.5.16",
+  "language": "javascript",
+  "storybookPackages": {
+    "@storybook/addon-actions": {
+      "version": "6.5.16"
+    },
+    "@storybook/addons": {
+      "version": "6.5.16"
+    },
+    "@storybook/builder-webpack4": {
+      "version": "6.5.16"
+    },
+    "@storybook/manager-webpack4": {
+      "version": "6.5.16"
+    },
+    "@storybook/react": {
+      "version": "6.5.16"
+    },
+    "@storybook/testing-library": {
+      "version": "0.0.13"
+    },
+    "@storybook/theming": {
+      "version": "6.5.16"
+    },
+    "msw-storybook-addon": {
+      "version": "1.7.0"
+    },
+    "storybook-mock-date-decorator": {
+      "version": "1.0.0"
+    }
+  },
+  "framework": {
+    "name": "react"
+  },
+  "addons": {
+    "@storybook/addon-links": {
+      "version": "6.5.16"
+    },
+    "@storybook/addon-essentials": {
+      "version": "6.5.16"
+    },
+    "@storybook/addon-interactions": {
+      "version": "6.5.16"
+    }
+  }
+}

--- a/node-src/__mocks__/storybookMainConfig/js-cjs/.storybook/main.js
+++ b/node-src/__mocks__/storybookMainConfig/js-cjs/.storybook/main.js
@@ -1,0 +1,1 @@
+module.exports = { staticDirs: ['./static', '../public'] };

--- a/node-src/__mocks__/storybookMainConfig/js-cjs/package.json
+++ b/node-src/__mocks__/storybookMainConfig/js-cjs/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "fixture-js-cjs"
+}

--- a/node-src/__mocks__/storybookMainConfig/js-cjs/storybook-static/project.json
+++ b/node-src/__mocks__/storybookMainConfig/js-cjs/storybook-static/project.json
@@ -1,0 +1,29 @@
+{
+  "generatedAt": 1716299331397,
+  "hasCustomBabel": false,
+  "hasCustomWebpack": true,
+  "hasStaticDirs": true,
+  "hasStorybookEslint": false,
+  "refCount": 0,
+  "packageManager": { "type": "yarn", "version": "1.22.19" },
+  "typescriptOptions": { "reactDocgen": "react-docgen-typescript" },
+  "preview": { "usesGlobals": false },
+  "framework": { "name": "@storybook/react-webpack5", "options": {}, "version": "8.1.5" },
+  "builder": "@storybook/builder-webpack5",
+  "renderer": "@storybook/react",
+  "storybookVersion": "8.1.5",
+  "storybookVersionSpecifier": "^8.1.5",
+  "language": "typescript",
+  "storybookPackages": {
+    "@storybook/csf-tools": { "version": "8.1.5" },
+    "@storybook/linter-config": { "version": "4.0.0" },
+    "@storybook/react": { "version": "8.1.5" },
+    "@storybook/react-webpack5": { "version": "8.1.5" },
+    "storybook": { "version": "8.1.5" }
+  },
+  "addons": {
+    "@storybook/addon-essentials": { "version": "8.1.5" },
+    "@storybook/addon-webpack5-compiler-swc": { "version": "1.0.2" },
+    "chromatic": { "version": "11.4.0", "versionSpecifier": "latest" }
+  }
+}

--- a/node-src/__mocks__/storybookMainConfig/js-esm/.storybook/main.js
+++ b/node-src/__mocks__/storybookMainConfig/js-esm/.storybook/main.js
@@ -1,0 +1,1 @@
+export default { staticDirs: ['./static', '../public'] };

--- a/node-src/__mocks__/storybookMainConfig/js-esm/package.json
+++ b/node-src/__mocks__/storybookMainConfig/js-esm/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "fixture-js-esm",
+  "type": "module"
+}

--- a/node-src/__mocks__/storybookMainConfig/mjs-esm/.storybook/main.mjs
+++ b/node-src/__mocks__/storybookMainConfig/mjs-esm/.storybook/main.mjs
@@ -1,0 +1,1 @@
+export default { staticDirs: ['./static', '../public'] };

--- a/node-src/__mocks__/storybookMainConfig/mjs-esm/package.json
+++ b/node-src/__mocks__/storybookMainConfig/mjs-esm/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "fixture-mjs-esm"
+}

--- a/node-src/__mocks__/storybookMainConfig/ts-esm/.storybook/main.ts
+++ b/node-src/__mocks__/storybookMainConfig/ts-esm/.storybook/main.ts
@@ -1,0 +1,1 @@
+export default { staticDirs: ['./static', '../public'] };

--- a/node-src/__mocks__/storybookMainConfig/ts-esm/package.json
+++ b/node-src/__mocks__/storybookMainConfig/ts-esm/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "fixture-ts-esm"
+}

--- a/node-src/lib/getOptions.test.ts
+++ b/node-src/lib/getOptions.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it, vi } from 'vitest';
 
 import { Context } from '../types';
 import getEnvironment from './getEnvironment';
-import getOptions from './getOptions';
+import getOptions, { findBuildScriptName } from './getOptions';
 import parseArguments from './parseArguments';
 import TestLogger from './testLogger';
 
@@ -333,5 +333,21 @@ describe('getOptions', () => {
     expect(getOptions(getContext(['--diagnostics-file', 'output.json']))).toMatchObject({
       diagnosticsFile: 'output.json',
     });
+  });
+});
+
+describe('findBuildScriptName', () => {
+  it('prefers the user-configured name', () => {
+    expect(findBuildScriptName({ 'build-storybook': 'build-storybook' }, 'custom')).toBe('custom');
+  });
+
+  it('falls back to a script that runs build-storybook under another name', () => {
+    expect(findBuildScriptName({ otherBuildStorybook: 'build-storybook --stats-json' })).toBe(
+      'otherBuildStorybook'
+    );
+  });
+
+  it('names the conventional script when there is nothing to find', () => {
+    expect(findBuildScriptName({ lint: 'eslint .' })).toBe('build-storybook');
   });
 });

--- a/node-src/lib/getOptions.ts
+++ b/node-src/lib/getOptions.ts
@@ -315,7 +315,6 @@ export const getPartialOptions = (ctx: InitialContext): Partial<Options> => {
  * @returns An object containing parsed options
  */
 // TODO: refactor this function
-// eslint-disable-next-line complexity
 export default function getOptions(
   ctx: InitialContext,
   partialOptions = getPartialOptions(ctx)
@@ -354,17 +353,7 @@ export default function getOptions(
     process.exit(252);
   }
 
-  const { scripts } = packageJson;
-  if (typeof buildScriptName !== 'string') {
-    buildScriptName = 'build-storybook';
-    if (!scripts[buildScriptName]) {
-      const [key] =
-        Object.entries(scripts as Record<string, string>).find(([, script]) =>
-          script.startsWith('build-storybook')
-        ) || [];
-      if (key) buildScriptName = key;
-    }
-  }
+  buildScriptName = findBuildScriptName(packageJson.scripts, buildScriptName);
 
   // The missingBuildScriptName throw that previously lived here has moved to
   // storybookInfo.ts, where it is gated on !isReactNativeApp. It could not remain
@@ -373,4 +362,29 @@ export default function getOptions(
   // getStorybookMetadata reads options.buildScriptName during the storybookInfo task
   // and needs the value resolved before that task runs.
   return { ...options, buildScriptName };
+}
+
+/**
+ * Resolves the package.json script that builds Storybook.
+ *
+ * @param scripts The project's package.json scripts.
+ * @param buildScriptName The script name the user asked for, if any.
+ *
+ * @returns The user's script name, or the one that looks like a Storybook build.
+ */
+export function findBuildScriptName(
+  scripts: Record<string, string> = {},
+  buildScriptName?: string
+) {
+  if (buildScriptName) {
+    return buildScriptName;
+  }
+
+  if (scripts['build-storybook']) {
+    return 'build-storybook';
+  }
+
+  const [key] =
+    Object.entries(scripts).find(([, command]) => command.startsWith('build-storybook')) || [];
+  return key ?? 'build-storybook';
 }

--- a/node-src/lib/getStorybookInfo.test.ts
+++ b/node-src/lib/getStorybookInfo.test.ts
@@ -2,6 +2,12 @@ import TestLogger from '@cli/testLogger';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import getStorybookInfo from './getStorybookInfo';
+import { getStorybookMetadata } from './getStorybookMetadata';
+
+vi.mock('./getStorybookMetadata', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./getStorybookMetadata')>();
+  return { ...actual, getStorybookMetadata: vi.fn(actual.getStorybookMetadata) };
+});
 
 vi.useFakeTimers();
 
@@ -120,7 +126,20 @@ describe('getStorybookInfo', () => {
   });
 
   describe('with --storybook-build-dir', () => {
-    it('returns version from packageJson', async () => {
+    it('combines prebuilt metadata with static directories derived from source', async () => {
+      const ctx = getContext({
+        options: { storybookBuildDir: 'bin-src/__mocks__/normalProjectJson' },
+        packageJson: { dependencies: REACT },
+      });
+      expect(await getStorybookInfo(ctx)).toEqual({
+        builder: { name: '@storybook/builder-webpack5', packageVersion: expect.any(String) },
+        staticDir: ['static'],
+        version: expect.any(String),
+      });
+    });
+
+    it('still returns prebuilt metadata when the source config cannot be read', async () => {
+      vi.mocked(getStorybookMetadata).mockRejectedValueOnce(new Error('no source config'));
       const ctx = getContext({
         options: { storybookBuildDir: 'bin-src/__mocks__/normalProjectJson' },
         packageJson: { dependencies: REACT },
@@ -146,6 +165,7 @@ describe('getStorybookInfo', () => {
       });
       expect(await getStorybookInfo(ctx)).toEqual({
         builder: { name: 'webpack4', packageVersion: '6.5.16' },
+        staticDir: ['static'],
         version: '6.5.16',
       });
     });

--- a/node-src/lib/getStorybookInfo.test.ts
+++ b/node-src/lib/getStorybookInfo.test.ts
@@ -18,6 +18,8 @@ const getContext = (overrides: any) => ({ ...baseDeps, ...overrides });
 const REACT = { '@storybook/react': '1.2.3' };
 const VUE = { '@storybook/vue': '1.2.3' };
 
+const FIXTURES = 'node-src/__mocks__/storybookMainConfig';
+
 afterEach(() => {
   log.info.mockReset();
   log.warn.mockReset();
@@ -128,12 +130,15 @@ describe('getStorybookInfo', () => {
   describe('with --storybook-build-dir', () => {
     it('combines prebuilt metadata with static directories derived from source', async () => {
       const ctx = getContext({
-        options: { storybookBuildDir: 'bin-src/__mocks__/normalProjectJson' },
+        options: {
+          storybookBuildDir: `${FIXTURES}/js-cjs/storybook-static`,
+          storybookConfigDir: `${FIXTURES}/js-cjs/.storybook`,
+        },
         packageJson: { dependencies: REACT },
       });
       expect(await getStorybookInfo(ctx)).toEqual({
         builder: { name: '@storybook/builder-webpack5', packageVersion: expect.any(String) },
-        staticDir: ['static'],
+        staticDir: [`${FIXTURES}/js-cjs/.storybook/static`, `${FIXTURES}/js-cjs/public`],
         version: expect.any(String),
       });
     });
@@ -141,7 +146,10 @@ describe('getStorybookInfo', () => {
     it('still returns prebuilt metadata when the source config cannot be read', async () => {
       vi.mocked(getStorybookMetadata).mockRejectedValueOnce(new Error('no source config'));
       const ctx = getContext({
-        options: { storybookBuildDir: 'bin-src/__mocks__/normalProjectJson' },
+        options: {
+          storybookBuildDir: `${FIXTURES}/js-cjs/storybook-static`,
+          storybookConfigDir: `${FIXTURES}/js-cjs/.storybook`,
+        },
         packageJson: { dependencies: REACT },
       });
       expect(await getStorybookInfo(ctx)).toEqual({
@@ -160,12 +168,15 @@ describe('getStorybookInfo', () => {
 
     it('returns the correct metadata for Storybook 6', async () => {
       const ctx = getContext({
-        options: { storybookBuildDir: 'bin-src/__mocks__/sb6ProjectJson' },
+        options: {
+          storybookBuildDir: `${FIXTURES}/cjs/storybook-static`,
+          storybookConfigDir: `${FIXTURES}/cjs/.storybook`,
+        },
         packageJson: { dependencies: REACT },
       });
       expect(await getStorybookInfo(ctx)).toEqual({
         builder: { name: 'webpack4', packageVersion: '6.5.16' },
-        staticDir: ['static'],
+        staticDir: [`${FIXTURES}/cjs/.storybook/static`, `${FIXTURES}/cjs/public`],
         version: '6.5.16',
       });
     });

--- a/node-src/lib/getStorybookInfo.ts
+++ b/node-src/lib/getStorybookInfo.ts
@@ -22,11 +22,21 @@ export default async function getStorybookInfo(
       const projectJsonPath = path.resolve(deps.options.storybookBuildDir, 'project.json');
       // This test makes sure we fall through if the file does not exist.
       if (pathExistsSync(projectJsonPath)) {
+        // Reading the source config is best-effort: a prebuilt Storybook may not ship one, and its
+        // failure must not stop us reading project.json.
+        let sourceMetadata: Partial<Storybook> = {};
+        try {
+          sourceMetadata = await getStorybookMetadata(deps);
+        } catch (err) {
+          deps.log.debug(err);
+        }
+
         /*
           This await is needed in order to for the catch block
           to get the result in the case that this function fails.
         */
-        return await getStorybookMetadataFromProjectJson(projectJsonPath);
+        const prebuiltMetadata = await getStorybookMetadataFromProjectJson(projectJsonPath);
+        return { ...sourceMetadata, ...prebuiltMetadata };
       }
     }
     // Same for this await.

--- a/node-src/lib/getStorybookMetadata.test.ts
+++ b/node-src/lib/getStorybookMetadata.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 
-import { findStaticDirectories } from './getStorybookMetadata';
+import { findStaticDirectories, getStorybookMetadata } from './getStorybookMetadata';
 
 const makeConfig = (returnValue: any) => ({
   getSafeFieldValue: vi.fn().mockReturnValue(returnValue),
@@ -50,9 +50,16 @@ describe('findStaticDirs', () => {
     expect(findStaticDirectories(config, true)).toEqual({});
   });
 
-  it('returns {} when v7 is false', () => {
-    const config = makeConfig(['./static']);
-    expect(findStaticDirectories(config, false)).toEqual({});
+  it('reads staticDirs off an evaluated CommonJS config module', () => {
+    expect(findStaticDirectories({ staticDirs: ['./static'] }, false)).toEqual({
+      staticDir: ['.storybook/static'],
+    });
+  });
+
+  it('reads staticDirs off the default export of an evaluated ESM config module', () => {
+    expect(findStaticDirectories({ default: { staticDirs: ['./static'] } }, false)).toEqual({
+      staticDir: ['.storybook/static'],
+    });
   });
 
   it('returns {} when mainConfig is null', () => {
@@ -72,5 +79,44 @@ describe('findStaticDirs', () => {
   it('returns {} when all entries have no valid path', () => {
     const config = makeConfig([null, undefined, { to: '/' }]);
     expect(findStaticDirectories(config, true)).toEqual({});
+  });
+});
+
+// Each fixture is a real project directory, because whether `require()` of the config succeeds
+// depends on the file's extension and the nearest package.json `type`.
+const FIXTURES = 'node-src/__mocks__/storybookMainConfig';
+
+function getDeps(project: string) {
+  return {
+    log: { debug: vi.fn(), info: vi.fn(), warn: vi.fn() },
+    options: { storybookConfigDir: `${FIXTURES}/${project}/.storybook` },
+    // Pinned so the viewlayer lookup can't reach into this repo's own node_modules.
+    env: { CHROMATIC_STORYBOOK_VERSION: '@storybook/react@8.0.0' },
+    packageJson: {},
+  } as any;
+}
+
+describe('getStorybookMetadata staticDirs discovery', () => {
+  it.each([
+    { project: 'ts-esm', file: 'main.ts', format: 'esm' },
+    { project: 'js-esm', file: 'main.js', format: 'esm' },
+    { project: 'js-cjs', file: 'main.js', format: 'cjs' },
+    { project: 'mjs-esm', file: 'main.mjs', format: 'esm' },
+    { project: 'cjs', file: 'main.cjs', format: 'cjs' },
+  ])('resolves staticDirs from $file ($format)', async ({ project }) => {
+    const metadata = await getStorybookMetadata(getDeps(project));
+
+    expect(metadata.staticDir).toEqual([
+      `${FIXTURES}/${project}/.storybook/static`,
+      `${FIXTURES}/${project}/public`,
+    ]);
+  });
+});
+
+describe('getStorybookMetadata builder discovery', () => {
+  it('detects the builder from an evaluated ESM config module', async () => {
+    const metadata = await getStorybookMetadata(getDeps('builder-js-esm'));
+
+    expect(metadata.builder?.name).toBe('@storybook/react-vite');
   });
 });

--- a/node-src/lib/getStorybookMetadata.ts
+++ b/node-src/lib/getStorybookMetadata.ts
@@ -114,15 +114,20 @@ const findStorybookVersion = async ({ env, log, options, packageJson }: Storyboo
   ]);
 };
 
-const findConfigFlags = async ({
-  options,
-  packageJson,
-}: Pick<StorybookInfoDeps, 'options' | 'packageJson'>) => {
-  const { scripts = {} } = packageJson;
-  if (!options.buildScriptName || !scripts[options.buildScriptName]) return {};
+/**
+ * Reads the `-c` and `-s` flags out of the project's Storybook build script.
+ *
+ * @param deps The resolved options and the project's package.json.
+ *
+ * @returns The config directory and static directories the build script names, if any.
+ */
+export const findConfigFlags = async (deps: Pick<StorybookInfoDeps, 'options' | 'packageJson'>) => {
+  const { buildScriptName } = deps.options;
+  const { scripts = {} } = deps.packageJson;
+  if (!buildScriptName || !scripts[buildScriptName]) return {};
 
   const { flags } = meow({
-    argv: parseArgsStringToArgv(scripts[options.buildScriptName]),
+    argv: parseArgsStringToArgv(scripts[buildScriptName]),
     flags: {
       configDir: { type: 'string', alias: 'c' },
       staticDir: { type: 'string', alias: 's' },
@@ -131,19 +136,35 @@ const findConfigFlags = async ({
 
   return {
     configDir: flags.configDir,
-    staticDir: flags.staticDir && flags.staticDir.split(','),
+    staticDir: flags.staticDir ? flags.staticDir.split(',') : undefined,
   };
 };
 
-// TODO: refactor this function
-// eslint-disable-next-line complexity
-export const findBuilder = async (mainConfig, v7) => {
+/**
+ * Reads a top-level field out of the main config, in either of the two forms it can take.
+ *
+ * An evaluated module exposes its fields as plain properties, nested under `default` for ESM. A
+ * parsed AST answers `getSafeFieldValue` instead.
+ *
+ * @param mainConfig The main config, either an evaluated module or a parsed AST.
+ * @param isAstConfig Whether `mainConfig` is a parsed AST rather than an evaluated module.
+ * @param field The top-level field to read.
+ *
+ * @returns The field's value, or `undefined` when it is absent.
+ */
+export const readMainConfigField = (mainConfig: any, isAstConfig: boolean, field: string) => {
+  if (!mainConfig) return undefined;
+  if (isAstConfig) return mainConfig.getSafeFieldValue([field]);
+  return mainConfig.default?.[field] ?? mainConfig[field];
+};
+
+export const findBuilder = async (mainConfig, isAstConfig) => {
   if (!mainConfig) {
     return { builder: { name: 'unknown', packageVersion: '0' } };
   }
 
-  const framework = v7 ? mainConfig.getSafeFieldValue(['framework']) : mainConfig?.framework;
-  const core = v7 ? mainConfig.getSafeFieldValue(['core']) : mainConfig?.core;
+  const framework = readMainConfigField(mainConfig, isAstConfig, 'framework');
+  const core = readMainConfigField(mainConfig, isAstConfig, 'core');
 
   if (framework?.name) {
     const sbV7BuilderName = framework.name;
@@ -177,24 +198,31 @@ export const findBuilder = async (mainConfig, v7) => {
 // TODO: Update this when we start tracking refs within the project.json file; if refs are tracked there, we can skip this logic
 // Only used by Chromatic - surfaces Storybook refs and is used when announcing a build.
 // The refs are consumed by the MCP Addon for hosted Storybooks with composition on Chromatic.
-const findReferences = async (mainConfig, v7) => {
+const findReferences = async (mainConfig, isAstConfig) => {
   // The MCP Addon was first added within version 9; there is no need to check for older versions
-  if (!mainConfig || !v7) {
+  if (!mainConfig || !isAstConfig) {
     return {};
   }
 
-  const references = mainConfig.getSafeFieldValue(['refs']);
+  const references = readMainConfigField(mainConfig, isAstConfig, 'refs');
   return references ? { refs: references } : {};
 };
 
+/**
+ * Resolves the project-relative static directories declared by the main config.
+ *
+ * @param mainConfig The main config, either an evaluated module or a parsed AST.
+ * @param isAstConfig Whether `mainConfig` is a parsed AST rather than an evaluated module.
+ * @param configDirectory The project-relative Storybook config directory entries resolve against.
+ *
+ * @returns The resolved static directories, or `{}` when the config declares none.
+ */
 export const findStaticDirectories = (
   mainConfig: any,
-  v7: boolean,
+  isAstConfig: boolean,
   configDirectory = '.storybook'
 ): { staticDir?: string[] } => {
-  if (!mainConfig || !v7) return {};
-
-  const staticDirectories = mainConfig.getSafeFieldValue(['staticDirs']);
+  const staticDirectories = readMainConfigField(mainConfig, isAstConfig, 'staticDirs');
   if (!Array.isArray(staticDirectories) || staticDirectories.length === 0) return {};
 
   // staticDirs entries can be plain strings or { from, to } DirectoryMapping objects
@@ -221,47 +249,62 @@ export const findStorybookConfigFile = async (
   return configFile && path.join(configDirectory, configFile);
 };
 
-// TODO: refactor this function
-export const getStorybookMetadata = async (
-  deps: StorybookInfoDeps
-  // eslint-disable-next-line complexity
-): Promise<Partial<Storybook>> => {
-  const configDirectory = deps.options.storybookConfigDir ?? '.storybook';
-
+/**
+ * Loads the Storybook main config, as either an evaluated module or a parsed AST.
+ *
+ * Which form we get depends on whether `require()` of the config succeeds.
+ *
+ * @param configDirectory The Storybook config directory, absolute or relative to the cwd.
+ * @param log The logger to report the parse path to.
+ *
+ * @returns The config and whether it is a parsed AST; no config when neither path succeeded.
+ */
+export const readMainConfig = async (
+  configDirectory: string,
+  log: StorybookInfoDeps['log']
+): Promise<{ mainConfig?: any; isAstConfig: boolean }> => {
   // @ts-expect-error __non_webpack_require__ is only defined when bundled with webpack, and allows us to bypass webpack's module system to require files at runtime
   // eslint-disable-next-line unicorn/prefer-module
   const r = typeof __non_webpack_require__ === 'undefined' ? require : __non_webpack_require__;
 
-  let mainConfig;
-  let v7 = false;
   try {
-    mainConfig = await r(path.resolve(configDirectory, 'main'));
-    deps.log.debug({ configDirectory, mainConfig });
+    const mainConfig = await r(path.resolve(configDirectory, 'main'));
+    log.debug({ configDirectory, mainConfig });
+    return { mainConfig, isAstConfig: false };
   } catch (err) {
-    deps.log.debug({ storybookV6error: err });
-    try {
-      const storybookConfig = await findStorybookConfigFile(
-        deps.options.storybookConfigDir,
-        /^main\.[jt]sx?$/
-      );
-      if (!storybookConfig) {
-        throw new Error('Failed to locate Storybook config file');
-      }
-
-      mainConfig = await readConfig(storybookConfig);
-      deps.log.debug({ configDirectory, mainConfig: printConfig(mainConfig) });
-      v7 = true;
-    } catch (err) {
-      deps.log.debug({ storybookV7error: err });
-    }
+    log.debug({ storybookV6error: err });
   }
+
+  try {
+    // Include `.mjs` and `.cjs` can't be resolved in the step above because `require()` only
+    // auto-appends `.js`/`.json`/`.node` to an extensionless path.
+    const storybookConfig = await findStorybookConfigFile(configDirectory, /^main\.[cm]?[jt]sx?$/);
+    if (!storybookConfig) {
+      throw new Error('Failed to locate Storybook config file');
+    }
+
+    const mainConfig = await readConfig(storybookConfig);
+    log.debug({ configDirectory, mainConfig: printConfig(mainConfig) });
+    return { mainConfig, isAstConfig: true };
+  } catch (err) {
+    log.debug({ storybookV7error: err });
+    return { isAstConfig: false };
+  }
+};
+
+// TODO: refactor this function
+export const getStorybookMetadata = async (
+  deps: StorybookInfoDeps
+): Promise<Partial<Storybook>> => {
+  const configDirectory = deps.options.storybookConfigDir ?? '.storybook';
+  const { mainConfig, isAstConfig } = await readMainConfig(configDirectory, deps.log);
 
   const info = await Promise.allSettled([
     findConfigFlags(deps),
     findStorybookVersion(deps),
-    findBuilder(mainConfig, v7),
-    findReferences(mainConfig, v7),
-    findStaticDirectories(mainConfig, v7, configDirectory),
+    findBuilder(mainConfig, isAstConfig),
+    findReferences(mainConfig, isAstConfig),
+    findStaticDirectories(mainConfig, isAstConfig, configDirectory),
   ]);
 
   deps.log.debug(info);


### PR DESCRIPTION
When we started reading the `.storybook/main` config file, we looked at some specific formats. In TurboSnap 2.0, we need to determine static directories and such so we need to expand the structures we support to read more flavors of the config file to give us a better chance at resolving the Storybook config details.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>18.2.1--canary.1424.31514307173.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@18.2.1--canary.1424.31514307173.0
  # or 
  yarn add chromatic@18.2.1--canary.1424.31514307173.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
