### PR TITLE
Include more git info in diagnostics and debug logging for ancestor calculation

### DIFF
--- a/node-src/git/getParentCommits.test.ts
+++ b/node-src/git/getParentCommits.test.ts
@@ -101,7 +101,10 @@ describe('getParentCommits', () => {
     const client = createClient({ repository, builds: [] });
     const git = { branch: 'main', ...(await getCommit(ctx)) };
 
-    const parentCommits = await getParentCommits({ client, log, options } as any, withGit(git));
+    const { ancestorCommits: parentCommits } = await getParentCommits(
+      { client, log, options } as any,
+      withGit(git)
+    );
     expectCommitsToEqualNames(parentCommits, [], repository);
   });
 
@@ -114,7 +117,10 @@ describe('getParentCommits', () => {
     const client = createClient({ repository, builds: [['F', 'main']] });
     const git = { branch: 'main', ...(await getCommit(ctx)) };
 
-    const parentCommits = await getParentCommits({ client, log, options } as any, withGit(git));
+    const { ancestorCommits: parentCommits } = await getParentCommits(
+      { client, log, options } as any,
+      withGit(git)
+    );
     expectCommitsToEqualNames(parentCommits, ['F'], repository);
   });
 
@@ -127,7 +133,10 @@ describe('getParentCommits', () => {
     const client = createClient({ repository, builds: [['B', 'main']] });
     const git = { branch: 'main', ...(await getCommit(ctx)) };
 
-    const parentCommits = await getParentCommits({ client, log, options } as any, withGit(git));
+    const { ancestorCommits: parentCommits } = await getParentCommits(
+      { client, log, options } as any,
+      withGit(git)
+    );
     expectCommitsToEqualNames(parentCommits, ['B'], repository);
   });
 
@@ -146,7 +155,10 @@ describe('getParentCommits', () => {
     });
     const git = { branch: 'main', ...(await getCommit(ctx)) };
 
-    const parentCommits = await getParentCommits({ client, log, options } as any, withGit(git));
+    const { ancestorCommits: parentCommits } = await getParentCommits(
+      { client, log, options } as any,
+      withGit(git)
+    );
     expectCommitsToEqualNames(parentCommits, ['E', 'D'], repository);
   });
 
@@ -168,7 +180,10 @@ describe('getParentCommits', () => {
     });
     const git = { branch: 'main', ...(await getCommit(ctx)) };
 
-    const parentCommits = await getParentCommits({ client, log, options } as any, withGit(git));
+    const { ancestorCommits: parentCommits } = await getParentCommits(
+      { client, log, options } as any,
+      withGit(git)
+    );
     expectCommitsToEqualNames(parentCommits, ['D', 'C', 'B'], repository);
   });
 
@@ -187,7 +202,10 @@ describe('getParentCommits', () => {
     });
     const git = { branch: 'main', ...(await getCommit(ctx)) };
 
-    const parentCommits = await getParentCommits({ client, log, options } as any, withGit(git));
+    const { ancestorCommits: parentCommits } = await getParentCommits(
+      { client, log, options } as any,
+      withGit(git)
+    );
     expectCommitsToEqualNames(parentCommits, ['C', 'B'], repository);
   });
 
@@ -209,7 +227,10 @@ describe('getParentCommits', () => {
     });
     const git = { branch: 'main', ...(await getCommit(ctx)) };
 
-    const parentCommits = await getParentCommits({ client, log, options } as any, withGit(git));
+    const { ancestorCommits: parentCommits } = await getParentCommits(
+      { client, log, options } as any,
+      withGit(git)
+    );
     expectCommitsToEqualNames(parentCommits, ['B'], repository);
   });
 
@@ -232,7 +253,10 @@ describe('getParentCommits', () => {
     });
     const git = { branch: 'main', ...(await getCommit(ctx)) };
 
-    const parentCommits = await getParentCommits({ client, log, options } as any, withGit(git));
+    const { ancestorCommits: parentCommits } = await getParentCommits(
+      { client, log, options } as any,
+      withGit(git)
+    );
     expectCommitsToEqualNames(parentCommits, ['E', 'D'], repository);
   });
 
@@ -247,7 +271,10 @@ describe('getParentCommits', () => {
     const client = createClient({ repository, builds: [['C', 'main']] });
     const git = { branch: 'main', ...(await getCommit(ctx)) };
 
-    const parentCommits = await getParentCommits({ client, log, options } as any, withGit(git));
+    const { ancestorCommits: parentCommits } = await getParentCommits(
+      { client, log, options } as any,
+      withGit(git)
+    );
     expectCommitsToEqualNames(parentCommits, ['C'], repository);
   });
 
@@ -270,7 +297,10 @@ describe('getParentCommits', () => {
     });
     const git = { branch: 'main', ...(await getCommit(ctx)) };
 
-    const parentCommits = await getParentCommits({ client, log, options } as any, withGit(git));
+    const { ancestorCommits: parentCommits } = await getParentCommits(
+      { client, log, options } as any,
+      withGit(git)
+    );
     expectCommitsToEqualNames(parentCommits, ['D'], repository);
   });
 
@@ -289,7 +319,10 @@ describe('getParentCommits', () => {
     });
     const git = { branch: 'main', ...(await getCommit(ctx)) };
 
-    const parentCommits = await getParentCommits({ client, log, options } as any, withGit(git));
+    const { ancestorCommits: parentCommits } = await getParentCommits(
+      { client, log, options } as any,
+      withGit(git)
+    );
     expectCommitsToEqualNames(parentCommits, ['C'], repository);
   });
 
@@ -302,7 +335,10 @@ describe('getParentCommits', () => {
     const client = createClient({ repository, builds: [['D', 'branch']] });
     const git = { branch: 'main', ...(await getCommit(ctx)) };
 
-    const parentCommits = await getParentCommits({ client, log, options } as any, withGit(git));
+    const { ancestorCommits: parentCommits } = await getParentCommits(
+      { client, log, options } as any,
+      withGit(git)
+    );
     expectCommitsToEqualNames(parentCommits, [], repository);
   });
 
@@ -315,7 +351,10 @@ describe('getParentCommits', () => {
     const client = createClient({ repository, builds: [['E', 'branch']] });
     const git = { branch: 'main', ...(await getCommit(ctx)) };
 
-    const parentCommits = await getParentCommits({ client, log, options } as any, withGit(git));
+    const { ancestorCommits: parentCommits } = await getParentCommits(
+      { client, log, options } as any,
+      withGit(git)
+    );
     expectCommitsToEqualNames(parentCommits, [], repository);
   });
 
@@ -328,7 +367,10 @@ describe('getParentCommits', () => {
     const client = createClient({ repository, builds: [['B', 'branch']] });
     const git = { branch: 'main', ...(await getCommit(ctx)) };
 
-    const parentCommits = await getParentCommits({ client, log, options } as any, withGit(git));
+    const { ancestorCommits: parentCommits } = await getParentCommits(
+      { client, log, options } as any,
+      withGit(git)
+    );
     expectCommitsToEqualNames(parentCommits, [], repository);
   });
 
@@ -348,7 +390,10 @@ describe('getParentCommits', () => {
     });
     const git = { branch: 'main', ...(await getCommit(ctx)) };
 
-    const parentCommits = await getParentCommits({ client, log, options } as any, withGit(git));
+    const { ancestorCommits: parentCommits } = await getParentCommits(
+      { client, log, options } as any,
+      withGit(git)
+    );
     expectCommitsToEqualNames(parentCommits, [], repository);
   });
 
@@ -361,7 +406,10 @@ describe('getParentCommits', () => {
     const client = createClient({ repository, builds: [['D', 'main']] });
     const git = { branch: 'main', ...(await getCommit(ctx)) };
 
-    const parentCommits = await getParentCommits({ client, log, options } as any, withGit(git));
+    const { ancestorCommits: parentCommits } = await getParentCommits(
+      { client, log, options } as any,
+      withGit(git)
+    );
     expectCommitsToEqualNames(parentCommits, ['D'], repository);
   });
 
