### PR TITLE
[TurboSnap v2] Add Storybook version detection

### DIFF
--- a/node-src/lib/turbosnap/v2/projectFiles.fake.ts
+++ b/node-src/lib/turbosnap/v2/projectFiles.fake.ts
@@ -1,0 +1,76 @@
+import path from 'path';
+
+import { AbsolutePath } from '../../../types';
+import { FileHash } from './graph';
+import { ProjectFiles } from './projectFiles';
+
+/**
+ * A disk described as a value, for the in-memory adapter. Every field is optional, so a suite
+ * describes only the part of the disk its assertion turns on.
+ */
+export interface InMemoryDisk {
+  /** Entry names per absolute directory. A path a key exists for is a directory. */
+  directories?: Record<AbsolutePath, string[]>;
+  /** Content hash per absolute file path. A file with no entry here hashes as `x`. */
+  fileHashes?: Record<AbsolutePath, FileHash>;
+  /** Installed version per package name, whatever directory it is resolved from. */
+  packageVersions?: Record<string, string>;
+  /**
+   * Whether a path has no file on disk. Everything else is a file, which is what keeps a suite from
+   * having to list every source file its stats fixture names.
+   */
+  isAbsent?: (absolutePath: AbsolutePath) => boolean;
+}
+
+/**
+ * The adapter backed by a disk supplied as a value, so a suite describes its disk instead of mocking
+ * `fs`. Symlinks, cycles and unreadable directories are not modelled: those are rules of the real
+ * disk, and pinning them against a fake only proves the fake follows them. See projectFiles.test.ts,
+ * which pins them against real temporary directories.
+ *
+ * @param disk The disk to read, read on each call so a test can set it after the adapter is
+ * constructed.
+ *
+ * @returns The in-memory adapter.
+ */
+export function inMemoryProjectFiles(disk: InMemoryDisk): ProjectFiles {
+  function isDirectory(absolutePath: AbsolutePath): boolean {
+    return Boolean(disk.directories?.[absolutePath]);
+  }
+
+  function isFile(absolutePath: AbsolutePath): boolean {
+    return !isDirectory(absolutePath) && !disk.isAbsent?.(absolutePath);
+  }
+
+  function listTree(absoluteDirectory: AbsolutePath): AbsolutePath[] {
+    const entries = disk.directories?.[absoluteDirectory];
+    if (!entries) {
+      return [];
+    }
+
+    return entries.flatMap((name) => {
+      const entryPath = path.join(absoluteDirectory, name);
+      return disk.directories?.[entryPath] ? listTree(entryPath) : [entryPath];
+    });
+  }
+
+  return {
+    isFile,
+    isDirectory,
+    packageVersion: (_fromDirectory: AbsolutePath, packageName: string) =>
+      disk.packageVersions?.[packageName],
+    hashAll: async (absolutePaths: AbsolutePath[]) => {
+      // The real reader throws for anything it cannot read, so refusing here too keeps the callers'
+      // "don't hash a directory" guards honest: a suite that lost one sees this instead of a hash.
+      const unreadable = absolutePaths.find((absolutePath) => !isFile(absolutePath));
+      if (unreadable) {
+        throw new Error(`Could not hash ${unreadable}`);
+      }
+
+      return Object.fromEntries(
+        absolutePaths.map((absolutePath) => [absolutePath, disk.fileHashes?.[absolutePath] ?? 'x'])
+      );
+    },
+    listTree,
+  };
+}

