### PR TITLE
[TurboSnap v2] Add helpers to parse `preview-stats.json`

### DIFF
--- a/node-src/index.test.ts
+++ b/node-src/index.test.ts
@@ -361,7 +361,7 @@ vi.mock('./lib/emailHash');
 vi.mock('./lib/getHasRouter');
 
 vi.mock('./lib/getFileHashes', () => ({
-  getFileHashes: (files: string[]) =>
+  getFileHashes: ({ files }: { files: string[] }) =>
     Promise.resolve(Object.fromEntries(files.map((f) => [f, 'hash']))),
 }));
 

--- a/node-src/lib/getFileHashes.test.ts
+++ b/node-src/lib/getFileHashes.test.ts
@@ -4,7 +4,11 @@ import { getFileHashes } from './getFileHashes';
 
 describe('getFileHashes', () => {
   it('should return a map of file paths to hashes', async () => {
-    const hashes = await getFileHashes(['iframe.html', 'index.html'], 'node-src/__mocks__', 2);
+    const hashes = await getFileHashes({
+      files: ['iframe.html', 'index.html'],
+      directory: 'node-src/__mocks__',
+      concurrency: 2,
+    });
 
     expect(hashes).toEqual({
       'iframe.html': '80b7ac41594507e8',

--- a/node-src/lib/getFileHashes.ts
+++ b/node-src/lib/getFileHashes.ts
@@ -3,6 +3,8 @@ import pLimit from 'p-limit';
 import path from 'path';
 import xxHashWasm, { XXHash, XXHashAPI } from 'xxhash-wasm';
 
+import getEnvironment from './getEnvironment';
+
 const hashFile = (buffer: Buffer, path: string, xxhash: XXHashAPI): Promise<string> => {
   const BUFFER_SIZE = buffer.length;
 
@@ -54,7 +56,19 @@ const hashFile = (buffer: Buffer, path: string, xxhash: XXHashAPI): Promise<stri
   });
 };
 
-export const getFileHashes = async (files: string[], directory: string, concurrency: number) => {
+interface GetFileHashesInput {
+  files: string[];
+  /** Files to hash in parallel. Defaults to `CHROMATIC_HASH_CONCURRENCY` when omitted. */
+  concurrency?: number;
+  /** Joined onto each file. Omit (or leave empty) when `files` are already absolute paths. */
+  directory?: string;
+}
+
+export const getFileHashes = async ({
+  files,
+  concurrency = getEnvironment().CHROMATIC_HASH_CONCURRENCY,
+  directory = '',
+}: GetFileHashesInput) => {
   // Limit the number of concurrent file reads and hashing operations.
   const limit = pLimit(concurrency);
   const xxhash = await xxHashWasm();
@@ -65,7 +79,8 @@ export const getFileHashes = async (files: string[], directory: string, concurre
         // Allocate the 64K read buffer (matching WASM memory page size) inside the limit, so peak
         // memory is bounded by `concurrency` rather than by the number of files.
         const buffer = Buffer.allocUnsafe(64 * 1024);
-        return [file, await hashFile(buffer, path.join(directory, file), xxhash)] as const;
+        const filePath = directory ? path.join(directory, file) : file;
+        return [file, await hashFile(buffer, filePath, xxhash)] as const;
       })
     )
   );

--- a/node-src/lib/turbosnap/v2/graph.test.ts
+++ b/node-src/lib/turbosnap/v2/graph.test.ts
@@ -29,23 +29,23 @@ function makeFiles(graph: Record<FilePath, FilePath[]>): Map<FilePath, TurboSnap
 }
 
 describe('hashEntryIdentity', () => {
-  it('joins the key and the value with a colon', () => {
-    expect(hashEntryIdentity(['a.ts', 'H1'])).toBe('a.ts:H1');
+  it('encodes the key and the value as a JSON pair', () => {
+    expect(hashEntryIdentity(['a.ts', 'H1'])).toBe('["a.ts","H1"]');
   });
 
   it('keeps two entries distinct when the same bytes split differently between key and value', () => {
-    // The delimiter is what records where the key ends, so a file at path `ab` hashing to `c` stays
-    // distinct from one at `a` hashing to `bc`.
+    // The quotes record where the key ends, so a file at path `ab` hashing to `c` stays distinct
+    // from one at `a` hashing to `bc`.
     expect(hashEntryIdentity(['ab', 'c'])).not.toBe(hashEntryIdentity(['a', 'bc']));
   });
 
   it('puts the key before the value', () => {
     // A swap would encode just as well, but every previously published hash would change.
-    expect(hashEntryIdentity(['k', 'v'])).toBe('k:v');
+    expect(hashEntryIdentity(['k', 'v'])).toBe('["k","v"]');
   });
 
   it('encodes an empty value distinctly from an absent one being empty too', () => {
-    expect(hashEntryIdentity(['a.ts', ''])).toBe('a.ts:');
+    expect(hashEntryIdentity(['a.ts', ''])).toBe('["a.ts",""]');
   });
 });
 
@@ -77,6 +77,22 @@ describe('hashEntryIdentities', () => {
     );
   });
 
+  it('distinguishes entry sets that split the same bytes across the entry boundary', () => {
+    // With no delimiter between entries these would collide: `a`+`xb` then `y`+`` concatenates to
+    // the same bytes as `a`+`x` then `by`+``. The per-entry JSON encoding keeps them apart.
+    expect(
+      hashEntryIdentities([
+        ['a', 'xb'],
+        ['y', ''],
+      ])
+    ).not.toBe(
+      hashEntryIdentities([
+        ['a', 'x'],
+        ['by', ''],
+      ])
+    );
+  });
+
   it('distinguishes a renamed key from an unchanged one', () => {
     expect(hashEntryIdentities([['a.ts', 'H1']])).not.toBe(hashEntryIdentities([['b.ts', 'H1']]));
   });
@@ -92,7 +108,7 @@ describe('rollUpEntryHashes', () => {
         ],
         identity
       )
-    ).toBe('a.ts:H1b.ts:H2');
+    ).toBe('["a.ts","H1"]["b.ts","H2"]');
   });
 });
 