@@ -374,7 +422,10 @@ describe('getParentCommits', () => {
     const client = createClient({ repository, builds: [['z', 'branch']] });
     const git = { branch: 'main', ...(await getCommit(ctx)) };
 
-    const parentCommits = await getParentCommits({ client, log, options } as any, withGit(git));
+    const { ancestorCommits: parentCommits } = await getParentCommits(
+      { client, log, options } as any,
+      withGit(git)
+    );
     expectCommitsToEqualNames(parentCommits, [], repository);
   });
 
@@ -387,7 +438,10 @@ describe('getParentCommits', () => {
     const client = createClient({ repository, builds: [['A', 'branch']] });
     const git = { branch: 'main', ...(await getCommit(ctx)) };
 
-    const parentCommits = await getParentCommits({ client, log, options } as any, withGit(git));
+    const { ancestorCommits: parentCommits } = await getParentCommits(
+      { client, log, options } as any,
+      withGit(git)
+    );
     expectCommitsToEqualNames(parentCommits, ['A'], repository);
   });
 
@@ -413,7 +467,10 @@ describe('getParentCommits', () => {
     };
     const git = { branch: 'branch', ...(await getCommit(ctx)) };
 
-    const parentCommits = await getParentCommits({ client, log, options } as any, withGit(git));
+    const { ancestorCommits: parentCommits } = await getParentCommits(
+      { client, log, options } as any,
+      withGit(git)
+    );
     expectCommitsToEqualNames(parentCommits, ['A'], repository);
   });
 
@@ -437,7 +494,10 @@ describe('getParentCommits', () => {
     });
     const git = { branch: 'branch', ...(await getCommit(ctx)) };
 
-    const parentCommits = await getParentCommits({ client, log, options } as any, withGit(git));
+    const { ancestorCommits: parentCommits } = await getParentCommits(
+      { client, log, options } as any,
+      withGit(git)
+    );
     expectCommitsToEqualNames(parentCommits, ['D'], repository);
   });
 
@@ -461,7 +521,10 @@ describe('getParentCommits', () => {
     });
     const git = { branch: 'branch', ...(await getCommit(ctx)) };
 
-    const parentCommits = await getParentCommits({ client, log, options } as any, withGit(git));
+    const { ancestorCommits: parentCommits } = await getParentCommits(
+      { client, log, options } as any,
+      withGit(git)
+    );
     expectCommitsToEqualNames(parentCommits, ['D'], repository);
   });
 
@@ -485,7 +548,10 @@ describe('getParentCommits', () => {
     });
     const git = { branch: 'branch', ...(await getCommit(ctx)) };
 
-    const parentCommits = await getParentCommits({ client, log, options } as any, withGit(git));
+    const { ancestorCommits: parentCommits } = await getParentCommits(
+      { client, log, options } as any,
+      withGit(git)
+    );
     expectCommitsToEqualNames(parentCommits, ['C'], repository);
   });
 
@@ -508,7 +574,7 @@ describe('getParentCommits', () => {
     });
     const git = { branch: 'branch', ...(await getCommit(ctx)) };
 
-    const parentCommits = await getParentCommits(
+    const { ancestorCommits: parentCommits } = await getParentCommits(
       { client, log, options } as any,
       withGit(git, { ignoreLastBuildOnBranch: true })
     );
@@ -541,7 +607,10 @@ describe('getParentCommits', () => {
     });
     const git = { branch: 'branch', ...(await getCommit(ctx)) };
 
-    const parentCommits = await getParentCommits({ client, log, options } as any, withGit(git));
+    const { ancestorCommits: parentCommits } = await getParentCommits(
+      { client, log, options } as any,
+      withGit(git)
+    );
     expect(parentCommits).toEqual([Zhash, repository.commitMap.C.hash]);
   });
 
@@ -566,7 +635,10 @@ describe('getParentCommits', () => {
     });
     const git = { branch: 'branch', ...(await getCommit(ctx)) };
 
-    const parentCommits = await getParentCommits({ client, log, options } as any, withGit(git));
+    const { ancestorCommits: parentCommits } = await getParentCommits(
+      { client, log, options } as any,
+      withGit(git)
+    );
     expectCommitsToEqualNames(parentCommits, ['B'], repository);
   });
 
@@ -589,7 +661,10 @@ describe('getParentCommits', () => {
     });
     const git = { branch: 'branch', ...(await getCommit(ctx)) };
 
-    const parentCommits = await getParentCommits({ client, log, options } as any, withGit(git));
+    const { ancestorCommits: parentCommits } = await getParentCommits(
+      { client, log, options } as any,
+      withGit(git)
+    );
     expectCommitsToEqualNames(parentCommits, ['E'], repository);
   });
 
@@ -614,7 +689,10 @@ describe('getParentCommits', () => {
     const git = { branch: 'HEAD', ...(await getCommit(ctx)) };
 
     // We can pass 'HEAD' as the branch if we fail to find any other branch info from another source
-    const parentCommits = await getParentCommits({ client, log, options } as any, withGit(git));
+    const { ancestorCommits: parentCommits } = await getParentCommits(
+      { client, log, options } as any,
+      withGit(git)
+    );
     expectCommitsToEqualNames(parentCommits, ['C'], repository);
   });
 
@@ -640,7 +718,10 @@ describe('getParentCommits', () => {
       });
       const git = { branch: 'main', ...(await getCommit(ctx)) };
 
-      const parentCommits = await getParentCommits({ client, log, options } as any, withGit(git));
+      const { ancestorCommits: parentCommits } = await getParentCommits(
+        { client, log, options } as any,
+        withGit(git)
+      );
       // This doesn't include 'C' as D "covers" it.
       expectCommitsToEqualNames(parentCommits, ['D'], repository);
     });
@@ -664,7 +745,10 @@ describe('getParentCommits', () => {
       });
       const git = { branch: 'main', ...(await getCommit(ctx)) };
 
-      const parentCommits = await getParentCommits({ client, log, options } as any, withGit(git));
+      const { ancestorCommits: parentCommits } = await getParentCommits(
+        { client, log, options } as any,
+        withGit(git)
+      );
       expectCommitsToEqualNames(parentCommits, ['D', 'C'], repository);
     });
 
@@ -687,7 +771,10 @@ describe('getParentCommits', () => {
       });
       const git = { branch: 'main', ...(await getCommit(ctx)) };
 
-      const parentCommits = await getParentCommits({ client, log, options } as any, withGit(git));
+      const { ancestorCommits: parentCommits } = await getParentCommits(
+        { client, log, options } as any,
+        withGit(git)
+      );
       expectCommitsToEqualNames(parentCommits, ['C', 'B'], repository);
     });
 
@@ -710,7 +797,10 @@ describe('getParentCommits', () => {
       });
       const git = { branch: 'main', ...(await getCommit(ctx)) };
 
-      const parentCommits = await getParentCommits({ client, log, options } as any, withGit(git));
+      const { ancestorCommits: parentCommits } = await getParentCommits(
+        { client, log, options } as any,
+        withGit(git)
+      );
       // This doesn't include A as B "covers" it.
       expectCommitsToEqualNames(parentCommits, ['B'], repository);
     });
@@ -731,7 +821,10 @@ describe('getParentCommits', () => {
       });
       const git = { branch: 'main', ...(await getCommit(ctx)) };
 
-      const parentCommits = await getParentCommits({ client, log, options } as any, withGit(git));
+      const { ancestorCommits: parentCommits } = await getParentCommits(
+        { client, log, options } as any,
+        withGit(git)
+      );
       expectCommitsToEqualNames(parentCommits, ['C'], repository);
     });
 
@@ -754,7 +847,10 @@ describe('getParentCommits', () => {
       });
       const git = { branch: 'main', ...(await getCommit(ctx)) };
 
-      const parentCommits = await getParentCommits({ client, log, options } as any, withGit(git));
+      const { ancestorCommits: parentCommits } = await getParentCommits(
+        { client, log, options } as any,
+        withGit(git)
+      );
       expectCommitsToEqualNames(parentCommits, ['MISSING', 'A'], repository);
     });
 
@@ -786,7 +882,10 @@ describe('getParentCommits', () => {
       });
       const git = { branch: 'main', ...(await getCommit(ctx)) };
 
