### PR TITLE
Improve Storybook main config parsing

### DIFF
--- a/node-src/__mocks__/storybookMainConfig/js-cjs-default-export/.storybook/main.js
+++ b/node-src/__mocks__/storybookMainConfig/js-cjs-default-export/.storybook/main.js
@@ -1,0 +1,4 @@
+// A cjs config that nests its fields under `default`, the shape `require()` gives back for an ESM
+// config. `require()` of this file succeeds on every supported Node, so the reader's `default`
+// unwrap is exercised regardless of whether the runtime has `require(esm)`.
+module.exports = { default: { staticDirs: ['./static', '../public'] } };

--- a/node-src/__mocks__/storybookMainConfig/js-cjs-default-export/package.json
+++ b/node-src/__mocks__/storybookMainConfig/js-cjs-default-export/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "fixture-js-cjs-default-export"
+}

--- a/node-src/__mocks__/storybookMainConfig/js-cjs-refs-function/.storybook/main.js
+++ b/node-src/__mocks__/storybookMainConfig/js-cjs-refs-function/.storybook/main.js
@@ -1,0 +1,7 @@
+// Storybook lets `refs` be a function. `require()` of this config hands the function back, where a
+// parsed AST hands back nothing, so this fixture pins that we drop it either way.
+module.exports = {
+  refs: (config, { configType }) => ({
+    design: { title: configType, url: 'https://example.chromatic.com' },
+  }),
+};

--- a/node-src/__mocks__/storybookMainConfig/js-cjs-refs-function/package.json
+++ b/node-src/__mocks__/storybookMainConfig/js-cjs-refs-function/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "fixture-js-cjs-refs-function"
+}

--- a/node-src/__mocks__/storybookMainConfig/js-cjs-refs/.storybook/main.js
+++ b/node-src/__mocks__/storybookMainConfig/js-cjs-refs/.storybook/main.js
@@ -1,0 +1,3 @@
+module.exports = {
+  refs: { design: { title: 'Design System', url: 'https://example.chromatic.com' } },
+};

--- a/node-src/__mocks__/storybookMainConfig/js-cjs-refs/package.json
+++ b/node-src/__mocks__/storybookMainConfig/js-cjs-refs/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "fixture-js-cjs-refs"
+}

--- a/node-src/__mocks__/storybookMainConfig/js-esm-unrequirable/.storybook/main.js
+++ b/node-src/__mocks__/storybookMainConfig/js-esm-unrequirable/.storybook/main.js
@@ -1,0 +1,5 @@
+// The missing import makes `require()` of this config throw on every supported Node, with or
+// without `require(esm)`, so this fixture always takes the AST fallback.
+import 'chromatic-fixture-missing-package';
+
+export default { staticDirs: ['./static', '../public'] };

--- a/node-src/__mocks__/storybookMainConfig/js-esm-unrequirable/package.json
+++ b/node-src/__mocks__/storybookMainConfig/js-esm-unrequirable/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "fixture-js-esm-unrequirable",
+  "type": "module"
+}

--- a/node-src/lib/getStorybookMetadata.test.ts
+++ b/node-src/lib/getStorybookMetadata.test.ts
@@ -1,15 +1,20 @@
 import { describe, expect, it, vi } from 'vitest';
 
-import { findStaticDirectories, getStorybookMetadata } from './getStorybookMetadata';
+import {
+  findStaticDirectories,
+  getStorybookMetadata,
+  MainConfigReader,
+  readMainConfig,
+} from './getStorybookMetadata';
 