--- a/node-src/lib/turbosnap/v2/storybookVersion.test.ts
+++ b/node-src/lib/turbosnap/v2/storybookVersion.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+
+import { inMemoryProjectFiles } from './projectFiles.fake';
+import { resolveStorybookVersion } from './storybookVersion';
+
+const projectRoot = '/repo/packages/ui';
+
+describe('resolveStorybookVersion', () => {
+  it('reads the version from the `storybook` package on Storybook 9 and later', () => {
+    const disk = { packageVersions: { storybook: '9.1.20', '@storybook/core': '8.6.18' } };
+
+    expect(resolveStorybookVersion(projectRoot, inMemoryProjectFiles(disk))).toBe('9.1.20');
+  });
+
+  it('falls back to `@storybook/core` on Storybook 8, where `storybook` is the CLI', () => {
+    const disk = { packageVersions: { '@storybook/core': '8.6.18' } };
+
+    expect(resolveStorybookVersion(projectRoot, inMemoryProjectFiles(disk))).toBe('8.6.18');
+  });
+
+  it('throws when no Storybook package can be resolved, so the caller falls back to v1', () => {
+    let err: Error | undefined;
+    try {
+      resolveStorybookVersion(projectRoot, inMemoryProjectFiles({}));
+    } catch (error) {
+      err = error as Error;
+    }
+
+    expect(err?.message).toContain('Could not resolve a Storybook version');
+    expect(err?.message).toContain(projectRoot);
+  });
+});

