### PR TITLE
Restore patch build functionality

### DIFF
--- a/node-src/index.test.ts
+++ b/node-src/index.test.ts
@@ -323,15 +323,31 @@ vi.mock('./git/git', () => ({
   getStorybookCreationDate: () => Promise.resolve(new Date('2025-11-01')),
   getNumberOfComitters: () => Promise.resolve(17),
   getCommittedFileCount: () => Promise.resolve(100),
+  isClean: vi.fn(),
+  isUpToDate: vi.fn(),
+  getUpdateMessage: vi.fn(),
+  findMergeBase: vi.fn(),
+  checkout: vi.fn(),
+  checkoutPrevious: vi.fn(),
+  discardChanges: vi.fn(),
 }));
 
 vi.mock('./git/getParentCommits', () => ({
   getParentCommits: () => Promise.resolve(['baseline']),
 }));
 
+vi.mock('./lib/installDependencies', () => ({
+  default: vi.fn(() => Promise.resolve('')),
+}));
+
 const getCommit = vi.mocked(git.getCommit);
 const getBranch = vi.mocked(git.getBranch);
 const getSlug = vi.mocked(git.getSlug);
+const isClean = vi.mocked(git.isClean);
+const isUpToDate = vi.mocked(git.isUpToDate);
+const findMergeBase = vi.mocked(git.findMergeBase);
+const checkout = vi.mocked(git.checkout);
+const checkoutPrevious = vi.mocked(git.checkoutPrevious);
 const expectSkipNoProjectToken = (ctx: ReturnType<typeof getContext>) => {
   expect(ctx.exitCode).toBe(0);
   expect(ctx.testLogger.warnings[0]).toMatch(
@@ -382,6 +398,11 @@ beforeEach(() => {
   });
   getBranch.mockResolvedValue('branch');
   getSlug.mockResolvedValue('user/repo');
+  isClean.mockResolvedValue(true);
+  isUpToDate.mockResolvedValue(true);
+  findMergeBase.mockResolvedValue('mergebasesha');
+  checkout.mockResolvedValue('');
+  checkoutPrevious.mockResolvedValue('');
 });
 afterEach(() => {
   process.env = processEnvironment;
@@ -487,6 +508,41 @@ it('runs in simple situations', async () => {
     committerEmail: 'test@test.com',
     committerName: 'tester',
     storybookUrl: 'https://5d67dc0374b2e300209c41e7-pfkaemtlit.chromatic.com/',
+  });
+});
+
+describe('with patch builds', () => {
+  it('checks out the merge base before gathering git info', async () => {
+    const callOrder: string[] = [];
+    checkout.mockImplementation(async () => {
+      callOrder.push('checkout');
+      return '';
+    });
+    getCommit.mockImplementation(async () => {
+      callOrder.push('getCommit');
+      return {
+        commit: 'commit',
+        committedAt: 1234,
+        committerEmail: 'test@test.com',
+        committerName: 'tester',
+      };
+    });
+
+    const ctx = getContext(['--project-token=asdf1234', '--patch-build=feature...main']);
+    await runAll(ctx);
+
+    expect(checkout).toHaveBeenCalledWith(expect.anything(), 'mergebasesha');
+    expect(callOrder.indexOf('checkout')).toBeLessThan(callOrder.indexOf('getCommit'));
+  });
+
+  it('restores the original branch even when a later step fails', async () => {
+    getCommit.mockRejectedValue(new Error('boom'));
+
+    const ctx = getContext(['--project-token=asdf1234', '--patch-build=feature...main']);
+    await runAll(ctx);
+
+    expect(checkout).toHaveBeenCalledWith(expect.anything(), 'mergebasesha');
+    expect(checkoutPrevious).toHaveBeenCalled();
   });
 });
 

--- a/node-src/index.ts
+++ b/node-src/index.ts
@@ -40,11 +40,13 @@ import { renderBuild } from './renderer/build';
 import { renderGitInfo } from './renderer/gitInfo';
 import { renderInitialize } from './renderer/initialize';
 import { renderPrepare } from './renderer/prepare';
+import { renderPrepareWorkspace } from './renderer/prepareWorkspace';
 import { renderSnapshot } from './renderer/snapshot';
 import { renderStorybookInfo } from './renderer/storybookInfo';
 import { renderUpload } from './renderer/upload';
 import { renderVerify } from './renderer/verify';
 import getTasks from './tasks';
+import { runRestoreWorkspace } from './tasks/restoreWorkspace';
 import { Context, Flags, Options } from './types';
 import { endActivity } from './ui/components/activity';
 import buildCanceled from './ui/messages/errors/buildCanceled';
