### PR TITLE
Support `DO_NOT_TRACK` & `CHROMATIC_DISABLE_TELEMETRY`

### DIFF
--- a/node-src/lib/analytics/index.test.ts
+++ b/node-src/lib/analytics/index.test.ts
@@ -15,9 +15,11 @@ function makeContext() {
 describe('createAnalyticsClient', () => {
   afterEach(() => {
     delete process.env.CHROMATIC_DISABLE_ANALYTICS;
+    delete process.env.CHROMATIC_DISABLE_TELEMETRY;
+    delete process.env.DO_NOT_TRACK;
   });
 
-  it('returns an Index client when CHROMATIC_DISABLE_ANALYTICS is not set', () => {
+  it('returns an Index client when no disabling environment variable is not set', () => {
     const ctx = makeContext();
     const client = createAnalyticsClient(ctx);
     expect(client).toBeInstanceOf(IndexAnalyticsClient);
@@ -25,6 +27,20 @@ describe('createAnalyticsClient', () => {
 
   it('returns a log-only client when CHROMATIC_DISABLE_ANALYTICS is set', () => {
     process.env.CHROMATIC_DISABLE_ANALYTICS = 'true';
+    const ctx = makeContext();
+    const client = createAnalyticsClient(ctx);
+    expect(client).toBeInstanceOf(LogOnlyAnalyticsClient);
+  });
+
+  it('returns a log-only client when CHROMATIC_DISABLE_TELEMETRY is set', () => {
+    process.env.CHROMATIC_DISABLE_TELEMETRY = '1';
+    const ctx = makeContext();
+    const client = createAnalyticsClient(ctx);
+    expect(client).toBeInstanceOf(LogOnlyAnalyticsClient);
+  });
+
+  it('returns a log-only client when DO_NOT_TRACK is set', () => {
+    process.env.DO_NOT_TRACK = 'YES';
     const ctx = makeContext();
     const client = createAnalyticsClient(ctx);
     expect(client).toBeInstanceOf(LogOnlyAnalyticsClient);

--- a/node-src/lib/analytics/index.ts
+++ b/node-src/lib/analytics/index.ts
@@ -13,11 +13,21 @@ export type { AnalyticsClient } from './types';
  * @returns An analytics client instance.
  */
 export function createAnalyticsClient(ctx: Context): AnalyticsClient {
-  if (process.env.CHROMATIC_DISABLE_ANALYTICS === 'true') {
-    ctx.log.debug('[analytics] disabled via CHROMATIC_DISABLE_ANALYTICS, using log-only client');
+  const analyticsDisabled = [
+    'CHROMATIC_DISABLE_ANALYTICS',
+    'CHROMATIC_DISABLE_TELEMETRY',
+    'DO_NOT_TRACK',
+  ].some((name) => environmentVariableIsTruthy(process.env[name]));
+
+  if (analyticsDisabled) {
+    ctx.log.debug('[analytics] disabled via environment variable, using log-only client');
     return new LogOnlyAnalyticsClient(ctx.log);
   }
 
   ctx.log.debug('[analytics] initializing Index analytics client');
   return new IndexAnalyticsClient({ client: ctx.client, logger: ctx.log });
+}
+
+function environmentVariableIsTruthy(envar?: string) {
+  return ['1', 'true', 'yes'].includes((envar || '').toLowerCase());
 }


### PR DESCRIPTION
Bring us in line with [Storybook](https://storybook.js.org/docs/configure/telemetry#how-to-opt-out) and [Vitest E2E](https://deploy-preview-868--chromatic-docs.netlify.app/docs/vitest/telemetry/#how-to-opt-out)
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>18.3.1--canary.1438.32161778593.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@18.3.1--canary.1438.32161778593.0
  # or 
  yarn add chromatic@18.3.1--canary.1438.32161778593.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