--- a/node-src/lib/turbosnap/v2/storybookVersion.test.ts
+++ b/node-src/lib/turbosnap/v2/storybookVersion.test.ts
@@ -6,19 +6,19 @@ import { resolveStorybookVersion } from './storybookVersion';
 const projectRoot = '/repo/packages/ui';
 
 describe('resolveStorybookVersion', () => {
-  it('reads the version from the `storybook` package on Storybook 9 and later', () => {
+  it('reads the version from the `storybook` package when both are available', () => {
     const disk = { packageVersions: { storybook: '9.1.20', '@storybook/core': '8.6.18' } };
 
     expect(resolveStorybookVersion(projectRoot, inMemoryProjectFiles(disk))).toBe('9.1.20');
   });
 
-  it('falls back to `@storybook/core` on Storybook 8, where `storybook` is the CLI', () => {
+  it('falls back to `@storybook/core` when the `storybook` meta-package cannot be resolved', () => {
     const disk = { packageVersions: { '@storybook/core': '8.6.18' } };
 
     expect(resolveStorybookVersion(projectRoot, inMemoryProjectFiles(disk))).toBe('8.6.18');
   });
 
-  it('throws when no Storybook package can be resolved, so the caller falls back to v1', () => {
+  it('throws when no Storybook package can be resolved because the Storybook version is required', () => {
     let err: Error | undefined;
     try {
       resolveStorybookVersion(projectRoot, inMemoryProjectFiles({}));

--- a/node-src/lib/turbosnap/v2/storybookVersion.ts
+++ b/node-src/lib/turbosnap/v2/storybookVersion.ts
@@ -1,10 +1,11 @@
 import { AbsolutePath } from '../../../types';
 import { ProjectFiles } from './projectFiles';
 
-// The packages that own Storybook's preview runtime, newest layout first.
+// The packages that own Storybook's preview runtime, most-preferred first. Both report the same
+// lockstep version when present; the order is about which one a given install can resolve.
 const STORYBOOK_CORE_PACKAGES = [
-  'storybook', // Storybook 9 and later
-  '@storybook/core', // Storybook 8 and earlier
+  'storybook', // the meta-package, when the project can resolve it
+  '@storybook/core', // the core package it wraps; reachable under strict installs (pnpm, PnP) where the meta-package isn't
 ];
 
 /**

--- a/node-src/lib/turbosnap/v2/storybookVersion.ts
+++ b/node-src/lib/turbosnap/v2/storybookVersion.ts
@@ -1,3 +1,4 @@
+import { AbsolutePath } from '../../../types';
 import { ProjectFiles } from './projectFiles';
 
 // The packages that own Storybook's preview runtime, newest layout first.
@@ -25,7 +26,10 @@ const STORYBOOK_CORE_PACKAGES = [
  *
  * @returns The installed Storybook version (e.g. `9.1.20`).
  */
-export function resolveStorybookVersion(projectRoot: string, projectFiles: ProjectFiles): string {
+export function resolveStorybookVersion(
+  projectRoot: AbsolutePath,
+  projectFiles: ProjectFiles
+): string {
   for (const packageName of STORYBOOK_CORE_PACKAGES) {
     const version = projectFiles.packageVersion(projectRoot, packageName);
     if (version) {

--- a/node-src/lib/turbosnap/v2/storybookVersion.ts
+++ b/node-src/lib/turbosnap/v2/storybookVersion.ts
@@ -1,0 +1,41 @@
+import { ProjectFiles } from './projectFiles';
+
+// The packages that own Storybook's preview runtime, newest layout first.
+const STORYBOOK_CORE_PACKAGES = [
+  'storybook', // Storybook 9 and later
+  '@storybook/core', // Storybook 8 and earlier
+];
+
+/**
+ * Reads the installed Storybook version from the resolved core package's own `package.json`.
+ *
+ * This backs the `storybookVersion` manifest entry, which gates recapture on a Storybook upgrade
+ * that file hashing cannot see. The view layer (e.g. `@storybook/react`) is always bundled into the
+ * preview, so it appears in `preview-stats.json` and a view-layer upgrade already changes the story
+ * hashes. The core preview runtime is different: on some builder/version combinations it is served
+ * as an externalized bundle (e.g. an `storybook/internal/*` bare specifier), so it never appears as
+ * a hashable file in `preview-stats.json`. The version gate covers exactly that blind spot.
+ *
+ * We therefore do not reuse `ctx.storybook.version`: that reports the view-layer package. It also
+ * resolves relative to the working directory without walking up to a hoisted install, and can be a
+ * bare semver range rather than a concrete version.
+ *
+ * @param projectRoot The absolute Storybook project root to resolve from.
+ * @param projectFiles How to read the disk.
+ *
+ * @returns The installed Storybook version (e.g. `9.1.20`).
+ */
+export function resolveStorybookVersion(projectRoot: string, projectFiles: ProjectFiles): string {
+  for (const packageName of STORYBOOK_CORE_PACKAGES) {
+    const version = projectFiles.packageVersion(projectRoot, packageName);
+    if (version) {
+      return version;
+    }
+  }
+
+  // Without a version there is no gate on a Storybook upgrade, so refuse to build a manifest that
+  // would silently under-capture.
+  throw new Error(
+    `Could not resolve a Storybook version from ${projectRoot}: none of ${STORYBOOK_CORE_PACKAGES.join(', ')} could be resolved with a version.`
+  );
+}

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -7,6 +7,7 @@ export default defineConfig({
     coverage: {
       include: ['{bin,node}-src/**/*.{ts,tsx}', 'isChromatic.{mjs,js}'],
       exclude: [
+        '**/*.fake.ts',
         '**/*.stories.{t,j}s',
         '**/*.frames.{t,j}s',
         '**/lib/{testLogger,testUtilities}.ts',


### PR DESCRIPTION
Related to CAP-4864

Just as the title says, this adds detection for determining the Storybook core version. We use this in the manifest to bail the entire build when the Storybook version changes.

```
{
  "storybookHash": "<a single hash of the entire storybook>",
  "storybookFilesHashes": {
    "storybookGlobals": "<a single hash of all globals>",
    "storybookVersion": "<storybook version string>",               <-- this is what this change populates
    "storybookConfigFiles": "<a single hash of all config files",
    "staticFiles": "<a single hash of all static files>"
  },
  "storybookConfigFiles": {
    <file path of config files>: <hash of that source file>
  },
  "staticFiles": {
    <file path of static files>: <hash of that source file>
  },
  "storyFiles": {
    <file path of story files>: <hash of that source file>
  },
  ...
}
```

Note: We don't use `ctx.storybook.version` because it looks for the viewer version and is more lenient than we need to be for TurboSnap v2. I'd rather isolate this change to TurboSnap v2 for now and maybe come back to fixing up `ctx.storybook.version` later.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>18.6.1--canary.1440.32890850505.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@18.6.1--canary.1440.32890850505.0
  # or 
  yarn add chromatic@18.6.1--canary.1440.32890850505.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
