### PR TITLE
Bound `getFileHashes` peak memory by concurrency

### DIFF
--- a/node-src/lib/getFileHashes.ts
+++ b/node-src/lib/getFileHashes.ts
@@ -59,12 +59,14 @@ export const getFileHashes = async (files: string[], directory: string, concurre
   const limit = pLimit(concurrency);
   const xxhash = await xxHashWasm();
 
-  // Pre-allocate a 64K buffer for each file, matching WASM memory page size.
-  const buffers = files.map((file) => [Buffer.allocUnsafe(64 * 1024), file] as const);
-
   const hashes = await Promise.all(
-    buffers.map(([buffer, file]) =>
-      limit(async () => [file, await hashFile(buffer, path.join(directory, file), xxhash)] as const)
+    files.map((file) =>
+      limit(async () => {
+        // Allocate the 64K read buffer (matching WASM memory page size) inside the limit, so peak
+        // memory is bounded by `concurrency` rather than by the number of files.
+        const buffer = Buffer.allocUnsafe(64 * 1024);
+        return [file, await hashFile(buffer, path.join(directory, file), xxhash)] as const;
+      })
     )
   );
 


### PR DESCRIPTION
TurboSnap 2.0 hashes more files than what we were doing for file deduplication so the memory requirements for running it increased. This restructures that setup to bound buffer creation to concurrency instead of the number of files.

We discussed this change and figured it was a simpler approach by leaning on the garbage collector to start. If we continue to see issues, we'll look at expanding it to a buffer pool (https://github.com/chromaui/chromatic-cli/pull/1259).
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>18.2.1--canary.1426.31514316468.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@18.2.1--canary.1426.31514316468.0
  # or 
  yarn add chromatic@18.2.1--canary.1426.31514316468.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