-const makeConfig = (returnValue: any) => ({
-  getSafeFieldValue: vi.fn().mockReturnValue(returnValue),
-});
+function makeConfig(returnValue: any): MainConfigReader {
+  return { readField: vi.fn().mockReturnValue(returnValue) };
+}
 
 describe('findStaticDirs', () => {
   it('returns string entries resolved relative to configDirectory', () => {
     const config = makeConfig(['./static', '../public']);
-    expect(findStaticDirectories(config, true, '.storybook')).toEqual({
+    expect(findStaticDirectories(config, '.storybook')).toEqual({
       staticDir: ['.storybook/static', 'public'],
     });
   });
@@ -19,66 +24,54 @@ describe('findStaticDirs', () => {
       { from: './static', to: '/' },
       { from: '../public', to: '/public' },
     ]);
-    expect(findStaticDirectories(config, true, '.storybook')).toEqual({
+    expect(findStaticDirectories(config, '.storybook')).toEqual({
       staticDir: ['.storybook/static', 'public'],
     });
   });
 
   it('handles mixed string and object entries', () => {
     const config = makeConfig(['./static', { from: '../public', to: '/' }]);
-    expect(findStaticDirectories(config, true, '.storybook')).toEqual({
+    expect(findStaticDirectories(config, '.storybook')).toEqual({
       staticDir: ['.storybook/static', 'public'],
     });
   });
 
   it('leaves absolute paths unchanged', () => {
     const config = makeConfig(['/absolute/path']);
-    expect(findStaticDirectories(config, true, '.storybook')).toEqual({
+    expect(findStaticDirectories(config, '.storybook')).toEqual({
       staticDir: ['/absolute/path'],
     });
   });
 
   it('uses nested configDirectory when provided', () => {
     const config = makeConfig(['./static']);
-    expect(findStaticDirectories(config, true, 'packages/ui/.storybook')).toEqual({
+    expect(findStaticDirectories(config, 'packages/ui/.storybook')).toEqual({
       staticDir: ['packages/ui/.storybook/static'],
     });
   });
 
   it('returns {} for empty array', () => {
     const config = makeConfig([]);
-    expect(findStaticDirectories(config, true)).toEqual({});
+    expect(findStaticDirectories(config)).toEqual({});
   });
 
-  it('reads staticDirs off an evaluated CommonJS config module', () => {
-    expect(findStaticDirectories({ staticDirs: ['./static'] }, false)).toEqual({
-      staticDir: ['.storybook/static'],
-    });
-  });
-
-  it('reads staticDirs off the default export of an evaluated ESM config module', () => {
-    expect(findStaticDirectories({ default: { staticDirs: ['./static'] } }, false)).toEqual({
-      staticDir: ['.storybook/static'],
-    });
-  });
-
-  it('returns {} when mainConfig is null', () => {
-    expect(findStaticDirectories(null, true)).toEqual({});
+  it('returns {} when the main config could not be read', () => {
+    expect(findStaticDirectories(undefined)).toEqual({});
   });
 
   it('returns {} when staticDirs is not present on config', () => {
     const config = makeConfig(undefined);
-    expect(findStaticDirectories(config, true)).toEqual({});
+    expect(findStaticDirectories(config)).toEqual({});
   });
 
   it('returns {} when staticDirs is a non-array value', () => {
     const config = makeConfig('./static');
-    expect(findStaticDirectories(config, true)).toEqual({});
+    expect(findStaticDirectories(config)).toEqual({});
   });
 
   it('returns {} when all entries have no valid path', () => {
     const config = makeConfig([null, undefined, { to: '/' }]);
-    expect(findStaticDirectories(config, true)).toEqual({});
+    expect(findStaticDirectories(config)).toEqual({});
   });
 });
 
@@ -96,14 +89,41 @@ function getDeps(project: string) {
   } as any;
 }
 
+describe('readMainConfig reader', () => {
+  it('reads a top-level field off an evaluated module', async () => {
+    const mainConfig = await readMainConfig(`${FIXTURES}/js-cjs/.storybook`, getDeps('js-cjs').log);
+
+    expect(mainConfig?.readField('staticDirs')).toEqual(['./static', '../public']);
+  });
+
+  it('unwraps a default export off an evaluated module', async () => {
+    const mainConfig = await readMainConfig(
+      `${FIXTURES}/js-cjs-default-export/.storybook`,
+      getDeps('js-cjs-default-export').log
+    );
+
+    expect(mainConfig?.readField('staticDirs')).toEqual(['./static', '../public']);
+  });
+
+  it('returns undefined when neither read path yields a config', async () => {
+    const mainConfig = await readMainConfig(
+      `${FIXTURES}/does-not-exist/.storybook`,
+      getDeps('does-not-exist').log
+    );
+
+    expect(mainConfig).toBeUndefined();
+  });
+});
+
 describe('getStorybookMetadata staticDirs discovery', () => {
   it.each([
-    { project: 'ts-esm', file: 'main.ts', format: 'esm' },
-    { project: 'js-esm', file: 'main.js', format: 'esm' },
-    { project: 'js-cjs', file: 'main.js', format: 'cjs' },
-    { project: 'mjs-esm', file: 'main.mjs', format: 'esm' },
-    { project: 'cjs', file: 'main.cjs', format: 'cjs' },
-  ])('resolves staticDirs from $file ($format)', async ({ project }) => {
+    { project: 'ts-esm', shape: 'a parsed main.ts' },
+    { project: 'js-cjs', shape: 'an evaluated cjs main.js' },
+    { project: 'js-esm', shape: 'an esm main.js' },
+    { project: 'js-esm-unrequirable', shape: "a main.js require() can't evaluate" },
+    { project: 'mjs-esm', shape: 'a parsed main.mjs' },
+    { project: 'cjs', shape: 'a parsed main.cjs' },
+  ])('resolves staticDirs from $shape', async ({ project }) => {
     const metadata = await getStorybookMetadata(getDeps(project));
 
     expect(metadata.staticDir).toEqual([
@@ -113,8 +133,55 @@ describe('getStorybookMetadata staticDirs discovery', () => {
   });
 });
 
-describe('getStorybookMetadata builder discovery', () => {
-  it('detects the builder from an evaluated ESM config module', async () => {
+describe('getStorybookMetadata fields visible on ctx.storybook', () => {
+  it.each([
+    { project: 'ts-esm', shape: 'a parsed main.ts', fields: ['staticDir', 'version'] },
+    { project: 'mjs-esm', shape: 'a parsed main.mjs', fields: ['staticDir', 'version'] },
+    { project: 'cjs', shape: 'a parsed main.cjs', fields: ['staticDir', 'version'] },
+    { project: 'js-cjs', shape: 'an evaluated cjs main.js', fields: ['staticDir', 'version'] },
+    {
+      project: 'js-esm-unrequirable',
+      shape: 'a parsed main.js',
+      fields: ['staticDir', 'version'],
+    },
+    {
+      project: 'builder-js-esm',
+      shape: 'a main.js declaring a framework',
+      fields: ['builder', 'version'],
+    },
+    { project: 'js-cjs-refs', shape: 'a main.js declaring refs', fields: ['refs', 'version'] },
+    {
+      project: 'js-cjs-refs-function',
+      shape: 'a main.js declaring refs as a function',
+      fields: ['version'],
+    },
+  ])('exposes exactly $fields for $shape', async ({ project, fields }) => {
+    const metadata = await getStorybookMetadata(getDeps(project));
+
+    expect(Object.keys(metadata).sort()).toEqual(fields);
+  });
+
+  it('exposes staticDir and version for an esm main.js regardless of the runtime read path', async () => {
+    const metadata = await getStorybookMetadata(getDeps('js-esm'));
+
+    expect(Object.keys(metadata).sort()).toEqual(['staticDir', 'version']);
+  });
+
+  it('reports the refs declared by an evaluated config', async () => {
+    const metadata = await getStorybookMetadata(getDeps('js-cjs-refs'));
+
+    expect(metadata.refs).toEqual({
+      design: { title: 'Design System', url: 'https://example.chromatic.com' },
+    });
+  });
+
+  it('drops refs the config declares as a function, which we cannot evaluate', async () => {
+    const metadata = await getStorybookMetadata(getDeps('js-cjs-refs-function'));
+
+    expect(metadata.refs).toBeUndefined();
+  });
+
+  it('reports the builder declared by the framework field', async () => {
     const metadata = await getStorybookMetadata(getDeps('builder-js-esm'));
 
     expect(metadata.builder?.name).toBe('@storybook/react-vite');

--- a/node-src/lib/getStorybookMetadata.ts
+++ b/node-src/lib/getStorybookMetadata.ts
@@ -109,6 +109,10 @@ async function findBuilder(mainConfig?: MainConfigReader) {
 // Only used by Chromatic - surfaces Storybook refs and is used when announcing a build.
 // The refs are consumed by the MCP Addon for hosted Storybooks with composition on Chromatic.
 async function findReferences(mainConfig?: MainConfigReader) {
+  if (!mainConfig) {
+    return {};
+  }
+
   // An evaluated config can hand back a `refs` function, which we can't make sense of.
   const references = objectField(mainConfig, 'refs');
   return references ? { refs: references } : {};
@@ -358,7 +362,7 @@ async function findStorybookVersion({ env, log, options, packageJson }: Storyboo
  * @returns The field's value when it is a plain object, otherwise `undefined`.
  */
 function objectField(
-  mainConfig: MainConfigReader | undefined,
+  mainConfig: MainConfigReader,
   field: string
 ): Record<string, unknown> | undefined {
   const value = mainConfig?.readField(field);

--- a/node-src/lib/getStorybookMetadata.ts
+++ b/node-src/lib/getStorybookMetadata.ts
@@ -17,13 +17,20 @@ import { viewLayers } from './viewLayers';
 /**
  * Reads the `-c` and `-s` flags out of the project's Storybook build script.
  *
- * @param deps The resolved options and the project's package.json.
+ * @param input The project's package.json and the resolved build script name.
+ * @param input.buildScriptName The package.json script that builds Storybook.
+ * @param input.packageJson The project's package.json.
  *
  * @returns The config directory and static directories the build script names, if any.
  */
-export const findConfigFlags = async (deps: Pick<StorybookInfoDeps, 'options' | 'packageJson'>) => {
-  const { buildScriptName } = deps.options;
-  const { scripts = {} } = deps.packageJson;
+export async function findConfigFlags({
+  buildScriptName,
+  packageJson,
+}: {
+  buildScriptName?: string;
+  packageJson: StorybookInfoDeps['packageJson'];
+}) {
+  const { scripts = {} } = packageJson;
   if (!buildScriptName || !scripts[buildScriptName]) return {};
 
   const { flags } = meow({
@@ -38,35 +45,36 @@ export const findConfigFlags = async (deps: Pick<StorybookInfoDeps, 'options' | 
     configDir: flags.configDir,
     staticDir: flags.staticDir ? flags.staticDir.split(',') : undefined,
   };
-};
+}
 
 /**
- * Reads a top-level field out of the main config, in either of the two forms it can take.
+ * A loaded Storybook main config, which answers field reads in whichever form the config took.
  *
  * An evaluated module exposes its fields as plain properties, nested under `default` for ESM. A
- * parsed AST answers `getSafeFieldValue` instead.
- *
- * @param mainConfig The main config, either an evaluated module or a parsed AST.
- * @param isAstConfig Whether `mainConfig` is a parsed AST rather than an evaluated module.
- * @param field The top-level field to read.
- *
- * @returns The field's value, or `undefined` when it is absent.
+ * parsed AST answers `getSafeFieldValue` instead. `readMainConfig` hides that behind `readField`, so
+ * callers read fields the same way without caring which form the config took.
  */
-export const readMainConfigField = (mainConfig: any, isAstConfig: boolean, field: string) => {
-  if (!mainConfig) return undefined;
-  if (isAstConfig) return mainConfig.getSafeFieldValue([field]);
-  return mainConfig.default?.[field] ?? mainConfig[field];
-};
+export interface MainConfigReader {
+  /** Reads a top-level field, returning `undefined` when it is absent. */
+  readField: (field: string) => unknown;
+}
 
-export const findBuilder = async (mainConfig, isAstConfig) => {
+/**
+ * Resolves the builder the main config declares, along with its installed version.
+ *
+ * @param mainConfig The loaded main config, or undefined when it could not be read.
+ *
+ * @returns The builder name and package version, or an unknown builder without a config.
+ */
+export async function findBuilder(mainConfig?: MainConfigReader) {
   if (!mainConfig) {
     return { builder: { name: 'unknown', packageVersion: '0' } };
   }
 
-  const framework = readMainConfigField(mainConfig, isAstConfig, 'framework');
-  const core = readMainConfigField(mainConfig, isAstConfig, 'core');
+  const framework = objectField(mainConfig, 'framework');
+  const core = objectField(mainConfig, 'core');
 
-  if (framework?.name) {
+  if (typeof framework?.name === 'string') {
     const sbV7BuilderName = framework.name;
 
     return Promise.race([
@@ -80,9 +88,11 @@ export const findBuilder = async (mainConfig, isAstConfig) => {
   }
 
   let name = 'webpack4'; // default builder in Storybook v6
-  if (core?.builder) {
-    const { builder } = core;
-    name = typeof builder === 'string' ? builder : builder.name;
+  const builder = core?.builder;
+  if (typeof builder === 'string') {
+    name = builder;
+  } else if (isRecord(builder) && typeof builder.name === 'string') {
+    name = builder.name;
   }
 
   return Promise.race([
@@ -93,76 +103,82 @@ export const findBuilder = async (mainConfig, isAstConfig) => {
       }),
     timeout(10_000),
   ]);
-};
+}
 
 // TODO: Update this when we start tracking refs within the project.json file; if refs are tracked there, we can skip this logic
 // Only used by Chromatic - surfaces Storybook refs and is used when announcing a build.
 // The refs are consumed by the MCP Addon for hosted Storybooks with composition on Chromatic.
-const findReferences = async (mainConfig, isAstConfig) => {
-  // The MCP Addon was first added within version 9; there is no need to check for older versions
-  if (!mainConfig || !isAstConfig) {
-    return {};
-  }
-
-  const references = readMainConfigField(mainConfig, isAstConfig, 'refs');
+async function findReferences(mainConfig?: MainConfigReader) {
+  // An evaluated config can hand back a `refs` function, which we can't make sense of.
+  const references = objectField(mainConfig, 'refs');
   return references ? { refs: references } : {};
-};
+}
 
 /**
  * Resolves the project-relative static directories declared by the main config.
  *
- * @param mainConfig The main config, either an evaluated module or a parsed AST.
- * @param isAstConfig Whether `mainConfig` is a parsed AST rather than an evaluated module.
+ * @param mainConfig The loaded main config, or undefined when it could not be read.
  * @param configDirectory The project-relative Storybook config directory entries resolve against.
  *
  * @returns The resolved static directories, or `{}` when the config declares none.
  */
-export const findStaticDirectories = (
-  mainConfig: any,
-  isAstConfig: boolean,
+export function findStaticDirectories(
+  mainConfig: MainConfigReader | undefined,
   configDirectory = '.storybook'
-): { staticDir?: string[] } => {
-  const staticDirectories = readMainConfigField(mainConfig, isAstConfig, 'staticDirs');
+): { staticDir?: string[] } {
+  const staticDirectories = mainConfig?.readField('staticDirs');
   if (!Array.isArray(staticDirectories) || staticDirectories.length === 0) return {};
 
-  // staticDirs entries can be plain strings or { from, to } DirectoryMapping objects
-  const directories = staticDirectories
+  const directoriesFromConfig = staticDirectories
     .map((entry: string | { from: string }) => (typeof entry === 'string' ? entry : entry?.from))
-    .filter(Boolean) as string[];
+    .filter(Boolean);
 
   // Convert directories to posix for cross-platform consistency
   const safeConfigDirectory = posix(configDirectory);
-  const resolvedDirectories = directories.map((directory) =>
+  const resolvedDirectories = directoriesFromConfig.map((directory) =>
     path.posix.isAbsolute(directory) ? directory : path.posix.join(safeConfigDirectory, directory)
   );
 
   return resolvedDirectories.length > 0 ? { staticDir: resolvedDirectories } : {};
-};
+}
 
-export const findStorybookConfigFile = async (
+// The main config files we parse into an AST when `require()` of the config fails. Widening this
+// widens what lands on `ctx.storybook`.
+const MAIN_CONFIG_PATTERN = /^main\.[cm]?[jt]sx?$/;
+
+/**
+ * Finds the first file in the Storybook config directory that matches the given pattern.
+ *
+ * @param storybookConfigDirectory The Storybook config directory, absolute or relative to the cwd.
+ * @param pattern The pattern to match against the files in the config directory.
+ *
+ * @returns The path to the first matching file, or `undefined` when none match.
+ */
+export async function findStorybookConfigFile(
   storybookConfigDirectory: string | undefined,
   pattern: RegExp
-) => {
+) {
   const configDirectory = storybookConfigDirectory ?? '.storybook';
   const files = await readdir(configDirectory);
   const configFile = files.find((file) => pattern.test(file));
   return configFile && path.join(configDirectory, configFile);
-};
+}
 
 /**
  * Loads the Storybook main config, as either an evaluated module or a parsed AST.
  *
- * Which form we get depends on whether `require()` of the config succeeds.
+ * Which form we get depends on whether `require()` of the config succeeds. Callers get a reader
+ * either way, so the two forms stay isolated to this function.
  *
  * @param configDirectory The Storybook config directory, absolute or relative to the cwd.
  * @param log The logger to report the parse path to.
  *
- * @returns The config and whether it is a parsed AST; no config when neither path succeeded.
+ * @returns The config reader, or undefined when neither path yielded a config.
  */
-export const readMainConfig = async (
+export async function readMainConfig(
   configDirectory: string,
   log: StorybookInfoDeps['log']
-): Promise<{ mainConfig?: any; isAstConfig: boolean }> => {
+): Promise<MainConfigReader | undefined> {
   // @ts-expect-error __non_webpack_require__ is only defined when bundled with webpack, and allows us to bypass webpack's module system to require files at runtime
   // eslint-disable-next-line unicorn/prefer-module
   const r = typeof __non_webpack_require__ === 'undefined' ? require : __non_webpack_require__;
@@ -170,41 +186,48 @@ export const readMainConfig = async (
   try {
     const mainConfig = await r(path.resolve(configDirectory, 'main'));
     log.debug({ configDirectory, mainConfig });
-    return { mainConfig, isAstConfig: false };
+    // An evaluated module that exports nothing is treated the same as no config at all.
+    if (!mainConfig) return undefined;
+    return { readField: (field) => mainConfig.default?.[field] ?? mainConfig[field] };
   } catch (err) {
     log.debug({ storybookV6error: err });
   }
 
   try {
-    // Include `.mjs` and `.cjs` can't be resolved in the step above because `require()` only
-    // auto-appends `.js`/`.json`/`.node` to an extensionless path.
-    const storybookConfig = await findStorybookConfigFile(configDirectory, /^main\.[cm]?[jt]sx?$/);
+    const storybookConfig = await findStorybookConfigFile(configDirectory, MAIN_CONFIG_PATTERN);
     if (!storybookConfig) {
       throw new Error('Failed to locate Storybook config file');
     }
 
     const mainConfig = await readConfig(storybookConfig);
     log.debug({ configDirectory, mainConfig: printConfig(mainConfig) });
-    return { mainConfig, isAstConfig: true };
+    return { readField: (field) => mainConfig.getSafeFieldValue([field]) };
   } catch (err) {
     log.debug({ storybookV7error: err });
-    return { isAstConfig: false };
+    return undefined;
   }
-};
+}
 
-// TODO: refactor this function
-export const getStorybookMetadata = async (
-  deps: StorybookInfoDeps
-): Promise<Partial<Storybook>> => {
+/**
+ * Finds the Storybook metadata from the given dependencies.
+ *
+ * @param deps The dependencies to find the metadata with.
+ *
+ * @returns The Storybook metadata, or an empty object when none could be found.
+ */
+export async function getStorybookMetadata(deps: StorybookInfoDeps): Promise<Partial<Storybook>> {
   const configDirectory = deps.options.storybookConfigDir ?? '.storybook';
-  const { mainConfig, isAstConfig } = await readMainConfig(configDirectory, deps.log);
+  const mainConfig = await readMainConfig(configDirectory, deps.log);
 
   const info = await Promise.allSettled([
-    findConfigFlags(deps),
+    findConfigFlags({
+      buildScriptName: deps.options.buildScriptName,
+      packageJson: deps.packageJson,
+    }),
     findStorybookVersion(deps),
-    findBuilder(mainConfig, isAstConfig),
-    findReferences(mainConfig, isAstConfig),
-    findStaticDirectories(mainConfig, isAstConfig, configDirectory),
+    findBuilder(mainConfig),
+    findReferences(mainConfig),
+    findStaticDirectories(mainConfig, configDirectory),
   ]);
 
   deps.log.debug(info);
@@ -221,7 +244,7 @@ export const getStorybookMetadata = async (
     }
   }
   return metadata;
-};
+}
 
 function resolvePackageJson(pkg: string) {
   try {
@@ -323,4 +346,25 @@ async function findStorybookVersion({ env, log, options, packageJson }: Storyboo
     }),
     timeout(10_000),
   ]);
+}
+
+/**
+ * Reads a field only when it holds a plain object, which is all our callers can use. An evaluated
+ * config can hand back a function or a class instance where a parsed AST hands back nothing.
+ *
+ * @param mainConfig The loaded main config, or undefined when it could not be read.
+ * @param field The top-level field to read.
+ *
+ * @returns The field's value when it is a plain object, otherwise `undefined`.
+ */
+function objectField(
+  mainConfig: MainConfigReader | undefined,
+  field: string
+): Record<string, unknown> | undefined {
+  const value = mainConfig?.readField(field);
+  return isRecord(value) ? value : undefined;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
 }

--- a/node-src/lib/getStorybookMetadata.ts
+++ b/node-src/lib/getStorybookMetadata.ts
@@ -14,106 +14,6 @@ import { posix } from './posix';
 import { raceFulfilled, timeout } from './promises';
 import { viewLayers } from './viewLayers';
 
-export const resolvePackageJson = (pkg: string) => {
-  try {
-    const packagePath = path.resolve(`node_modules/${pkg}/package.json`);
-    return readJson(packagePath);
-  } catch (error) {
-    return Promise.reject(error);
-  }
-};
-
-const findDependency = (
-  { dependencies, devDependencies, peerDependencies }: StorybookInfoDeps['packageJson'],
-  predicate: (key: string) => string
-) => [
-  Object.keys(dependencies || {}).find((dependency) => predicate(dependency)),
-  Object.keys(devDependencies || {}).find((dependency) => predicate(dependency)),
-  Object.keys(peerDependencies || {}).find((dependency) => predicate(dependency)),
-];
-
-const getDependencyInfo = (
-  { packageJson, log }: Pick<StorybookInfoDeps, 'packageJson' | 'log'>,
-  dependencyMap: Record<string, string>
-) => {
-  // eslint-disable-next-line unicorn/prevent-abbreviations
-  const [dep, devDep, peerDep] = findDependency(packageJson, (key) => dependencyMap[key]);
-  const [pkg, version] = dep || devDep || peerDep || [];
-  const dependency = viewLayers[pkg];
-
-  if (dep && devDep && dep[0] === devDep[0]) {
-    log.warn(
-      `Found "${dep[0]}" in both "dependencies" and "devDependencies". This is probably a mistake.`
-    );
-  }
-  if (dep && peerDep && dep[0] === peerDep[0]) {
-    log.warn(
-      `Found "${dep[0]}" in both "dependencies" and "peerDependencies". This is probably a mistake.`
-    );
-  }
-  return { dependency, version, dependencyPackage: pkg };
-};
-
-const findStorybookVersion = async ({ env, log, options, packageJson }: StorybookInfoDeps) => {
-  // Allow setting Storybook version via CHROMATIC_STORYBOOK_VERSION='@storybook/react@4.0-alpha.8' for unusual cases
-  if (env.CHROMATIC_STORYBOOK_VERSION) {
-    const [, p, v] = env.CHROMATIC_STORYBOOK_VERSION.match(/(.+)@(.+)$/) || [];
-    const version = semver.valid(v); // ensures we get a specific version, not a range
-    if (!p || !version) {
-      throw new Error(
-        'Invalid CHROMATIC_STORYBOOK_VERSION; expecting something like "@storybook/react@6.2.0".'
-      );
-    }
-    const viewLayer = viewLayers[p] || viewLayers[`@storybook/${p}`];
-    if (!viewLayer) {
-      throw new Error(`Unsupported viewlayer specified in CHROMATIC_STORYBOOK_VERSION: ${p}`);
-    }
-    return { version };
-  }
-
-  const {
-    dependency: viewLayer,
-    version,
-    dependencyPackage: pkg,
-  } = getDependencyInfo({ log, packageJson }, viewLayers);
-
-  if (viewLayer) {
-    if (options.storybookBuildDir) {
-      // If we aren't going to invoke the Storybook CLI later, we can exit early.
-      // Note that `version` can be a semver range in this case.
-      return { version };
-    }
-    // Verify that the viewlayer package is actually present in node_modules.
-    return Promise.race([
-      resolvePackageJson(pkg)
-        .then((json) => ({ version: json.version }))
-        .catch(() => {
-          throw new Error(packageDoesNotExist(pkg));
-        }),
-      timeout(10_000),
-    ]);
-  }
-
-  if (!options.interactive) {
-    log.info(`No viewlayer package listed in dependencies. Checking transitive dependencies.`);
-  }
-
-  // We might have a transitive dependency (e.g. through `@nuxtjs/storybook` which depends on
-  // `@storybook/vue`). In this case we look for any viewlayer package present in node_modules,
-  // and return the first one we find.
-  return Promise.race([
-    raceFulfilled(
-      Object.entries(viewLayers).map(async ([key]) => {
-        const json = await resolvePackageJson(key);
-        return { version: json.version };
-      })
-    ).catch(() => {
-      throw new Error(packageDoesNotExist(pkg));
-    }),
-    timeout(10_000),
-  ]);
-};
-
 /**
  * Reads the `-c` and `-s` flags out of the project's Storybook build script.
  *
@@ -322,3 +222,105 @@ export const getStorybookMetadata = async (
   }
   return metadata;
 };
+
+function resolvePackageJson(pkg: string) {
+  try {
+    const packagePath = path.resolve(`node_modules/${pkg}/package.json`);
+    return readJson(packagePath);
+  } catch (error) {
+    return Promise.reject(error);
+  }
+}
+
+function findDependency(
+  { dependencies, devDependencies, peerDependencies }: StorybookInfoDeps['packageJson'],
+  predicate: (key: string) => string
+) {
+  return [
+    Object.keys(dependencies || {}).find((dependency) => predicate(dependency)),
+    Object.keys(devDependencies || {}).find((dependency) => predicate(dependency)),
+    Object.keys(peerDependencies || {}).find((dependency) => predicate(dependency)),
+  ];
+}
+
+function getDependencyInfo(
+  { packageJson, log }: Pick<StorybookInfoDeps, 'packageJson' | 'log'>,
+  dependencyMap: Record<string, string>
+) {
+  // eslint-disable-next-line unicorn/prevent-abbreviations
+  const [dep, devDep, peerDep] = findDependency(packageJson, (key) => dependencyMap[key]);
+  const [pkg, version] = dep || devDep || peerDep || [];
+  const dependency = viewLayers[pkg];
+
+  if (dep && devDep && dep[0] === devDep[0]) {
+    log.warn(
+      `Found "${dep[0]}" in both "dependencies" and "devDependencies". This is probably a mistake.`
+    );
+  }
+  if (dep && peerDep && dep[0] === peerDep[0]) {
+    log.warn(
+      `Found "${dep[0]}" in both "dependencies" and "peerDependencies". This is probably a mistake.`
+    );
+  }
+  return { dependency, version, dependencyPackage: pkg };
+}
+
+async function findStorybookVersion({ env, log, options, packageJson }: StorybookInfoDeps) {
+  // Allow setting Storybook version via CHROMATIC_STORYBOOK_VERSION='@storybook/react@4.0-alpha.8' for unusual cases
+  if (env.CHROMATIC_STORYBOOK_VERSION) {
+    const [, p, v] = env.CHROMATIC_STORYBOOK_VERSION.match(/(.+)@(.+)$/) || [];
+    const version = semver.valid(v); // ensures we get a specific version, not a range
+    if (!p || !version) {
+      throw new Error(
+        'Invalid CHROMATIC_STORYBOOK_VERSION; expecting something like "@storybook/react@6.2.0".'
+      );
+    }
+    const viewLayer = viewLayers[p] || viewLayers[`@storybook/${p}`];
+    if (!viewLayer) {
+      throw new Error(`Unsupported viewlayer specified in CHROMATIC_STORYBOOK_VERSION: ${p}`);
+    }
+    return { version };
+  }
+
+  const {
+    dependency: viewLayer,
+    version,
+    dependencyPackage: pkg,
+  } = getDependencyInfo({ log, packageJson }, viewLayers);
+
+  if (viewLayer) {
+    if (options.storybookBuildDir) {
+      // If we aren't going to invoke the Storybook CLI later, we can exit early.
+      // Note that `version` can be a semver range in this case.
+      return { version };
+    }
+    // Verify that the viewlayer package is actually present in node_modules.
+    return Promise.race([
+      resolvePackageJson(pkg)
+        .then((json) => ({ version: json.version }))
+        .catch(() => {
+          throw new Error(packageDoesNotExist(pkg));
+        }),
+      timeout(10_000),
+    ]);
+  }
+
+  if (!options.interactive) {
+    log.info(`No viewlayer package listed in dependencies. Checking transitive dependencies.`);
+  }
+
+  // We might have a transitive dependency (e.g. through `@nuxtjs/storybook` which depends on
+  // `@storybook/vue`). In this case we look for any viewlayer package present in node_modules,
+  // and return the first one we find.
+  return Promise.race([
+    raceFulfilled(
+      Object.entries(viewLayers).map(async ([key]) => {
+        const json = await resolvePackageJson(key);
+        return { version: json.version };
+      })
+    ).catch(() => {
+      throw new Error(packageDoesNotExist(pkg));
+    }),
+    timeout(10_000),
+  ]);
+}

--- a/node-src/lib/getStorybookMetadata.ts
+++ b/node-src/lib/getStorybookMetadata.ts
@@ -148,7 +148,7 @@ export function findStaticDirectories(
 
 // The main config files we parse into an AST when `require()` of the config fails. Widening this
 // widens what lands on `ctx.storybook`.
-const MAIN_CONFIG_PATTERN = /^main\.[cm]?[jt]sx?$/;
+export const MAIN_CONFIG_PATTERN = /^main\.[cm]?[jt]sx?$/;
 
 /**
  * Finds the first file in the Storybook config directory that matches the given pattern.

--- a/node-src/lib/getStorybookMetadata.ts
+++ b/node-src/lib/getStorybookMetadata.ts
@@ -66,7 +66,7 @@ export interface MainConfigReader {
  *
  * @returns The builder name and package version, or an unknown builder without a config.
  */
-export async function findBuilder(mainConfig?: MainConfigReader) {
+async function findBuilder(mainConfig?: MainConfigReader) {
   if (!mainConfig) {
     return { builder: { name: 'unknown', packageVersion: '0' } };
   }

--- a/node-src/lib/uploadMetadataFiles.test.ts
+++ b/node-src/lib/uploadMetadataFiles.test.ts
@@ -14,9 +14,13 @@ vi.mock('fs', () => ({
   writeFileSync: vi.fn().mockResolvedValue(undefined),
 }));
 
-vi.mock('./getStorybookMetadata', () => ({
-  findStorybookConfigFile: vi.fn(() => Promise.resolve(false)),
-}));
+vi.mock('./getStorybookMetadata', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./getStorybookMetadata')>();
+  return {
+    ...actual,
+    findStorybookConfigFile: vi.fn(() => Promise.resolve(false)),
+  };
+});
 
 vi.mock('./uploadFiles', () => ({
   uploadFiles: vi.fn().mockResolvedValue(undefined),

--- a/node-src/lib/uploadMetadataFiles.ts
+++ b/node-src/lib/uploadMetadataFiles.ts
@@ -7,7 +7,7 @@ import { main as trimStatsFile } from '../../bin-src/trimStatsFile';
 import { Context, FileDesc } from '../types';
 import metadataHtml from '../ui/html/metadata.html';
 import uploadingMetadata from '../ui/messages/info/uploadingMetadata';
-import { findStorybookConfigFile } from './getStorybookMetadata';
+import { findStorybookConfigFile, MAIN_CONFIG_PATTERN } from './getStorybookMetadata';
 import { uploadMetadata } from './upload';
 
 const fileSize = (path: string): Promise<number> =>
@@ -32,7 +32,7 @@ export async function uploadMetadataFiles(ctx: Context) {
         ctx.options.logFile,
         ctx.options.diagnosticsFile,
         ctx.options.storybookLogFile,
-        await findStorybookConfigFile(ctx.options.storybookConfigDir, /^main\.[jt]sx?$/).catch(
+        await findStorybookConfigFile(ctx.options.storybookConfigDir, MAIN_CONFIG_PATTERN).catch(
           () => undefined
         ),
         await findStorybookConfigFile(ctx.options.storybookConfigDir, /^preview\.[jt]sx?$/).catch(


### PR DESCRIPTION
Relates to CAP-4864

This PR is to isolate the Storybook main config parsing so callers don't need to know _how_ the config was parsed. The caller simply gets a return function to read the config values.

I also reorganized some helper functions to remove unnecessary exports and move them to the bottom of the file to keep the important bits at the top.

> [!NOTE]
> This now exposes `refs` for non-AST parsed config files!

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>18.4.1--canary.1432.32179171462.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@18.4.1--canary.1432.32179171462.0
  # or 
  yarn add chromatic@18.4.1--canary.1432.32179171462.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
