### PR TITLE
Fix CI release step

### DIFF
--- a/package.json
+++ b/package.json
@@ -258,7 +258,12 @@
       "force": true
     },
     "plugins": [
-      "npm",
+      [
+        "npm",
+        {
+          "setRcToken": false
+        }
+      ],
       "released",
       [
         "slack",

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -21,7 +21,7 @@ async function main() {
   } else {
     console.info(`📌 Temporarily bumping version to '${nextVersion}' for canary release`);
     await $`npm --no-git-tag-version version ${nextVersion}`;
-    publishAction('canary');
+    await publishAction('canary');
     console.info('🧹 Resetting changes');
     await $`git reset --hard`;
   }


### PR DESCRIPTION
For some reason, the `release` CI step was failing pretty consistently with an `NPM_TOKEN` error. It appears our CI pipeline was trying to write `NPM_TOKEN` but nothing was found because we use trusted publishing. This fixes that by configuring `auto` to not write the token before running.

I also noticed a missing `await` in our release script so I added that back in.

Example of failed CI run: https://github.com/chromaui/chromatic-cli/actions/runs/31502506688/job/93818149778?pr=1432

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>18.3.1--canary.1435.32161769833.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@18.3.1--canary.1435.32161769833.0
  # or 
  yarn add chromatic@18.3.1--canary.1435.32161769833.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
