### PR TITLE
[TurboSnap v2] Add story detection

### DIFF
--- a/bin-src/trimStatsFile.ts
+++ b/bin-src/trimStatsFile.ts
@@ -3,7 +3,7 @@ import { outputFile } from 'fs-extra';
 import { readStatsFile } from '../node-src/tasks/readStatsFile';
 
 const dedupe = <T>(array: T[]) => [...new Set(array)];
-const isUserCode = ({ name, moduleName = name }: { name?: string; moduleName?: string }) =>
+const isUserCode = ({ name, moduleName = name }: { name?: string; moduleName?: string | null }) =>
   moduleName &&
   !moduleName.startsWith('(webpack)') &&
   !/(node_modules|webpack\/runtime)\//.test(moduleName);

--- a/node-src/lib/turbosnap/v1/getDependentStoryFiles.ts
+++ b/node-src/lib/turbosnap/v1/getDependentStoryFiles.ts
@@ -36,7 +36,9 @@ const isDocumentationFile = (name: string) =>
 const isUserModule = (module_: Module | Reason) =>
   (module_ as Module).id !== undefined &&
   (module_ as Module).id !== null &&
-  !INTERNALS.some((re) => re.test((module_ as Module).name || (module_ as Reason).moduleName));
+  !INTERNALS.some((re) =>
+    re.test((module_ as Module).name || (module_ as Reason).moduleName || '')
+  );
 
 // For any path in node_modules, return the package name, including scope prefix if any.
 const getPackageName = (modulePath: string) => {
@@ -192,7 +194,9 @@ export async function getDependentStoryFiles(
       }
 
       const normalizedReasons = module_.reasons
-        ?.map((reason) => normalize(reason.moduleName))
+        ?.map((reason) => reason.moduleName)
+        .filter((moduleName): moduleName is FilePath => typeof moduleName === 'string')
+        .map((moduleName) => normalize(moduleName))
         .filter((reasonName) => reasonName && reasonName !== normalizedName);
       if (normalizedReasons) {
         reasonsById.set(module_.id, normalizedReasons);

--- a/node-src/lib/turbosnap/v2/paths.ts
+++ b/node-src/lib/turbosnap/v2/paths.ts
@@ -1,8 +1,47 @@
 import path from 'path';
 
-import { AbsolutePath } from '../../../types';
+import { AbsolutePath, Module } from '../../../types';
 import { relativeTo } from '../../getStorybookProjectRoot';
 import { FilePath } from './graph';
+
+/**
+ * The source file names a stats module stands for. A concatenated module's `name` is a group label
+ * (e.g. `./x.stories.tsx + 1 modules`), so its real files are read from the inner `modules`; a
+ * plain module names itself.
+ *
+ * webpack and rspack both carry the real (absolute) source path in `nameForCondition`, so it is
+ * preferred over `name` where present.
+ *
+ * @param module The stats module to read the file names of.
+ *
+ * @returns The source file names, with empty entries dropped.
+ */
+export function moduleFileNames(module: Module): FilePath[] {
+  const names = module.modules?.length
+    ? module.modules.map((inner) => inner.nameForCondition ?? inner.name)
+    : [module.nameForCondition ?? module.name];
+  return names.filter(Boolean);
+}
+
+/**
+ * The canonical path of a stats module's root source file: the first of its {@link moduleFileNames},
+ * normalized. Only the root identifies the module and matches it against importers; the other inner
+ * names of a concatenation group are its descendants.
+ *
+ * @param module The stats module.
+ * @param projectRoot The absolute Storybook project root to anchor against.
+ * @param statsRoot The directory relative stats paths are named from.
+ *
+ * @returns The canonical root path, or undefined when the module names no files.
+ */
+export function rootFilePath(
+  module: Module,
+  projectRoot: AbsolutePath,
+  statsRoot: AbsolutePath
+): FilePath | undefined {
+  const [rootName] = moduleFileNames(module);
+  return rootName === undefined ? undefined : normalizeStatsPath(rootName, projectRoot, statsRoot);
+}
 
 /**
  * Strips a trailing ` + N modules` suffix from a concatenated module's name, leaving the root file.

--- a/node-src/lib/turbosnap/v2/paths.ts
+++ b/node-src/lib/turbosnap/v2/paths.ts
@@ -16,7 +16,7 @@ import { FilePath } from './graph';
  *
  * @returns The source file names, with empty entries dropped.
  */
-export function moduleFileNames(module: Module): FilePath[] {
+function moduleFileNames(module: Module): FilePath[] {
   const names = module.modules?.length
     ? module.modules.map((inner) => inner.nameForCondition ?? inner.name)
     : [module.nameForCondition ?? module.name];

--- a/node-src/lib/turbosnap/v2/storyDetection.test.ts
+++ b/node-src/lib/turbosnap/v2/storyDetection.test.ts
@@ -16,11 +16,14 @@ const projectRoot = '/repo/packages/ui';
  * @returns The detection result.
  */
 function detect(stats: Stats, onDiskFiles: string[]) {
-  return detectStoryFiles(stats, {
-    projectRoot,
-    statsRoot: projectRoot,
-    onDiskFiles: new Set(onDiskFiles),
-  });
+  return detectStoryFiles(
+    {
+      projectRoot,
+      statsRoot: projectRoot,
+      onDiskFiles: new Set(onDiskFiles),
+    },
+    stats
+  );
 }
 
 describe('detectStoryFiles through a require-context', () => {

--- a/node-src/lib/turbosnap/v2/storyDetection.test.ts
+++ b/node-src/lib/turbosnap/v2/storyDetection.test.ts
@@ -6,20 +6,20 @@ import { detectStoryFiles } from './storyDetection';
 const projectRoot = '/repo/packages/ui';
 
 /**
- * Detects the story files in `stats`, treating exactly `realFiles` as having a file on disk. A
+ * Detects the story files in `stats`, treating exactly `onDiskFiles` as having a file on disk. A
  * canonical path absent from that list is a synthetic node (a require-context glob, a generated
  * entry, an external).
  *
  * @param stats The stats file to parse.
- * @param realFiles The canonical paths that have a file on disk.
+ * @param onDiskFiles The canonical paths that have a file on disk.
  *
  * @returns The detection result.
  */
-function detect(stats: Stats, realFiles: string[]) {
+function detect(stats: Stats, onDiskFiles: string[]) {
   return detectStoryFiles(stats, {
     projectRoot,
     statsRoot: projectRoot,
-    realFiles: new Set(realFiles),
+    onDiskFiles: new Set(onDiskFiles),
   });
 }
 
@@ -137,18 +137,18 @@ describe('detectStoryFiles through a config-entry require-context', () => {
     ],
   };
 
-  const realFiles = [
+  const onDiskFiles = [
     './src/lib/Button.stories.tsx',
     './src/lib/Button.tsx',
     './.storybook/preview.ts',
   ];
 
   it('detects a concatenated story imported via a context imported by the config entry', () => {
-    expect([...detect(stats, realFiles)]).toEqual(['./src/lib/Button.stories.tsx']);
+    expect([...detect(stats, onDiskFiles)]).toEqual(['./src/lib/Button.stories.tsx']);
   });
 
   it('does not treat a real file imported directly by the config entry as a story', () => {
-    expect([...detect(stats, realFiles)]).not.toContain('./.storybook/preview.ts');
+    expect([...detect(stats, onDiskFiles)]).not.toContain('./.storybook/preview.ts');
   });
 });
 

--- a/node-src/lib/turbosnap/v2/storyDetection.test.ts
+++ b/node-src/lib/turbosnap/v2/storyDetection.test.ts
@@ -1,0 +1,272 @@
+import { describe, expect, it } from 'vitest';
+
+import { Stats } from '../../../types';
+import { detectStoryFiles } from './storyDetection';
+
+const projectRoot = '/repo/packages/ui';
+
+/**
+ * Detects the story files in `stats`, treating exactly `realFiles` as having a file on disk. A
+ * canonical path absent from that list is a synthetic node (a require-context glob, a generated
+ * entry, an external).
+ *
+ * @param stats The stats file to parse.
+ * @param realFiles The canonical paths that have a file on disk.
+ *
+ * @returns The detection result.
+ */
+function detect(stats: Stats, realFiles: string[]) {
+  return detectStoryFiles(stats, {
+    projectRoot,
+    statsRoot: projectRoot,
+    realFiles: new Set(realFiles),
+  });
+}
+
+describe('detectStoryFiles through a require-context', () => {
+  // Webpack/rspack don't import story files directly from the entry: the entry imports a lazy
+  // require-context (a glob module that is not a real file), and that context imports the stories.
+  const glob = './src/lib/ lazy namespace object';
+
+  it('detects stories imported via a lazy require-context imported by the entry', () => {
+    const story = '/repo/packages/ui/src/lib/Button.stories.tsx';
+    const storyFiles = detect(
+      {
+        modules: [
+          { id: 1, name: glob, reasons: [{ moduleName: './storybook-stories.js' }] },
+          { id: 2, name: story, reasons: [{ moduleName: glob }] },
+        ],
+      },
+      ['./src/lib/Button.stories.tsx']
+    );
+
+    expect([...storyFiles]).toEqual(['./src/lib/Button.stories.tsx']);
+  });
+
+  it('does not treat the require-context glob itself as a story file', () => {
+    const story = '/repo/packages/ui/src/lib/Button.stories.tsx';
+    const storyFiles = detect(
+      {
+        modules: [
+          { id: 1, name: glob, reasons: [{ moduleName: './storybook-stories.js' }] },
+          { id: 2, name: story, reasons: [{ moduleName: glob }] },
+        ],
+      },
+      ['./src/lib/Button.stories.tsx']
+    );
+
+    expect([...storyFiles].some((key) => key.includes('lazy'))).toBe(false);
+  });
+
+  // When a builder relocates its entry to a path we don't recognize, the context above the stories
+  // is never tied to a known entry, so those stories go undetected. We accept that gap for now.
+  it('detects no stories when the builder entry is relocated to an unrecognized path', () => {
+    const relocatedEntry = './node_modules/.cache/storybook-next/storybook-stories.js';
+    const story = '/repo/packages/ui/src/lib/Button.stories.tsx';
+    const storyFiles = detect(
+      {
+        modules: [
+          { id: 1, name: glob, reasons: [{ moduleName: relocatedEntry }] },
+          { id: 2, name: story, reasons: [{ moduleName: glob }] },
+        ],
+      },
+      ['./src/lib/Button.stories.tsx', relocatedEntry]
+    );
+
+    expect(storyFiles.size).toBe(0);
+  });
+
+  it('does not treat a real file that no story entry imports as a story', () => {
+    const helper = '/repo/packages/ui/src/utils/format.ts';
+    const appFile = '/repo/packages/ui/src/App.tsx';
+    const storyFiles = detect(
+      {
+        modules: [
+          { id: 1, name: glob, reasons: [{ moduleName: './storybook-stories.js' }] },
+          { id: 2, name: helper, reasons: [{ moduleName: appFile }] },
+        ],
+      },
+      ['./src/utils/format.ts', './src/App.tsx']
+    );
+
+    expect([...storyFiles]).toEqual([]);
+  });
+
+  it('does not treat an application file behind its own lazy context as a story', () => {
+    const applicationImporter = '/repo/packages/ui/src/loadExamples.ts';
+    const importedFile = '/repo/packages/ui/src/examples/Button.tsx';
+    const storyFiles = detect(
+      {
+        modules: [
+          { id: 1, name: applicationImporter },
+          { id: 2, name: glob, reasons: [{ moduleName: applicationImporter }] },
+          { id: 3, name: importedFile, reasons: [{ moduleName: glob }] },
+        ],
+      },
+      ['./src/loadExamples.ts', './src/examples/Button.tsx']
+    );
+
+    expect([...storyFiles]).toEqual([]);
+  });
+});
+
+describe('detectStoryFiles through a config-entry require-context', () => {
+  // rsbuild imports the require-context from the config entry (not storybook-stories.js), and the
+  // stories themselves are concatenated modules.
+  const glob = './src/lib|lazy|namespace object';
+  const configEntry = './node_modules/.cache/storybook-rsbuild-builder/storybook-config-entry.js';
+  const story = '/repo/packages/ui/src/lib/Button.stories.tsx';
+  const impl = '/repo/packages/ui/src/lib/Button.tsx';
+
+  const stats: Stats = {
+    modules: [
+      { id: 1, name: glob, reasons: [{ moduleName: `${configEntry} + 1 modules` }] },
+      {
+        id: 2,
+        name: `${story} + 1 modules`,
+        modules: [{ name: story }, { name: impl }],
+        reasons: [{ moduleName: glob }],
+      },
+      // A real file the config entry imports directly (like `.storybook/preview.ts`); it must not
+      // be mistaken for a story just because the config entry imports it.
+      {
+        id: 3,
+        name: '/repo/packages/ui/.storybook/preview.ts',
+        reasons: [{ moduleName: `${configEntry} + 1 modules` }],
+      },
+    ],
+  };
+
+  const realFiles = [
+    './src/lib/Button.stories.tsx',
+    './src/lib/Button.tsx',
+    './.storybook/preview.ts',
+  ];
+
+  it('detects a concatenated story imported via a context imported by the config entry', () => {
+    expect([...detect(stats, realFiles)]).toEqual(['./src/lib/Button.stories.tsx']);
+  });
+
+  it('does not treat a real file imported directly by the config entry as a story', () => {
+    expect([...detect(stats, realFiles)]).not.toContain('./.storybook/preview.ts');
+  });
+});
+
+describe('detectStoryFiles when the builder omits the `./` prefix', () => {
+  const configEntry = 'storybook-config-entry.js';
+  const glob = String.raw`src/lib|lazy|/^\.\/.*$/|namespace object`;
+  const story = '/repo/packages/ui/src/lib/Button.stories.tsx';
+  const impl = '/repo/packages/ui/src/lib/Button.tsx';
+
+  it('detects the story behind a bare-named context imported by a bare-named entry', () => {
+    const storyFiles = detect(
+      {
+        modules: [
+          { id: 1, name: glob, reasons: [{ moduleName: configEntry }] },
+          { id: 2, name: story, reasons: [{ moduleName: glob }] },
+          { id: 3, name: impl, reasons: [{ moduleName: story }] },
+          // Storybook's preview runtime globals. The config entry imports them and they have no file
+          // on disk, which is exactly the shape of a require-context — but an external imports
+          // nothing, so it must never become a story importer.
+          {
+            id: 4,
+            name: 'external "__STORYBOOK_MODULE_PREVIEW_API__"',
+            reasons: [{ moduleName: configEntry }],
+          },
+        ],
+      },
+      ['./src/lib/Button.stories.tsx', './src/lib/Button.tsx']
+    );
+
+    expect([...storyFiles]).toEqual(['./src/lib/Button.stories.tsx']);
+  });
+});
+
+// Note: A "swept" story is a story that lives inside node_modules that can accidentally be imported
+// by the entry's require-context glob.
+describe('detectStoryFiles of swept node_modules stories', () => {
+  // On storybook-builder-rsbuild 1.x–3.3.x, a stories glob whose directory prefix is not
+  // slash-bounded lets rspack's require-context sweep a dependency's story into the graph.
+  const sweepingGlob = String.raw`..|lazy|/^\.\/.*$/|include: /(?!.*node_modules)…/|namespace object`;
+  const story = '/repo/packages/ui/src/lib/Button.stories.tsx';
+  const swept = '/repo/packages/ui/node_modules/fake-dep/Widget.stories.tsx';
+  const shared = '/repo/packages/ui/node_modules/react-dom/index.js';
+
+  it('does not treat a swept node_modules story as a story file', () => {
+    const storyFiles = detect(
+      {
+        modules: [
+          { id: 1, name: sweepingGlob, reasons: [{ moduleName: './storybook-stories.js' }] },
+          { id: 2, name: story, reasons: [{ moduleName: sweepingGlob }] },
+          { id: 3, name: swept, reasons: [{ moduleName: sweepingGlob }] },
+          { id: 4, name: shared, reasons: [{ moduleName: swept }] },
+        ],
+      },
+      [
+        './src/lib/Button.stories.tsx',
+        './node_modules/fake-dep/Widget.stories.tsx',
+        './node_modules/react-dom/index.js',
+      ]
+    );
+
+    expect([...storyFiles]).toEqual(['./src/lib/Button.stories.tsx']);
+  });
+
+  it('keeps a node_modules story a deliberate node_modules glob asked for', () => {
+    // A glob naming `node_modules` (e.g. `../node_modules/@myorg/ui/**/*.stories.js`) is indexed by
+    // Storybook. The context is rooted in `node_modules`, so the sweep is intentional and the story
+    // key is real and matchable.
+    const deliberateGlob = String.raw`./node_modules/@myorg/ui|lazy|/^\.\/.*$/|namespace object`;
+    const shipped = '/repo/packages/ui/node_modules/@myorg/ui/Button.stories.js';
+    const storyFiles = detect(
+      {
+        modules: [
+          { id: 1, name: deliberateGlob, reasons: [{ moduleName: './storybook-stories.js' }] },
+          { id: 2, name: shipped, reasons: [{ moduleName: deliberateGlob }] },
+        ],
+      },
+      ['./node_modules/@myorg/ui/Button.stories.js']
+    );
+
+    expect([...storyFiles]).toEqual(['./node_modules/@myorg/ui/Button.stories.js']);
+  });
+
+  it('keeps a node_modules story when any claiming context did not exclude node_modules', () => {
+    // The same node_modules story is reached through two contexts, both imported by the stories
+    // entry: one glob excludes node_modules, the other is a deliberate node_modules glob that does
+    // not. Because not every context that claims the story excluded node_modules, the deliberate one
+    // makes it indexed and matchable, so it's kept as a story file.
+    const excludingGlob = './src/lib|lazy|namespace object';
+    const deliberateGlob = String.raw`./node_modules/@myorg/ui|lazy|/^\.\/.*$/|namespace object`;
+    const shipped = '/repo/packages/ui/node_modules/@myorg/ui/Button.stories.js';
+    const storyFiles = detect(
+      {
+        modules: [
+          { id: 1, name: excludingGlob, reasons: [{ moduleName: './storybook-stories.js' }] },
+          { id: 2, name: deliberateGlob, reasons: [{ moduleName: './storybook-stories.js' }] },
+          {
+            id: 3,
+            name: shipped,
+            reasons: [{ moduleName: excludingGlob }, { moduleName: deliberateGlob }],
+          },
+        ],
+      },
+      ['./node_modules/@myorg/ui/Button.stories.js']
+    );
+
+    expect([...storyFiles]).toEqual(['./node_modules/@myorg/ui/Button.stories.js']);
+  });
+
+  it('keeps a node_modules story imported directly by the stories entry', () => {
+    // Vite has no require-context: `storybook-stories.js` imports the matched files directly, and
+    // that list comes from the same glob resolution the indexer uses. So a node_modules story there
+    // is deliberate by construction.
+    const shipped = '/repo/packages/ui/node_modules/@myorg/ui/Button.stories.js';
+    const storyFiles = detect(
+      { modules: [{ id: 1, name: shipped, reasons: [{ moduleName: './storybook-stories.js' }] }] },
+      ['./node_modules/@myorg/ui/Button.stories.js']
+    );
+
+    expect([...storyFiles]).toEqual(['./node_modules/@myorg/ui/Button.stories.js']);
+  });
+});

--- a/node-src/lib/turbosnap/v2/storyDetection.ts
+++ b/node-src/lib/turbosnap/v2/storyDetection.ts
@@ -90,7 +90,7 @@ export function detectStoryFiles(
     // those.
     const matchedStoryImporters = (module.reasons ?? [])
       .map((reason) => reason.moduleName)
-      .filter(Boolean)
+      .filter((name): name is FilePath => typeof name === 'string')
       .map((name) => normalizeStatsPath(name, projectRoot, statsRoot))
       .filter((importer) => storyImporters.has(importer));
 
@@ -189,7 +189,7 @@ function collectStoryImporters(
 
     const importers = (module.reasons ?? [])
       .map((reason) => reason.moduleName)
-      .filter(Boolean)
+      .filter((name): name is FilePath => typeof name === 'string')
       .map((name) => canonical(name));
 
     const importedByEntry = importers.some((importer) => entryFiles.has(importer));

--- a/node-src/lib/turbosnap/v2/storyDetection.ts
+++ b/node-src/lib/turbosnap/v2/storyDetection.ts
@@ -10,6 +10,19 @@ export interface OnDiskFiles {
   has(filePath: FilePath): boolean;
 }
 
+/**
+ * What story detection needs to resolve stats paths and tell real files apart from the
+ * require-context glob.
+ */
+interface StoryDetectionContext {
+  // The absolute Storybook project root that module paths anchor against.
+  projectRoot: AbsolutePath;
+  // The directory relative stats paths are named from.
+  statsRoot: AbsolutePath;
+  // Which canonical paths have a real file on disk.
+  onDiskFiles: OnDiskFiles;
+}
+
 // Generated entry points that import all story files. We use this to determine if a file is a story
 // file because they may not always be *.stories.* files because it's configurable.
 const STORIES_ENTRY_FILES = new Set([
@@ -51,60 +64,94 @@ const LAZY_CONTEXT_MARKER = / lazy |\|lazy\|/;
 /**
  * Detects which modules in the stats are story files.
  *
+ * @param context The context required for story detection. See {@link StoryDetectionContext}.
  * @param stats The stats file to parse.
- * @param context The context to resolve stats paths and tell real files apart from the require-context glob.
- * @param context.projectRoot The absolute Storybook project root that module paths anchor against.
- * @param context.statsRoot The directory relative stats paths are named from.
- * @param context.onDiskFiles Which canonical paths have a real file on disk, used to tell real files
- * apart from the require-context glob.
  *
  * @returns The canonical paths of the story files.
  */
-export function detectStoryFiles(
-  stats: Stats,
-  context: { projectRoot: AbsolutePath; statsRoot: AbsolutePath; onDiskFiles: OnDiskFiles }
-): Set<FilePath> {
-  const { projectRoot, statsRoot, onDiskFiles } = context;
-  const { storyImporters, contextsExcludingNodeModules } = collectStoryImporters(
-    stats,
-    projectRoot,
-    onDiskFiles,
-    statsRoot
-  );
+export function detectStoryFiles(context: StoryDetectionContext, stats: Stats): Set<FilePath> {
+  const modules = processModules(context, stats);
+  const { storyImporters, contextsExcludingNodeModules } = collectStoryImporters(context, modules);
 
   const storyFiles = new Set<FilePath>();
-  for (const module of stats.modules) {
-    // An external has no on-disk file, so we can skip it.
-    if (EXTERNAL_MODULE.test(module.name)) {
+  for (const module of modules) {
+    // Story files must live on disk
+    if (!module.onDisk) {
       continue;
     }
 
-    const sourceFilePath = rootFilePath(module, projectRoot, statsRoot);
-    if (!sourceFilePath) {
-      continue;
-    }
+    const matchedStoryImporters = module.importers.filter((importer) =>
+      storyImporters.has(importer)
+    );
 
-    // Importers hold the builder's own entry paths (e.g. `./storybook-stories.js`), canonicalised so
-    // they compare against the canonical keys collectStoryImporters returns — the builder may spell
-    // the same entry with or without a `./` prefix. Entry reasons carry a null moduleName, so drop
-    // those.
-    const matchedStoryImporters = (module.reasons ?? [])
-      .map((reason) => reason.moduleName)
-      .filter((name): name is FilePath => typeof name === 'string')
-      .map((name) => normalizeStatsPath(name, projectRoot, statsRoot))
-      .filter((importer) => storyImporters.has(importer));
-
-    // Only real files are story files; requiring a file on disk excludes the require-context glob
-    // itself (which is imported by an entry but has no on-disk file).
-    if (
-      onDiskFiles.has(sourceFilePath) &&
-      isStoryFile(sourceFilePath, matchedStoryImporters, contextsExcludingNodeModules)
-    ) {
-      storyFiles.add(sourceFilePath);
+    if (isStoryFile(module.filePath, matchedStoryImporters, contextsExcludingNodeModules)) {
+      storyFiles.add(module.filePath);
     }
   }
 
   return storyFiles;
+}
+
+/**
+ * A raw stats module after the per-module work every step needs: the canonical file path, whether it
+ * has a file on disk, and its canonical importer names.
+ */
+interface ProcessedModule {
+  // The raw stats module name, left un-normalized: `isLazyContext` and `excludesNodeModules` read
+  // the literal ` lazy ` marker and the include-regex text, which normalization would destroy. Do
+  // not key on it or treat it as a path — use `filePath` for that.
+  rawName: string;
+  // The module's canonical root file path (see {@link rootFilePath}). Also serves as its importer key.
+  filePath: FilePath;
+  // Whether `filePath` has a real file on disk.
+  onDisk: boolean;
+  // The canonical importer names, from the module reasons.
+  importers: FilePath[];
+}
+
+/**
+ * Walks the stats modules once and turns each into a {@link ProcessedModule}, so the heavy per-module
+ * work (the canonical path and the canonical importer names) runs one time and both steps read the
+ * same shape.
+ *
+ * A module is kept when it is not an external and has a non-null canonical file path. On-disk and
+ * off-disk modules are both kept.
+ *
+ * @param context The context required for story detection. See {@link StoryDetectionContext}.
+ * @param stats The stats file to parse.
+ *
+ * @returns The processed modules.
+ */
+function processModules(context: StoryDetectionContext, stats: Stats): ProcessedModule[] {
+  const { projectRoot, statsRoot, onDiskFiles } = context;
+  const processed: ProcessedModule[] = [];
+
+  for (const module of stats.modules) {
+    // An external has no on-disk file and imports nothing, so it can never be or import a story.
+    if (EXTERNAL_MODULE.test(module.name)) {
+      continue;
+    }
+
+    const filePath = rootFilePath(module, projectRoot, statsRoot);
+    if (!filePath) {
+      continue;
+    }
+
+    // Entry reasons carry a null moduleName, so drop those before canonicalising.
+    const importers = (module.reasons ?? [])
+      .map((reason) => reason.moduleName)
+      .filter((name): name is FilePath => typeof name === 'string')
+      .map((name) => normalizeStatsPath(name, projectRoot, statsRoot));
+
+    processed.push({
+      rawName: module.name,
+      filePath,
+      onDisk: onDiskFiles.has(filePath),
+      importers,
+    });
+  }
+
+  return processed;
 }
 
 /**
@@ -145,23 +192,19 @@ function isStoryFile(
  * such context (a module imported by an entry file that isn't itself a real file) as a story
  * importer too, so both builders are covered.
  *
- * @param stats The stats file to parse.
- * @param projectRoot The absolute Storybook project root that module paths anchor against.
- * @param onDiskFiles Which canonical paths have a real file on disk, used to tell real files apart
- * from the require-context glob.
- * @param statsRoot The directory relative stats paths are named from.
+ * @param context The context required for story detection. See {@link StoryDetectionContext}.
+ * @param modules The processed modules to scan (see {@link processModules}).
  *
  * @returns The set of canonical importer keys that indicate a story file.
  */
 function collectStoryImporters(
-  stats: Stats,
-  projectRoot: AbsolutePath,
-  onDiskFiles: OnDiskFiles,
-  statsRoot: AbsolutePath
+  context: StoryDetectionContext,
+  modules: ProcessedModule[]
 ): {
   storyImporters: Set<string>;
   contextsExcludingNodeModules: Set<string>;
 } {
+  const { projectRoot, statsRoot } = context;
   const canonical = (name: string) => normalizeStatsPath(name, projectRoot, statsRoot);
 
   // The stories entry directly imports stories (Vite), so it is a story importer on its own; the
@@ -175,28 +218,17 @@ function collectStoryImporters(
   const storyImporters = new Set([...STORIES_ENTRY_FILES].map((name) => canonical(name)));
   const contextsExcludingNodeModules = new Set<string>();
 
-  for (const module of stats.modules) {
-    const root = rootFilePath(module, projectRoot, statsRoot);
-    if (!module.name || !root || onDiskFiles.has(root)) {
+  for (const module of modules) {
+    // The require-context is off-disk; real files it imports are handled by the classify step.
+    if (module.onDisk) {
       continue;
     }
 
-    // An external is a graph leaf, so it can never import a story. It has no on-disk file either,
-    // which would otherwise let it through as a require-context.
-    if (EXTERNAL_MODULE.test(module.name)) {
-      continue;
-    }
-
-    const importers = (module.reasons ?? [])
-      .map((reason) => reason.moduleName)
-      .filter((name): name is FilePath => typeof name === 'string')
-      .map((name) => canonical(name));
-
-    const importedByEntry = importers.some((importer) => entryFiles.has(importer));
+    const importedByEntry = module.importers.some((importer) => entryFiles.has(importer));
     if (importedByEntry) {
-      storyImporters.add(canonical(module.name));
-      if (isLazyContext(module.name) && excludesNodeModules(module.name)) {
-        contextsExcludingNodeModules.add(canonical(module.name));
+      storyImporters.add(module.filePath);
+      if (isLazyContext(module.rawName) && excludesNodeModules(module.rawName)) {
+        contextsExcludingNodeModules.add(module.filePath);
       }
     }
   }

--- a/node-src/lib/turbosnap/v2/storyDetection.ts
+++ b/node-src/lib/turbosnap/v2/storyDetection.ts
@@ -6,7 +6,7 @@ import { normalizeStatsPath, rootFilePath } from './paths';
  * Whether a canonical path has a real file on disk. You can use things that adhere to this
  * interface such as `Map` or `Set`.
  */
-export interface RealFiles {
+export interface OnDiskFiles {
   has(filePath: FilePath): boolean;
 }
 
@@ -55,20 +55,20 @@ const LAZY_CONTEXT_MARKER = / lazy |\|lazy\|/;
  * @param context The context to resolve stats paths and tell real files apart from the require-context glob.
  * @param context.projectRoot The absolute Storybook project root that module paths anchor against.
  * @param context.statsRoot The directory relative stats paths are named from.
- * @param context.realFiles Which canonical paths have a real file on disk, used to tell real files
+ * @param context.onDiskFiles Which canonical paths have a real file on disk, used to tell real files
  * apart from the require-context glob.
  *
  * @returns The canonical paths of the story files.
  */
 export function detectStoryFiles(
   stats: Stats,
-  context: { projectRoot: AbsolutePath; statsRoot: AbsolutePath; realFiles: RealFiles }
+  context: { projectRoot: AbsolutePath; statsRoot: AbsolutePath; onDiskFiles: OnDiskFiles }
 ): Set<FilePath> {
-  const { projectRoot, statsRoot, realFiles } = context;
+  const { projectRoot, statsRoot, onDiskFiles } = context;
   const { storyImporters, contextsExcludingNodeModules } = collectStoryImporters(
     stats,
     projectRoot,
-    realFiles,
+    onDiskFiles,
     statsRoot
   );
 
@@ -97,7 +97,7 @@ export function detectStoryFiles(
     // Only real files are story files; requiring a file on disk excludes the require-context glob
     // itself (which is imported by an entry but has no on-disk file).
     if (
-      realFiles.has(sourceFilePath) &&
+      onDiskFiles.has(sourceFilePath) &&
       isStoryFile(sourceFilePath, matchedStoryImporters, contextsExcludingNodeModules)
     ) {
       storyFiles.add(sourceFilePath);
@@ -147,7 +147,7 @@ function isStoryFile(
  *
  * @param stats The stats file to parse.
  * @param projectRoot The absolute Storybook project root that module paths anchor against.
- * @param realFiles Which canonical paths have a real file on disk, used to tell real files apart
+ * @param onDiskFiles Which canonical paths have a real file on disk, used to tell real files apart
  * from the require-context glob.
  * @param statsRoot The directory relative stats paths are named from.
  *
@@ -156,7 +156,7 @@ function isStoryFile(
 function collectStoryImporters(
   stats: Stats,
   projectRoot: AbsolutePath,
-  realFiles: RealFiles,
+  onDiskFiles: OnDiskFiles,
   statsRoot: AbsolutePath
 ): {
   storyImporters: Set<string>;
@@ -177,7 +177,7 @@ function collectStoryImporters(
 
   for (const module of stats.modules) {
     const root = rootFilePath(module, projectRoot, statsRoot);
-    if (!module.name || !root || realFiles.has(root)) {
+    if (!module.name || !root || onDiskFiles.has(root)) {
       continue;
     }
 

--- a/node-src/lib/turbosnap/v2/storyDetection.ts
+++ b/node-src/lib/turbosnap/v2/storyDetection.ts
@@ -1,0 +1,230 @@
+import { AbsolutePath, Stats } from '../../../types';
+import { FilePath } from './graph';
+import { normalizeStatsPath, rootFilePath } from './paths';
+
+/**
+ * Whether a canonical path has a real file on disk. You can use things that adhere to this
+ * interface such as `Map` or `Set`.
+ */
+export interface RealFiles {
+  has(filePath: FilePath): boolean;
+}
+
+// Generated entry points that import all story files. We use this to determine if a file is a story
+// file because they may not always be *.stories.* files because it's configurable.
+const STORIES_ENTRY_FILES = new Set([
+  // v6 store (SB <= 6.3)
+  './generated-stories-entry.js',
+  // v6 store with .cjs extension (SB 6.5)
+  './generated-stories-entry.cjs',
+  // v7 store (SB >= 6.4)
+  './storybook-stories.js',
+  // vite builder
+  '/virtual:/@storybook/builder-vite/storybook-stories.js',
+  'virtual:@storybook/builder-vite/storybook-stories.js',
+  // rspack builder
+  './node_modules/.cache/storybook/default/dev-server/storybook-stories.js',
+  './node_modules/.cache/storybook-rsbuild-builder/storybook-stories.js',
+]);
+
+// Config entry files import the story require-context. They import non-story files too (e.g.
+// `.storybook/preview.ts`), so they only help locate the context — they are not treated as direct
+// story importers.
+const CONFIG_ENTRY_FILES = new Set([
+  './storybook-config-entry.js',
+  './node_modules/.cache/storybook-rsbuild-builder/storybook-config-entry.js',
+  './node_modules/.cache/storybook/storybook-rsbuild-builder/storybook-config-entry.js',
+]);
+
+// Webpack/rspack name a module the bundle does not own `external "<request>"` (e.g. Storybook's
+// preview runtime globals). It has no on-disk file and imports nothing.
+const EXTERNAL_MODULE = /^external "/;
+
+// A `node_modules` segment anywhere in a path. Matched segment-wise rather than by substring because
+// a canonical key may reach a hoisted install through `../`, and because a context's own name embeds
+// the literal text `node_modules` inside its include regex.
+const NODE_MODULES_SEGMENT = /(^|\/)node_modules\//;
+
+// Webpack spells contexts with ` lazy `; rspack delimits the same marker with pipes.
+const LAZY_CONTEXT_MARKER = / lazy |\|lazy\|/;
+
+/**
+ * Detects which modules in the stats are story files.
+ *
+ * @param stats The stats file to parse.
+ * @param context The context to resolve stats paths and tell real files apart from the require-context glob.
+ * @param context.projectRoot The absolute Storybook project root that module paths anchor against.
+ * @param context.statsRoot The directory relative stats paths are named from.
+ * @param context.realFiles Which canonical paths have a real file on disk, used to tell real files
+ * apart from the require-context glob.
+ *
+ * @returns The canonical paths of the story files.
+ */
+export function detectStoryFiles(
+  stats: Stats,
+  context: { projectRoot: AbsolutePath; statsRoot: AbsolutePath; realFiles: RealFiles }
+): Set<FilePath> {
+  const { projectRoot, statsRoot, realFiles } = context;
+  const { storyImporters, contextsExcludingNodeModules } = collectStoryImporters(
+    stats,
+    projectRoot,
+    realFiles,
+    statsRoot
+  );
+
+  const storyFiles = new Set<FilePath>();
+  for (const module of stats.modules) {
+    // An external has no on-disk file, so we can skip it.
+    if (EXTERNAL_MODULE.test(module.name)) {
+      continue;
+    }
+
+    const sourceFilePath = rootFilePath(module, projectRoot, statsRoot);
+    if (!sourceFilePath) {
+      continue;
+    }
+
+    // Importers hold the builder's own entry paths (e.g. `./storybook-stories.js`), canonicalised so
+    // they compare against the canonical keys collectStoryImporters returns — the builder may spell
+    // the same entry with or without a `./` prefix. Entry reasons carry a null moduleName, so drop
+    // those.
+    const matchedStoryImporters = (module.reasons ?? [])
+      .map((reason) => reason.moduleName)
+      .filter(Boolean)
+      .map((name) => normalizeStatsPath(name, projectRoot, statsRoot))
+      .filter((importer) => storyImporters.has(importer));
+
+    // Only real files are story files; requiring a file on disk excludes the require-context glob
+    // itself (which is imported by an entry but has no on-disk file).
+    if (
+      realFiles.has(sourceFilePath) &&
+      isStoryFile(sourceFilePath, matchedStoryImporters, contextsExcludingNodeModules)
+    ) {
+      storyFiles.add(sourceFilePath);
+    }
+  }
+
+  return storyFiles;
+}
+
+/**
+ * Whether a module is a story file, given the story importers that claim it.
+ *
+ * A `node_modules` story claimed only by contexts that excluded `node_modules` is refused, because it
+ * is unmatchable: the indexer ignored it, so it is absent from `index.json`.
+ *
+ * A story a `node_modules` glob deliberately asked for survives, because its context did not exclude
+ * `node_modules`. So does a story on Vite, where the stories entry imports the matched files directly
+ * from the very list the indexer built, so no context claims it.
+ *
+ * @param filePath The module's canonical file path.
+ * @param matchedStoryImporters The story importers that claim it.
+ * @param contextsExcludingNodeModules Canonical keys of the lazy contexts whose glob excluded
+ * `node_modules`; see {@link excludesNodeModules}.
+ *
+ * @returns Whether the module is a story file.
+ */
+function isStoryFile(
+  filePath: FilePath,
+  matchedStoryImporters: FilePath[],
+  contextsExcludingNodeModules: Set<string>
+): boolean {
+  if (matchedStoryImporters.length === 0) {
+    return false;
+  }
+  if (!NODE_MODULES_SEGMENT.test(filePath)) {
+    return true;
+  }
+  return !matchedStoryImporters.every((importer) => contextsExcludingNodeModules.has(importer));
+}
+
+/**
+ * Collects the module names a story file may be imported from. Vite imports stories straight from
+ * the builder entry, but webpack/rspack wrap them in a lazy require-context: an entry (the stories
+ * entry or the config entry) imports the context and the context imports the stories. Treat any
+ * such context (a module imported by an entry file that isn't itself a real file) as a story
+ * importer too, so both builders are covered.
+ *
+ * @param stats The stats file to parse.
+ * @param projectRoot The absolute Storybook project root that module paths anchor against.
+ * @param realFiles Which canonical paths have a real file on disk, used to tell real files apart
+ * from the require-context glob.
+ * @param statsRoot The directory relative stats paths are named from.
+ *
+ * @returns The set of canonical importer keys that indicate a story file.
+ */
+function collectStoryImporters(
+  stats: Stats,
+  projectRoot: string,
+  realFiles: RealFiles,
+  statsRoot: string
+): {
+  storyImporters: Set<string>;
+  contextsExcludingNodeModules: Set<string>;
+} {
+  const canonical = (name: string) => normalizeStatsPath(name, projectRoot, statsRoot);
+
+  // The stories entry directly imports stories (Vite), so it is a story importer on its own; the
+  // config entry only helps locate the require-context, so it is not. The catalogue holds raw builder
+  // spellings, which anchor at the build's cwd (`statsRoot`), so both sides of the comparison
+  // canonicalise the same way: rsbuild spells the same entry both `storybook-stories.js` and
+  // `./storybook-stories.js`, and the raw spelling never matched.
+  const entryFiles = new Set(
+    [...STORIES_ENTRY_FILES, ...CONFIG_ENTRY_FILES].map((name) => canonical(name))
+  );
+  const storyImporters = new Set([...STORIES_ENTRY_FILES].map((name) => canonical(name)));
+  const contextsExcludingNodeModules = new Set<string>();
+
+  for (const module of stats.modules) {
+    const root = rootFilePath(module, projectRoot, statsRoot);
+    if (!module.name || !root || realFiles.has(root)) {
+      continue;
+    }
+
+    // An external is a graph leaf, so it can never import a story. It has no on-disk file either,
+    // which would otherwise let it through as a require-context.
+    if (EXTERNAL_MODULE.test(module.name)) {
+      continue;
+    }
+
+    const importers = (module.reasons ?? [])
+      .map((reason) => reason.moduleName)
+      .filter(Boolean)
+      .map((name) => canonical(name));
+
+    const importedByEntry = importers.some((importer) => entryFiles.has(importer));
+    if (importedByEntry) {
+      storyImporters.add(canonical(module.name));
+      if (isLazyContext(module.name) && excludesNodeModules(module.name)) {
+        contextsExcludingNodeModules.add(canonical(module.name));
+      }
+    }
+  }
+
+  return { storyImporters, contextsExcludingNodeModules };
+}
+
+/**
+ * Whether a module name is a lazy require-context: the glob module a builder generates in place of
+ * direct story imports. It is not a file on disk.
+ *
+ * @param moduleName The raw module name from the stats.
+ *
+ * @returns Whether the module is a lazy require-context.
+ */
+function isLazyContext(moduleName: string): boolean {
+  return LAZY_CONTEXT_MARKER.test(moduleName);
+}
+
+/**
+ * Whether a lazy context's stories glob excludes `node_modules`. A glob that does not name
+ * `node_modules` excludes it: Storybook's indexer then ignores `node_modules` and so does the
+ * builder, so such a context should never yield a story from there.
+ *
+ * @param contextName The raw name of a lazy require-context.
+ *
+ * @returns Whether the context's glob excluded `node_modules`.
+ */
+function excludesNodeModules(contextName: string): boolean {
+  return !NODE_MODULES_SEGMENT.test(contextName.split(LAZY_CONTEXT_MARKER)[0]);
+}

--- a/node-src/lib/turbosnap/v2/storyDetection.ts
+++ b/node-src/lib/turbosnap/v2/storyDetection.ts
@@ -155,9 +155,9 @@ function isStoryFile(
  */
 function collectStoryImporters(
   stats: Stats,
-  projectRoot: string,
+  projectRoot: AbsolutePath,
   realFiles: RealFiles,
-  statsRoot: string
+  statsRoot: AbsolutePath
 ): {
   storyImporters: Set<string>;
   contextsExcludingNodeModules: Set<string>;

--- a/node-src/types.ts
+++ b/node-src/types.ts
@@ -526,7 +526,8 @@ export interface TaskUpdate {
 export type TaskReporter = (update: TaskUpdate) => void;
 
 export interface Reason {
-  moduleName: string;
+  // An entry module's reason carries a null moduleName, so treat it as optional.
+  moduleName: string | null;
 }
 
 export interface Module {


### PR DESCRIPTION
Related to CAP-4864

This change grabs all the story files from the manifest in a similar way to TurboSnap v1. A lot of the logic is duplicated but that's on purpose. We want to keep them isolated so we can iterate on v2 in the future without worrying about breaking v1.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>18.6.1--canary.1441.32890871950.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@18.6.1--canary.1441.32890871950.0
  # or 
  yarn add chromatic@18.6.1--canary.1441.32890871950.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
