### PR TITLE
fix: pass Chromatic Project ID in `buildStorybook`

### DIFF
--- a/node-src/tasks/build/buildStorybook.test.ts
+++ b/node-src/tasks/build/buildStorybook.test.ts
@@ -106,6 +106,34 @@ describe('buildStorybook', () => {
     );
   });
 
+  it('passes CHROMATIC_PROJECT_ID', async () => {
+    const deps = {
+      env: { STORYBOOK_BUILD_TIMEOUT: 1000 },
+      log: new TestLogger(),
+      options: {},
+    } as any;
+    const input = {
+      ...baseInput,
+      buildCommand: 'npm exec -- build-archive-storybook',
+      projectId: 'example-project-id',
+    };
+
+    await buildStorybook(deps, input);
+    const [cmd, ...args] = parseCommandString(input.buildCommand);
+    expect(execa).toHaveBeenCalledWith(
+      cmd,
+      args,
+      expect.objectContaining({
+        env: {
+          CI: '1',
+          NODE_ENV: 'production',
+          STORYBOOK_INVOKED_BY: 'chromatic',
+          CHROMATIC_PROJECT_ID: 'example-project-id',
+        },
+      })
+    );
+  });
+
   it('allows overriding NODE_ENV with STORYBOOK_NODE_ENV', async () => {
     const deps = {
       env: { STORYBOOK_BUILD_TIMEOUT: 1000, STORYBOOK_NODE_ENV: 'test' },

--- a/node-src/tasks/build/buildStorybook.ts
+++ b/node-src/tasks/build/buildStorybook.ts
@@ -20,6 +20,7 @@ type BuildStorybookDeps = Pick<Deps, 'options' | 'log' | 'env' | 'analytics' | '
 
 interface BuildStorybookInput {
   buildCommand?: string;
+  projectId?: string;
   runtimeMetadata?: Context['runtimeMetadata'];
   storybook?: Context['storybook'];
   git: Context['git'];
@@ -177,6 +178,7 @@ export const buildStorybook = async (
         CI: '1',
         NODE_ENV: deps.env.STORYBOOK_NODE_ENV || 'production',
         STORYBOOK_INVOKED_BY: 'chromatic',
+        CHROMATIC_PROJECT_ID: input.projectId,
       },
     });
   } catch (err) {

--- a/node-src/tasks/build/index.test.ts
+++ b/node-src/tasks/build/index.test.ts
@@ -117,7 +117,7 @@ describe('extractBuildInput', () => {
       storybook: { version: '7' },
       flags: { buildCommand: 'x' },
       git: { changedFiles: ['a.js'] },
-      announcedBuild: { browsers: ['ios'] },
+      announcedBuild: { browsers: ['ios'], app: { id: 'example-project-id' } },
       runtimeMetadata: { nodePlatform: 'darwin' },
     } as any;
     expect(extractBuildInput(ctx)).toEqual({
@@ -126,6 +126,7 @@ describe('extractBuildInput', () => {
       storybook: { version: '7' },
       flags: { buildCommand: 'x' },
       browsers: ['ios'],
+      projectId: 'example-project-id',
       runtimeMetadata: { nodePlatform: 'darwin' },
       git: { changedFiles: ['a.js'] },
     });

--- a/node-src/tasks/build/index.ts
+++ b/node-src/tasks/build/index.ts
@@ -14,6 +14,7 @@ export interface BuildInput {
   storybook?: Context['storybook'];
   flags: Context['flags'];
   browsers?: string[];
+  projectId?: string;
   runtimeMetadata?: Context['runtimeMetadata'];
   git: Context['git'];
 }
@@ -103,6 +104,7 @@ async function buildWebProject(deps: Deps, input: BuildInput): Promise<TaskResul
     },
     {
       buildCommand,
+      projectId: input.projectId,
       runtimeMetadata: input.runtimeMetadata,
       storybook: input.storybook,
       git: input.git,
@@ -139,6 +141,7 @@ export const extractBuildInput = (ctx: Context): BuildInput => ({
   storybook: ctx.storybook,
   flags: ctx.flags,
   browsers: ctx.announcedBuild?.browsers,
+  projectId: ctx.announcedBuild?.app?.id,
   runtimeMetadata: ctx.runtimeMetadata,
   git: ctx.git,
 });


### PR DESCRIPTION

When Chromatic CLI builds Storybook, pass `CHROMATIC_PROJECT_ID` in the spawned process's environment variables. The E2E packages (and Storybook itself too) can then identify which Chromatic project is calling them.

- Related to Milestone 5 of https://github.com/chromaui/chromatic-e2e/issues/419
- Used by `@chromatic-com/vitest` in https://github.com/chromaui/chromatic-e2e/pull/436
  - Example telemetry logs:
    <details>

    ```js
    {
      anonymousId: '3dc9496ca0d9b9e30a046f336eb66300111235c87476d6a360cc0e5b81df7b77',
      event: 'vitest_storybook_build_started',
      messageId: 'aa536d12-a70f-4995-b8ee-3e63894bd0f4',
      timestamp: 2026-08-12T10:11:20.261Z,
      properties: {
        sessionId: '5ac186eb-95ea-4761-9a57-02b66c661132',
        projectId: '3dc9496ca0d9b9e30a046f336eb66300111235c87476d6a360cc0e5b81df7b77',
        level: 'info',
        payload: {
          isCalledFromCLI: true,
          chromaticProjectId: '69d8f64ba22267db6c7c27d6'
        },
        metadata: {
          isCI: true,
          pluginVersion: '0.1.8',
          nodeVersion: '22.23.2',
          vitestVersion: '4.1.8',
          isVitestProjects: false,
          packageManager: 'pnpm',
          packageManagerVersion: '10.33.0',
          chromaticVersion: '18.2.1--canary.1437.31582587810.0'
        }
      }
    }
    {
      anonymousId: '3dc9496ca0d9b9e30a046f336eb66300111235c87476d6a360cc0e5b81df7b77',
      event: 'vitest_archives_resolved',
      messageId: '01970ca0-7e26-4132-8ffc-bb172e5610bf',
      timestamp: 2026-08-12T10:11:20.284Z,
      properties: {
        sessionId: '5ac186eb-95ea-4761-9a57-02b66c661132',
        projectId: '3dc9496ca0d9b9e30a046f336eb66300111235c87476d6a360cc0e5b81df7b77',
        level: 'info',
        payload: {
          success: true,
          isCustomLocation: false,
          command: 'buildArchiveStorybook',
          chromaticProjectId: '69d8f64ba22267db6c7c27d6'
        },
        metadata: {
          isCI: true,
          pluginVersion: '0.1.8',
          nodeVersion: '22.23.2',
          vitestVersion: '4.1.8',
          isVitestProjects: false,
          packageManager: 'pnpm',
          packageManagerVersion: '10.33.0',
          chromaticVersion: '18.2.1--canary.1437.31582587810.0'
        }
      }
    }
    {
      anonymousId: '3dc9496ca0d9b9e30a046f336eb66300111235c87476d6a360cc0e5b81df7b77',
      event: 'vitest_storybook_build_completed',
      messageId: 'a08c27cd-0828-458e-a58e-967b32ea044e',
      timestamp: 2026-08-12T10:11:22.627Z,
      properties: {
        sessionId: '5ac186eb-95ea-4761-9a57-02b66c661132',
        projectId: '3dc9496ca0d9b9e30a046f336eb66300111235c87476d6a360cc0e5b81df7b77',
        level: 'info',
        payload: { success: true, chromaticProjectId: '69d8f64ba22267db6c7c27d6' },
        metadata: {
          isCI: true,
          pluginVersion: '0.1.8',
          nodeVersion: '22.23.2',
          vitestVersion: '4.1.8',
          isVitestProjects: false,
          packageManager: 'pnpm',
          packageManagerVersion: '10.33.0',
          chromaticVersion: '18.2.1--canary.1437.31582587810.0'
        }
      }
    }
    ```

    </details>

<hr />

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>18.3.1--canary.1437.32161774866.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@18.3.1--canary.1437.32161774866.0
  # or 
  yarn add chromatic@18.3.1--canary.1437.32161774866.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