-      const parentCommits = await getParentCommits({ client, log, options } as any, withGit(git));
+      const { ancestorCommits: parentCommits } = await getParentCommits(
+        { client, log, options } as any,
+        withGit(git)
+      );
       expectCommitsToEqualNames(parentCommits, ['C', 'B'], repository);
     });
 
@@ -808,7 +907,10 @@ describe('getParentCommits', () => {
       });
       const git = { branch: 'main', ...(await getCommit(ctx)) };
 
-      const parentCommits = await getParentCommits({ client, log, options } as any, withGit(git));
+      const { ancestorCommits: parentCommits } = await getParentCommits(
+        { client, log, options } as any,
+        withGit(git)
+      );
       expectCommitsToEqualNames(parentCommits, ['E', 'D'], repository);
     });
   });

--- a/node-src/git/getParentCommits.test.ts
+++ b/node-src/git/getParentCommits.test.ts
@@ -914,4 +914,79 @@ describe('getParentCommits', () => {
       expectCommitsToEqualNames(parentCommits, ['E', 'D'], repository);
     });
   });
+
+  describe('visitedCommits', () => {
+    it('marks commits with hasBuild correctly', async () => {
+      //  A -[B]-(C) [main]
+      const repository = repositories.simpleLoop;
+      await checkoutCommit('C', 'main', repository);
+      const client = createClient({ repository, builds: [['B', 'main']] });
+      const git = { branch: 'main', ...(await getCommit(ctx)) };
+
+      const { visitedCommits } = await getParentCommits(
+        { client, log, options } as any,
+        withGit(git)
+      );
+
+      const { commitMap } = repository;
+      const visited = Object.fromEntries(visitedCommits.map((v) => [v.commit, v]));
+
+      expect(visited[commitMap.C.hash].hasBuild).toBe(false);
+      expect(visited[commitMap.B.hash].hasBuild).toBe(true);
+    });
+
+    it('marks the PR merge commit as isMergePoint', async () => {
+      //  A - B -[C]      [main]
+      //            \
+      //            (E)   [main, squash merge of branch]
+      //           /
+      //         [D]      [branch]
+      const repository = repositories.simpleLoop;
+      await checkoutCommit('E', 'main', repository);
+      const client = createClient({
+        repository,
+        builds: [
+          ['C', 'main'],
+          ['D', 'branch'],
+        ],
+        prs: [['E', 'branch']],
+      });
+      const git = { branch: 'main', ...(await getCommit(ctx)) };
+
+      const { visitedCommits } = await getParentCommits(
+        { client, log, options } as any,
+        withGit(git)
+      );
+
+      const { commitMap } = repository;
+      const visited = Object.fromEntries(visitedCommits.map((v) => [v.commit, v]));
+
+      expect(visited[commitMap.E.hash].isMergePoint).toBe(true);
+      expect(visited[commitMap.C.hash].isMergePoint).toBe(false);
+    });
+
+    it('marks commits at the shallow boundary as isShallowBoundary', async () => {
+      //  A -[B]-(C)- D - F  [main]
+      //            \   /
+      //              E
+      const repository = repositories.simpleLoop;
+      await checkoutCommit('C', 'main', repository);
+      const { commitMap } = repository;
+      const client = createClient({ repository, builds: [['B', 'main']] });
+      const git = {
+        branch: 'main',
+        ...(await getCommit(ctx)),
+        shallowBoundaryCommits: [commitMap.B.hash],
+      };
+
+      const { visitedCommits } = await getParentCommits(
+        { client, log, options } as any,
+        withGit(git)
+      );
+
+      const visited = Object.fromEntries(visitedCommits.map((v) => [v.commit, v]));
+      expect(visited[commitMap.B.hash].isShallowBoundary).toBe(true);
+      expect(visited[commitMap.C.hash].isShallowBoundary).toBe(false);
+    });
+  });
 });

--- a/node-src/git/getParentCommits.ts
+++ b/node-src/git/getParentCommits.ts
@@ -345,6 +345,7 @@ export async function getParentCommits(
       // BitBucket returns 10 char prefixes for merge commit shas :shrug:
       isMergePoint: [...mergePointCommits].some((sha) => commit.startsWith(sha)),
       isProbableSquashMerge,
+      isShallowBoundary: !!git.shallowBoundaryCommits?.includes(commit),
     }));
   } catch (err) {
     log.debug('Failed to retrieve visited commit details', err);

--- a/node-src/git/getParentCommits.ts
+++ b/node-src/git/getParentCommits.ts
@@ -342,7 +342,8 @@ export async function getParentCommits(
       commit,
       parentCommits,
       hasBuild: commitsWithBuildsSet.has(commit),
-      isMergePoint: mergePointCommits.has(commit),
+      // BitBucket returns 10 char prefixes for merge commit shas :shrug:
+      isMergePoint: [...mergePointCommits].some((sha) => commit.startsWith(sha)),
       isProbableSquashMerge,
     }));
   } catch (err) {

--- a/node-src/git/getParentCommits.ts
+++ b/node-src/git/getParentCommits.ts
@@ -318,7 +318,7 @@ export async function getParentCommits(
         extraParentCommits.push(lastHeadBuildCommit);
       }
       // The commit at the same position in mergeInfoList is the merge point
-      const mergePoint = mergeInfoList?.[index]?.commit;
+      const mergePoint = mergeInfoList[index]?.commit;
       if (mergePoint) mergePointCommits.add(mergePoint);
     }
   }

--- a/node-src/git/getParentCommits.ts
+++ b/node-src/git/getParentCommits.ts
@@ -158,6 +158,11 @@ async function step(
     `step: candidateCommits: ${candidateCommits}, visitedCommitsWithoutBuilds: ${visitedCommitsWithoutBuilds}`
   );
 