@@ -103,7 +119,9 @@ describe('rollUpFileHashes', () => {
   ]);
 
   it('looks each file up by path and rolls the pairs together into a single hash', () => {
-    expect(rollUpFileHashes(hashes, ['./a.ts', './b.ts'], identity)).toBe('./a.ts:H1./b.ts:H2');
+    expect(rollUpFileHashes(hashes, ['./a.ts', './b.ts'], identity)).toBe(
+      '["./a.ts","H1"]["./b.ts","H2"]'
+    );
   });
 
   it('does not depend on the order the files are supplied in', () => {
@@ -115,7 +133,7 @@ describe('rollUpFileHashes', () => {
   it('substitutes an empty content hash for a file with no entry in `hashes`', () => {
     // Synthetic nodes (globs, externals, virtual modules) are walked but never hashed. They still
     // contribute their path, so the roll-up records that they were part of the subtree.
-    expect(rollUpFileHashes(hashes, ['virtual:stories'], identity)).toBe('virtual:stories:');
+    expect(rollUpFileHashes(hashes, ['virtual:stories'], identity)).toBe('["virtual:stories",""]');
   });
 
   it('changes when a file moves, even though its content is identical', () => {

--- a/node-src/lib/turbosnap/v2/graph.test.ts
+++ b/node-src/lib/turbosnap/v2/graph.test.ts
@@ -1,0 +1,185 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  collectTransitiveDependencies,
+  FileHash,
+  FilePath,
+  hashEntryIdentities,
+  hashEntryIdentity,
+  rollUpEntryHashes,
+  rollUpFileHashes,
+  TurboSnapFile,
+} from './graph';
+
+// The function that hashes the bytes. We just return the input so the tests can assert on the exact
+// bytes that reach the hash function. What matters here is the encoding, not xxhash itself.
+function identity(input: string): string {
+  return input;
+}
+
+// A helper function to build the map of dependencies for a given graph. The graph is a simple
+// object where the keys are file paths and the values are file paths of its dependencies.
+function makeFiles(graph: Record<FilePath, FilePath[]>): Map<FilePath, TurboSnapFile> {
+  return new Map(
+    Object.entries(graph).map(([filePath, dependencies]) => [
+      filePath,
+      { hash: `hash-${filePath}`, dependencies: new Set(dependencies) },
+    ])
+  );
+}
+
+describe('hashEntryIdentity', () => {
+  it('joins the key and the value with a colon', () => {
+    expect(hashEntryIdentity(['a.ts', 'H1'])).toBe('a.ts:H1');
+  });
+
+  it('keeps two entries distinct when the same bytes split differently between key and value', () => {
+    // The delimiter is what records where the key ends, so a file at path `ab` hashing to `c` stays
+    // distinct from one at `a` hashing to `bc`.
+    expect(hashEntryIdentity(['ab', 'c'])).not.toBe(hashEntryIdentity(['a', 'bc']));
+  });
+
+  it('puts the key before the value', () => {
+    // A swap would encode just as well, but every previously published hash would change.
+    expect(hashEntryIdentity(['k', 'v'])).toBe('k:v');
+  });
+
+  it('encodes an empty value distinctly from an absent one being empty too', () => {
+    expect(hashEntryIdentity(['a.ts', ''])).toBe('a.ts:');
+  });
+});
+
+describe('hashEntryIdentities', () => {
+  it('sorts entries so iteration order does not reach the hash', () => {
+    const forwards = hashEntryIdentities([
+      ['a.ts', 'H1'],
+      ['b.ts', 'H2'],
+    ]);
+    const backwards = hashEntryIdentities([
+      ['b.ts', 'H2'],
+      ['a.ts', 'H1'],
+    ]);
+
+    expect(forwards).toBe(backwards);
+  });
+
+  it('distinguishes entry sets that split the same bytes differently', () => {
+    expect(
+      hashEntryIdentities([
+        ['ab', 'c'],
+        ['d', 'e'],
+      ])
+    ).not.toBe(
+      hashEntryIdentities([
+        ['a', 'bc'],
+        ['d', 'e'],
+      ])
+    );
+  });
+
+  it('distinguishes a renamed key from an unchanged one', () => {
+    expect(hashEntryIdentities([['a.ts', 'H1']])).not.toBe(hashEntryIdentities([['b.ts', 'H1']]));
+  });
+});
+
+describe('rollUpEntryHashes', () => {
+  it('hashes the encoded entries', () => {
+    expect(
+      rollUpEntryHashes(
+        [
+          ['a.ts', 'H1'],
+          ['b.ts', 'H2'],
+        ],
+        identity
+      )
+    ).toBe('a.ts:H1b.ts:H2');
+  });
+});
+
+describe('rollUpFileHashes', () => {
+  const hashes = new Map<FilePath, FileHash>([
+    ['./a.ts', 'H1'],
+    ['./b.ts', 'H2'],
+  ]);
+
+  it('looks each file up by path and rolls the pairs together into a single hash', () => {
+    expect(rollUpFileHashes(hashes, ['./a.ts', './b.ts'], identity)).toBe('./a.ts:H1./b.ts:H2');
+  });
+
+  it('does not depend on the order the files are supplied in', () => {
+    expect(rollUpFileHashes(hashes, ['./b.ts', './a.ts'], identity)).toBe(
+      rollUpFileHashes(hashes, ['./a.ts', './b.ts'], identity)
+    );
+  });
+
+  it('substitutes an empty content hash for a file with no entry in `hashes`', () => {
+    // Synthetic nodes (globs, externals, virtual modules) are walked but never hashed. They still
+    // contribute their path, so the roll-up records that they were part of the subtree.
+    expect(rollUpFileHashes(hashes, ['virtual:stories'], identity)).toBe('virtual:stories:');
+  });
+
+  it('changes when a file moves, even though its content is identical', () => {
+    // A file's path reaches the output, so the same bytes at a new path have to move the hash.
+    const moved = new Map<FilePath, FileHash>([['./moved/a.ts', 'H1']]);
+
+    expect(rollUpFileHashes(moved, ['./moved/a.ts'], identity)).not.toBe(
+      rollUpFileHashes(hashes, ['./a.ts'], identity)
+    );
+  });
+
+  it('changes when a file is added to the subtree', () => {
+    expect(rollUpFileHashes(hashes, ['./a.ts'], identity)).not.toBe(
+      rollUpFileHashes(hashes, ['./a.ts', './b.ts'], identity)
+    );
+  });
+});
+
+describe('collectTransitiveDependencies', () => {
+  it('includes the file itself', () => {
+    const files = makeFiles({ './a.ts': [] });
+
+    expect([...collectTransitiveDependencies(files, './a.ts')]).toEqual(['./a.ts']);
+  });
+
+  it('walks through intermediate files to the leaves', () => {
+    const files = makeFiles({ './a.ts': ['./b.ts'], './b.ts': ['./c.ts'], './c.ts': [] });
+
+    expect([...collectTransitiveDependencies(files, './a.ts')].sort()).toEqual([
+      './a.ts',
+      './b.ts',
+      './c.ts',
+    ]);
+  });
+
+  it('handles a dependency cycle', () => {
+    const files = makeFiles({ './a.ts': ['./b.ts'], './b.ts': ['./a.ts'] });
+
+    expect([...collectTransitiveDependencies(files, './a.ts')].sort()).toEqual([
+      './a.ts',
+      './b.ts',
+    ]);
+  });
+
+  it('handles a file that depends on itself', () => {
+    const files = makeFiles({ './a.ts': ['./a.ts'] });
+
+    expect([...collectTransitiveDependencies(files, './a.ts')]).toEqual(['./a.ts']);
+  });
+
+  it('returns just the file itself when it has no node in the graph', () => {
+    expect([...collectTransitiveDependencies(new Map(), 'virtual:stories')]).toEqual([
+      'virtual:stories',
+    ]);
+  });
+
+  it('accumulates into a supplied set across calls', () => {
+    const files = makeFiles({ './a.ts': ['./shared.ts'], './b.ts': ['./shared.ts'] });
+    const accumulator = new Set<FilePath>();
+
+    collectTransitiveDependencies(files, './a.ts', accumulator);
+    const returned = collectTransitiveDependencies(files, './b.ts', accumulator);
+
+    expect(returned).toBe(accumulator);
+    expect([...accumulator].sort()).toEqual(['./a.ts', './b.ts', './shared.ts']);
+  });
+});

--- a/node-src/lib/turbosnap/v2/graph.ts
+++ b/node-src/lib/turbosnap/v2/graph.ts
@@ -97,13 +97,16 @@ export function collectTransitiveDependencies(
   filePath: FilePath,
   dependencies = new Set<FilePath>()
 ) {
-  if (dependencies.has(filePath)) {
-    return dependencies;
-  }
+  const unvisited: FilePath[] = [filePath];
 
-  dependencies.add(filePath);
-  for (const dependency of files.get(filePath)?.dependencies ?? []) {
-    collectTransitiveDependencies(files, dependency, dependencies);
+  while (unvisited.length > 0) {
+    const current = unvisited.pop();
+    if (current === undefined || dependencies.has(current)) {
+      continue;
+    }
+
+    dependencies.add(current);
+    unvisited.push(...(files.get(current)?.dependencies ?? []));
   }
 
   return dependencies;

--- a/node-src/lib/turbosnap/v2/graph.ts
+++ b/node-src/lib/turbosnap/v2/graph.ts
@@ -1,0 +1,108 @@
+export type FilePath = string;
+export type FileHash = string;
+
+export interface TurboSnapFile {
+  hash: FileHash;
+  dependencies: Set<FilePath>;
+}
+
+/**
+ * Rolls a set of files up into a single hash, looking each file's content hash up by path.
+ *
+ * @param hashes The content hashes keyed by canonical file path.
+ * @param filePaths The files to roll up.
+ * @param h64ToString The hash function.
+ *
+ * @returns The rolled-up hash.
+ */
+export function rollUpFileHashes(
+  hashes: Map<FilePath, FileHash>,
+  filePaths: Iterable<FilePath>,
+  h64ToString: (input: string) => string
+): FileHash {
+  const entries = [...filePaths].map((filePath): [FilePath, FileHash] => [
+    filePath,
+    hashes.get(filePath) ?? '',
+  ]);
+  return rollUpEntryHashes(entries, h64ToString);
+}
+
+/**
+ * Rolls path/content-hash pairs up into a single hash. Entries are sorted so the result doesn't
+ * depend on iteration order.
+ *
+ * Every roll-up depends on both content and path, because a file's path can impact the output of
+ * where the story is served from Storybook.
+ *
+ * Example: src/Button.stories.tsx -> src/Components/Button.stories.tsx
+ *
+ * Moving that file to the new path can change where it lives in the Storybook (and the ID that's
+ * used to navigate to it). To play it safe, we recapture to force a reupload of the hosted
+ * Storybook.
+ *
+ * @param entries The path/content-hash pairs to roll up.
+ * @param h64ToString The hash function.
+ *
+ * @returns The rolled-up hash.
+ */
+export function rollUpEntryHashes(
+  entries: Iterable<[FilePath, FileHash]>,
+  h64ToString: (input: string) => string
+): FileHash {
+  return h64ToString(hashEntryIdentities(entries));
+}
+
+/**
+ * Encodes a set of key/value pairs as one string, sorted so the result doesn't depend on iteration
+ * order.
+ *
+ * @param entries The key/value pairs to encode.
+ *
+ * @returns The encoded entries, concatenated.
+ */
+export function hashEntryIdentities(entries: Iterable<[FilePath, FileHash]>): string {
+  return [...entries]
+    .map((entry) => hashEntryIdentity(entry))
+    .sort()
+    .join('');
+}
+
+/**
+ * Encodes a key and value as a single string, separated by a colon so a change to either side moves
+ * the result.
+ *
+ * @param entry The key/value pair to encode.
+ * @param entry."0" The file path, which comes first in the encoding.
+ * @param entry."1" The content hash, which comes second in the encoding.
+ *
+ * @returns The encoded entry.
+ */
+export function hashEntryIdentity([path, hash]: [FilePath, FileHash]): string {
+  return `${path}:${hash}`;
+}
+
+/**
+ * Walks the dependency graph from a file, collecting it and every file it transitively depends on.
+ *
+ * @param files The map of files to their hashes and dependencies.
+ * @param filePath The file to collect the transitive dependencies of.
+ * @param dependencies The set of dependencies to add to.
+ *
+ * @returns A set of all the files that the given file transitively depends on.
+ */
+export function collectTransitiveDependencies(
+  files: Map<FilePath, TurboSnapFile>,
+  filePath: FilePath,
+  dependencies = new Set<FilePath>()
+) {
+  if (dependencies.has(filePath)) {
+    return dependencies;
+  }
+
+  dependencies.add(filePath);
+  for (const dependency of files.get(filePath)?.dependencies ?? []) {
+    collectTransitiveDependencies(files, dependency, dependencies);
+  }
+
+  return dependencies;
+}

--- a/node-src/lib/turbosnap/v2/graph.ts
+++ b/node-src/lib/turbosnap/v2/graph.ts
@@ -68,8 +68,10 @@ export function hashEntryIdentities(entries: Iterable<[FilePath, FileHash]>): st
 }
 
 /**
- * Encodes a key and value as a single string, separated by a colon so a change to either side moves
- * the result.
+ * Encodes a key and value as a single string. JSON is a self-delimiting encoding: the quotes and
+ * brackets bound each side and every path/hash character, so no pair of entries can concatenate into
+ * the same string as a different pair. That keeps the roll-up free of hash collisions, and a change
+ * to either side still moves the result.
  *
  * @param entry The key/value pair to encode.
  * @param entry."0" The file path, which comes first in the encoding.
@@ -78,7 +80,7 @@ export function hashEntryIdentities(entries: Iterable<[FilePath, FileHash]>): st
  * @returns The encoded entry.
  */
 export function hashEntryIdentity([path, hash]: [FilePath, FileHash]): string {
-  return `${path}:${hash}`;
+  return JSON.stringify([path, hash]);
 }
 
 /**

--- a/node-src/lib/turbosnap/v2/paths.test.ts
+++ b/node-src/lib/turbosnap/v2/paths.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+
+import { normalizeStatsPath, resolveStatsPath } from './paths';
+
+const projectRoot = '/repo/packages/ui';
+
+describe('normalizeStatsPath', () => {
+  it('keeps a project-relative path as-is, with its ./ prefix', () => {
+    expect(normalizeStatsPath('./src/Button.stories.tsx', projectRoot)).toBe(
+      './src/Button.stories.tsx'
+    );
+  });
+
+  it('relativizes an absolute path against the project root', () => {
+    expect(normalizeStatsPath('/repo/packages/ui/src/Button.stories.tsx', projectRoot)).toBe(
+      './src/Button.stories.tsx'
+    );
+  });
+
+  it('gives a sibling-package dependency a ../ prefix instead of ./', () => {
+    expect(normalizeStatsPath('/repo/packages/shared/theme.ts', projectRoot)).toBe(
+      '../shared/theme.ts'
+    );
+  });
+
+  it('normalizes a hoisted node_modules path the same way from either spelling', () => {
+    // Vite writes `./../../node_modules/...`; rspack writes the absolute path. Both should
+    // normalize to the same key.
+    expect(
+      normalizeStatsPath('./../../node_modules/@storybook/react/dist/entry-preview.js', projectRoot)
+    ).toBe('../../node_modules/@storybook/react/dist/entry-preview.js');
+    expect(
+      normalizeStatsPath('/repo/node_modules/@storybook/react/dist/entry-preview.js', projectRoot)
+    ).toBe('../../node_modules/@storybook/react/dist/entry-preview.js');
+  });
+
+  it('returns virtual modules unchanged', () => {
+    expect(
+      normalizeStatsPath('virtual:@storybook/builder-vite/storybook-stories.js', projectRoot)
+    ).toBe('virtual:@storybook/builder-vite/storybook-stories.js');
+  });
+
+  it('strips a trailing " + N modules" suffix from a concatenated module name', () => {
+    expect(normalizeStatsPath('./src/lib/Button/Button.stories.tsx + 1 modules', projectRoot)).toBe(
+      './src/lib/Button/Button.stories.tsx'
+    );
+  });
+
+  it('strips a singular " + 1 module" suffix', () => {
+    expect(normalizeStatsPath('./src/a.ts + 1 module', projectRoot)).toBe('./src/a.ts');
+  });
+
+  it('resolves a relative stats path against statsRoot, not the project root', () => {
+    // A builder may name relative paths from the repository root even though manifest keys anchor at
+    // the project, so the same file has to normalize back to a project-relative key.
+    expect(normalizeStatsPath('./packages/ui/src/Button.stories.tsx', projectRoot, '/repo')).toBe(
+      './src/Button.stories.tsx'
+    );
+  });
+});
+
+describe('resolveStatsPath', () => {
+  it('resolves a relative path against the project root', () => {
+    expect(resolveStatsPath('./src/x.ts', projectRoot)).toBe('/repo/packages/ui/src/x.ts');
+  });
+
+  it('returns an absolute path unchanged', () => {
+    expect(resolveStatsPath('/repo/packages/shared/theme.ts', projectRoot)).toBe(
+      '/repo/packages/shared/theme.ts'
+    );
+  });
+});

--- a/node-src/lib/turbosnap/v2/paths.ts
+++ b/node-src/lib/turbosnap/v2/paths.ts
@@ -1,5 +1,6 @@
 import path from 'path';
 
+import { AbsolutePath } from '../../../types';
 import { relativeTo } from '../../getStorybookProjectRoot';
 import { FilePath } from './graph';
 
@@ -29,8 +30,8 @@ export function stripConcatenatedModuleSuffix(statsPath: FilePath): FilePath {
  */
 export function normalizeStatsPath(
   statsPath: FilePath,
-  projectRoot: FilePath,
-  statsRoot = projectRoot
+  projectRoot: AbsolutePath,
+  statsRoot: AbsolutePath = projectRoot
 ): FilePath {
   if (statsPath.includes('virtual:')) {
     return statsPath;
@@ -60,7 +61,7 @@ function prefixInProjectPath(relativePath: FilePath): FilePath {
  *
  * @returns The absolute path to the file on disk.
  */
-export function resolveStatsPath(statsPath: FilePath, statsRoot: FilePath): FilePath {
+export function resolveStatsPath(statsPath: FilePath, statsRoot: AbsolutePath): AbsolutePath {
   const stripped = stripConcatenatedModuleSuffix(statsPath);
   return path.isAbsolute(stripped) ? stripped : path.resolve(statsRoot, stripped);
 }

--- a/node-src/lib/turbosnap/v2/paths.ts
+++ b/node-src/lib/turbosnap/v2/paths.ts
@@ -1,6 +1,6 @@
 import path from 'path';
 
-import { posix } from '../../posix';
+import { relativeTo } from '../../getStorybookProjectRoot';
 import { FilePath } from './graph';
 
 /**
@@ -36,9 +36,7 @@ export function normalizeStatsPath(
     return statsPath;
   }
 
-  const stripped = stripConcatenatedModuleSuffix(statsPath);
-  const absolutePath = path.isAbsolute(stripped) ? stripped : path.resolve(statsRoot, stripped);
-  return prefixInProjectPath(posix(path.relative(projectRoot, absolutePath)));
+  return prefixInProjectPath(relativeTo(projectRoot, resolveStatsPath(statsPath, statsRoot)));
 }
 
 /**

--- a/node-src/lib/turbosnap/v2/paths.ts
+++ b/node-src/lib/turbosnap/v2/paths.ts
@@ -1,0 +1,68 @@
+import path from 'path';
+
+import { posix } from '../../posix';
+import { FilePath } from './graph';
+
+/**
+ * Strips a trailing ` + N modules` suffix from a concatenated module's name, leaving the root file.
+ *
+ * @param statsPath The module name from the stats file.
+ *
+ * @returns The name without the concatenation suffix.
+ */
+export function stripConcatenatedModuleSuffix(statsPath: FilePath): FilePath {
+  return statsPath.replace(/ \+ \d+ modules?$/, '');
+}
+
+/**
+ * Converts a stats module path into the canonical manifest key: a POSIX path relative to the
+ * Storybook project root. Relative stats paths are first resolved from `statsRoot`, because a
+ * builder may name them from the repository root even though manifest keys anchor at the project.
+ * Virtual modules (e.g. Vite's `virtual:` entries) have no on-disk location and are returned
+ * unchanged.
+ *
+ * @param statsPath The module name from the stats file (relative like `./src/x` or absolute).
+ * @param projectRoot The absolute Storybook project root to anchor against.
+ * @param statsRoot The directory relative stats paths are named from. Defaults to the project root.
+ *
+ * @returns The canonical project-root-relative POSIX path.
+ */
+export function normalizeStatsPath(
+  statsPath: FilePath,
+  projectRoot: FilePath,
+  statsRoot = projectRoot
+): FilePath {
+  if (statsPath.includes('virtual:')) {
+    return statsPath;
+  }
+
+  const stripped = stripConcatenatedModuleSuffix(statsPath);
+  const absolutePath = path.isAbsolute(stripped) ? stripped : path.resolve(statsRoot, stripped);
+  return prefixInProjectPath(posix(path.relative(projectRoot, absolutePath)));
+}
+
+/**
+ * Adds the `./` prefix that marks a path as living inside the project. A path that already escapes
+ * the project keeps its leading `../`, which is prefix enough to read.
+ *
+ * @param relativePath The project-relative POSIX path.
+ *
+ * @returns The path with an explicit prefix.
+ */
+function prefixInProjectPath(relativePath: FilePath): FilePath {
+  return relativePath.startsWith('../') ? relativePath : `./${relativePath}`;
+}
+
+/**
+ * Resolves a stats module path to an absolute on-disk path for hashing, anchoring relative paths at
+ * the Storybook project root.
+ *
+ * @param statsPath The module name from the stats file.
+ * @param statsRoot The absolute directory relative stats paths are named from.
+ *
+ * @returns The absolute path to the file on disk.
+ */
+export function resolveStatsPath(statsPath: FilePath, statsRoot: FilePath): FilePath {
+  const stripped = stripConcatenatedModuleSuffix(statsPath);
+  return path.isAbsolute(stripped) ? stripped : path.resolve(statsRoot, stripped);
+}

--- a/node-src/lib/turbosnap/v2/projectFiles.test.ts
+++ b/node-src/lib/turbosnap/v2/projectFiles.test.ts
@@ -1,0 +1,280 @@
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import path from 'path';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { realProjectFiles } from './projectFiles';
+
+// The real adapter's whole job is knowing what the disk means, so these run against real temporary
+// directories: real symlinks, a real cycle and a real unreadable directory. A fake that simulates
+// symlink semantics can only prove the fake follows them.
+let temporaryDirectories: string[] = [];
+let lockedDirectories: string[] = [];
+
+afterEach(() => {
+  // Unlock the directories before removal because it's required in order to remove them.
+  for (const directory of lockedDirectories) {
+    chmodSync(directory, 0o755);
+  }
+  for (const directory of temporaryDirectories) {
+    rmSync(directory, { recursive: true, force: true });
+  }
+  // Reset the lists, so the next test's cleanup doesn't chmod a path this one already removed.
+  temporaryDirectories = [];
+  lockedDirectories = [];
+});
+
+/**
+ * Creates a temporary directory in the system's temporary directory.
+ *
+ * @returns The absolute path of the directory.
+ */
+function temporaryDirectory(): string {
+  const directory = mkdtempSync(path.join(tmpdir(), 'chromatic-project-files-'));
+  temporaryDirectories.push(directory);
+  return directory;
+}
+
+/**
+ * Writes a file, creating its parent directories.
+ *
+ * @param root The directory to write within.
+ * @param relativePath The file's path relative to `root`.
+ * @param content The bytes to write, its own path by default so two files differ.
+ *
+ * @returns The absolute path written.
+ */
+function write(root: string, relativePath: string, content = relativePath): string {
+  const absolutePath = path.join(root, relativePath);
+  mkdirSync(path.dirname(absolutePath), { recursive: true });
+  writeFileSync(absolutePath, content);
+  return absolutePath;
+}
+
+/**
+ * "Installs" a package under a directory's `node_modules` to match a real repository structure.
+ *
+ * @param root The directory to install within.
+ * @param packageName The package's name.
+ * @param packageJson The manifest to write, verbatim.
+ */
+function install(root: string, packageName: string, packageJson: Record<string, unknown>) {
+  write(root, `node_modules/${packageName}/package.json`, JSON.stringify(packageJson));
+}
+
+/**
+ * Updates the permissions of the path so it's unreadable, so a test can test failed read
+ * operations.
+ *
+ * @param absolutePath The file or directory to lock.
+ */
+function lock(absolutePath: string) {
+  lockedDirectories.push(absolutePath);
+  chmodSync(absolutePath, 0o000);
+}
+
+describe('realProjectFiles listTree', () => {
+  it('lists every file under the directory, recursively', async () => {
+    const root = temporaryDirectory();
+    write(root, 'static/logo.svg');
+    write(root, 'static/nested/deep/font.woff2');
+
+    const files = await realProjectFiles().listTree(path.join(root, 'static'));
+
+    expect(files.sort()).toEqual([
+      path.join(root, 'static/logo.svg'),
+      path.join(root, 'static/nested/deep/font.woff2'),
+    ]);
+  });
+
+  it('names a symlinked file by the link path, since that is the URL it is served at', async () => {
+    const root = temporaryDirectory();
+    const target = write(root, 'vendor/real-logo.svg');
+    mkdirSync(path.join(root, 'static'));
+    symlinkSync(target, path.join(root, 'static/logo.svg'));
+
+    const files = await realProjectFiles().listTree(path.join(root, 'static'));
+
+    expect(files).toEqual([path.join(root, 'static/logo.svg')]);
+  });
+
+  it('descends into a symlinked directory, so a vendored asset tree is not invisible', async () => {
+    const root = temporaryDirectory();
+    write(root, 'node_modules/pkg/dist/a.png');
+    write(root, 'node_modules/pkg/dist/b.png');
+    mkdirSync(path.join(root, 'static'));
+    symlinkSync(path.join(root, 'node_modules/pkg/dist'), path.join(root, 'static/vendor'));
+
+    const files = await realProjectFiles().listTree(path.join(root, 'static'));
+
+    expect(files.sort()).toEqual([
+      path.join(root, 'static/vendor/a.png'),
+      path.join(root, 'static/vendor/b.png'),
+    ]);
+  });
+
+  it('contributes nothing for a broken symlink, finishing the rest of the sweep', async () => {
+    const root = temporaryDirectory();
+    write(root, 'static/keep.svg');
+    symlinkSync(path.join(root, 'gone.svg'), path.join(root, 'static/logo.svg'));
+
+    const files = await realProjectFiles().listTree(path.join(root, 'static'));
+
+    expect(files).toEqual([path.join(root, 'static/keep.svg')]);
+  });
+
+  it('visits a symlink cycle once', async () => {
+    const root = temporaryDirectory();
+    write(root, 'static/logo.svg');
+    symlinkSync(path.join(root, 'static'), path.join(root, 'static/loop'));
+
+    const files = await realProjectFiles().listTree(path.join(root, 'static'));
+
+    expect(files).toEqual([path.join(root, 'static/logo.svg')]);
+  });
+
+  it('is empty for a directory that does not exist, since a missing staticDir is not an error', async () => {
+    const root = temporaryDirectory();
+
+    const files = await realProjectFiles().listTree(path.join(root, 'absent'));
+
+    expect(files).toEqual([]);
+  });
+
+  it('is empty for an unreadable directory, rather than failing the whole sweep', async () => {
+    const root = temporaryDirectory();
+    write(root, 'locked/secret.ts');
+    // A directory can resolve and still refuse to be listed (EACCES), which the walk meets at a
+    // different point than a missing directory.
+    lock(path.join(root, 'locked'));
+
+    const files = await realProjectFiles().listTree(path.join(root, 'locked'));
+
+    expect(files).toEqual([]);
+  });
+});
+
+describe('realProjectFiles isFile and isDirectory', () => {
+  it('reads a regular file as a file and not a directory', () => {
+    const root = temporaryDirectory();
+    const filePath = write(root, 'src/Button.tsx');
+
+    expect(realProjectFiles().isFile(filePath)).toBe(true);
+    expect(realProjectFiles().isDirectory(filePath)).toBe(false);
+  });
+
+  it('reads a directory as a directory and not a file, which is what keeps EISDIR out of hashing', () => {
+    // `storybook-builder-rsbuild` 3.3.0/3.3.1 name a module after a directory, and reading one
+    // throws EISDIR.
+    const root = temporaryDirectory();
+    write(root, 'node_modules/@storybook/react/dist/entry-preview.js');
+    const directoryNamedAsAModule = path.join(root, 'node_modules/@storybook/react/dist');
+
+    expect(realProjectFiles().isFile(directoryNamedAsAModule)).toBe(false);
+    expect(realProjectFiles().isDirectory(directoryNamedAsAModule)).toBe(true);
+  });
+
+  it('reads an absent path as false for both', () => {
+    const root = temporaryDirectory();
+    const absent = path.join(root, 'src/gone.tsx');
+
+    expect(realProjectFiles().isFile(absent)).toBe(false);
+    expect(realProjectFiles().isDirectory(absent)).toBe(false);
+  });
+
+  it('reads a symlink to a file as a file', () => {
+    const root = temporaryDirectory();
+    const target = write(root, 'vendor/real-logo.svg');
+    mkdirSync(path.join(root, 'static'));
+    symlinkSync(target, path.join(root, 'static/logo.svg'));
+
+    expect(realProjectFiles().isFile(path.join(root, 'static/logo.svg'))).toBe(true);
+  });
+});
+
+describe('realProjectFiles hashAll', () => {
+  it('hashes each file, keyed by the absolute path it was read from', async () => {
+    const root = temporaryDirectory();
+    const button = write(root, 'src/Button.tsx');
+    const header = write(root, 'src/Header.tsx');
+
+    const hashes = await realProjectFiles().hashAll([button, header]);
+
+    expect(Object.keys(hashes).sort()).toEqual([button, header].sort());
+    expect(hashes[button]).not.toBe(hashes[header]);
+  });
+
+  it('hashes content, so identical bytes at two paths hash the same', async () => {
+    const root = temporaryDirectory();
+    const original = write(root, 'src/Button.tsx', 'export const Button = () => null;');
+    const copy = write(root, 'src/copy/Button.tsx', 'export const Button = () => null;');
+
+    const hashes = await realProjectFiles().hashAll([original, copy]);
+
+    expect(hashes[original]).toBe(hashes[copy]);
+  });
+
+  it('hashes nothing for no paths', async () => {
+    expect(await realProjectFiles().hashAll([])).toEqual({});
+  });
+
+  it('read errors throw with the file that it failed to read', async () => {
+    const root = temporaryDirectory();
+    const readable = write(root, 'src/Button.tsx');
+    const unreadable = write(root, 'src/Secret.tsx');
+    lock(unreadable);
+
+    let err: Error | undefined;
+    try {
+      await realProjectFiles().hashAll([readable, unreadable]);
+    } catch (error) {
+      err = error as Error;
+    }
+
+    expect(err?.message).toContain(unreadable);
+  });
+});
+
+describe('realProjectFiles packageVersion', () => {
+  it('reads the installed version from a real package layout', () => {
+    const root = temporaryDirectory();
+    install(root, 'storybook', { name: 'storybook', version: '9.1.20' });
+
+    expect(realProjectFiles().packageVersion(root, 'storybook')).toBe('9.1.20');
+  });
+
+  it('walks up from the directory, so a workspace-hoisted install is found', () => {
+    const repositoryRoot = temporaryDirectory();
+    const projectRoot = path.join(repositoryRoot, 'packages/ui');
+    mkdirSync(projectRoot, { recursive: true });
+    install(repositoryRoot, 'storybook', { name: 'storybook', version: '9.1.20' });
+
+    expect(realProjectFiles().packageVersion(projectRoot, 'storybook')).toBe('9.1.20');
+  });
+
+  it('reports no version for a package that does not export its own manifest', () => {
+    // Resolving `${name}/package.json` is what avoids the `dist/*` entries an `exports` map usually
+    // omits; a package that does not export the manifest either simply has no version to report.
+    const root = temporaryDirectory();
+    install(root, 'sealed', {
+      name: 'sealed',
+      version: '1.2.3',
+      exports: { '.': './index.js' },
+    });
+
+    expect(realProjectFiles().packageVersion(root, 'sealed')).toBeUndefined();
+  });
+
+  it('reports no version for a package whose manifest has none', () => {
+    const root = temporaryDirectory();
+    install(root, 'storybook', { name: 'storybook' });
+
+    expect(realProjectFiles().packageVersion(root, 'storybook')).toBeUndefined();
+  });
+
+  it('reports no version for a package that is not installed', () => {
+    const root = temporaryDirectory();
+
+    expect(realProjectFiles().packageVersion(root, '@storybook/builder-vite')).toBeUndefined();
+  });
+});

--- a/node-src/lib/turbosnap/v2/projectFiles.test.ts
+++ b/node-src/lib/turbosnap/v2/projectFiles.test.ts
@@ -79,7 +79,7 @@ describe('realProjectFiles listTree', () => {
     write(root, 'static/logo.svg');
     write(root, 'static/nested/deep/font.woff2');
 
-    const files = await realProjectFiles().listTree(path.join(root, 'static'));
+    const files = realProjectFiles().listTree(path.join(root, 'static'));
 
     expect(files.sort()).toEqual([
       path.join(root, 'static/logo.svg'),
@@ -93,7 +93,7 @@ describe('realProjectFiles listTree', () => {
     mkdirSync(path.join(root, 'static'));
     symlinkSync(target, path.join(root, 'static/logo.svg'));
 
-    const files = await realProjectFiles().listTree(path.join(root, 'static'));
+    const files = realProjectFiles().listTree(path.join(root, 'static'));
 
     expect(files).toEqual([path.join(root, 'static/logo.svg')]);
   });
@@ -105,7 +105,7 @@ describe('realProjectFiles listTree', () => {
     mkdirSync(path.join(root, 'static'));
     symlinkSync(path.join(root, 'node_modules/pkg/dist'), path.join(root, 'static/vendor'));
 
-    const files = await realProjectFiles().listTree(path.join(root, 'static'));
+    const files = realProjectFiles().listTree(path.join(root, 'static'));
 
     expect(files.sort()).toEqual([
       path.join(root, 'static/vendor/a.png'),
@@ -118,7 +118,7 @@ describe('realProjectFiles listTree', () => {
     write(root, 'static/keep.svg');
     symlinkSync(path.join(root, 'gone.svg'), path.join(root, 'static/logo.svg'));
 
-    const files = await realProjectFiles().listTree(path.join(root, 'static'));
+    const files = realProjectFiles().listTree(path.join(root, 'static'));
 
     expect(files).toEqual([path.join(root, 'static/keep.svg')]);
   });
@@ -128,7 +128,7 @@ describe('realProjectFiles listTree', () => {
     write(root, 'static/logo.svg');
     symlinkSync(path.join(root, 'static'), path.join(root, 'static/loop'));
 
-    const files = await realProjectFiles().listTree(path.join(root, 'static'));
+    const files = realProjectFiles().listTree(path.join(root, 'static'));
 
     expect(files).toEqual([path.join(root, 'static/logo.svg')]);
   });
@@ -136,7 +136,7 @@ describe('realProjectFiles listTree', () => {
   it('is empty for a directory that does not exist, since a missing staticDir is not an error', async () => {
     const root = temporaryDirectory();
 
-    const files = await realProjectFiles().listTree(path.join(root, 'absent'));
+    const files = realProjectFiles().listTree(path.join(root, 'absent'));
 
     expect(files).toEqual([]);
   });
@@ -148,7 +148,7 @@ describe('realProjectFiles listTree', () => {
     // different point than a missing directory.
     lock(path.join(root, 'locked'));
 
-    const files = await realProjectFiles().listTree(path.join(root, 'locked'));
+    const files = realProjectFiles().listTree(path.join(root, 'locked'));
 
     expect(files).toEqual([]);
   });

--- a/node-src/lib/turbosnap/v2/projectFiles.ts
+++ b/node-src/lib/turbosnap/v2/projectFiles.ts
@@ -3,22 +3,23 @@ import { readdir, realpath, stat } from 'fs/promises';
 import { createRequire } from 'module';
 import path from 'path';
 
+import { AbsolutePath } from '../../../types';
 import { getFileHashes } from '../../getFileHashes';
-import { FileHash, FilePath } from './graph';
+import { FileHash } from './graph';
 
 /**
  * Every disk read TurboSnap v2 makes, behind one interface, so the rules about what the disk means
  * live here rather than at each call site.
  */
 export interface ProjectFiles {
-  isFile(absolutePath: FilePath): boolean;
-  isDirectory(absolutePath: FilePath): boolean;
+  isFile(absolutePath: AbsolutePath): boolean;
+  isDirectory(absolutePath: AbsolutePath): boolean;
   /** Undefined when unresolvable; resolves the package manifest, not a dist path. */
-  packageVersion(fromDirectory: FilePath, packageName: string): string | undefined;
+  packageVersion(fromDirectory: AbsolutePath, packageName: string): string | undefined;
   /** Throws, naming the path, when a file cannot be read. */
-  hashAll(absolutePaths: FilePath[]): Promise<Record<FilePath, FileHash>>;
+  hashAll(absolutePaths: AbsolutePath[]): Promise<Record<AbsolutePath, FileHash>>;
   /** Follows symlinks, names files by the link path, terminates on a cycle, empty when absent. */
-  listTree(absoluteDirectory: FilePath): Promise<FilePath[]>;
+  listTree(absoluteDirectory: AbsolutePath): Promise<AbsolutePath[]>;
 }
 
 /**
@@ -29,13 +30,13 @@ export interface ProjectFiles {
  */
 export function realProjectFiles(): ProjectFiles {
   return {
-    isFile: (absolutePath: FilePath) =>
+    isFile: (absolutePath: AbsolutePath) =>
       statSync(absolutePath, { throwIfNoEntry: false })?.isFile() ?? false,
-    isDirectory: (absolutePath: FilePath) =>
+    isDirectory: (absolutePath: AbsolutePath) =>
       statSync(absolutePath, { throwIfNoEntry: false })?.isDirectory() ?? false,
     packageVersion: readPackageVersion,
     hashAll: hashFileContents,
-    listTree: (absoluteDirectory: FilePath) => listFilesRecursively(absoluteDirectory),
+    listTree: (absoluteDirectory: AbsolutePath) => listFilesRecursively(absoluteDirectory),
   };
 }
 
@@ -47,7 +48,7 @@ export function realProjectFiles(): ProjectFiles {
  *
  * @returns The installed version, or undefined when the package cannot be resolved or read.
  */
-function readPackageVersion(fromDirectory: FilePath, packageName: string): string | undefined {
+function readPackageVersion(fromDirectory: AbsolutePath, packageName: string): string | undefined {
   const requireFromDirectory = createRequire(path.join(fromDirectory, 'package.json'));
 
   try {
@@ -66,7 +67,9 @@ function readPackageVersion(fromDirectory: FilePath, packageName: string): strin
  *
  * @returns The content hash of each file, keyed by the absolute path it was read from.
  */
-async function hashFileContents(absolutePaths: FilePath[]): Promise<Record<FilePath, FileHash>> {
+async function hashFileContents(
+  absolutePaths: AbsolutePath[]
+): Promise<Record<AbsolutePath, FileHash>> {
   if (absolutePaths.length === 0) return {};
 
   try {
@@ -86,7 +89,7 @@ async function hashFileContents(absolutePaths: FilePath[]): Promise<Record<FileP
  *
  * @returns The path, or a description of the set it came from.
  */
-function namePathThatFailed(error: any, absolutePaths: FilePath[]): string {
+function namePathThatFailed(error: any, absolutePaths: AbsolutePath[]): string {
   return error?.path ? String(error.path) : `one of the ${absolutePaths.length} files hashed`;
 }
 
@@ -101,9 +104,9 @@ function namePathThatFailed(error: any, absolutePaths: FilePath[]): string {
  * @returns The absolute path of every file found.
  */
 async function listFilesRecursively(
-  directory: FilePath,
-  visitedDirectories = new Set<FilePath>()
-): Promise<FilePath[]> {
+  directory: AbsolutePath,
+  visitedDirectories = new Set<AbsolutePath>()
+): Promise<AbsolutePath[]> {
   // Resolving before walking is what stops a symlink loop from diverging. Static files are hashed
   // unbounded by design, so there is no count cap to fall back on.
   let realDirectory;

--- a/node-src/lib/turbosnap/v2/projectFiles.ts
+++ b/node-src/lib/turbosnap/v2/projectFiles.ts
@@ -15,8 +15,11 @@ export interface ProjectFiles {
   isDirectory(absolutePath: AbsolutePath): boolean;
   /** Undefined when unresolvable; resolves the package manifest, not a dist path. */
   packageVersion(fromDirectory: AbsolutePath, packageName: string): string | undefined;
-  /** Throws, naming the path, when a file cannot be read. */
-  hashAll(absolutePaths: AbsolutePath[]): Promise<Record<AbsolutePath, FileHash>>;
+  /** Throws, naming the path, when a file cannot be read. `concurrency` bounds parallel reads. */
+  hashAll(
+    absolutePaths: AbsolutePath[],
+    concurrency?: number
+  ): Promise<Record<AbsolutePath, FileHash>>;
   /** Follows symlinks, names files by the link path, terminates on a cycle, empty when absent. */
   listTree(absoluteDirectory: AbsolutePath): AbsolutePath[];
 }
@@ -63,18 +66,18 @@ function readPackageVersion(fromDirectory: AbsolutePath, packageName: string): s
  * Content-hashes files by absolute path, bounded by a concurrency limit.
  *
  * @param absolutePaths The absolute paths to hash.
+ * @param concurrency The number of files to hash at once. Defaults via `getFileHashes` when omitted.
  *
  * @returns The content hash of each file, keyed by the absolute path it was read from.
  */
 async function hashFileContents(
-  absolutePaths: AbsolutePath[]
+  absolutePaths: AbsolutePath[],
+  concurrency?: number
 ): Promise<Record<AbsolutePath, FileHash>> {
   if (absolutePaths.length === 0) return {};
 
   try {
-    // getFileHashes joins its directory argument with each file; pass '' so the absolute paths are
-    // used as-is, and it returns hashes keyed by those absolute paths.
-    return await getFileHashes(absolutePaths, '', 10);
+    return await getFileHashes({ files: absolutePaths, concurrency });
   } catch (error) {
     throw new Error(`Could not hash ${namePathThatFailed(error, absolutePaths)}: ${error.message}`);
   }

--- a/node-src/lib/turbosnap/v2/projectFiles.ts
+++ b/node-src/lib/turbosnap/v2/projectFiles.ts
@@ -1,5 +1,4 @@
-import { readFileSync, statSync } from 'fs';
-import { readdir, realpath, stat } from 'fs/promises';
+import { readdirSync, readFileSync, realpathSync, statSync } from 'fs';
 import { createRequire } from 'module';
 import path from 'path';
 
@@ -19,7 +18,7 @@ export interface ProjectFiles {
   /** Throws, naming the path, when a file cannot be read. */
   hashAll(absolutePaths: AbsolutePath[]): Promise<Record<AbsolutePath, FileHash>>;
   /** Follows symlinks, names files by the link path, terminates on a cycle, empty when absent. */
-  listTree(absoluteDirectory: AbsolutePath): Promise<AbsolutePath[]>;
+  listTree(absoluteDirectory: AbsolutePath): AbsolutePath[];
 }
 
 /**
@@ -103,45 +102,48 @@ function namePathThatFailed(error: any, absolutePaths: AbsolutePath[]): string {
  *
  * @returns The absolute path of every file found.
  */
-async function listFilesRecursively(
+function listFilesRecursively(
   directory: AbsolutePath,
   visitedDirectories = new Set<AbsolutePath>()
-): Promise<AbsolutePath[]> {
-  // Resolving before walking is what stops a symlink loop from diverging. Static files are hashed
-  // unbounded by design, so there is no count cap to fall back on.
+): AbsolutePath[] {
   let realDirectory;
   try {
-    realDirectory = await realpath(directory);
+    realDirectory = realpathSync(directory);
   } catch {
     return [];
   }
-  if (visitedDirectories.has(realDirectory)) return [];
+
+  if (visitedDirectories.has(realDirectory)) {
+    return [];
+  }
   visitedDirectories.add(realDirectory);
 
   let entries;
   try {
-    entries = await readdir(directory, { withFileTypes: true });
+    entries = readdirSync(directory, { withFileTypes: true });
   } catch {
     return [];
   }
 
-  const files = await Promise.all(
-    entries.map(async (entry) => {
-      const entryPath = path.join(directory, entry.name);
-      if (entry.isDirectory()) return listFilesRecursively(entryPath, visitedDirectories);
-      if (entry.isFile()) return [entryPath];
+  return entries.flatMap((entry) => {
+    const entryPath = path.join(directory, entry.name);
+    if (entry.isDirectory()) {
+      return listFilesRecursively(entryPath, visitedDirectories);
+    }
+    if (entry.isFile()) {
+      return [entryPath];
+    }
 
-      // A symlink is neither, so ask `stat`, which follows it. Anything else with no bytes of its own
-      // — a socket, a device, a broken link — contributes nothing.
-      try {
-        const stats = await stat(entryPath);
-        if (stats.isDirectory()) return listFilesRecursively(entryPath, visitedDirectories);
-        return stats.isFile() ? [entryPath] : [];
-      } catch {
-        return [];
+    // A symlink is neither, so ask `stat`, which follows it. Anything else with no bytes of its own
+    // — a socket, a device, a broken link — contributes nothing.
+    try {
+      const stats = statSync(entryPath);
+      if (stats.isDirectory()) {
+        return listFilesRecursively(entryPath, visitedDirectories);
       }
-    })
-  );
-
-  return files.flat();
+      return stats.isFile() ? [entryPath] : [];
+    } catch {
+      return [];
+    }
+  });
 }

--- a/node-src/lib/turbosnap/v2/projectFiles.ts
+++ b/node-src/lib/turbosnap/v2/projectFiles.ts
@@ -1,0 +1,144 @@
+import { readFileSync, statSync } from 'fs';
+import { readdir, realpath, stat } from 'fs/promises';
+import { createRequire } from 'module';
+import path from 'path';
+
+import { getFileHashes } from '../../getFileHashes';
+import { FileHash, FilePath } from './graph';
+
+/**
+ * Every disk read TurboSnap v2 makes, behind one interface, so the rules about what the disk means
+ * live here rather than at each call site.
+ */
+export interface ProjectFiles {
+  isFile(absolutePath: FilePath): boolean;
+  isDirectory(absolutePath: FilePath): boolean;
+  /** Undefined when unresolvable; resolves the package manifest, not a dist path. */
+  packageVersion(fromDirectory: FilePath, packageName: string): string | undefined;
+  /** Throws, naming the path, when a file cannot be read. */
+  hashAll(absolutePaths: FilePath[]): Promise<Record<FilePath, FileHash>>;
+  /** Follows symlinks, names files by the link path, terminates on a cycle, empty when absent. */
+  listTree(absoluteDirectory: FilePath): Promise<FilePath[]>;
+}
+
+/**
+ * The adapter backed by the real disk. Constructed explicitly by the caller, never defaulted: a
+ * default is exactly how a test would silently read the machine it runs on.
+ *
+ * @returns An adapter to read from the real file system.
+ */
+export function realProjectFiles(): ProjectFiles {
+  return {
+    isFile: (absolutePath: FilePath) =>
+      statSync(absolutePath, { throwIfNoEntry: false })?.isFile() ?? false,
+    isDirectory: (absolutePath: FilePath) =>
+      statSync(absolutePath, { throwIfNoEntry: false })?.isDirectory() ?? false,
+    packageVersion: readPackageVersion,
+    hashAll: hashFileContents,
+    listTree: (absoluteDirectory: FilePath) => listFilesRecursively(absoluteDirectory),
+  };
+}
+
+/**
+ * Reads a package's installed version from its own `package.json`, resolved from a directory.
+ *
+ * @param fromDirectory The absolute directory to resolve from.
+ * @param packageName The package to read the version of.
+ *
+ * @returns The installed version, or undefined when the package cannot be resolved or read.
+ */
+function readPackageVersion(fromDirectory: FilePath, packageName: string): string | undefined {
+  const requireFromDirectory = createRequire(path.join(fromDirectory, 'package.json'));
+
+  try {
+    const packageJsonPath = requireFromDirectory.resolve(`${packageName}/package.json`);
+    const { version } = JSON.parse(readFileSync(packageJsonPath, 'utf8'));
+    return version;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Content-hashes files by absolute path, bounded by a concurrency limit.
+ *
+ * @param absolutePaths The absolute paths to hash.
+ *
+ * @returns The content hash of each file, keyed by the absolute path it was read from.
+ */
+async function hashFileContents(absolutePaths: FilePath[]): Promise<Record<FilePath, FileHash>> {
+  if (absolutePaths.length === 0) return {};
+
+  try {
+    // getFileHashes joins its directory argument with each file; pass '' so the absolute paths are
+    // used as-is, and it returns hashes keyed by those absolute paths.
+    return await getFileHashes(absolutePaths, '', 10);
+  } catch (error) {
+    throw new Error(`Could not hash ${namePathThatFailed(error, absolutePaths)}: ${error.message}`);
+  }
+}
+
+/**
+ * Names the file a failed read was about.
+ *
+ * @param error The thrown read failure.
+ * @param absolutePaths The paths the read was asked about.
+ *
+ * @returns The path, or a description of the set it came from.
+ */
+function namePathThatFailed(error: any, absolutePaths: FilePath[]): string {
+  return error?.path ? String(error.path) : `one of the ${absolutePaths.length} files hashed`;
+}
+
+/**
+ * Lists every file under a directory, recursively, following symlinks. A directory that doesn't exist
+ * contributes nothing rather than throwing: a configured-but-missing `staticDir` is not an error, and
+ * v1 never matches such a path either. The same holds for a broken symlink, whose target can't be read.
+ *
+ * @param directory The absolute directory to walk.
+ * @param visitedDirectories Resolved real paths already walked, so a symlink cycle terminates.
+ *
+ * @returns The absolute path of every file found.
+ */
+async function listFilesRecursively(
+  directory: FilePath,
+  visitedDirectories = new Set<FilePath>()
+): Promise<FilePath[]> {
+  // Resolving before walking is what stops a symlink loop from diverging. Static files are hashed
+  // unbounded by design, so there is no count cap to fall back on.
+  let realDirectory;
+  try {
+    realDirectory = await realpath(directory);
+  } catch {
+    return [];
+  }
+  if (visitedDirectories.has(realDirectory)) return [];
+  visitedDirectories.add(realDirectory);
+
+  let entries;
+  try {
+    entries = await readdir(directory, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+
+  const files = await Promise.all(
+    entries.map(async (entry) => {
+      const entryPath = path.join(directory, entry.name);
+      if (entry.isDirectory()) return listFilesRecursively(entryPath, visitedDirectories);
+      if (entry.isFile()) return [entryPath];
+
+      // A symlink is neither, so ask `stat`, which follows it. Anything else with no bytes of its own
+      // — a socket, a device, a broken link — contributes nothing.
+      try {
+        const stats = await stat(entryPath);
+        if (stats.isDirectory()) return listFilesRecursively(entryPath, visitedDirectories);
+        return stats.isFile() ? [entryPath] : [];
+      } catch {
+        return [];
+      }
+    })
+  );
+
+  return files.flat();
+}

--- a/node-src/share.test.ts
+++ b/node-src/share.test.ts
@@ -29,7 +29,7 @@ vi.mock('./lib/share', () => ({
 vi.mock('./lib/uploadFiles');
 
 vi.mock('./lib/getFileHashes', () => ({
-  getFileHashes: (files: string[]) =>
+  getFileHashes: ({ files }: { files: string[] }) =>
     Promise.resolve(Object.fromEntries(files.map((f) => [f, 'hash']))),
 }));
 

--- a/node-src/tasks/prepare/calculateFileHashes.test.ts
+++ b/node-src/tasks/prepare/calculateFileHashes.test.ts
@@ -4,7 +4,7 @@ import TestLogger from '../../lib/testLogger';
 import { calculateFileHashes } from './calculateFileHashes';
 
 vi.mock('../../lib/getFileHashes', () => ({
-  getFileHashes: (files: string[]) =>
+  getFileHashes: ({ files }: { files: string[] }) =>
     Promise.resolve(Object.fromEntries(files.map((f) => [f, 'hash']))),
 }));
 

--- a/node-src/tasks/prepare/calculateFileHashes.ts
+++ b/node-src/tasks/prepare/calculateFileHashes.ts
@@ -32,11 +32,11 @@ export async function calculateFileHashes(
 
   try {
     const start = Date.now();
-    const hashes = await getFileHashes(
-      input.fileInfo.paths,
-      input.sourceDir,
-      deps.env.CHROMATIC_HASH_CONCURRENCY
-    );
+    const hashes = await getFileHashes({
+      files: input.fileInfo.paths,
+      directory: input.sourceDir,
+      concurrency: deps.env.CHROMATIC_HASH_CONCURRENCY,
+    });
     deps.log.debug(`Calculated file hashes in ${Date.now() - start}ms`);
     return { hashes };
   } catch (err) {

--- a/node-src/types.ts
+++ b/node-src/types.ts
@@ -532,7 +532,10 @@ export interface Reason {
 export interface Module {
   id: string | number | null;
   name: string;
-  modules?: Pick<Module, 'name'>[];
+  // The absolute path of the module's source file in the webpack/rspack stats. The `name` field is
+  // the group name (e.g. `./x.stories.tsx + 1 modules`).
+  nameForCondition?: string;
+  modules?: Pick<Module, 'name' | 'nameForCondition'>[];
   reasons?: Reason[];
 }
 


### PR DESCRIPTION
Relates to CAP-4864

This sets up some helpers for TurboSnap v2 to parse the `preview-stats.json` file from the builders. It's currently unused and will be used in follow-up PRs.

The idea behind these helpers is to use `preview-stats.json` to build our TurboSnap manifest that looks something like this:

```
{
  "storybookHash": "<a single hash of the entire storybook>",
  "storybookFilesHashes": {
    "storybookGlobals": "<a single hash of all globals>",
    "storybookVersion": "<storybook version string>",
    "storybookConfigFiles": "<a single hash of all config files",
    "staticFiles": "<a single hash of all static files>"
  },
  "storybookConfigFiles": {
    <file path of config files>: <hash of that source file>
  },
  "staticFiles": {
    <file path of static files>: <hash of that source file>
  },
  "storyFiles": {
    <file path of story files>: <hash of that source file>
  },
  ...
}
```

Our goal is to have high-level hashes at the top so we can short-circuit early on.

For example:
- If `storybookHash` matches the baseline, we don't need to compare anything else because it didn't change
- If `storybookHash` doesn't change but `storybookVersion` changes, then we recapture everything (same as TurboSnap v1) because Storybook was upgraded/downgraded

Then the fields below are finer-grained details about which file changed.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>18.6.1--canary.1436.32890861155.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@18.6.1--canary.1436.32890861155.0
  # or 
  yarn add chromatic@18.6.1--canary.1436.32890861155.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