@@ -350,6 +352,10 @@ async function runBuild(ctx: Context) {
         // Queue up any non-Listr log messages while Listr is running
         ctx.log.queue();
       }
+      // Check out the merge base before the rest of the pipeline runs against it.
+      if (ctx.options.patchHeadRef && ctx.options.patchBaseRef) {
+        await renderPrepareWorkspace(ctx);
+      }
       await renderAuth(ctx);
       await renderGitInfo(ctx);
       await renderStorybookInfo(ctx);
@@ -382,6 +388,22 @@ async function runBuild(ctx: Context) {
       }
       throw rewriteErrorMessage(err, taskError(ctx, err));
     } finally {
+      if (ctx.mergeBase) {
+        try {
+          // Always restore the original branch, even if the pipeline above failed partway
+          // through or set ctx.skip — called directly rather than through the render pipeline so
+          // it can't itself be short-circuited by ctx.skip.
+          await runRestoreWorkspace(ctx);
+        } catch (restoreError) {
+          // Never let a restore failure mask the original pipeline error, but the user does need
+          // to know their workspace may still be checked out on the merge base commit.
+          Sentry.captureException(restoreError);
+          ctx.log.error(
+            `Failed to restore your workspace to its original branch: ${restoreError.message}`
+          );
+        }
+      }
+
       // Handle potential runtime errors from JSDOM
       const { runtimeErrors, runtimeWarnings } = ctx;
       if (

--- a/node-src/renderer/prepareWorkspace.ts
+++ b/node-src/renderer/prepareWorkspace.ts
@@ -1,0 +1,30 @@
+import {
+  applyPrepareWorkspaceOutput,
+  extractPrepareWorkspaceInput,
+  runPrepareWorkspace,
+} from '../tasks/prepareWorkspace';
+import { Context } from '../types';
+import { initial, pending, success } from '../ui/tasks/prepareWorkspace';
+import { runTask } from './engine';
+import { clackTaskLogRenderer } from './engine/clack/taskLogRenderer';
+import { getRenderer } from './engine/getRenderer';
+
+/**
+ * Render the prepareWorkspace task.
+ *
+ * @param ctx The CLI context.
+ */
+export async function renderPrepareWorkspace(ctx: Context): Promise<void> {
+  await runTask(
+    ctx,
+    {
+      name: 'prepareWorkspace',
+      title: initial.title,
+      transitions: { pending, success },
+      extractInput: extractPrepareWorkspaceInput,
+      run: runPrepareWorkspace,
+      applyOutput: applyPrepareWorkspaceOutput,
+    },
+    getRenderer(ctx, clackTaskLogRenderer)
+  );
+}

--- a/node-src/tasks/index.test.ts
+++ b/node-src/tasks/index.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+
+import { Context } from '../types';
+import getTasks, { runPatchBuild, runUploadBuild } from './index';
+
+const makeContext = (options: Partial<Context['options']> = {}) => ({ options }) as Context;
+
+describe('getTasks', () => {
+  it('selects the patch build task list when patchHeadRef and patchBaseRef are both set', () => {
+    const ctx = makeContext({ patchHeadRef: 'feature', patchBaseRef: 'main' });
+
+    const tasks = getTasks(ctx);
+
+    expect(tasks).toHaveLength(runPatchBuild.length);
+    expect(tasks.map((task) => task.title)).toEqual(['Prepare workspace', 'Restore workspace']);
+  });
+
+  it('selects the upload build task list when neither patch ref option is set', () => {
+    const ctx = makeContext({});
+
+    const tasks = getTasks(ctx);
+
+    expect(tasks).toHaveLength(runUploadBuild.length);
+  });
+
+  it('selects the upload build task list when only patchHeadRef is set', () => {
+    const ctx = makeContext({ patchHeadRef: 'feature' });
+
+    const tasks = getTasks(ctx);
+
+    expect(tasks).toHaveLength(runUploadBuild.length);
+  });
+
+  it('selects the upload build task list when only patchBaseRef is set', () => {
+    const ctx = makeContext({ patchBaseRef: 'main' });
+
+    const tasks = getTasks(ctx);
+
+    expect(tasks).toHaveLength(runUploadBuild.length);
+  });
+
+  it('appends the report task when junitReport is set', () => {
+    const ctx = makeContext({ junitReport: 'chromatic-build-{buildNumber}.xml' });
+
+    const tasks = getTasks(ctx);
+
+    expect(tasks).toHaveLength(runUploadBuild.length + 1);
+    expect(tasks.at(-1)?.title).toBe('Generate build report');
+  });
+
+  it('appends the report task to the patch build task list when junitReport is set', () => {
+    const ctx = makeContext({
+      patchHeadRef: 'feature',
+      patchBaseRef: 'main',
+      junitReport: 'chromatic-build-{buildNumber}.xml',
+    });
+
+    const tasks = getTasks(ctx);
+
+    expect(tasks).toHaveLength(runPatchBuild.length + 1);
+    expect(tasks.at(-1)?.title).toBe('Generate build report');
+  });
+});

--- a/node-src/tasks/index.test.ts
+++ b/node-src/tasks/index.test.ts
@@ -1,42 +1,17 @@
 import { describe, expect, it } from 'vitest';
 
 import { Context } from '../types';
-import getTasks, { runPatchBuild, runUploadBuild } from './index';
+import getTasks from './index';
 
 const makeContext = (options: Partial<Context['options']> = {}) => ({ options }) as Context;
 
 describe('getTasks', () => {
-  it('selects the patch build task list when patchHeadRef and patchBaseRef are both set', () => {
-    const ctx = makeContext({ patchHeadRef: 'feature', patchBaseRef: 'main' });
-
-    const tasks = getTasks(ctx);
-
-    expect(tasks).toHaveLength(runPatchBuild.length);
-    expect(tasks.map((task) => task.title)).toEqual(['Prepare workspace', 'Restore workspace']);
-  });
-
-  it('selects the upload build task list when neither patch ref option is set', () => {
+  it('returns no tasks when junitReport is not set', () => {
     const ctx = makeContext({});
 
     const tasks = getTasks(ctx);
 
-    expect(tasks).toHaveLength(runUploadBuild.length);
-  });
-
-  it('selects the upload build task list when only patchHeadRef is set', () => {
-    const ctx = makeContext({ patchHeadRef: 'feature' });
-
-    const tasks = getTasks(ctx);
-
-    expect(tasks).toHaveLength(runUploadBuild.length);
-  });
-
-  it('selects the upload build task list when only patchBaseRef is set', () => {
-    const ctx = makeContext({ patchBaseRef: 'main' });
-
-    const tasks = getTasks(ctx);
-
-    expect(tasks).toHaveLength(runUploadBuild.length);
+    expect(tasks).toHaveLength(0);
   });
 
   it('appends the report task when junitReport is set', () => {
@@ -44,20 +19,7 @@ describe('getTasks', () => {
 
     const tasks = getTasks(ctx);
 
-    expect(tasks).toHaveLength(runUploadBuild.length + 1);
-    expect(tasks.at(-1)?.title).toBe('Generate build report');
-  });
-
-  it('appends the report task to the patch build task list when junitReport is set', () => {
-    const ctx = makeContext({
-      patchHeadRef: 'feature',
-      patchBaseRef: 'main',
-      junitReport: 'chromatic-build-{buildNumber}.xml',
-    });
-
-    const tasks = getTasks(ctx);
-
-    expect(tasks).toHaveLength(runPatchBuild.length + 1);
-    expect(tasks.at(-1)?.title).toBe('Generate build report');
+    expect(tasks).toHaveLength(1);
+    expect(tasks[0]?.title).toBe('Generate build report');
   });
 });

--- a/node-src/tasks/index.ts
+++ b/node-src/tasks/index.ts
@@ -1,31 +1,24 @@
 import Listr from 'listr';
 
 import { Context } from '../types';
-import prepareWorkspace from './prepareWorkspace';
 import report from './report';
-import restoreWorkspace from './restoreWorkspace';
 import uploadShare from './uploadShare';
 
 export const runShare = [uploadShare];
 
-// snapshot migrated to the Clack renderer (`renderSnapshot`, called directly in `index.ts`); only
-// the conditionally-appended `report` task may remain in this Listr block.
-export const runUploadBuild: ((ctx: Context) => Listr.ListrTask<Context>)[] = [];
-
-export const runPatchBuild = [prepareWorkspace, ...runUploadBuild, restoreWorkspace];
-
 /**
  * Prepare the list of tasks to run for a new build.
+ *
+ * `auth` through `snapshot`, and the patch-build workspace prep/restore, all run directly via
+ * `render*` calls in `runBuild` (`node-src/index.ts`) now; the only task that may still remain in
+ * this Listr block is the conditionally-appended `report` task.
  *
  * @param ctx The context set when executing the CLI.
  *
  * @returns The list of tasks to be completed.
  */
 export default function index(ctx: Context): Listr.ListrTask<Context>[] {
-  const tasks =
-    ctx.options.patchHeadRef && ctx.options.patchBaseRef ? runPatchBuild : runUploadBuild;
+  const tasks = ctx.options.junitReport ? [report] : [];
 
-  const tasksWithReport = ctx.options.junitReport ? [...tasks, report] : tasks;
-
-  return tasksWithReport.map((task) => task(ctx));
+  return tasks.map((task) => task(ctx));
 }

--- a/node-src/tasks/index.ts
+++ b/node-src/tasks/index.ts
@@ -23,11 +23,9 @@ export const runPatchBuild = [prepareWorkspace, ...runUploadBuild, restoreWorksp
  */
 export default function index(ctx: Context): Listr.ListrTask<Context>[] {
   const tasks =
-    ctx.options.patchHeadRef && ctx.options.patchBaseRef ? runUploadBuild : runUploadBuild;
+    ctx.options.patchHeadRef && ctx.options.patchBaseRef ? runPatchBuild : runUploadBuild;
 
-  if (ctx.options.junitReport) {
-    tasks.push(report);
-  }
+  const tasksWithReport = ctx.options.junitReport ? [...tasks, report] : tasks;
 
-  return tasks.map((task) => task(ctx));
+  return tasksWithReport.map((task) => task(ctx));
 }

--- a/node-src/tasks/prepareWorkspace.test.ts
+++ b/node-src/tasks/prepareWorkspace.test.ts
@@ -2,12 +2,12 @@ import { describe, expect, it, vi } from 'vitest';
 
 import * as git from '../git/git';
 import installDeps from '../lib/installDependencies';
+import { TaskFailure } from '../lib/setExitCode';
 import TestLogger from '../lib/testLogger';
 import { runPrepareWorkspace } from './prepareWorkspace';
 
 vi.mock('../git/git');
 vi.mock('../lib/installDependencies');
-vi.mock('./restoreWorkspace');
 
 const checkout = vi.mocked(git.checkout);
 const isClean = vi.mocked(git.isClean);
@@ -16,57 +16,68 @@ const findMergeBase = vi.mocked(git.findMergeBase);
 const installDependencies = vi.mocked(installDeps);
 
 const log = new TestLogger();
+const input = { patchHeadRef: 'head', patchBaseRef: 'base' };
+const makeDeps = () => ({ log, options: input, report: vi.fn() }) as any;
+
+const catchError = (promise: Promise<unknown>) =>
+  promise.then(
+    () => {
+      throw new Error('Expected runPrepareWorkspace to reject');
+    },
+    (error) => error
+  );
 
 describe('runPrepareWorkspace', () => {
   it('retrieves the merge base, does a git checkout and installs dependencies', async () => {
     isClean.mockResolvedValue(true);
     isUpToDate.mockResolvedValue(true);
     findMergeBase.mockResolvedValue('1234asd');
-    const ctx = { log, options: { patchHeadRef: 'head', patchBaseRef: 'base' } } as any;
+    const deps = makeDeps();
 
-    await runPrepareWorkspace(ctx, {} as any);
-    expect(ctx.mergeBase).toBe('1234asd');
-    expect(checkout).toHaveBeenCalledWith(ctx, '1234asd');
+    const result = await runPrepareWorkspace(deps, input);
+
+    expect(result).toEqual({ kind: 'continue', output: { mergeBase: '1234asd' } });
+    expect(checkout).toHaveBeenCalledWith(deps, '1234asd');
     expect(installDependencies).toHaveBeenCalled();
   });
 
   it('fails when not clean', async () => {
     isClean.mockResolvedValue(false);
-    const ctx = { log, options: { patchHeadRef: 'head', patchBaseRef: 'base' } } as any;
+    const deps = makeDeps();
 
-    await expect(runPrepareWorkspace(ctx, {} as any)).rejects.toThrow(
-      'Working directory is not clean'
-    );
-    expect(ctx.mergeBase).toBe(undefined);
-    expect(ctx.exitCode).toBe(101);
-    expect(ctx.userError).toBe(true);
+    const error = await catchError(runPrepareWorkspace(deps, input));
+
+    expect(error).toBeInstanceOf(TaskFailure);
+    expect(error.message).toBe('Working directory is not clean');
+    expect(error.exitCode).toBe(101);
+    expect(error.userError).toBe(true);
   });
 
   it('fails when not up-to-date', async () => {
     isClean.mockResolvedValue(true);
     isUpToDate.mockResolvedValue(false);
-    const ctx = { log, options: { patchHeadRef: 'head', patchBaseRef: 'base' } } as any;
+    const deps = makeDeps();
 
-    await expect(runPrepareWorkspace(ctx, {} as any)).rejects.toThrow(
-      'Workspace not up-to-date with remote'
-    );
-    expect(ctx.mergeBase).toBe(undefined);
-    expect(ctx.exitCode).toBe(102);
-    expect(ctx.userError).toBe(true);
+    const error = await catchError(runPrepareWorkspace(deps, input));
+
+    expect(error).toBeInstanceOf(TaskFailure);
+    expect(error.message).toBe('Workspace not up-to-date with remote');
+    expect(error.exitCode).toBe(102);
+    expect(error.userError).toBe(true);
   });
 
   it('fails when no merge base is found', async () => {
     isClean.mockResolvedValue(true);
     isUpToDate.mockResolvedValue(true);
     findMergeBase.mockResolvedValue(undefined);
-    const ctx = { log, options: { patchHeadRef: 'head', patchBaseRef: 'base' } } as any;
+    const deps = makeDeps();
 
-    await expect(runPrepareWorkspace(ctx, {} as any)).rejects.toThrow(
-      'Could not find a merge base'
-    );
-    expect(ctx.mergeBase).toBe(undefined);
-    expect(ctx.exitCode).toBe(103);
-    expect(ctx.userError).toBe(true);
+    const error = await catchError(runPrepareWorkspace(deps, input));
+
+    expect(error).toBeInstanceOf(TaskFailure);
+    expect(error.message).toBe('Could not find a merge base');
+    expect(error.exitCode).toBe(103);
+    expect(error.userError).toBe(true);
   });
 
   it("fails when dependencies can't be installed", async () => {
@@ -74,12 +85,13 @@ describe('runPrepareWorkspace', () => {
     isUpToDate.mockResolvedValue(true);
     findMergeBase.mockResolvedValue('1234asd');
     installDependencies.mockRejectedValue(new Error('some error'));
-    const ctx = { log, options: { patchHeadRef: 'head', patchBaseRef: 'base' } } as any;
+    const deps = makeDeps();
 
-    await expect(runPrepareWorkspace(ctx, {} as any)).rejects.toThrow(
-      'Failed to install dependencies'
-    );
-    expect(ctx.mergeBase).toBe(undefined);
-    expect(ctx.exitCode).toBe(104);
+    const error = await catchError(runPrepareWorkspace(deps, input));
+
+    expect(error).toBeInstanceOf(TaskFailure);
+    expect(error.message).toBe('Failed to install dependencies');
+    expect(error.exitCode).toBe(104);
+    expect(error.userError).toBe(false);
   });
 });

--- a/node-src/tasks/prepareWorkspace.test.ts
+++ b/node-src/tasks/prepareWorkspace.test.ts
@@ -84,7 +84,7 @@ describe('runPrepareWorkspace', () => {
     isClean.mockResolvedValue(true);
     isUpToDate.mockResolvedValue(true);
     findMergeBase.mockResolvedValue('1234asd');
-    installDependencies.mockRejectedValue(new Error('some error'));
+    installDependencies.mockRejectedValueOnce(new Error('some error'));
     const deps = makeDeps();
 
     const error = await catchError(runPrepareWorkspace(deps, input));

--- a/node-src/tasks/prepareWorkspace.ts
+++ b/node-src/tasks/prepareWorkspace.ts
@@ -1,69 +1,82 @@
-import Listr from 'listr';
-
 import { checkout, findMergeBase, getUpdateMessage, isClean, isUpToDate } from '../git/git';
 import installDependencies from '../lib/installDependencies';
-import { exitCodes, setExitCode } from '../lib/setExitCode';
-import { createTask, transitionTo } from '../lib/tasks';
-import { Context, Task } from '../types';
+import { exitCodes, TaskFailure } from '../lib/setExitCode';
+import { Context, Deps, TaskFunction } from '../types';
 import mergeBaseNotFound from '../ui/messages/errors/mergeBaseNotFound';
 import workspaceNotClean from '../ui/messages/errors/workspaceNotClean';
 import workspaceNotUpToDate from '../ui/messages/errors/workspaceNotUpToDate';
-import {
-  checkoutMergeBase,
-  initial,
-  installingDependencies,
-  lookupMergeBase,
-  pending,
-  success,
-} from '../ui/tasks/prepareWorkspace';
-import { runRestoreWorkspace } from './restoreWorkspace';
 
-export const runPrepareWorkspace = async (ctx: Context, task: Task) => {
-  const { patchHeadRef, patchBaseRef } = ctx.options;
+export type PrepareWorkspaceDeps = Pick<Deps, 'log' | 'options' | 'report'>;
+
+export interface PrepareWorkspaceInput {
+  patchHeadRef: string;
+  patchBaseRef: string;
+}
+
+export interface PrepareWorkspaceOutput {
+  mergeBase: string;
+}
+
+export const extractPrepareWorkspaceInput = (ctx: Context): PrepareWorkspaceInput => ({
+  patchHeadRef: ctx.options.patchHeadRef,
+  patchBaseRef: ctx.options.patchBaseRef,
+});
+
+export const runPrepareWorkspace: TaskFunction<
+  PrepareWorkspaceInput,
+  PrepareWorkspaceOutput,
+  PrepareWorkspaceDeps
+> = async (deps, input) => {
+  const { patchHeadRef, patchBaseRef } = input;
 
   // Make sure the git repo is in a clean state (no changes / untracked files).
-  if (!(await isClean(ctx))) {
-    setExitCode(ctx, exitCodes.GIT_NOT_CLEAN, true);
-    ctx.log.error(workspaceNotClean());
-    throw new Error('Working directory is not clean');
+  if (!(await isClean(deps))) {
+    deps.log.error(workspaceNotClean());
+    throw new TaskFailure('Working directory is not clean', {
+      exitCode: exitCodes.GIT_NOT_CLEAN,
+      userError: true,
+    });
   }
 
   // Make sure both the head and base branches are up-to-date with the remote.
-  if (!(await isUpToDate(ctx))) {
-    setExitCode(ctx, exitCodes.GIT_OUT_OF_DATE, true);
-    ctx.log.error(workspaceNotUpToDate(await getUpdateMessage(ctx)));
-    throw new Error('Workspace not up-to-date with remote');
+  if (!(await isUpToDate(deps))) {
+    deps.log.error(workspaceNotUpToDate(await getUpdateMessage(deps)));
+    throw new TaskFailure('Workspace not up-to-date with remote', {
+      exitCode: exitCodes.GIT_OUT_OF_DATE,
+      userError: true,
+    });
   }
 
-  transitionTo(lookupMergeBase)(ctx, task);
+  deps.report({
+    output: `Looking up the git merge base for '${patchHeadRef}' on '${patchBaseRef}'`,
+  });
 
   // Get the merge base commit hash.
-  ctx.mergeBase = await findMergeBase(ctx, patchHeadRef, patchBaseRef);
-  if (!ctx.mergeBase) {
-    setExitCode(ctx, exitCodes.GIT_NO_MERGE_BASE, true);
-    ctx.log.error(mergeBaseNotFound(ctx.options));
-    throw new Error('Could not find a merge base');
+  const mergeBase = await findMergeBase(deps, patchHeadRef, patchBaseRef);
+  if (!mergeBase) {
+    deps.log.error(mergeBaseNotFound(deps.options));
+    throw new TaskFailure('Could not find a merge base', {
+      exitCode: exitCodes.GIT_NO_MERGE_BASE,
+      userError: true,
+    });
   }
 
-  transitionTo(checkoutMergeBase)(ctx, task);
-  await checkout(ctx, ctx.mergeBase);
+  deps.report({ output: `Checking out merge base commit '${mergeBase.slice(0, 7)}'` });
+  await checkout(deps, mergeBase);
 
+  deps.report({ output: 'Installing dependencies' });
   try {
-    transitionTo(installingDependencies)(ctx, task);
     await installDependencies(); // this might modify a lockfile
   } catch (err) {
-    ctx.mergeBase = undefined;
-    setExitCode(ctx, exitCodes.NPM_INSTALL_FAILED);
-    ctx.log.error(err);
-    await runRestoreWorkspace(ctx); // make sure we clean up even when something breaks
-    throw new Error('Failed to install dependencies');
+    deps.log.error(err);
+    throw new TaskFailure('Failed to install dependencies', {
+      exitCode: exitCodes.NPM_INSTALL_FAILED,
+    });
   }
+
+  return { kind: 'continue', output: { mergeBase } };
 };
 
-export default function main(_: Context): Listr.ListrTask<Context> {
-  return createTask({
-    name: 'prepareWorkspace',
-    title: initial.title,
-    steps: [transitionTo(pending), runPrepareWorkspace, transitionTo(success, true)],
-  });
-}
+export const applyPrepareWorkspaceOutput = (ctx: Context, output: PrepareWorkspaceOutput) => {
+  ctx.mergeBase = output.mergeBase;
+};

--- a/node-src/tasks/prepareWorkspace.ts
+++ b/node-src/tasks/prepareWorkspace.ts
@@ -1,3 +1,5 @@
+import Listr from 'listr';
+
 import { checkout, findMergeBase, getUpdateMessage, isClean, isUpToDate } from '../git/git';
 import installDependencies from '../lib/installDependencies';
 import { exitCodes, setExitCode } from '../lib/setExitCode';
@@ -58,8 +60,10 @@ export const runPrepareWorkspace = async (ctx: Context, task: Task) => {
   }
 };
 
-export default createTask({
-  name: 'prepareWorkspace',
-  title: initial.title,
-  steps: [transitionTo(pending), runPrepareWorkspace, transitionTo(success, true)],
-});
+export default function main(_: Context): Listr.ListrTask<Context> {
+  return createTask({
+    name: 'prepareWorkspace',
+    title: initial.title,
+    steps: [transitionTo(pending), runPrepareWorkspace, transitionTo(success, true)],
+  });
+}

--- a/node-src/tasks/prepareWorkspace.ts
+++ b/node-src/tasks/prepareWorkspace.ts
@@ -5,6 +5,7 @@ import { Context, Deps, TaskFunction } from '../types';
 import mergeBaseNotFound from '../ui/messages/errors/mergeBaseNotFound';
 import workspaceNotClean from '../ui/messages/errors/workspaceNotClean';
 import workspaceNotUpToDate from '../ui/messages/errors/workspaceNotUpToDate';
+import { runRestoreWorkspace } from './restoreWorkspace';
 
 export type PrepareWorkspaceDeps = Pick<Deps, 'log' | 'options' | 'report'>;
 
@@ -69,6 +70,7 @@ export const runPrepareWorkspace: TaskFunction<
     await installDependencies(); // this might modify a lockfile
   } catch (err) {
     deps.log.error(err);
+    await runRestoreWorkspace(deps); // checkout already happened; don't strand the user
     throw new TaskFailure('Failed to install dependencies', {
       exitCode: exitCodes.NPM_INSTALL_FAILED,
     });

--- a/node-src/tasks/restoreWorkspace.test.ts
+++ b/node-src/tasks/restoreWorkspace.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import * as git from '../git/git';
+import installDeps from '../lib/installDependencies';
+import TestLogger from '../lib/testLogger';
+import { runRestoreWorkspace } from './restoreWorkspace';
+
+vi.mock('../git/git');
+vi.mock('../lib/installDependencies');
+
+const checkoutPrevious = vi.mocked(git.checkoutPrevious);
+const discardChanges = vi.mocked(git.discardChanges);
+const installDependencies = vi.mocked(installDeps);
+
+describe('runRestoreWorkspace', () => {
+  it('discards changes, checks out the previous branch and reinstalls dependencies', async () => {
+    const ctx = { log: new TestLogger() } as any;
+
+    await runRestoreWorkspace(ctx);
+
+    expect(discardChanges).toHaveBeenCalledTimes(2);
+    expect(checkoutPrevious).toHaveBeenCalledWith(ctx);
+    expect(installDependencies).toHaveBeenCalled();
+  });
+
+  it('checks out the previous branch before discarding lockfile changes', async () => {
+    const order: string[] = [];
+    checkoutPrevious.mockImplementation(async () => {
+      order.push('checkoutPrevious');
+      return '';
+    });
+    discardChanges.mockImplementation(async () => {
+      order.push('discardChanges');
+      return '';
+    });
+    const ctx = { log: new TestLogger() } as any;
+
+    await runRestoreWorkspace(ctx);
+
+    expect(order).toEqual(['discardChanges', 'checkoutPrevious', 'discardChanges']);
+  });
+});

--- a/node-src/tasks/restoreWorkspace.ts
+++ b/node-src/tasks/restoreWorkspace.ts
@@ -1,3 +1,5 @@
+import Listr from 'listr';
+
 import { checkoutPrevious, discardChanges } from '../git/git';
 import installDependencies from '../lib/installDependencies';
 import { createTask, transitionTo } from '../lib/tasks';
@@ -11,8 +13,10 @@ export const runRestoreWorkspace = async (ctx: Context) => {
   await discardChanges(ctx); // drop lockfile changes
 };
 
-export default createTask({
-  name: 'restoreWorkspace',
-  title: initial.title,
-  steps: [transitionTo(pending), runRestoreWorkspace, transitionTo(success, true)],
-});
+export default function main(_: Context): Listr.ListrTask<Context> {
+  return createTask({
+    name: 'restoreWorkspace',
+    title: initial.title,
+    steps: [transitionTo(pending), runRestoreWorkspace, transitionTo(success, true)],
+  });
+}

--- a/node-src/tasks/restoreWorkspace.ts
+++ b/node-src/tasks/restoreWorkspace.ts
@@ -1,22 +1,20 @@
-import Listr from 'listr';
-
 import { checkoutPrevious, discardChanges } from '../git/git';
 import installDependencies from '../lib/installDependencies';
-import { createTask, transitionTo } from '../lib/tasks';
 import { Context } from '../types';
-import { initial, pending, success } from '../ui/tasks/restoreWorkspace';
+import { pending, success } from '../ui/tasks/restoreWorkspace';
 
+/**
+ * Restore the workspace to its original branch after a patch build. Called directly (not through
+ * the `runTask`/render pipeline) so it always runs during teardown, even if an upstream task set
+ * `ctx.skip` to halt the rest of the pipeline.
+ *
+ * @param ctx The CLI context.
+ */
 export const runRestoreWorkspace = async (ctx: Context) => {
+  ctx.log.info(pending().output);
   await discardChanges(ctx); // we need a clean state before checkout
   await checkoutPrevious(ctx);
   await installDependencies();
   await discardChanges(ctx); // drop lockfile changes
+  ctx.log.info(success().title);
 };
-
-export default function main(_: Context): Listr.ListrTask<Context> {
-  return createTask({
-    name: 'restoreWorkspace',
-    title: initial.title,
-    steps: [transitionTo(pending), runRestoreWorkspace, transitionTo(success, true)],
-  });
-}

--- a/node-src/tasks/restoreWorkspace.ts
+++ b/node-src/tasks/restoreWorkspace.ts
@@ -1,16 +1,18 @@
 import { checkoutPrevious, discardChanges } from '../git/git';
 import installDependencies from '../lib/installDependencies';
-import { Context } from '../types';
+import { Deps } from '../types';
 import { pending, success } from '../ui/tasks/restoreWorkspace';
+
+export type RestoreWorkspaceDeps = Pick<Deps, 'log' | 'options'>;
 
 /**
  * Restore the workspace to its original branch after a patch build. Called directly (not through
  * the `runTask`/render pipeline) so it always runs during teardown, even if an upstream task set
  * `ctx.skip` to halt the rest of the pipeline.
  *
- * @param ctx The CLI context.
+ * @param ctx The CLI context, or any subset of `Deps` that provides `log` and `options`.
  */
-export const runRestoreWorkspace = async (ctx: Context) => {
+export const runRestoreWorkspace = async (ctx: RestoreWorkspaceDeps) => {
   ctx.log.info(pending().output);
   await discardChanges(ctx); // we need a clean state before checkout
   await checkoutPrevious(ctx);

--- a/node-src/ui/tasks/prepareWorkspace.stories.ts
+++ b/node-src/ui/tasks/prepareWorkspace.stories.ts
@@ -1,12 +1,5 @@
 import task from '../components/task';
-import {
-  checkoutMergeBase,
-  initial,
-  installingDependencies,
-  lookupMergeBase,
-  pending,
-  success,
-} from './prepareWorkspace';
+import { initial, pending, success } from './prepareWorkspace';
 
 export default {
   title: 'CLI/Tasks/PrepareWorkspace',
@@ -23,11 +16,5 @@ const mergeBase = '3f35708745837024bec510c0e5d8a3ac00ba6467';
 export const Initial = () => initial;
 
 export const Pending = () => pending();
-
-export const LookupMergeBase = () => lookupMergeBase({ options } as any);
-
-export const CheckoutMergeBase = () => checkoutMergeBase({ options, mergeBase } as any);
-
-export const InstallingDependencies = () => installingDependencies();
 
 export const Success = () => success({ options, mergeBase } as any);

--- a/node-src/ui/tasks/prepareWorkspace.ts
+++ b/node-src/ui/tasks/prepareWorkspace.ts
@@ -11,24 +11,6 @@ export const pending = () => ({
   output: `Ensuring your git workspace is clean and up-to-date`,
 });
 
-export const lookupMergeBase = (ctx: Context) => ({
-  status: 'pending',
-  title: 'Preparing your workspace',
-  output: `Looking up the git merge base for '${ctx.options.patchHeadRef}' on '${ctx.options.patchBaseRef}'`,
-});
-
-export const checkoutMergeBase = (ctx: Context) => ({
-  status: 'pending',
-  title: 'Preparing your workspace',
-  output: `Checking out merge base commit '${ctx.mergeBase?.slice(0, 7)}'`,
-});
-
-export const installingDependencies = () => ({
-  status: 'pending',
-  title: 'Preparing your workspace',
-  output: 'Installing dependencies',
-});
-
 export const success = (ctx: Context) => ({
   status: 'success',
   title: `Prepared your workspace`,


### PR DESCRIPTION
In a previous bad merge we lost the patch build workflow.  This restores it adds a regression test.

The simple fix (go back to using `runPatchBuild`) no longer worked after the Clack migration so the process was moved into `runBuild` directly.

Closes chromaui/chromatic-cli#1423

<details><summary>📦 Published PR as canary version: 18.3.0--canary.1428.31514305056.0</summary>

✨ Test out this PR locally via:

```bash
npm install chromatic@18.3.0--canary.1428.31514305056.0
# or 
yarn add chromatic@18.3.0--canary.1428.31514305056.0
```

</details>