+  const hitBoundaries = candidateCommits?.filter((c) => git.shallowBoundaryCommits?.includes(c));
+  if (hitBoundaries?.length) {
+    log.debug({ hitBoundaries }, `step: reached shallow boundary commit(s) during walk`);
+  }
+
   // No more commits uncovered commitsWithBuilds!
   if (!candidateCommits?.length) {
     log.debug('step: no candidateCommits; we are done');
@@ -255,8 +260,9 @@ export async function getParentCommits(
       log.debug(`Adding last branch build commit ${lastBuild.commit} to commits with builds`);
       initialCommitsWithBuilds.push(lastBuild.commit);
     } else {
+      const isShallowBoundary = git.shallowBoundaryCommits?.includes(lastBuild.commit);
       log.debug(
-        `Last branch build commit ${lastBuild.commit} not in index, blindly appending to parents`
+        `Last branch build commit ${lastBuild.commit} not in index${isShallowBoundary ? ' (shallow boundary)' : ''}, blindly appending to parents`
       );
       extraParentCommits.push(lastBuild.commit);
     }
@@ -299,8 +305,9 @@ export async function getParentCommits(
         log.debug(`Adding merged PR build commit ${lastHeadBuildCommit} to commits with builds`);
         commitsWithBuilds.push(lastHeadBuildCommit);
       } else {
+        const isShallowBoundary = git.shallowBoundaryCommits?.includes(lastHeadBuildCommit);
         log.debug(
-          `Merged PR build commit ${lastHeadBuildCommit} not in index, blindly appending to parents`
+          `Merged PR build commit ${lastHeadBuildCommit} not in index${isShallowBoundary ? ' (shallow boundary)' : ''}, blindly appending to parents`
         );
         extraParentCommits.push(lastHeadBuildCommit);
       }

--- a/node-src/git/getParentCommits.ts
+++ b/node-src/git/getParentCommits.ts
@@ -335,10 +335,9 @@ export async function getParentCommits(
     ...new Set([...(visitedCommitsWithoutBuilds ?? []), ...commitsWithBuilds]),
   ];
   const commitsWithBuildsSet = new Set(commitsWithBuilds);
-  let visitedCommits: VisitedCommit[] | undefined;
-  try {
-    const details = await getVisitedCommitDetails(deps, allVisitedShas);
-    visitedCommits = details.map(({ commit, parentCommits, isProbableSquashMerge }) => ({
+  const details = await getVisitedCommitDetails(deps, allVisitedShas);
+  const visitedCommits: VisitedCommit[] = details.map(
+    ({ commit, parentCommits, isProbableSquashMerge }) => ({
       commit,
       parentCommits,
       hasBuild: commitsWithBuildsSet.has(commit),
@@ -346,10 +345,8 @@ export async function getParentCommits(
       isMergePoint: [...mergePointCommits].some((sha) => commit.startsWith(sha)),
       isProbableSquashMerge,
       isShallowBoundary: !!git.shallowBoundaryCommits?.includes(commit),
-    }));
-  } catch (err) {
-    log.debug('Failed to retrieve visited commit details', err);
-  }
+    })
+  );
 
   log.debug(
     `visitedCommits: total=${allVisitedShas.length}, withBuilds=${commitsWithBuildsSet.size}, mergePoints=${mergePointCommits.size}`

--- a/node-src/git/getParentCommits.ts
+++ b/node-src/git/getParentCommits.ts
@@ -49,6 +49,7 @@ const MergeCommitsQuery = gql`
   query MergeCommitsQuery($mergeInfoList: [MergedInfoInput]!) {
     app {
       mergedPullRequests(mergeInfoList: $mergeInfoList) {
+        mergeCommitSha
         lastHeadBuild {
           commit
         }
@@ -60,6 +61,7 @@ export interface MergeCommitsQueryResult {
   app: {
     mergedPullRequests: [
       {
+        mergeCommitSha: string;
         lastHeadBuild: {
           commit: string;
         };
@@ -301,7 +303,7 @@ export async function getParentCommits(
 
   // Track which visited commits the platform index identified as PR merge points.
   const mergePointCommits = new Set<string>();
-  for (const [index, pullRequest] of mergedPullRequests.entries()) {
+  for (const pullRequest of mergedPullRequests) {
     // Add the most recent build on a (merged) branch as an ancestor if we visit a commit
     // during our ancestor selection that was the merge commit for that PR.
     // @see https://www.chromatic.com/docs/branching-and-baselines#squash-and-rebase-merging
@@ -317,9 +319,7 @@ export async function getParentCommits(
         );
         extraParentCommits.push(lastHeadBuildCommit);
       }
-      // The commit at the same position in mergeInfoList is the merge point
-      const mergePoint = mergeInfoList[index]?.commit;
-      if (mergePoint) mergePointCommits.add(mergePoint);
+      if (pullRequest.mergeCommitSha) mergePointCommits.add(pullRequest.mergeCommitSha);
     }
   }
 

--- a/node-src/git/getParentCommits.ts
+++ b/node-src/git/getParentCommits.ts
@@ -1,9 +1,9 @@
 import gql from 'fake-tag';
 
 import { localBuildsSpecifier } from '../lib/localBuildsSpecifier';
-import { Deps, Git } from '../types';
+import { Deps, Git, VisitedCommit } from '../types';
 import { execGitCommand, GitDeps } from './execGit';
-import { commitExists } from './git';
+import { commitExists, getVisitedCommitDetails } from './git';
 
 export const FETCH_N_INITIAL_BUILD_COMMITS = 20;
 
@@ -215,7 +215,11 @@ async function maximallyDescendentCommits(deps: GitDeps, commits: string[]) {
  * @param options.ignoreLastBuildOnBranch Ignore the last Chromatic build associated with this
  * branch.
  *
- * @returns A list of parent commits associated with this branch.
+ * @returns An object with:
+ *   - `ancestorCommits` – the baseline parent commits to pass to the Chromatic build.
+ *   - `visitedCommits` – every commit inspected during the walk, annotated with parent SHAs,
+ *     build presence, and PR merge-point status. Populated on a best-effort basis; `undefined`
+ *     if the git call to fetch commit details fails.
  */
 // TODO: refactor this function
 // eslint-disable-next-line complexity, max-statements
@@ -237,7 +241,7 @@ export async function getParentCommits(
 
   if (!firstBuild) {
     log.debug('App has no builds, returning []');
-    return [];
+    return { ancestorCommits: [], visitedCommits: [] as VisitedCommit[] };
   }
 
   const initialCommitsWithBuilds: string[] = [];
@@ -295,7 +299,9 @@ export async function getParentCommits(
     { retries: 5 } // This query requires a request to an upstream provider which may fail
   );
 
-  for (const pullRequest of mergedPullRequests) {
+  // Track which visited commits the platform index identified as PR merge points.
+  const mergePointCommits = new Set<string>();
+  for (const [index, pullRequest] of mergedPullRequests.entries()) {
     // Add the most recent build on a (merged) branch as an ancestor if we visit a commit
     // during our ancestor selection that was the merge commit for that PR.
     // @see https://www.chromatic.com/docs/branching-and-baselines#squash-and-rebase-merging
@@ -311,6 +317,9 @@ export async function getParentCommits(
         );
         extraParentCommits.push(lastHeadBuildCommit);
       }
+      // The commit at the same position in mergeInfoList is the merge point
+      const mergePoint = mergeInfoList?.[index]?.commit;
+      if (mergePoint) mergePointCommits.add(mergePoint);
     }
   }
 
@@ -320,5 +329,29 @@ export async function getParentCommits(
   const descendentCommits = await maximallyDescendentCommits({ log }, commitsWithBuilds);
 
   const ancestorCommits = [...extraParentCommits, ...(descendentCommits || [])];
-  return ancestorCommits;
+
+  // Build the visited commit list from everything the walk touched, on a best-effort basis.
+  const allVisitedShas = [
+    ...new Set([...(visitedCommitsWithoutBuilds ?? []), ...commitsWithBuilds]),
+  ];
+  const commitsWithBuildsSet = new Set(commitsWithBuilds);
+  let visitedCommits: VisitedCommit[] | undefined;
+  try {
+    const details = await getVisitedCommitDetails(deps, allVisitedShas);
+    visitedCommits = details.map(({ commit, parentCommits, isProbableSquashMerge }) => ({
+      commit,
+      parentCommits,
+      hasBuild: commitsWithBuildsSet.has(commit),
+      isMergePoint: mergePointCommits.has(commit),
+      isProbableSquashMerge,
+    }));
+  } catch (err) {
+    log.debug('Failed to retrieve visited commit details', err);
+  }
+
+  log.debug(
+    `visitedCommits: total=${allVisitedShas.length}, withBuilds=${commitsWithBuildsSet.size}, mergePoints=${mergePointCommits.size}`
+  );
+
+  return { ancestorCommits, visitedCommits };
 }

--- a/node-src/git/git.test.ts
+++ b/node-src/git/git.test.ts
@@ -14,10 +14,13 @@ import {
   getBranch,
   getChangedFiles,
   getChangedFilesWithStatus,
+  getCloneDepth,
+  getCloneFilter,
   getCommit,
   getCommittedFileCount,
   getNumberOfCommitters,
   getRepositoryCreationDate,
+  getShallowBoundaryCommits,
   getSlug,
   getStorybookCreationDate,
   getUncommittedHash,
@@ -28,6 +31,7 @@ import {
 } from './git';
 
 vi.mock('./execGit');
+vi.mock('fs/promises', () => ({ readFile: vi.fn() }));
 vi.mock('tmp-promise', () => ({
   file: vi.fn().mockResolvedValue({ path: '/tmp/fake-target' }),
 }));
@@ -35,6 +39,9 @@ vi.mock('tmp-promise', () => ({
 const execGitCommand = vi.mocked(execGit.execGitCommand);
 const execGitCommandOneLine = vi.mocked(execGit.execGitCommandOneLine);
 const execGitCommandCountLines = vi.mocked(execGit.execGitCommandCountLines);
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { readFile } = vi.mocked(await import('fs/promises'));
 
 const ctx = { log: new TestLogger() };
 
@@ -359,5 +366,54 @@ describe('getCommittedFileCount', () => {
   it('parses the count successfully', async () => {
     execGitCommandCountLines.mockResolvedValue(17);
     expect(await getCommittedFileCount(ctx, ['page', 'screen'], ['js', 'ts'])).toEqual(17);
+  });
+});
+
+describe('getCloneDepth', () => {
+  it('returns shallow when git reports true', async () => {
+    execGitCommandOneLine.mockResolvedValue('true');
+    expect(await getCloneDepth(ctx)).toBe('shallow');
+  });
+
+  it('returns full when git reports false', async () => {
+    execGitCommandOneLine.mockResolvedValue('false');
+    expect(await getCloneDepth(ctx)).toBe('full');
+  });
+});
+
+describe('getShallowBoundaryCommits', () => {
+  it('returns the boundary commits listed in the shallow file', async () => {
+    execGitCommandOneLine.mockResolvedValue('/path/to/.git/shallow');
+    readFile.mockResolvedValue('abc1234\ndef5678\n');
+    expect(await getShallowBoundaryCommits(ctx)).toEqual(['abc1234', 'def5678']);
+  });
+
+  it('returns an empty array when the shallow file does not exist', async () => {
+    execGitCommandOneLine.mockResolvedValue('/path/to/.git/shallow');
+    readFile.mockRejectedValue(new Error('ENOENT'));
+    expect(await getShallowBoundaryCommits(ctx)).toEqual([]);
+  });
+
+  it('returns an empty array for an empty shallow file', async () => {
+    execGitCommandOneLine.mockResolvedValue('/path/to/.git/shallow');
+    readFile.mockResolvedValue('');
+    expect(await getShallowBoundaryCommits(ctx)).toEqual([]);
+  });
+});
+
+describe('getCloneFilter', () => {
+  it('returns blobless when the filter is blob:none', async () => {
+    execGitCommandOneLine.mockResolvedValue('blob:none');
+    expect(await getCloneFilter(ctx)).toBe('blobless');
+  });
+
+  it('returns treeless when the filter is tree:0', async () => {
+    execGitCommandOneLine.mockResolvedValue('tree:0');
+    expect(await getCloneFilter(ctx)).toBe('treeless');
+  });
+
+  it('returns full when no filter is configured (git config exits non-zero)', async () => {
+    execGitCommandOneLine.mockRejectedValue(new Error('exit code 1'));
+    expect(await getCloneFilter(ctx)).toBe('full');
   });
 });

--- a/node-src/git/git.test.ts
+++ b/node-src/git/git.test.ts
@@ -26,6 +26,7 @@ import {
   getUncommittedHash,
   getUserEmail,
   getVersion,
+  getVisitedCommitDetails,
   hasPreviousCommit,
   NULL_BYTE,
 } from './git';
@@ -415,5 +416,56 @@ describe('getCloneFilter', () => {
   it('returns full when no filter is configured (git config exits non-zero)', async () => {
     execGitCommandOneLine.mockRejectedValue(new Error('exit code 1'));
     expect(await getCloneFilter(ctx)).toBe('full');
+  });
+});
+
+describe('getVisitedCommitDetails', () => {
+  it('returns an empty array when given no commits', async () => {
+    expect(await getVisitedCommitDetails(ctx, [])).toEqual([]);
+    expect(execGitCommand).not.toHaveBeenCalled();
+  });
+
+  it('parses commit SHA, parent SHAs, and marks non-squash subject', async () => {
+    execGitCommand.mockResolvedValue('abc123\0def456 ghi789\0Regular commit message\0');
+    expect(await getVisitedCommitDetails(ctx, ['abc123'])).toEqual([
+      { commit: 'abc123', parentCommits: ['def456', 'ghi789'], isProbableSquashMerge: false },
+    ]);
+  });
+
+  it('sets isProbableSquashMerge true when subject contains (#N)', async () => {
+    execGitCommand.mockResolvedValue('abc123\0def456\0Merge my feature (#42)\0');
+    const [result] = await getVisitedCommitDetails(ctx, ['abc123']);
+    expect(result.isProbableSquashMerge).toBe(true);
+  });
+
+  it('sets isProbableSquashMerge false for a regular merge commit subject', async () => {
+    execGitCommand.mockResolvedValue(
+      'abc123\0def456 ghi789\0Merge pull request #42 from org/branch\0'
+    );
+    const [result] = await getVisitedCommitDetails(ctx, ['abc123']);
+    expect(result.isProbableSquashMerge).toBe(false);
+  });
+
+  it('returns an empty parentCommits array for a root commit', async () => {
+    execGitCommand.mockResolvedValue('abc123\0\0Initial commit\0');
+    expect(await getVisitedCommitDetails(ctx, ['abc123'])).toEqual([
+      { commit: 'abc123', parentCommits: [], isProbableSquashMerge: false },
+    ]);
+  });
+
+  it('parses multiple commits', async () => {
+    execGitCommand.mockResolvedValue(
+      'aaa111\0bbb222\0Fix bug (#10)\0\nccc333\0ddd444\0Regular commit\0'
+    );
+    const results = await getVisitedCommitDetails(ctx, ['aaa111', 'ccc333']);
+    expect(results).toEqual([
+      { commit: 'aaa111', parentCommits: ['bbb222'], isProbableSquashMerge: true },
+      { commit: 'ccc333', parentCommits: ['ddd444'], isProbableSquashMerge: false },
+    ]);
+  });
+
+  it('returns an empty array when git returns no output', async () => {
+    execGitCommand.mockResolvedValue('');
+    expect(await getVisitedCommitDetails(ctx, ['abc123'])).toEqual([]);
   });
 });

--- a/node-src/git/git.test.ts
+++ b/node-src/git/git.test.ts
@@ -41,7 +41,6 @@ const execGitCommand = vi.mocked(execGit.execGitCommand);
 const execGitCommandOneLine = vi.mocked(execGit.execGitCommandOneLine);
 const execGitCommandCountLines = vi.mocked(execGit.execGitCommandCountLines);
 
-// eslint-disable-next-line @typescript-eslint/no-require-imports
 const { readFile } = vi.mocked(await import('fs/promises'));
 
 const ctx = { log: new TestLogger() };

--- a/node-src/git/git.ts
+++ b/node-src/git/git.ts
@@ -682,6 +682,10 @@ export async function getCloneDepth(deps: GitDeps): Promise<CloneDepth> {
  */
 export async function getShallowBoundaryCommits(deps: GitDeps): Promise<string[]> {
   const shallowFilePath = await execGitCommandOneLine(deps, `git rev-parse --git-path shallow`);
+  // Security check: ensure the shallow file path looks right before reading it
+  if (!/\.git[/\\]shallow$/.test(shallowFilePath.trim())) {
+    throw new Error(`Unexpected shallow file path: ${shallowFilePath}`);
+  }
   const contents = await readFile(shallowFilePath.trim(), 'utf8').catch(() => '');
   return contents.split(newline).filter(Boolean);
 }

--- a/node-src/git/git.ts
+++ b/node-src/git/git.ts
@@ -1,4 +1,5 @@
 /* eslint-disable max-lines */
+import { readFile } from 'fs/promises';
 import { EOL } from 'os';
 import pLimit from 'p-limit';
 import path from 'path';
@@ -9,6 +10,7 @@ import {
   BaselineCheckoutFailedError,
   GitCommandError,
 } from '../lib/turbosnap/v1/errors';
+import { CloneDepth, CloneFilter } from '../types';
 import { DEFAULT_METADATA_GIT_TIMEOUT_MILLISECONDS } from './constants';
 import {
   execGitCommand,
@@ -649,4 +651,61 @@ export async function getCommittedFileCount(
   } catch {
     return undefined;
   }
+}
+
+/**
+ * Determine whether the current repository has a shallow clone (truncated commit history).
+ *
+ * Uses `git rev-parse --is-shallow-repository` (available since Git 2.15). Throws on older Git
+ * versions or unexpected failures, so callers should handle errors and treat them as unknown.
+ *
+ * @param deps Function dependencies.
+ *
+ * @returns `'shallow'` if the repository has truncated history, `'full'` otherwise.
+ */
+export async function getCloneDepth(deps: GitDeps): Promise<CloneDepth> {
+  const result = await execGitCommandOneLine(deps, `git rev-parse --is-shallow-repository`);
+  return result.trim() === 'true' ? 'shallow' : 'full';
+}
+
+/**
+ * Return the shallow boundary commits: commits that are present locally but whose parents were
+ * not fetched. These are the SHAs listed in the `.git/shallow` file.
+ *
+ * The file path is resolved via `git rev-parse --git-path shallow` so that git worktrees are
+ * handled correctly. If the file does not exist (i.e. the repository is not shallow) an empty
+ * array is returned.
+ *
+ * @param deps Function dependencies.
+ *
+ * @returns A list of commit SHAs at the shallow boundary, or `[]` for a non-shallow repository.
+ */
+export async function getShallowBoundaryCommits(deps: GitDeps): Promise<string[]> {
+  const shallowFilePath = await execGitCommandOneLine(deps, `git rev-parse --git-path shallow`);
+  const contents = await readFile(shallowFilePath.trim(), 'utf8').catch(() => '');
+  return contents.split(newline).filter(Boolean);
+}
+
+/**
+ * Determine whether the repository uses a partial clone filter, and if so which kind.
+ *
+ * Reads `remote.origin.partialclonefilter` from the git config. Git exits non-zero when the key
+ * is absent (i.e. for a standard full clone), so the non-zero case is treated as `'full'`.
+ *
+ * @param deps Function dependencies.
+ *
+ * @returns
+ *   - `'blobless'` when cloned with `--filter=blob:none`
+ *   - `'treeless'` when cloned with `--filter=tree:0`
+ *   - `'full'` for a standard clone (no filter configured)
+ */
+export async function getCloneFilter(deps: GitDeps): Promise<CloneFilter> {
+  // git config exits non-zero when the key is absent, which is the normal case for a full clone.
+  const result = await execGitCommandOneLine(
+    deps,
+    `git config remote.origin.partialclonefilter`
+  ).catch(() => '');
+  if (result.trim() === 'blob:none') return 'blobless';
+  if (result.trim() === 'tree:0') return 'treeless';
+  return 'full';
 }

--- a/node-src/git/git.ts
+++ b/node-src/git/git.ts
@@ -10,7 +10,7 @@ import {
   BaselineCheckoutFailedError,
   GitCommandError,
 } from '../lib/turbosnap/v1/errors';
-import { CloneDepth, CloneFilter } from '../types';
+import { CloneDepth, CloneFilter, VisitedCommit } from '../types';
 import { DEFAULT_METADATA_GIT_TIMEOUT_MILLISECONDS } from './constants';
 import {
   execGitCommand,
@@ -684,6 +684,56 @@ export async function getShallowBoundaryCommits(deps: GitDeps): Promise<string[]
   const shallowFilePath = await execGitCommandOneLine(deps, `git rev-parse --git-path shallow`);
   const contents = await readFile(shallowFilePath.trim(), 'utf8').catch(() => '');
   return contents.split(newline).filter(Boolean);
+}
+
+// Matches the `(#N)` suffix that GitHub and Bitbucket Cloud append to squash merge subjects.
+const PROBABLE_SQUASH_MERGE_RE = /\(#\d+\)/;
+
+/**
+ * Fetch parent SHAs and compute squash-merge likelihood for each of the given commits in a
+ * single git call.
+ *
+ * Uses `git log --no-walk=unsorted` so git reads only the listed objects with no ancestor
+ * traversal. The commit subject is used to compute `isProbableSquashMerge` but is not
+ * included in the returned objects. The `hasBuild` and `isMergePoint` fields are left as
+ * `false` here; callers are responsible for annotating them from their own data.
+ *
+ * @param deps Function dependencies.
+ * @param commits The commit SHAs to look up.
+ *
+ * @returns One entry per commit containing its direct parent SHAs and squash-merge flag.
+ *   Returns an empty array when `commits` is empty.
+ */
+export async function getVisitedCommitDetails(
+  deps: GitDeps,
+  commits: string[]
+): Promise<Pick<VisitedCommit, 'commit' | 'parentCommits' | 'isProbableSquashMerge'>[]> {
+  if (commits.length === 0) return [];
+
+  // %H = full SHA, %P = space-separated parent SHAs, %s = subject line (first line of message)
+  // %x00 = NUL field separator (safe even with special chars in subject)
+  // --no-walk=unsorted shows only the listed objects, no ancestor traversal
+  const result = await execGitCommand(
+    deps,
+    `git log --no-walk=unsorted --format=%H%x00%P%x00%s%x00 ${commits.join(' ')}`
+  );
+  if (!result?.trim()) return [];
+
+  // Output is a sequence of: <sha>\0<parents>\0<subject>\0 per commit
+  const fields = result.split('\0');
+  const details: Pick<VisitedCommit, 'commit' | 'parentCommits' | 'isProbableSquashMerge'>[] = [];
+  for (let index = 0; index + 2 < fields.length; index += 3) {
+    const commit = fields[index].trim();
+    const parents = fields[index + 1].trim();
+    const subject = fields[index + 2].trim();
+    if (!commit) continue;
+    details.push({
+      commit,
+      parentCommits: parents ? parents.split(' ') : [],
+      isProbableSquashMerge: PROBABLE_SQUASH_MERGE_RE.test(subject),
+    });
+  }
+  return details;
 }
 
 /**

--- a/node-src/git/mocks/mockIndex.ts
+++ b/node-src/git/mocks/mockIndex.ts
@@ -64,6 +64,7 @@ const mocks = {
       const prLastBuild = pr && lastBuildOnBranch(builds, pr.headBranch);
       if (prLastBuild) {
         mergedPrs.push({
+          mergeCommitSha: pr.mergeCommitHash,
           lastHeadBuild: {
             commit: prLastBuild.commit,
           },

--- a/node-src/index.test.ts
+++ b/node-src/index.test.ts
@@ -336,7 +336,7 @@ vi.mock('./git/git', () => ({
 }));
 
 vi.mock('./git/getParentCommits', () => ({
-  getParentCommits: () => Promise.resolve(['baseline']),
+  getParentCommits: () => Promise.resolve({ ancestorCommits: ['baseline'], visitedCommits: [] }),
 }));
 
 vi.mock('./lib/installDependencies', () => ({

--- a/node-src/index.test.ts
+++ b/node-src/index.test.ts
@@ -330,6 +330,9 @@ vi.mock('./git/git', () => ({
   checkout: vi.fn(),
   checkoutPrevious: vi.fn(),
   discardChanges: vi.fn(),
+  getCloneDepth: () => Promise.resolve('full'),
+  getCloneFilter: () => Promise.resolve('full'),
+  getShallowBoundaryCommits: () => Promise.resolve([]),
 }));
 
 vi.mock('./git/getParentCommits', () => ({
@@ -1034,6 +1037,8 @@ describe('getGitInfo', () => {
       uncommittedHash: 'abc123',
       userEmail: 'test@test.com',
       userEmailHash: undefined,
+      cloneDepth: 'full',
+      cloneFilter: 'full',
     });
   });
 
@@ -1050,6 +1055,8 @@ describe('getGitInfo', () => {
       uncommittedHash: 'abc123',
       userEmail: 'test@test.com',
       userEmailHash: undefined,
+      cloneDepth: 'full',
+      cloneFilter: 'full',
     });
   });
 });

--- a/node-src/index.ts
+++ b/node-src/index.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines */
 import 'any-observable/register/zen';
 
 import * as Sentry from '@sentry/node';
@@ -9,6 +10,8 @@ import { setupContext } from './context';
 import getCommitAndBranch from './git/getCommitAndBranch';
 import {
   getBranch,
+  getCloneDepth,
+  getCloneFilter,
   getCommit,
   getRepositoryRoot,
   getSlug,
@@ -47,7 +50,7 @@ import { renderUpload } from './renderer/upload';
 import { renderVerify } from './renderer/verify';
 import getTasks from './tasks';
 import { runRestoreWorkspace } from './tasks/restoreWorkspace';
-import { Context, Flags, Options } from './types';
+import { CloneDepth, CloneFilter, Context, Flags, Options } from './types';
 import { endActivity } from './ui/components/activity';
 import buildCanceled from './ui/messages/errors/buildCanceled';
 import fatalError from './ui/messages/errors/fatalError';
@@ -334,7 +337,7 @@ async function getBranchForSkip(ctx: InitialContext, partialOptions: Partial<Opt
   }
 }
 
-// TODO: refactor this function
+// TODO: refactor this function (remove max-lines from file when we do)
 // eslint-disable-next-line complexity, max-statements
 async function runBuild(ctx: Context) {
   try {
@@ -454,6 +457,8 @@ export interface GitInfo {
   userEmail: string;
   userEmailHash: string;
   repositoryRootDir: string;
+  cloneDepth: CloneDepth;
+  cloneFilter: CloneFilter;
 }
 
 /**
@@ -483,6 +488,8 @@ export async function getGitInfo(ctx: Pick<Context, 'log'>): Promise<GitInfo> {
   const isValidSlug = !!ownerName && !!repoName && rest.length === 0;
 
   const uncommittedHash = (await getUncommittedHash(ctx)) || '';
+  const cloneDepth = await getCloneDepth(ctx);
+  const cloneFilter = await getCloneFilter(ctx);
   return {
     slug: isValidSlug ? slug : '',
     branch,
@@ -491,6 +498,8 @@ export async function getGitInfo(ctx: Pick<Context, 'log'>): Promise<GitInfo> {
     userEmail,
     userEmailHash,
     repositoryRootDir: repositoryRootDirectory,
+    cloneDepth,
+    cloneFilter,
   };
 }
 

--- a/node-src/tasks/gitInfo.test.ts
+++ b/node-src/tasks/gitInfo.test.ts
@@ -109,7 +109,7 @@ const buildInput = (overrides: Partial<GitInfoInput> = {}): GitInfoInput => ({
 beforeEach(() => {
   getCommitAndBranch.mockResolvedValue(commitInfo);
   getUncommittedHash.mockResolvedValue('abc123');
-  getParentCommits.mockResolvedValue(['asd2344']);
+  getParentCommits.mockResolvedValue({ ancestorCommits: ['asd2344'], visitedCommits: [] });
   getBaselineBuilds.mockResolvedValue([]);
   getChangedFilesWithReplacement.mockResolvedValue({ changedFiles: [] });
   getVersion.mockResolvedValue('Git v1.0.0');
@@ -218,7 +218,10 @@ describe('gatherGitInfo', () => {
 
   it('returns continue with rebuildForBuildId when force-rebuild prevents skip', async () => {
     const lastBuild = { id: 'last-build-id', status: 'PASSED', storybookUrl: 'https://x' };
-    getParentCommits.mockResolvedValue([commitInfo.commit]);
+    getParentCommits.mockResolvedValue({
+      ancestorCommits: [commitInfo.commit],
+      visitedCommits: [],
+    });
     client.runQuery.mockReturnValue({ app: { isOnboarding: false, lastBuild } });
 
     const result = await gatherGitInfo(
@@ -247,7 +250,10 @@ describe('gatherGitInfo', () => {
       inheritedCaptureCount: 9,
     };
 
-    getParentCommits.mockResolvedValue([commitInfo.commit]);
+    getParentCommits.mockResolvedValue({
+      ancestorCommits: [commitInfo.commit],
+      visitedCommits: [],
+    });
     client.runQuery.mockReturnValue({ app: { lastBuild } });
 
     const result = await gatherGitInfo(buildDeps(), buildInput());

--- a/node-src/tasks/gitInfo.test.ts
+++ b/node-src/tasks/gitInfo.test.ts
@@ -64,6 +64,9 @@ const getStorybookCreationDate = vi.mocked(git.getStorybookCreationDate);
 const getNumberOfCommitters = vi.mocked(git.getNumberOfCommitters);
 const getCommittedFileCount = vi.mocked(git.getCommittedFileCount);
 const getUncommittedHash = vi.mocked(git.getUncommittedHash);
+const getCloneDepth = vi.mocked(git.getCloneDepth);
+const getCloneFilter = vi.mocked(git.getCloneFilter);
+const getShallowBoundaryCommits = vi.mocked(git.getShallowBoundaryCommits);
 const getBaselineBuilds = vi.mocked(getBaselineBuildsUnmocked);
 const getParentCommits = vi.mocked(getParentCommitsUnmocked);
 const getHasRouter = vi.mocked(getHasRouterUnmocked);
@@ -118,6 +121,9 @@ beforeEach(() => {
   getNumberOfCommitters.mockResolvedValue(17);
   getCommittedFileCount.mockResolvedValue(100);
   getHasRouter.mockReturnValue(true);
+  getCloneDepth.mockResolvedValue('full');
+  getCloneFilter.mockResolvedValue('full');
+  getShallowBoundaryCommits.mockResolvedValue([]);
 
   client.runQuery.mockReturnValue({ app: { isOnboarding: false } });
 });
@@ -502,5 +508,70 @@ describe('extractGitInfoInput', () => {
       externals: ['foo'],
       untraced: ['bar'],
     });
+  });
+});
+
+describe('gatherGitInfo clone detection', () => {
+  it('sets cloneDepth and cloneFilter to full for a standard clone', async () => {
+    const result = await gatherGitInfo(buildDeps(), buildInput());
+    expectKind(result, 'continue');
+    expect(result.output.git).toMatchObject({ cloneDepth: 'full', cloneFilter: 'full' });
+    expect(result.output.git.shallowBoundaryCommits).toBeUndefined();
+  });
+
+  it('sets cloneDepth to shallow and populates shallowBoundaryCommits', async () => {
+    getCloneDepth.mockResolvedValue('shallow');
+    getShallowBoundaryCommits.mockResolvedValue(['abc1234', 'def5678']);
+    const result = await gatherGitInfo(buildDeps(), buildInput());
+    expectKind(result, 'continue');
+    expect(result.output.git).toMatchObject({
+      cloneDepth: 'shallow',
+      shallowBoundaryCommits: ['abc1234', 'def5678'],
+    });
+  });
+
+  it('does not fetch shallowBoundaryCommits for a full clone', async () => {
+    getCloneDepth.mockResolvedValue('full');
+    const result = await gatherGitInfo(buildDeps(), buildInput());
+    expectKind(result, 'continue');
+    expect(getShallowBoundaryCommits).not.toHaveBeenCalled();
+    expect(result.output.git.shallowBoundaryCommits).toBeUndefined();
+  });
+
+  it('sets cloneFilter to blobless', async () => {
+    getCloneFilter.mockResolvedValue('blobless');
+    const result = await gatherGitInfo(buildDeps(), buildInput());
+    expectKind(result, 'continue');
+    expect(result.output.git.cloneFilter).toBe('blobless');
+  });
+
+  it('sets cloneFilter to treeless', async () => {
+    getCloneFilter.mockResolvedValue('treeless');
+    const result = await gatherGitInfo(buildDeps(), buildInput());
+    expectKind(result, 'continue');
+    expect(result.output.git.cloneFilter).toBe('treeless');
+  });
+
+  it('continues when getCloneDepth fails', async () => {
+    getCloneDepth.mockRejectedValue(new Error('unsupported git version'));
+    const result = await gatherGitInfo(buildDeps(), buildInput());
+    expectKind(result, 'continue');
+    expect(result.output.git.cloneDepth).toBeUndefined();
+    expect(result.output.git.shallowBoundaryCommits).toBeUndefined();
+  });
+
+  it('continues when getCloneFilter fails', async () => {
+    getCloneFilter.mockRejectedValue(new Error('git config failed'));
+    const result = await gatherGitInfo(buildDeps(), buildInput());
+    expectKind(result, 'continue');
+    expect(result.output.git.cloneFilter).toBeUndefined();
+  });
+
+  it('continues when getShallowBoundaryCommits fails', async () => {
+    getCloneDepth.mockResolvedValue('shallow');
+    getShallowBoundaryCommits.mockRejectedValue(new Error('could not read shallow file'));
+    const result = await gatherGitInfo(buildDeps(), buildInput());
+    expectKind(result, 'continue');
+    expect(result.output.git.shallowBoundaryCommits).toBeUndefined();
   });
 });

--- a/node-src/tasks/gitInfo.ts
+++ b/node-src/tasks/gitInfo.ts
@@ -5,10 +5,13 @@ import { getChangedFilesWithReplacement } from '../git/getChangedFilesWithReplac
 import getCommitAndBranch from '../git/getCommitAndBranch';
 import { getParentCommits } from '../git/getParentCommits';
 import {
+  getCloneDepth,
+  getCloneFilter,
   getCommittedFileCount,
   getNumberOfCommitters,
   getRepositoryCreationDate,
   getRepositoryRoot,
+  getShallowBoundaryCommits,
   getSlug,
   getStorybookCreationDate,
   getUncommittedHash,
@@ -208,6 +211,37 @@ export async function gatherGitInfo(
     log.warn(undefinedBranchOwner());
     git.branch = git.branch.replace(UNDEFINED_BRANCH_PREFIX_REGEXP, '');
   }
+
+  const [cloneDepth, cloneFilter] = await Promise.all([
+    getCloneDepth({ log, options }).catch((err) => {
+      log.debug({ err }, 'Failed to detect clone depth');
+      return undefined;
+    }),
+    getCloneFilter({ log, options }).catch((err) => {
+      log.debug({ err }, 'Failed to detect clone filter');
+      return undefined;
+    }),
+  ]);
+  const shallowBoundaryCommits =
+    cloneDepth === 'shallow'
+      ? await getShallowBoundaryCommits({ log, options }).catch((err) => {
+          log.debug({ err }, 'Failed to retrieve shallow boundary commits');
+          return [] as string[];
+        })
+      : [];
+
+  log.debug(
+    `Git clone type: ${JSON.stringify({
+      cloneDepth,
+      cloneFilter,
+      shallowBoundaryCommitCount: shallowBoundaryCommits.length,
+      firstShallowBoundaryCommits: shallowBoundaryCommits.slice(0, 50),
+    })}`
+  );
+
+  git.cloneDepth = cloneDepth;
+  git.cloneFilter = cloneFilter;
+  if (shallowBoundaryCommits.length > 0) git.shallowBoundaryCommits = shallowBoundaryCommits;
 
   const { branch, commit, slug } = git;
 

--- a/node-src/tasks/gitInfo.ts
+++ b/node-src/tasks/gitInfo.ts
@@ -261,7 +261,7 @@ export async function gatherGitInfo(
     throw new Error(skipFailed().output);
   }
 
-  const parentCommits = await getParentCommits(
+  const { ancestorCommits: parentCommits, visitedCommits } = await getParentCommits(
     { log, client, options },
     {
       git,
@@ -269,6 +269,7 @@ export async function gatherGitInfo(
     }
   );
   git.parentCommits = parentCommits;
+  git.visitedCommits = visitedCommits;
   log.debug(`Found parentCommits: ${parentCommits.join(', ')}`);
 
   const result = await client.runQuery<LastBuildQueryResult>(LastBuildQuery, {

--- a/node-src/tasks/initialize/announceBuild.ts
+++ b/node-src/tasks/initialize/announceBuild.ts
@@ -64,6 +64,10 @@ const parseAnnounceBuildMutationInput = (deps: AnnounceBuildDeps, input: Announc
     packageMetadataChanges,
     gitUserEmail,
     rootPath,
+    visitedCommits,
+    cloneFilter,
+    cloneDepth,
+    shallowBoundaryCommits,
     ...commitInfo
   } = input.git; // omit some fields;
   const { rebuildForBuildId, turboSnap } = input;

--- a/node-src/types.ts
+++ b/node-src/types.ts
@@ -171,6 +171,17 @@ type StorybookReference =
   | ((config: StorybookReferenceConfig & { sourceUrl: string }) => StorybookReferenceConfig)
   | { disable: boolean };
 
+/** Whether the clone has full or truncated commit history. */
+export type CloneDepth = 'full' | 'shallow';
+
+/**
+ * Whether git objects are fully present or filtered at clone time.
+ * - `'full'` — all objects fetched (standard clone)
+ * - `'blobless'` — file contents fetched on demand (`--filter=blob:none`)
+ * - `'treeless'` — tree and blob objects fetched on demand (`--filter=tree:0`)
+ */
+export type CloneFilter = 'full' | 'blobless' | 'treeless';
+
 export interface Git {
   version?: string;
   /** The absolute location on disk of the git project */
@@ -193,6 +204,16 @@ export interface Git {
   replacementBuildIds?: [string, string][];
   matchesBranch?: (glob: boolean | string) => boolean;
   packageMetadataChanges?: { changedFiles: string[]; commit: string }[];
+  /** Whether commit history was truncated at clone time (`git clone --depth`). */
+  cloneDepth?: CloneDepth;
+  /**
+   * Commits present in the clone whose parents were not fetched (the shallow boundary).
+   * Only set when `cloneDepth` is `'shallow'`. Each SHA is a commit that exists locally
+   * but whose parent commits are absent from the repository.
+   */
+  shallowBoundaryCommits?: string[];
+  /** Whether object fetching is filtered at clone time (`git clone --filter`). */
+  cloneFilter?: CloneFilter;
 }
 
 export interface ProjectMetadata {

--- a/node-src/types.ts
+++ b/node-src/types.ts
@@ -192,6 +192,11 @@ export interface VisitedCommit {
    * The subject itself is not stored.
    */
   isProbableSquashMerge: boolean;
+  /**
+   * This commit is at the shallow boundary of the clone (`git clone --depth`), meaning its
+   * parents were not fetched. Ancestor selection cannot look further back past this point.
+   */
+  isShallowBoundary: boolean;
 }
 
 /** Whether the clone has full or truncated commit history. */

--- a/node-src/types.ts
+++ b/node-src/types.ts
@@ -171,6 +171,29 @@ type StorybookReference =
   | ((config: StorybookReferenceConfig & { sourceUrl: string }) => StorybookReferenceConfig)
   | { disable: boolean };
 
+/**
+ * Metadata about a commit visited during the parent-commit walk in `getParentCommits`.
+ * Used for diagnostics — helps explain why a particular baseline was (or wasn't) chosen.
+ */
+export interface VisitedCommit {
+  /** The commit SHA. */
+  commit: string;
+  /** Direct parent SHAs. */
+  parentCommits: string[];
+  /** A Chromatic build exists for this commit. */
+  hasBuild: boolean;
+  /**
+   * The index told us this was a merge commit for a PR, likely a squash or rebase merge.
+   */
+  isMergePoint: boolean;
+  /**
+   * The commit subject matches `(#N)`, which is the default format appended by GitHub and
+   * Bitbucket Cloud for squash merges. Not reliable for GitLab (`!N`) or Bitbucket Server.
+   * The subject itself is not stored.
+   */
+  isProbableSquashMerge: boolean;
+}
+
 /** Whether the clone has full or truncated commit history. */
 export type CloneDepth = 'full' | 'shallow';
 
@@ -204,6 +227,8 @@ export interface Git {
   replacementBuildIds?: [string, string][];
   matchesBranch?: (glob: boolean | string) => boolean;
   packageMetadataChanges?: { changedFiles: string[]; commit: string }[];
+  /** All commits visited during the `getParentCommits` walk, with annotations */
+  visitedCommits?: VisitedCommit[];
   /** Whether commit history was truncated at clone time (`git clone --depth`). */
   cloneDepth?: CloneDepth;
   /**


### PR DESCRIPTION
Add the following to diagnostics and logging:

- git checkout depth (full vs shallow)
- git checkout filter (full vs blobless vs treeless)
- git shallow checkout boundaries
- commits visited by the ancestor detection with:
  - hash
  - parent hashes
  - whether they are a merge commit (according to upstream)
  - whether they have a commit message that makes it sound like they are a merge commit
  - whether they are a shallow checkout boundary.

This should make it much easier to diagnose unusual edge cases around ancestor detection failing for the reasons mentioned above (shallow/filtered checkouts, undetected merge commits, generally not seeing a commit we expect to find, due to commit structure).

To QA:

1. Do a checkout with various kinds of filtering/depth limitations
2. Run a build w/ the canary
3. Check the logs and diagnostics correctly include the limiting info.
4. Examine the visited commits carefully and check that they register when they hit a shallow clone
5. Do a squash merge on the repo
6. Run a build and check that the visited commits includes `{ isMergePoint: true, isProbableSquashMerge: true }`

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>18.6.0--canary.1429.32216369574.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@18.6.0--canary.1429.32216369574.0
  # or 
  yarn add chromatic@18.6.0--canary.1429.32216369574.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
