### PR TITLE
[TurboSnap v2] Build the full TurboSnap manifest

### DIFF
--- a/node-src/lib/getStorybookMetadata.ts
+++ b/node-src/lib/getStorybookMetadata.ts
@@ -187,6 +187,10 @@ function readConfigStaticDirectories(
 // widens what lands on `ctx.storybook`.
 export const MAIN_CONFIG_PATTERN = /^main\.[cm]?[jt]sx?$/;
 
+// The preview config filename: `preview` with any JS/TS module extension, same shape as
+// MAIN_CONFIG_PATTERN.
+export const PREVIEW_CONFIG_PATTERN = /^preview\.[cm]?[jt]sx?$/;
+
 /**
  * Finds the first file in the Storybook config directory that matches the given pattern.
  *

--- a/node-src/lib/turbosnap/v2/__fixtures__/manifestFixtures.ts
+++ b/node-src/lib/turbosnap/v2/__fixtures__/manifestFixtures.ts
@@ -1,6 +1,5 @@
 import { buildManifest } from '../manifest';
-import { OutOfGraphInput } from '../outOfGraphFiles';
-import { ProjectFiles } from '../projectFiles';
+import { ManifestInput } from '../manifestInput';
 import { InMemoryDisk, inMemoryProjectFiles } from '../projectFiles.fake';
 
 // Manifest keys anchor at the project root, so a file inside the project keys as `./src/...` and one
@@ -11,18 +10,10 @@ export const projectRoot = '/repo/packages/ui';
 // release cannot move a manifest these suites assert on.
 export const storybookVersion = '9.1.20';
 
-/** The context readStatsGraph takes; the same in-memory disk backs it and the out-of-graph sweep. */
-interface StatsContext {
-  projectRoot: string;
-  statsRoot: string;
-  projectFiles: ProjectFiles;
-}
-
-/** A fresh disk and the adapters that read it, so each test owns its own state and nothing leaks. */
+/** A fresh disk and the input that reads it, so each test owns its own state and nothing leaks. */
 export interface ManifestFixture {
   disk: InMemoryDisk;
-  outOfGraph: OutOfGraphInput;
-  statsContext: StatsContext;
+  input: ManifestInput;
 }
 
 /**
@@ -32,19 +23,18 @@ export interface ManifestFixture {
  *
  * @param overrides The disk to read; the installed Storybook version is seeded unless overridden.
  *
- * @returns The disk and the out-of-graph and stats adapters that read it.
+ * @returns The disk and the manifest input that reads it.
  */
 export function createFixture(overrides: InMemoryDisk = {}): ManifestFixture {
   const disk: InMemoryDisk = { packageVersions: { storybook: storybookVersion }, ...overrides };
-  const projectFiles = inMemoryProjectFiles(disk);
   return {
     disk,
-    outOfGraph: {
+    input: {
+      projectRoot,
       configDir: `${projectRoot}/.storybook`,
       staticDirs: [`${projectRoot}/.storybook/static`],
-      projectFiles,
+      projectFiles: inMemoryProjectFiles(disk),
     },
-    statsContext: { projectRoot, statsRoot: projectRoot, projectFiles },
   };
 }
 
@@ -83,7 +73,7 @@ export function syntheticAbsent(candidate: string): boolean {
  * @returns The manifest.
  */
 export function manifestWithPreview(previewFile: string) {
-  const { outOfGraph } = createFixture({
+  const { input } = createFixture({
     fileHashes: {
       '/repo/packages/ui/src/Button.stories.tsx': 'S',
       [`/repo/packages/ui/.storybook/${previewFile}`]: 'P',
@@ -104,7 +94,6 @@ export function manifestWithPreview(previewFile: string) {
         },
       ],
     },
-    projectRoot,
-    outOfGraph
+    input
   );
 }

--- a/node-src/lib/turbosnap/v2/__fixtures__/manifestFixtures.ts
+++ b/node-src/lib/turbosnap/v2/__fixtures__/manifestFixtures.ts
@@ -39,7 +39,11 @@ export function createFixture(overrides: InMemoryDisk = {}): ManifestFixture {
   const projectFiles = inMemoryProjectFiles(disk);
   return {
     disk,
-    outOfGraph: { configDir: '.storybook', staticDirs: ['.storybook/static'], projectFiles },
+    outOfGraph: {
+      configDir: `${projectRoot}/.storybook`,
+      staticDirs: [`${projectRoot}/.storybook/static`],
+      projectFiles,
+    },
     statsContext: { projectRoot, statsRoot: projectRoot, projectFiles },
   };
 }

--- a/node-src/lib/turbosnap/v2/__fixtures__/manifestFixtures.ts
+++ b/node-src/lib/turbosnap/v2/__fixtures__/manifestFixtures.ts
@@ -1,0 +1,106 @@
+import { buildManifest } from '../manifest';
+import { OutOfGraphInput } from '../outOfGraphFiles';
+import { ProjectFiles } from '../projectFiles';
+import { InMemoryDisk, inMemoryProjectFiles } from '../projectFiles.fake';
+
+// Manifest keys anchor at the project root, so a file inside the project keys as `./src/...` and one
+// outside it keeps its `../` prefix (e.g. a sibling package as `../shared/...`).
+export const projectRoot = '/repo/packages/ui';
+
+// The version the manifest reads off the installed Storybook package. Fixed here, so a Storybook
+// release cannot move a manifest these suites assert on.
+export const storybookVersion = '9.1.20';
+
+/** The context readStatsGraph takes; the same in-memory disk backs it and the out-of-graph sweep. */
+interface StatsContext {
+  projectRoot: string;
+  statsRoot: string;
+  projectFiles: ProjectFiles;
+}
+
+/** A fresh disk and the adapters that read it, so each test owns its own state and nothing leaks. */
+export interface ManifestFixture {
+  disk: InMemoryDisk;
+  outOfGraph: OutOfGraphInput;
+  statsContext: StatsContext;
+}
+
+/**
+ * Builds a fresh in-memory disk from the given description and wires the adapters that read it. A
+ * test constructs its own, so there is no shared disk to reset between tests. The returned `disk` is
+ * still mutable, for the before/after-edit suites that build, change a hash, and build again.
+ *
+ * @param overrides The disk to read; the installed Storybook version is seeded unless overridden.
+ *
+ * @returns The disk and the out-of-graph and stats adapters that read it.
+ */
+export function createFixture(overrides: InMemoryDisk = {}): ManifestFixture {
+  const disk: InMemoryDisk = { packageVersions: { storybook: storybookVersion }, ...overrides };
+  const projectFiles = inMemoryProjectFiles(disk);
+  return {
+    disk,
+    outOfGraph: { configDir: '.storybook', staticDirs: ['.storybook/static'], projectFiles },
+    statsContext: { projectRoot, statsRoot: projectRoot, projectFiles },
+  };
+}
+
+/**
+ * An `isAbsent` predicate for {@link createFixture}: the require-context glob is not a file on disk;
+ * everything else is.
+ *
+ * @param candidate The absolute path to test.
+ *
+ * @returns Whether the path has no file on disk.
+ */
+export function globAbsent(candidate: string): boolean {
+  return candidate.includes('lazy');
+}
+
+/**
+ * An `isAbsent` predicate for {@link createFixture}: the builder's generated entries and
+ * require-context globs, which is where a real project has no file on disk either.
+ *
+ * @param candidate The absolute path to test.
+ *
+ * @returns Whether the path has no file on disk.
+ */
+export function syntheticAbsent(candidate: string): boolean {
+  return ['storybook-stories.js', 'storybook-config-entry.js', 'lazy'].some((name) =>
+    candidate.includes(name)
+  );
+}
+
+/**
+ * Builds a manifest whose only Storybook-wide graph entry is the named preview file, with fixed
+ * bytes, so two spellings differ by key alone.
+ *
+ * @param previewFile The preview file's name within the config directory.
+ *
+ * @returns The manifest.
+ */
+export function manifestWithPreview(previewFile: string) {
+  const { outOfGraph } = createFixture({
+    fileHashes: {
+      '/repo/packages/ui/src/Button.stories.tsx': 'S',
+      [`/repo/packages/ui/.storybook/${previewFile}`]: 'P',
+    },
+  });
+  return buildManifest(
+    {
+      modules: [
+        {
+          id: 1,
+          name: '/repo/packages/ui/src/Button.stories.tsx',
+          reasons: [{ moduleName: './storybook-stories.js' }],
+        },
+        {
+          id: 2,
+          name: `/repo/packages/ui/.storybook/${previewFile}`,
+          reasons: [{ moduleName: './storybook-config-entry.js' }],
+        },
+      ],
+    },
+    projectRoot,
+    outOfGraph
+  );
+}

--- a/node-src/lib/turbosnap/v2/manifest.attribution.test.ts
+++ b/node-src/lib/turbosnap/v2/manifest.attribution.test.ts
@@ -23,12 +23,16 @@ describe('buildManifest with a require-context in the graph', () => {
     ],
   };
 
-  it('excludes the require-context glob (no file on disk) from the files map', async () => {
+  it('keeps the require-context glob in memory and excludes it from the serialized files', async () => {
     const { disk, outOfGraph } = createFixture({ isAbsent: globAbsent });
     disk.fileHashes = { [story]: 'S' };
     const manifest = await buildManifest(stats, projectRoot, outOfGraph);
-    expect([...manifest.files.keys()].some((key) => key.includes('lazy'))).toBe(false);
+    const serialized = serializeManifest(manifest);
+
+    expect([...manifest.files.keys()].some((key) => key.includes('lazy'))).toBe(true);
     expect(manifest.files.has('./src/lib/Button.stories.tsx')).toBe(true);
+    expect(Object.keys(serialized.files).some((key) => key.includes('lazy'))).toBe(false);
+    expect(serialized.files).toHaveProperty('./src/lib/Button.stories.tsx');
   });
 
   it('serializes the same manifest when only the require-context identity gains a concatenation suffix', async () => {
@@ -151,7 +155,9 @@ describe('buildManifest attribution', () => {
     expect([...manifest.attribution.storyReachable]).toEqual(['./src/lib/Widget.stories.tsx']);
     expect([...manifest.attribution.storybookGlobals]).toEqual([]);
     // The synthetic node is gone from the written graph, so this attribution is unreconstructable.
-    expect([...manifest.files.keys()].some((key) => key.includes('lazy'))).toBe(false);
+    expect(Object.keys(serializeManifest(manifest).files).some((key) => key.includes('lazy'))).toBe(
+      false
+    );
   });
 
   it('omits synthetic nodes from every set', async () => {

--- a/node-src/lib/turbosnap/v2/manifest.attribution.test.ts
+++ b/node-src/lib/turbosnap/v2/manifest.attribution.test.ts
@@ -24,9 +24,9 @@ describe('buildManifest with a require-context in the graph', () => {
   };
 
   it('keeps the require-context glob in memory and excludes it from the serialized files', async () => {
-    const { disk, outOfGraph } = createFixture({ isAbsent: globAbsent });
+    const { disk, input } = createFixture({ isAbsent: globAbsent });
     disk.fileHashes = { [story]: 'S' };
-    const manifest = await buildManifest(stats, projectRoot, outOfGraph);
+    const manifest = await buildManifest(stats, input);
     const serialized = serializeManifest(manifest);
 
     expect([...manifest.files.keys()].some((key) => key.includes('lazy'))).toBe(true);
@@ -36,7 +36,7 @@ describe('buildManifest with a require-context in the graph', () => {
   });
 
   it('serializes the same manifest when only the require-context identity gains a concatenation suffix', async () => {
-    const { disk, outOfGraph } = createFixture({ isAbsent: globAbsent });
+    const { disk, input } = createFixture({ isAbsent: globAbsent });
     const statsWithContext = (storyImporter: string): Stats => ({
       modules: [
         { id: 1, name: storyImporter, reasons: [{ moduleName: './storybook-stories.js' }] },
@@ -45,11 +45,9 @@ describe('buildManifest with a require-context in the graph', () => {
     });
     disk.fileHashes = { [story]: 'S' };
 
-    const plain = serializeManifest(
-      await buildManifest(statsWithContext(glob), projectRoot, outOfGraph)
-    );
+    const plain = serializeManifest(await buildManifest(statsWithContext(glob), input));
     const concatenated = serializeManifest(
-      await buildManifest(statsWithContext(`${glob} + 1 modules`), projectRoot, outOfGraph)
+      await buildManifest(statsWithContext(`${glob} + 1 modules`), input)
     );
 
     expect(concatenated).toEqual(plain);
@@ -75,11 +73,11 @@ describe('buildManifest story hashing behind a bare-named require-context', () =
   };
 
   it('rolls the story implementation into the story hash', async () => {
-    const { disk, outOfGraph } = createFixture({ isAbsent: syntheticAbsent });
+    const { disk, input } = createFixture({ isAbsent: syntheticAbsent });
     disk.fileHashes = { [story]: 'S', [impl]: 'B' };
-    const before = await buildManifest(stats, projectRoot, outOfGraph);
+    const before = await buildManifest(stats, input);
     disk.fileHashes = { [story]: 'S', [impl]: 'B2' };
-    const after = await buildManifest(stats, projectRoot, outOfGraph);
+    const after = await buildManifest(stats, input);
 
     expect(after.storyFileHashes.get('./src/lib/Button.stories.tsx')).not.toBe(
       before.storyFileHashes.get('./src/lib/Button.stories.tsx')
@@ -114,10 +112,10 @@ describe('buildManifest attribution', () => {
   };
 
   it('records each real file under the hashing home it landed in', async () => {
-    const { disk, outOfGraph } = createFixture({ isAbsent: syntheticAbsent });
+    const { disk, input } = createFixture({ isAbsent: syntheticAbsent });
     disk.fileHashes = { ...hashes };
 
-    const { attribution } = await buildManifest(stats, projectRoot, outOfGraph);
+    const { attribution } = await buildManifest(stats, input);
 
     expect([...attribution.storyReachable].sort()).toEqual([
       './node_modules/moment/moment.js',
@@ -139,7 +137,7 @@ describe('buildManifest attribution', () => {
     const lazyGlob = './src/lib/ lazy namespace object';
     const throughGlob = '/repo/packages/ui/src/lib/Widget.stories.tsx';
 
-    const { disk, outOfGraph } = createFixture({ isAbsent: syntheticAbsent });
+    const { disk, input } = createFixture({ isAbsent: syntheticAbsent });
     disk.fileHashes = { [throughGlob]: 'W' };
     const manifest = await buildManifest(
       {
@@ -148,8 +146,7 @@ describe('buildManifest attribution', () => {
           { id: 2, name: throughGlob, reasons: [{ moduleName: lazyGlob }] },
         ],
       },
-      projectRoot,
-      outOfGraph
+      input
     );
 
     expect([...manifest.attribution.storyReachable]).toEqual(['./src/lib/Widget.stories.tsx']);
@@ -161,10 +158,10 @@ describe('buildManifest attribution', () => {
   });
 
   it('omits synthetic nodes from every set', async () => {
-    const { disk, outOfGraph } = createFixture({ isAbsent: syntheticAbsent });
+    const { disk, input } = createFixture({ isAbsent: syntheticAbsent });
     disk.fileHashes = { ...hashes };
 
-    const { attribution } = await buildManifest(stats, projectRoot, outOfGraph);
+    const { attribution } = await buildManifest(stats, input);
 
     const all = [
       ...attribution.storyReachable,
@@ -176,10 +173,10 @@ describe('buildManifest attribution', () => {
   });
 
   it('serializes each set as a sorted, JSON-safe array', async () => {
-    const { disk, outOfGraph } = createFixture({ isAbsent: syntheticAbsent });
+    const { disk, input } = createFixture({ isAbsent: syntheticAbsent });
     disk.fileHashes = { ...hashes };
 
-    const serialized = serializeManifest(await buildManifest(stats, projectRoot, outOfGraph));
+    const serialized = serializeManifest(await buildManifest(stats, input));
 
     expect(serialized.attribution.previewSubtree).toEqual([
       './.storybook/preview.ts',
@@ -230,11 +227,11 @@ describe('buildManifest attribution closure', () => {
   }
 
   it('attributes a file that is hashed only inside a concatenated module', async () => {
-    const { disk, outOfGraph } = createFixture({
+    const { disk, input } = createFixture({
       isAbsent: syntheticAbsent,
       fileHashes: hashes('H1'),
     });
-    const before = await buildManifest(stats, projectRoot, outOfGraph);
+    const before = await buildManifest(stats, input);
 
     expect([...before.attribution.storybookGlobals].sort()).toEqual([
       './src/probe/hiddenInner.tsx',
@@ -242,7 +239,7 @@ describe('buildManifest attribution closure', () => {
     ]);
 
     disk.fileHashes = hashes('H2');
-    const after = await buildManifest(stats, projectRoot, outOfGraph);
+    const after = await buildManifest(stats, input);
 
     // Editing the inner file used to leave the manifest byte-identical.
     expect(after.storybookFileHashes.get(globalsKey)).not.toBe(
@@ -252,8 +249,8 @@ describe('buildManifest attribution closure', () => {
   });
 
   it('lands every hashed file in exactly one attribution home', async () => {
-    const { outOfGraph } = createFixture({ isAbsent: syntheticAbsent, fileHashes: hashes('H1') });
-    const { attribution } = await buildManifest(stats, projectRoot, outOfGraph);
+    const { input } = createFixture({ isAbsent: syntheticAbsent, fileHashes: hashes('H1') });
+    const { attribution } = await buildManifest(stats, input);
 
     // The story and preview subtrees are disjoint in this graph, so each file has one home only.
     const homes = Object.entries(attribution);
@@ -266,8 +263,8 @@ describe('buildManifest attribution closure', () => {
   });
 
   it('leaves no dependency reference outside the serialized graph', async () => {
-    const { outOfGraph } = createFixture({ isAbsent: syntheticAbsent, fileHashes: hashes('H1') });
-    const serialized = serializeManifest(await buildManifest(stats, projectRoot, outOfGraph));
+    const { input } = createFixture({ isAbsent: syntheticAbsent, fileHashes: hashes('H1') });
+    const serialized = serializeManifest(await buildManifest(stats, input));
 
     for (const file of Object.values(serialized.files)) {
       expect(file.dependencies.every((dependency) => dependency in serialized.files)).toBe(true);
@@ -299,9 +296,9 @@ describe('buildManifest attribution of swept node_modules stories', () => {
   };
 
   it('leaves the swept story subtree in the globals catch-all rather than draining it', async () => {
-    const { disk, outOfGraph } = createFixture({ isAbsent: globAbsent });
+    const { disk, input } = createFixture({ isAbsent: globAbsent });
     disk.fileHashes = { [story]: 'S', [swept]: 'W', [shared]: 'R' };
-    const manifest = await buildManifest(stats, projectRoot, outOfGraph);
+    const manifest = await buildManifest(stats, input);
     // The drain: were the swept story a story file, its subtree would be story-reachable and so
     // absent from the catch-all, and a change to the shared runtime would move nothing the Index
     // can match.
@@ -315,11 +312,11 @@ describe('buildManifest attribution of swept node_modules stories', () => {
   });
 
   it('recaptures a change to a shared runtime file the swept story imports', async () => {
-    const { disk, outOfGraph } = createFixture({ isAbsent: globAbsent });
+    const { disk, input } = createFixture({ isAbsent: globAbsent });
     disk.fileHashes = { [story]: 'S', [swept]: 'W', [shared]: 'R' };
-    const before = await buildManifest(stats, projectRoot, outOfGraph);
+    const before = await buildManifest(stats, input);
     disk.fileHashes = { [story]: 'S', [swept]: 'W', [shared]: 'R2' };
-    const after = await buildManifest(stats, projectRoot, outOfGraph);
+    const after = await buildManifest(stats, input);
 
     expect(after.storybookFileHashes.get('storybookGlobals')).not.toBe(
       before.storybookFileHashes.get('storybookGlobals')

--- a/node-src/lib/turbosnap/v2/manifest.attribution.test.ts
+++ b/node-src/lib/turbosnap/v2/manifest.attribution.test.ts
@@ -1,0 +1,322 @@
+import { describe, expect, it } from 'vitest';
+
+import { Stats } from '../../../types';
+import {
+  createFixture,
+  globAbsent,
+  projectRoot,
+  syntheticAbsent,
+} from './__fixtures__/manifestFixtures';
+import { buildManifest, serializeManifest } from './manifest';
+
+describe('buildManifest with a require-context in the graph', () => {
+  // Webpack/rspack don't import story files directly from the entry: the entry imports a lazy
+  // require-context (a glob module that is not a real file), and that context imports the stories.
+  // Which files that makes stories is storyDetection's rule; here it is only the synthetic node.
+  const glob = './src/lib/ lazy namespace object';
+  const story = '/repo/packages/ui/src/lib/Button.stories.tsx';
+
+  const stats: Stats = {
+    modules: [
+      { id: 1, name: glob, reasons: [{ moduleName: './storybook-stories.js' }] },
+      { id: 2, name: story, reasons: [{ moduleName: glob }] },
+    ],
+  };
+
+  it('excludes the require-context glob (no file on disk) from the files map', async () => {
+    const { disk, outOfGraph } = createFixture({ isAbsent: globAbsent });
+    disk.fileHashes = { [story]: 'S' };
+    const manifest = await buildManifest(stats, projectRoot, outOfGraph);
+    expect([...manifest.files.keys()].some((key) => key.includes('lazy'))).toBe(false);
+    expect(manifest.files.has('./src/lib/Button.stories.tsx')).toBe(true);
+  });
+
+  it('serializes the same manifest when only the require-context identity gains a concatenation suffix', async () => {
+    const { disk, outOfGraph } = createFixture({ isAbsent: globAbsent });
+    const statsWithContext = (storyImporter: string): Stats => ({
+      modules: [
+        { id: 1, name: storyImporter, reasons: [{ moduleName: './storybook-stories.js' }] },
+        { id: 2, name: story, reasons: [{ moduleName: storyImporter }] },
+      ],
+    });
+    disk.fileHashes = { [story]: 'S' };
+
+    const plain = serializeManifest(
+      await buildManifest(statsWithContext(glob), projectRoot, outOfGraph)
+    );
+    const concatenated = serializeManifest(
+      await buildManifest(statsWithContext(`${glob} + 1 modules`), projectRoot, outOfGraph)
+    );
+
+    expect(concatenated).toEqual(plain);
+  });
+});
+
+describe('buildManifest story hashing behind a bare-named require-context', () => {
+  // storybook-builder-rsbuild 3.x ships `withChromaticMinimalContract`, which re-derives module names
+  // via `path.relative(cwd, …)` — that never emits a `./` prefix, so the same graph carries both
+  // spellings of the config entry and the context. Recognizing them is storyDetection's rule; here it
+  // is the roll-up that has to reach through the synthetic node.
+  const configEntry = 'storybook-config-entry.js';
+  const glob = String.raw`src/lib|lazy|/^\.\/.*$/|namespace object`;
+  const story = '/repo/packages/ui/src/lib/Button.stories.tsx';
+  const impl = '/repo/packages/ui/src/lib/Button.tsx';
+
+  const stats: Stats = {
+    modules: [
+      { id: 1, name: glob, reasons: [{ moduleName: configEntry }] },
+      { id: 2, name: story, reasons: [{ moduleName: glob }] },
+      { id: 3, name: impl, reasons: [{ moduleName: story }] },
+    ],
+  };
+
+  it('rolls the story implementation into the story hash', async () => {
+    const { disk, outOfGraph } = createFixture({ isAbsent: syntheticAbsent });
+    disk.fileHashes = { [story]: 'S', [impl]: 'B' };
+    const before = await buildManifest(stats, projectRoot, outOfGraph);
+    disk.fileHashes = { [story]: 'S', [impl]: 'B2' };
+    const after = await buildManifest(stats, projectRoot, outOfGraph);
+
+    expect(after.storyFileHashes.get('./src/lib/Button.stories.tsx')).not.toBe(
+      before.storyFileHashes.get('./src/lib/Button.stories.tsx')
+    );
+  });
+});
+
+describe('buildManifest attribution', () => {
+  const story = '/repo/packages/ui/src/Button.stories.tsx';
+  const storyDep = '/repo/packages/ui/node_modules/moment/moment.js';
+  const preview = '/repo/packages/ui/.storybook/preview.ts';
+  const previewHelper = '/repo/packages/ui/.storybook/theme.ts';
+  const orphan = '/repo/packages/ui/node_modules/@storybook/react/dist/entry-preview.js';
+  const configEntry = './storybook-config-entry.js';
+
+  const stats: Stats = {
+    modules: [
+      { id: 1, name: story, reasons: [{ moduleName: './storybook-stories.js' }] },
+      { id: 2, name: storyDep, reasons: [{ moduleName: story }] },
+      { id: 3, name: preview, reasons: [{ moduleName: configEntry }] },
+      { id: 4, name: previewHelper, reasons: [{ moduleName: preview }] },
+      { id: 5, name: orphan, reasons: [{ moduleName: configEntry }] },
+    ],
+  };
+
+  const hashes = {
+    [story]: 'S',
+    [storyDep]: 'M',
+    [preview]: 'P',
+    [previewHelper]: 'PT',
+    [orphan]: 'EP',
+  };
+
+  it('records each real file under the hashing home it landed in', async () => {
+    const { disk, outOfGraph } = createFixture({ isAbsent: syntheticAbsent });
+    disk.fileHashes = { ...hashes };
+
+    const { attribution } = await buildManifest(stats, projectRoot, outOfGraph);
+
+    expect([...attribution.storyReachable].sort()).toEqual([
+      './node_modules/moment/moment.js',
+      './src/Button.stories.tsx',
+    ]);
+    expect([...attribution.previewSubtree].sort()).toEqual([
+      './.storybook/preview.ts',
+      './.storybook/theme.ts',
+    ]);
+    expect([...attribution.storybookGlobals]).toEqual([
+      './node_modules/@storybook/react/dist/entry-preview.js',
+    ]);
+  });
+
+  it('reports a file reached only through a synthetic node as story-reachable', async () => {
+    // The defect this exists to prevent: pruning runs after hashing, so the written graph has a hole
+    // where the require-context was. A reachability walk over it calls a correctly-attributed file
+    // an orphan — the artifact behind the false "moment is in the bucket" reading.
+    const lazyGlob = './src/lib/ lazy namespace object';
+    const throughGlob = '/repo/packages/ui/src/lib/Widget.stories.tsx';
+
+    const { disk, outOfGraph } = createFixture({ isAbsent: syntheticAbsent });
+    disk.fileHashes = { [throughGlob]: 'W' };
+    const manifest = await buildManifest(
+      {
+        modules: [
+          { id: 1, name: lazyGlob, reasons: [{ moduleName: './storybook-stories.js' }] },
+          { id: 2, name: throughGlob, reasons: [{ moduleName: lazyGlob }] },
+        ],
+      },
+      projectRoot,
+      outOfGraph
+    );
+
+    expect([...manifest.attribution.storyReachable]).toEqual(['./src/lib/Widget.stories.tsx']);
+    expect([...manifest.attribution.storybookGlobals]).toEqual([]);
+    // The synthetic node is gone from the written graph, so this attribution is unreconstructable.
+    expect([...manifest.files.keys()].some((key) => key.includes('lazy'))).toBe(false);
+  });
+
+  it('omits synthetic nodes from every set', async () => {
+    const { disk, outOfGraph } = createFixture({ isAbsent: syntheticAbsent });
+    disk.fileHashes = { ...hashes };
+
+    const { attribution } = await buildManifest(stats, projectRoot, outOfGraph);
+
+    const all = [
+      ...attribution.storyReachable,
+      ...attribution.previewSubtree,
+      ...attribution.storybookGlobals,
+    ];
+    expect(all.some((filePath) => filePath.includes('storybook-config-entry'))).toBe(false);
+    expect(all.some((filePath) => filePath.includes('storybook-stories'))).toBe(false);
+  });
+
+  it('serializes each set as a sorted, JSON-safe array', async () => {
+    const { disk, outOfGraph } = createFixture({ isAbsent: syntheticAbsent });
+    disk.fileHashes = { ...hashes };
+
+    const serialized = serializeManifest(await buildManifest(stats, projectRoot, outOfGraph));
+
+    expect(serialized.attribution.previewSubtree).toEqual([
+      './.storybook/preview.ts',
+      './.storybook/theme.ts',
+    ]);
+    // eslint-disable-next-line unicorn/prefer-structured-clone
+    expect(JSON.parse(JSON.stringify(serialized))).toEqual(serialized);
+  });
+});
+
+describe('buildManifest attribution closure', () => {
+  const story = '/repo/packages/ui/src/lib/Badge/Badge.stories.tsx';
+  const storyDep = '/repo/packages/ui/src/lib/Badge/Badge.tsx';
+  const preview = '/repo/packages/ui/.storybook/preview.ts';
+  const previewHelper = '/repo/packages/ui/.storybook/test.ts';
+  const orphanRoot = '/repo/packages/ui/src/probe/orphanRoot.tsx';
+  const hiddenInner = '/repo/packages/ui/src/probe/hiddenInner.tsx';
+  const globalsKey = 'storybookGlobals';
+  const configEntry = './storybook-config-entry.js';
+
+  // A concatenated module whose root is itself an orphan global. The inner file is hashed, but it is
+  // only recorded as a dependency of the root and never gets an entry of its own, so attribution
+  // closed over `files` could not see it.
+  const stats: Stats = {
+    modules: [
+      { id: 1, name: story, reasons: [{ moduleName: './storybook-stories.js' }] },
+      { id: 2, name: storyDep, reasons: [{ moduleName: story }] },
+      { id: 3, name: preview, reasons: [{ moduleName: configEntry }] },
+      { id: 4, name: previewHelper, reasons: [{ moduleName: preview }] },
+      {
+        id: 5,
+        name: `${orphanRoot} + 1 modules`,
+        modules: [{ name: orphanRoot }, { name: hiddenInner }],
+        reasons: [{ moduleName: configEntry }],
+      },
+    ],
+  };
+
+  function hashes(innerHash: string) {
+    return {
+      [story]: 'S',
+      [storyDep]: 'B',
+      [preview]: 'P',
+      [previewHelper]: 'PT',
+      [orphanRoot]: 'O',
+      [hiddenInner]: innerHash,
+    };
+  }
+
+  it('attributes a file that is hashed only inside a concatenated module', async () => {
+    const { disk, outOfGraph } = createFixture({
+      isAbsent: syntheticAbsent,
+      fileHashes: hashes('H1'),
+    });
+    const before = await buildManifest(stats, projectRoot, outOfGraph);
+
+    expect([...before.attribution.storybookGlobals].sort()).toEqual([
+      './src/probe/hiddenInner.tsx',
+      './src/probe/orphanRoot.tsx',
+    ]);
+
+    disk.fileHashes = hashes('H2');
+    const after = await buildManifest(stats, projectRoot, outOfGraph);
+
+    // Editing the inner file used to leave the manifest byte-identical.
+    expect(after.storybookFileHashes.get(globalsKey)).not.toBe(
+      before.storybookFileHashes.get(globalsKey)
+    );
+    expect(after.storybookHash).not.toBe(before.storybookHash);
+  });
+
+  it('lands every hashed file in exactly one attribution home', async () => {
+    const { outOfGraph } = createFixture({ isAbsent: syntheticAbsent, fileHashes: hashes('H1') });
+    const { attribution } = await buildManifest(stats, projectRoot, outOfGraph);
+
+    // The story and preview subtrees are disjoint in this graph, so each file has one home only.
+    const homes = Object.entries(attribution);
+    for (const hashedFile of Object.keys(hashes('H1'))) {
+      const filePath = hashedFile.replace(projectRoot, '.');
+      expect(homes.filter(([, files]) => files.has(filePath)).map(([home]) => home)).toHaveLength(
+        1
+      );
+    }
+  });
+
+  it('leaves no dependency reference outside the serialized graph', async () => {
+    const { outOfGraph } = createFixture({ isAbsent: syntheticAbsent, fileHashes: hashes('H1') });
+    const serialized = serializeManifest(await buildManifest(stats, projectRoot, outOfGraph));
+
+    for (const file of Object.values(serialized.files)) {
+      expect(file.dependencies.every((dependency) => dependency in serialized.files)).toBe(true);
+    }
+    expect(serialized.files['./src/probe/orphanRoot.tsx'].dependencies).toEqual([
+      './src/probe/hiddenInner.tsx',
+    ]);
+  });
+});
+
+describe('buildManifest attribution of swept node_modules stories', () => {
+  // On storybook-builder-rsbuild 1.x–3.3.x, a stories glob whose directory prefix is not
+  // slash-bounded lets rspack's require-context sweep a dependency's story into the graph: core
+  // prepends `(?!.*node_modules)` but strips the `^`, so the unanchored guard matches after the
+  // `node_modules` segment. Storybook's indexer applies `ignore: ["**/node_modules/**"]` to the same
+  // glob, so the swept story is absent from `index.json` and its key can never be matched.
+  const sweepingGlob = String.raw`..|lazy|/^\.\/.*$/|include: /(?!.*node_modules)…/|namespace object`;
+  const story = '/repo/packages/ui/src/lib/Button.stories.tsx';
+  const swept = '/repo/packages/ui/node_modules/fake-dep/Widget.stories.tsx';
+  const shared = '/repo/packages/ui/node_modules/react-dom/index.js';
+
+  const stats: Stats = {
+    modules: [
+      { id: 1, name: sweepingGlob, reasons: [{ moduleName: './storybook-stories.js' }] },
+      { id: 2, name: story, reasons: [{ moduleName: sweepingGlob }] },
+      { id: 3, name: swept, reasons: [{ moduleName: sweepingGlob }] },
+      { id: 4, name: shared, reasons: [{ moduleName: swept }] },
+    ],
+  };
+
+  it('leaves the swept story subtree in the globals catch-all rather than draining it', async () => {
+    const { disk, outOfGraph } = createFixture({ isAbsent: globAbsent });
+    disk.fileHashes = { [story]: 'S', [swept]: 'W', [shared]: 'R' };
+    const manifest = await buildManifest(stats, projectRoot, outOfGraph);
+    // The drain: were the swept story a story file, its subtree would be story-reachable and so
+    // absent from the catch-all, and a change to the shared runtime would move nothing the Index
+    // can match.
+    expect([...manifest.attribution.storybookGlobals]).toEqual(
+      expect.arrayContaining([
+        './node_modules/fake-dep/Widget.stories.tsx',
+        './node_modules/react-dom/index.js',
+      ])
+    );
+    expect([...manifest.attribution.storyReachable]).toEqual(['./src/lib/Button.stories.tsx']);
+  });
+
+  it('recaptures a change to a shared runtime file the swept story imports', async () => {
+    const { disk, outOfGraph } = createFixture({ isAbsent: globAbsent });
+    disk.fileHashes = { [story]: 'S', [swept]: 'W', [shared]: 'R' };
+    const before = await buildManifest(stats, projectRoot, outOfGraph);
+    disk.fileHashes = { [story]: 'S', [swept]: 'W', [shared]: 'R2' };
+    const after = await buildManifest(stats, projectRoot, outOfGraph);
+
+    expect(after.storybookFileHashes.get('storybookGlobals')).not.toBe(
+      before.storybookFileHashes.get('storybookGlobals')
+    );
+  });
+});

--- a/node-src/lib/turbosnap/v2/manifest.golden.test.ts
+++ b/node-src/lib/turbosnap/v2/manifest.golden.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from 'vitest';
+
+import { Stats } from '../../../types';
+import { createFixture, projectRoot } from './__fixtures__/manifestFixtures';
+import { buildManifest } from './manifest';
+
+/**
+ * ============================================================================
+ *  GOLDEN HASHES — DO NOT UPDATE TO MAKE A FAILURE GO AWAY
+ * ============================================================================
+ *
+ * These are the exact hashes the manifest publishes for a frozen fixture. The rest of the suite
+ * asserts hashes *relationally* ("this changes when that changes"), which cannot see a change to the
+ * hash recipe itself: reorder the fields in `hashEntryIdentity`, drop its length prefixes, or change
+ * what a roll-up folds in, and every relational test stays green while every published hash moves.
+ * This test is the only thing that catches that.
+ *
+ * WHY A FAILURE HERE MATTERS MORE THAN IT LOOKS
+ *
+ * These hashes are not local to one build. The backend compares a build's hashes against those
+ * stored for its *baselines*, so a recipe change does not bust one build's cache — it busts the
+ * comparison between every new build and every baseline recorded by an older CLI. That is every
+ * branch with a baseline, on every project, all at once: each one sees every story as changed and
+ * full-snapshots on its next run, and it stays that way until each branch has re-baselined under the
+ * new recipe. On a busy repo that is a large, and billable, snapshot spike.
+ *
+ * So: a diff here means the change under review invalidates TurboSnap caches fleet-wide. That is
+ * sometimes the right call, but it is never an incidental one.
+ *
+ * IF THIS TEST FAILS
+ *
+ *   1. You did not mean to change the hash recipe. Revert — the refactor was not behaviour-preserving.
+ *   2. You did mean to. Confirm the fleet-wide re-baseline is acceptable and intended, say so in the
+ *      PR description, then update the constants below in the same commit.
+ *
+ * Never regenerate these values without reading the diff first.
+ */
+
+// A fixture exercising every section that feeds a published hash: two stories with a shared and a
+// private dependency, a preview config with its own subtree, an orphan global reached only through
+// the framework's preview annotations, and both out-of-graph sweeps. Frozen — changing the fixture
+// changes the golden values without any recipe change, which defeats the point of the test.
+const buttonStory = '/repo/packages/ui/src/Button.stories.tsx';
+const headerStory = '/repo/packages/ui/src/Header.stories.tsx';
+const tokens = '/repo/packages/ui/src/tokens.ts';
+const moment = '/repo/packages/ui/node_modules/moment/moment.js';
+const preview = '/repo/packages/ui/.storybook/preview.ts';
+const previewTheme = '/repo/packages/ui/.storybook/theme.ts';
+const entryPreview = '/repo/packages/ui/node_modules/@storybook/react/dist/entry-preview.js';
+
+const GOLDEN_STATS: Stats = {
+  modules: [
+    { id: 1, name: buttonStory, reasons: [{ moduleName: './storybook-stories.js' }] },
+    { id: 2, name: headerStory, reasons: [{ moduleName: './storybook-stories.js' }] },
+    { id: 3, name: tokens, reasons: [{ moduleName: buttonStory }, { moduleName: headerStory }] },
+    { id: 4, name: moment, reasons: [{ moduleName: buttonStory }] },
+    { id: 5, name: preview, reasons: [{ moduleName: './storybook-config-entry.js' }] },
+    { id: 6, name: previewTheme, reasons: [{ moduleName: preview }] },
+    { id: 7, name: entryPreview, reasons: [{ moduleName: './storybook-config-entry.js' }] },
+  ],
+} as unknown as Stats;
+
+const GOLDEN_FILE_HASHES = {
+  [buttonStory]: 'aaaaaaaaaaaaaaaa',
+  [headerStory]: 'bbbbbbbbbbbbbbbb',
+  [tokens]: 'cccccccccccccccc',
+  [moment]: 'dddddddddddddddd',
+  [preview]: 'eeeeeeeeeeeeeeee',
+  [previewTheme]: 'ffffffffffffffff',
+  [entryPreview]: '1111111111111111',
+  '/repo/packages/ui/.storybook/main.ts': '2222222222222222',
+  '/repo/packages/ui/.storybook/static/mockServiceWorker.js': '3333333333333333',
+};
+
+const GOLDEN_DIRECTORY_TREE = {
+  '/repo/packages/ui/.storybook': ['main.ts', 'preview.ts', 'theme.ts', 'static'],
+  '/repo/packages/ui/.storybook/static': ['mockServiceWorker.js'],
+};
+
+// The published values. See the header before touching these.
+const GOLDEN_STORYBOOK_HASH = 'd86162bf43ae36ba';
+
+const GOLDEN_STORY_FILES: Record<string, string> = {
+  './src/Button.stories.tsx': '7b79c90e28f3ac31',
+  './src/Header.stories.tsx': 'bae0833d135c3c99',
+};
+
+const GOLDEN_STORYBOOK_FILES: Record<string, string> = {
+  preview: '9d9e21e4dd276f48',
+  storybookGlobals: '372009144b241f17',
+  storybookVersion: '9.1.20',
+  storybookConfigFiles: 'ccdd11764306552f',
+  staticFiles: 'c9527f087ba3d740',
+};
+
+function goldenFixture() {
+  return createFixture({
+    fileHashes: { ...GOLDEN_FILE_HASHES },
+    directories: { ...GOLDEN_DIRECTORY_TREE },
+    // Pinned here rather than taken from the fixture default, so a Storybook release — or an edit to
+    // that default — cannot move the golden values.
+    packageVersions: { storybook: '9.1.20' },
+  });
+}
+
+describe('manifest golden hashes', () => {
+  it('publishes the same storybookHash for the frozen fixture', async () => {
+    const { outOfGraph } = goldenFixture();
+    const manifest = await buildManifest(GOLDEN_STATS, projectRoot, outOfGraph);
+
+    expect(manifest.storybookHash).toBe(GOLDEN_STORYBOOK_HASH);
+  });
+
+  it('publishes the same per-story hashes for the frozen fixture', async () => {
+    const { outOfGraph } = goldenFixture();
+    const manifest = await buildManifest(GOLDEN_STATS, projectRoot, outOfGraph);
+
+    expect(Object.fromEntries(manifest.storyFileHashes)).toEqual(GOLDEN_STORY_FILES);
+  });
+
+  it('publishes the same storybookFileHashes for the frozen fixture', async () => {
+    const { outOfGraph } = goldenFixture();
+    const manifest = await buildManifest(GOLDEN_STATS, projectRoot, outOfGraph);
+
+    expect(Object.fromEntries(manifest.storybookFileHashes)).toEqual(GOLDEN_STORYBOOK_FILES);
+  });
+});

--- a/node-src/lib/turbosnap/v2/manifest.golden.test.ts
+++ b/node-src/lib/turbosnap/v2/manifest.golden.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import { Stats } from '../../../types';
-import { createFixture, projectRoot } from './__fixtures__/manifestFixtures';
+import { createFixture } from './__fixtures__/manifestFixtures';
 import { buildManifest } from './manifest';
 
 /**
@@ -105,22 +105,22 @@ function goldenFixture() {
 
 describe('manifest golden hashes', () => {
   it('publishes the same storybookHash for the frozen fixture', async () => {
-    const { outOfGraph } = goldenFixture();
-    const manifest = await buildManifest(GOLDEN_STATS, projectRoot, outOfGraph);
+    const { input } = goldenFixture();
+    const manifest = await buildManifest(GOLDEN_STATS, input);
 
     expect(manifest.storybookHash).toBe(GOLDEN_STORYBOOK_HASH);
   });
 
   it('publishes the same per-story hashes for the frozen fixture', async () => {
-    const { outOfGraph } = goldenFixture();
-    const manifest = await buildManifest(GOLDEN_STATS, projectRoot, outOfGraph);
+    const { input } = goldenFixture();
+    const manifest = await buildManifest(GOLDEN_STATS, input);
 
     expect(Object.fromEntries(manifest.storyFileHashes)).toEqual(GOLDEN_STORY_FILES);
   });
 
   it('publishes the same storybookFileHashes for the frozen fixture', async () => {
-    const { outOfGraph } = goldenFixture();
-    const manifest = await buildManifest(GOLDEN_STATS, projectRoot, outOfGraph);
+    const { input } = goldenFixture();
+    const manifest = await buildManifest(GOLDEN_STATS, input);
 
     expect(Object.fromEntries(manifest.storybookFileHashes)).toEqual(GOLDEN_STORYBOOK_FILES);
   });

--- a/node-src/lib/turbosnap/v2/manifest.hashing.test.ts
+++ b/node-src/lib/turbosnap/v2/manifest.hashing.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import { Stats } from '../../../types';
-import { createFixture, manifestWithPreview, projectRoot } from './__fixtures__/manifestFixtures';
+import { createFixture, manifestWithPreview } from './__fixtures__/manifestFixtures';
 import { buildManifest } from './manifest';
 
 // These suites are about how a hash responds: what moves it, what leaves it alone, and what stays
@@ -10,7 +10,7 @@ import { buildManifest } from './manifest';
 
 describe('buildManifest', () => {
   it('keys story files by their canonical project-root-relative path', async () => {
-    const { outOfGraph } = createFixture();
+    const { input } = createFixture();
     const stats: Stats = {
       modules: [
         {
@@ -26,7 +26,7 @@ describe('buildManifest', () => {
       ],
     };
 
-    const manifest = await buildManifest(stats, projectRoot, outOfGraph);
+    const manifest = await buildManifest(stats, input);
 
     expect([...manifest.storyFileHashes.keys()]).toEqual(['./src/Button.stories.tsx']);
     expect(manifest.files.has('./src/Button.stories.tsx')).toBe(true);
@@ -46,12 +46,12 @@ describe('buildManifest leaf inclusion', () => {
   };
 
   it('changes the story hash when a leaf dependency content changes', async () => {
-    const { disk, outOfGraph } = createFixture();
+    const { disk, input } = createFixture();
     disk.fileHashes = { [story]: 'S', [leaf]: 'T1' };
-    const before = await buildManifest(stats, projectRoot, outOfGraph);
+    const before = await buildManifest(stats, input);
 
     disk.fileHashes = { [story]: 'S', [leaf]: 'T2' };
-    const after = await buildManifest(stats, projectRoot, outOfGraph);
+    const after = await buildManifest(stats, input);
 
     expect(after.storyFileHashes.get('./src/Button.stories.tsx')).not.toBe(
       before.storyFileHashes.get('./src/Button.stories.tsx')
@@ -61,7 +61,7 @@ describe('buildManifest leaf inclusion', () => {
 
 describe('buildManifest relocation stability', () => {
   it('changes nothing at all when the whole project moves', async () => {
-    const { disk, outOfGraph } = createFixture();
+    const { disk, input } = createFixture();
     const before = await (async () => {
       disk.fileHashes = {
         '/repo/packages/ui/src/Button.stories.tsx': 'S',
@@ -82,8 +82,7 @@ describe('buildManifest relocation stability', () => {
             },
           ],
         },
-        '/repo/packages/ui',
-        outOfGraph
+        input
       );
     })();
 
@@ -107,8 +106,7 @@ describe('buildManifest relocation stability', () => {
             },
           ],
         },
-        '/repo/apps/web/ui',
-        outOfGraph
+        { ...input, projectRoot: '/repo/apps/web/ui' }
       );
     })();
 
@@ -136,7 +134,7 @@ describe('buildManifest relocation stability', () => {
   });
 
   it('re-keys a story file and moves the gate when the file is renamed within the project', async () => {
-    const { disk, outOfGraph } = createFixture();
+    const { disk, input } = createFixture();
     // An autotitled story derives its title, and so its story IDs, from its path: moving
     // `lib/Badge/AutoTitle.stories.tsx` to `lib/Renamed/` renames every story it holds without
     // changing a byte. The snapshots are keyed by those IDs, so the gate has to move.
@@ -150,8 +148,7 @@ describe('buildManifest relocation stability', () => {
             { id: 2, name: helper, reasons: [{ moduleName: story }] },
           ],
         },
-        projectRoot,
-        outOfGraph
+        input
       );
     }
 
@@ -173,7 +170,7 @@ describe('buildManifest relocation stability', () => {
   });
 
   it('moves a story hash when a dependency moves within the project', async () => {
-    const { disk, outOfGraph } = createFixture();
+    const { disk, input } = createFixture();
     const story = '/repo/packages/ui/src/Button.stories.tsx';
 
     // Build 1: deps a.ts and b.ts sort as [Button, a, b].
@@ -190,8 +187,7 @@ describe('buildManifest relocation stability', () => {
           { id: 3, name: '/repo/packages/ui/src/b.ts', reasons: [{ moduleName: story }] },
         ],
       },
-      projectRoot,
-      outOfGraph
+      input
     );
 
     // Build 2: a.ts moved to z.ts (content unchanged). A module's own path reaches the output — it
@@ -210,8 +206,7 @@ describe('buildManifest relocation stability', () => {
           { id: 3, name: '/repo/packages/ui/src/b.ts', reasons: [{ moduleName: story }] },
         ],
       },
-      projectRoot,
-      outOfGraph
+      input
     );
 
     expect(after.storyFileHashes.get('./src/Button.stories.tsx')).not.toBe(
@@ -220,7 +215,7 @@ describe('buildManifest relocation stability', () => {
   });
 
   it('moves a story hash when an external dependency relocates further from the project', async () => {
-    const { disk, outOfGraph } = createFixture();
+    const { disk, input } = createFixture();
     const story = '/repo/packages/ui/src/Button.stories.tsx';
 
     // Build 1: theme.ts lives in a sibling package. Anchored at the git root it keys as
@@ -236,8 +231,7 @@ describe('buildManifest relocation stability', () => {
           { id: 2, name: '/repo/packages/shared/theme.ts', reasons: [{ moduleName: story }] },
         ],
       },
-      projectRoot,
-      outOfGraph
+      input
     );
 
     // Build 2: the repo is restructured so theme.ts moves up to the repo root ('shared/theme.ts'),
@@ -255,8 +249,7 @@ describe('buildManifest relocation stability', () => {
           { id: 2, name: '/repo/shared/theme.ts', reasons: [{ moduleName: story }] },
         ],
       },
-      projectRoot,
-      outOfGraph
+      input
     );
 
     expect(after.storyFileHashes.get('./src/Button.stories.tsx')).not.toBe(
@@ -265,7 +258,7 @@ describe('buildManifest relocation stability', () => {
   });
 
   it('recaptures every dependent and moves the gate when a shared module moves with its bytes intact', async () => {
-    const { disk, outOfGraph } = createFixture();
+    const { disk, input } = createFixture();
     // The measured v1-parity regression: `Badge.tsx` -> `Badge/index.tsx` left the gate SAME and
     // recaptured 0 stories, while a tracing v1 recaptured both importers. Neither importer's bytes
     // change — only the moved module's path does.
@@ -285,8 +278,7 @@ describe('buildManifest relocation stability', () => {
             },
           ],
         },
-        projectRoot,
-        outOfGraph
+        input
       );
     };
 
@@ -303,7 +295,7 @@ describe('buildManifest relocation stability', () => {
   });
 
   it('produces the same storybookHash regardless of module iteration order', async () => {
-    const { outOfGraph } = createFixture({
+    const { input } = createFixture({
       fileHashes: {
         '/repo/packages/ui/src/A.stories.tsx': 'HA',
         '/repo/packages/ui/src/B.stories.tsx': 'HB',
@@ -322,8 +314,8 @@ describe('buildManifest relocation stability', () => {
       ],
     };
 
-    const first = await buildManifest(forwards, projectRoot, outOfGraph);
-    const second = await buildManifest(backwards, projectRoot, outOfGraph);
+    const first = await buildManifest(forwards, input);
+    const second = await buildManifest(backwards, input);
 
     expect(second.storybookHash).toBe(first.storybookHash);
   });

--- a/node-src/lib/turbosnap/v2/manifest.hashing.test.ts
+++ b/node-src/lib/turbosnap/v2/manifest.hashing.test.ts
@@ -1,0 +1,330 @@
+import { describe, expect, it } from 'vitest';
+
+import { Stats } from '../../../types';
+import { createFixture, manifestWithPreview, projectRoot } from './__fixtures__/manifestFixtures';
+import { buildManifest } from './manifest';
+
+// These suites are about how a hash responds: what moves it, what leaves it alone, and what stays
+// stable when the project moves. They run end-to-end through buildManifest on purpose — the claim is
+// about the whole pipeline, not about any one step. Builder spellings live in statsGraph.test.ts.
+
+describe('buildManifest', () => {
+  it('keys story files by their canonical project-root-relative path', async () => {
+    const { outOfGraph } = createFixture();
+    const stats: Stats = {
+      modules: [
+        {
+          id: 1,
+          name: '/repo/packages/ui/src/Button.stories.tsx',
+          reasons: [{ moduleName: './storybook-stories.js' }],
+        },
+        {
+          id: 2,
+          name: '/repo/packages/ui/src/helper.ts',
+          reasons: [{ moduleName: '/repo/packages/ui/src/Button.stories.tsx' }],
+        },
+      ],
+    };
+
+    const manifest = await buildManifest(stats, projectRoot, outOfGraph);
+
+    expect([...manifest.storyFileHashes.keys()]).toEqual(['./src/Button.stories.tsx']);
+    expect(manifest.files.has('./src/Button.stories.tsx')).toBe(true);
+  });
+});
+
+describe('buildManifest leaf inclusion', () => {
+  const story = '/repo/packages/ui/src/Button.stories.tsx';
+  const leaf = '/repo/packages/ui/src/theme.ts';
+
+  // theme.ts is a leaf: the story imports it, but it imports nothing itself.
+  const stats: Stats = {
+    modules: [
+      { id: 1, name: story, reasons: [{ moduleName: './storybook-stories.js' }] },
+      { id: 2, name: leaf, reasons: [{ moduleName: story }] },
+    ],
+  };
+
+  it('changes the story hash when a leaf dependency content changes', async () => {
+    const { disk, outOfGraph } = createFixture();
+    disk.fileHashes = { [story]: 'S', [leaf]: 'T1' };
+    const before = await buildManifest(stats, projectRoot, outOfGraph);
+
+    disk.fileHashes = { [story]: 'S', [leaf]: 'T2' };
+    const after = await buildManifest(stats, projectRoot, outOfGraph);
+
+    expect(after.storyFileHashes.get('./src/Button.stories.tsx')).not.toBe(
+      before.storyFileHashes.get('./src/Button.stories.tsx')
+    );
+  });
+});
+
+describe('buildManifest relocation stability', () => {
+  it('changes nothing at all when the whole project moves', async () => {
+    const { disk, outOfGraph } = createFixture();
+    const before = await (async () => {
+      disk.fileHashes = {
+        '/repo/packages/ui/src/Button.stories.tsx': 'S',
+        '/repo/packages/ui/src/helper.ts': 'H',
+      };
+      return buildManifest(
+        {
+          modules: [
+            {
+              id: 1,
+              name: '/repo/packages/ui/src/Button.stories.tsx',
+              reasons: [{ moduleName: './storybook-stories.js' }],
+            },
+            {
+              id: 2,
+              name: '/repo/packages/ui/src/helper.ts',
+              reasons: [{ moduleName: '/repo/packages/ui/src/Button.stories.tsx' }],
+            },
+          ],
+        },
+        '/repo/packages/ui',
+        outOfGraph
+      );
+    })();
+
+    const after = await (async () => {
+      disk.fileHashes = {
+        '/repo/apps/web/ui/src/Button.stories.tsx': 'S',
+        '/repo/apps/web/ui/src/helper.ts': 'H',
+      };
+      return buildManifest(
+        {
+          modules: [
+            {
+              id: 1,
+              name: '/repo/apps/web/ui/src/Button.stories.tsx',
+              reasons: [{ moduleName: './storybook-stories.js' }],
+            },
+            {
+              id: 2,
+              name: '/repo/apps/web/ui/src/helper.ts',
+              reasons: [{ moduleName: '/repo/apps/web/ui/src/Button.stories.tsx' }],
+            },
+          ],
+        },
+        '/repo/apps/web/ui',
+        outOfGraph
+      );
+    })();
+
+    // The keys are project-relative, so moving the whole project moves nothing at all: same keys,
+    // same hashes, same gate. The stories still render identically, so nothing should recapture.
+    expect([...after.storyFileHashes.keys()]).toEqual(['./src/Button.stories.tsx']);
+    expect([...after.storyFileHashes.keys()]).toEqual([...before.storyFileHashes.keys()]);
+    expect([...after.storyFileHashes.values()]).toEqual([...before.storyFileHashes.values()]);
+    expect(after.storybookHash).toBe(before.storybookHash);
+  });
+
+  it('changes the storybook hash when a Storybook-wide file is renamed within the project', async () => {
+    // A project move no longer touches any key, so the case that proves keys are in the gate is a
+    // rename *inside* the project: `preview.ts` -> `preview.tsx`, byte-for-byte identical.
+    const before = await manifestWithPreview('preview.ts');
+    const after = await manifestWithPreview('preview.tsx');
+
+    // The `preview` roll-up folds in each file's path as well as its bytes, so renaming preview.ts to
+    // preview.tsx moves the rolled-up value even though its key stays `preview`...
+    expect(after.storybookFileHashes.get('preview')).not.toBe(
+      before.storybookFileHashes.get('preview')
+    );
+    // ...and that value feeds the gate, so the rename shows up in the storybook hash too.
+    expect(after.storybookHash).not.toBe(before.storybookHash);
+  });
+
+  it('re-keys a story file and moves the gate when the file is renamed within the project', async () => {
+    const { disk, outOfGraph } = createFixture();
+    // An autotitled story derives its title, and so its story IDs, from its path: moving
+    // `lib/Badge/AutoTitle.stories.tsx` to `lib/Renamed/` renames every story it holds without
+    // changing a byte. The snapshots are keyed by those IDs, so the gate has to move.
+    const helper = '/repo/packages/ui/src/helper.ts';
+    async function manifestWithStoryAt(story: string) {
+      disk.fileHashes = { [story]: 'S', [helper]: 'H' };
+      return buildManifest(
+        {
+          modules: [
+            { id: 1, name: story, reasons: [{ moduleName: './storybook-stories.js' }] },
+            { id: 2, name: helper, reasons: [{ moduleName: story }] },
+          ],
+        },
+        projectRoot,
+        outOfGraph
+      );
+    }
+
+    const before = await manifestWithStoryAt(
+      '/repo/packages/ui/src/lib/Badge/AutoTitle.stories.tsx'
+    );
+    const after = await manifestWithStoryAt(
+      '/repo/packages/ui/src/lib/Renamed/AutoTitle.stories.tsx'
+    );
+
+    expect([...before.storyFileHashes.keys()]).toEqual(['./src/lib/Badge/AutoTitle.stories.tsx']);
+    expect([...after.storyFileHashes.keys()]).toEqual(['./src/lib/Renamed/AutoTitle.stories.tsx']);
+    // The roll-up covers the story file's own path, so the hash moves under its new key...
+    expect(after.storyFileHashes.get('./src/lib/Renamed/AutoTitle.stories.tsx')).not.toBe(
+      before.storyFileHashes.get('./src/lib/Badge/AutoTitle.stories.tsx')
+    );
+    // ...and the key is part of the gate too, so the rename is doubly visible.
+    expect(after.storybookHash).not.toBe(before.storybookHash);
+  });
+
+  it('moves a story hash when a dependency moves within the project', async () => {
+    const { disk, outOfGraph } = createFixture();
+    const story = '/repo/packages/ui/src/Button.stories.tsx';
+
+    // Build 1: deps a.ts and b.ts sort as [Button, a, b].
+    disk.fileHashes = {
+      [story]: 'S',
+      '/repo/packages/ui/src/a.ts': 'HA',
+      '/repo/packages/ui/src/b.ts': 'HB',
+    };
+    const before = await buildManifest(
+      {
+        modules: [
+          { id: 1, name: story, reasons: [{ moduleName: './storybook-stories.js' }] },
+          { id: 2, name: '/repo/packages/ui/src/a.ts', reasons: [{ moduleName: story }] },
+          { id: 3, name: '/repo/packages/ui/src/b.ts', reasons: [{ moduleName: story }] },
+        ],
+      },
+      projectRoot,
+      outOfGraph
+    );
+
+    // Build 2: a.ts moved to z.ts (content unchanged). A module's own path reaches the output — it
+    // is baked into `import.meta.url`, emitted chunk names and CSS-Module class names — so the same
+    // bytes at a new path can render differently and the story has to recapture.
+    disk.fileHashes = {
+      [story]: 'S',
+      '/repo/packages/ui/src/z.ts': 'HA',
+      '/repo/packages/ui/src/b.ts': 'HB',
+    };
+    const after = await buildManifest(
+      {
+        modules: [
+          { id: 1, name: story, reasons: [{ moduleName: './storybook-stories.js' }] },
+          { id: 2, name: '/repo/packages/ui/src/z.ts', reasons: [{ moduleName: story }] },
+          { id: 3, name: '/repo/packages/ui/src/b.ts', reasons: [{ moduleName: story }] },
+        ],
+      },
+      projectRoot,
+      outOfGraph
+    );
+
+    expect(after.storyFileHashes.get('./src/Button.stories.tsx')).not.toBe(
+      before.storyFileHashes.get('./src/Button.stories.tsx')
+    );
+  });
+
+  it('moves a story hash when an external dependency relocates further from the project', async () => {
+    const { disk, outOfGraph } = createFixture();
+    const story = '/repo/packages/ui/src/Button.stories.tsx';
+
+    // Build 1: theme.ts lives in a sibling package. Anchored at the git root it keys as
+    // '../shared/theme.ts'.
+    disk.fileHashes = {
+      [story]: 'S',
+      '/repo/packages/shared/theme.ts': 'HT',
+    };
+    const before = await buildManifest(
+      {
+        modules: [
+          { id: 1, name: story, reasons: [{ moduleName: './storybook-stories.js' }] },
+          { id: 2, name: '/repo/packages/shared/theme.ts', reasons: [{ moduleName: story }] },
+        ],
+      },
+      projectRoot,
+      outOfGraph
+    );
+
+    // Build 2: the repo is restructured so theme.ts moves up to the repo root ('shared/theme.ts'),
+    // but its content is unchanged. The story and its internal dependencies don't move. The key
+    // still moves relative to the project root, so the story recaptures — over-capture in the safe
+    // direction, and what a tracing v1 does here too.
+    disk.fileHashes = {
+      [story]: 'S',
+      '/repo/shared/theme.ts': 'HT',
+    };
+    const after = await buildManifest(
+      {
+        modules: [
+          { id: 1, name: story, reasons: [{ moduleName: './storybook-stories.js' }] },
+          { id: 2, name: '/repo/shared/theme.ts', reasons: [{ moduleName: story }] },
+        ],
+      },
+      projectRoot,
+      outOfGraph
+    );
+
+    expect(after.storyFileHashes.get('./src/Button.stories.tsx')).not.toBe(
+      before.storyFileHashes.get('./src/Button.stories.tsx')
+    );
+  });
+
+  it('recaptures every dependent and moves the gate when a shared module moves with its bytes intact', async () => {
+    const { disk, outOfGraph } = createFixture();
+    // The measured v1-parity regression: `Badge.tsx` -> `Badge/index.tsx` left the gate SAME and
+    // recaptured 0 stories, while a tracing v1 recaptured both importers. Neither importer's bytes
+    // change — only the moved module's path does.
+    const badgeStory = '/repo/packages/ui/src/Badge.stories.tsx';
+    const cardStory = '/repo/packages/ui/src/UserCard.stories.tsx';
+    const manifestWithBadgeAt = async (badge: string) => {
+      disk.fileHashes = { [badgeStory]: 'S1', [cardStory]: 'S2', [badge]: 'B' };
+      return buildManifest(
+        {
+          modules: [
+            { id: 1, name: badgeStory, reasons: [{ moduleName: './storybook-stories.js' }] },
+            { id: 2, name: cardStory, reasons: [{ moduleName: './storybook-stories.js' }] },
+            {
+              id: 3,
+              name: badge,
+              reasons: [{ moduleName: badgeStory }, { moduleName: cardStory }],
+            },
+          ],
+        },
+        projectRoot,
+        outOfGraph
+      );
+    };
+
+    const before = await manifestWithBadgeAt('/repo/packages/ui/src/Badge.tsx');
+    const after = await manifestWithBadgeAt('/repo/packages/ui/src/Badge/index.tsx');
+
+    expect(after.storyFileHashes.get('./src/Badge.stories.tsx')).not.toBe(
+      before.storyFileHashes.get('./src/Badge.stories.tsx')
+    );
+    expect(after.storyFileHashes.get('./src/UserCard.stories.tsx')).not.toBe(
+      before.storyFileHashes.get('./src/UserCard.stories.tsx')
+    );
+    expect(after.storybookHash).not.toBe(before.storybookHash);
+  });
+
+  it('produces the same storybookHash regardless of module iteration order', async () => {
+    const { outOfGraph } = createFixture({
+      fileHashes: {
+        '/repo/packages/ui/src/A.stories.tsx': 'HA',
+        '/repo/packages/ui/src/B.stories.tsx': 'HB',
+      },
+    });
+    const forwards: Stats = {
+      modules: [
+        { id: 1, name: './src/A.stories.tsx', reasons: [{ moduleName: './storybook-stories.js' }] },
+        { id: 2, name: './src/B.stories.tsx', reasons: [{ moduleName: './storybook-stories.js' }] },
+      ],
+    };
+    const backwards: Stats = {
+      modules: [
+        { id: 2, name: './src/B.stories.tsx', reasons: [{ moduleName: './storybook-stories.js' }] },
+        { id: 1, name: './src/A.stories.tsx', reasons: [{ moduleName: './storybook-stories.js' }] },
+      ],
+    };
+
+    const first = await buildManifest(forwards, projectRoot, outOfGraph);
+    const second = await buildManifest(backwards, projectRoot, outOfGraph);
+
+    expect(second.storybookHash).toBe(first.storybookHash);
+  });
+});

--- a/node-src/lib/turbosnap/v2/manifest.storybookFiles.test.ts
+++ b/node-src/lib/turbosnap/v2/manifest.storybookFiles.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import { Stats } from '../../../types';
-import { createFixture, projectRoot } from './__fixtures__/manifestFixtures';
+import { createFixture } from './__fixtures__/manifestFixtures';
 import { buildManifest, serializeManifest } from './manifest';
 
 describe('buildManifest storybookFiles', () => {
@@ -47,28 +47,28 @@ describe('buildManifest storybookFiles', () => {
   };
 
   it('keys the preview subtree under the `preview` category', async () => {
-    const { outOfGraph } = createFixture({ fileHashes: { ...baseHashes } });
+    const { input } = createFixture({ fileHashes: { ...baseHashes } });
 
-    const manifest = await buildManifest(makeStats(), projectRoot, outOfGraph);
+    const manifest = await buildManifest(makeStats(), input);
 
     expect([...manifest.storybookFileHashes.keys()]).toContain(previewKey);
   });
 
   it('rolls orphan globals into a single catch-all entry', async () => {
-    const { outOfGraph } = createFixture({ fileHashes: { ...baseHashes } });
+    const { input } = createFixture({ fileHashes: { ...baseHashes } });
 
-    const manifest = await buildManifest(makeStats(), projectRoot, outOfGraph);
+    const manifest = await buildManifest(makeStats(), input);
 
     expect([...manifest.storybookFileHashes.keys()]).toContain(globalsKey);
   });
 
   it('changes the catch-all entry when an orphan global content changes', async () => {
-    const { disk, outOfGraph } = createFixture({ fileHashes: { ...baseHashes } });
-    const before = await buildManifest(makeStats(), projectRoot, outOfGraph);
+    const { disk, input } = createFixture({ fileHashes: { ...baseHashes } });
+    const before = await buildManifest(makeStats(), input);
 
     // reactDom is reached only via the framework's preview annotations, so it lands in the bucket.
     disk.fileHashes = { ...baseHashes, [reactDom]: 'RD2' };
-    const after = await buildManifest(makeStats(), projectRoot, outOfGraph);
+    const after = await buildManifest(makeStats(), input);
 
     expect(after.storybookFileHashes.get(globalsKey)).not.toBe(
       before.storybookFileHashes.get(globalsKey)
@@ -76,11 +76,11 @@ describe('buildManifest storybookFiles', () => {
   });
 
   it('changes the storybook hash when the preview config changes, leaving story hashes pure', async () => {
-    const { disk, outOfGraph } = createFixture({ fileHashes: { ...baseHashes } });
-    const before = await buildManifest(makeStats(), projectRoot, outOfGraph);
+    const { disk, input } = createFixture({ fileHashes: { ...baseHashes } });
+    const before = await buildManifest(makeStats(), input);
 
     disk.fileHashes = { ...baseHashes, [preview]: 'P2' };
-    const after = await buildManifest(makeStats(), projectRoot, outOfGraph);
+    const after = await buildManifest(makeStats(), input);
 
     expect(after.storybookHash).not.toBe(before.storybookHash);
     // Pure per-story hashes: a config change must not perturb any individual story's hash. The
@@ -89,23 +89,23 @@ describe('buildManifest storybookFiles', () => {
   });
 
   it('changes the storybook hash when an orphan global changes', async () => {
-    const { disk, outOfGraph } = createFixture({ fileHashes: { ...baseHashes } });
-    const before = await buildManifest(makeStats(), projectRoot, outOfGraph);
+    const { disk, input } = createFixture({ fileHashes: { ...baseHashes } });
+    const before = await buildManifest(makeStats(), input);
 
     disk.fileHashes = { ...baseHashes, [entryPreview]: 'EP2' };
-    const after = await buildManifest(makeStats(), projectRoot, outOfGraph);
+    const after = await buildManifest(makeStats(), input);
 
     expect(after.storybookHash).not.toBe(before.storybookHash);
     expect([...after.storyFileHashes]).toEqual([...before.storyFileHashes]);
   });
 
   it('keeps a story dependency out of the catch-all, scoping the change to that story', async () => {
-    const { disk, outOfGraph } = createFixture({ fileHashes: { ...baseHashes } });
-    const before = await buildManifest(makeStats(), projectRoot, outOfGraph);
+    const { disk, input } = createFixture({ fileHashes: { ...baseHashes } });
+    const before = await buildManifest(makeStats(), input);
 
     // moment lives only in Button's subtree, so it is story-reachable and must not be bucketed.
     disk.fileHashes = { ...baseHashes, [moment]: 'M2' };
-    const after = await buildManifest(makeStats(), projectRoot, outOfGraph);
+    const after = await buildManifest(makeStats(), input);
 
     expect(after.storyFileHashes.get('./src/Button.stories.tsx')).not.toBe(
       before.storyFileHashes.get('./src/Button.stories.tsx')
@@ -119,13 +119,13 @@ describe('buildManifest storybookFiles', () => {
   });
 
   it('attributes a preview-subtree change to the preview entry, not the catch-all', async () => {
-    const { disk, outOfGraph } = createFixture({ fileHashes: { ...baseHashes } });
-    const before = await buildManifest(makeStats(), projectRoot, outOfGraph);
+    const { disk, input } = createFixture({ fileHashes: { ...baseHashes } });
+    const before = await buildManifest(makeStats(), input);
 
     // theme.ts is reached only through preview.ts, so it belongs to the keyed preview entry. Landing
     // in both would double-count it and destroy the backend's attribution.
     disk.fileHashes = { ...baseHashes, [previewHelper]: 'PT2' };
-    const after = await buildManifest(makeStats(), projectRoot, outOfGraph);
+    const after = await buildManifest(makeStats(), input);
 
     expect(after.storybookFileHashes.get(previewKey)).not.toBe(
       before.storybookFileHashes.get(previewKey)
@@ -137,15 +137,14 @@ describe('buildManifest storybookFiles', () => {
 
   it('omits the preview entry when the graph has no preview config', async () => {
     // Real case: a Storybook project with no `.storybook/preview.*` in its graph at all.
-    const { outOfGraph } = createFixture({ fileHashes: { [buttonStory]: 'S1' } });
+    const { input } = createFixture({ fileHashes: { [buttonStory]: 'S1' } });
     const manifest = await buildManifest(
       {
         modules: [
           { id: 1, name: buttonStory, reasons: [{ moduleName: './storybook-stories.js' }] },
         ],
       },
-      projectRoot,
-      outOfGraph
+      input
     );
 
     expect([...manifest.storybookFileHashes.keys()]).not.toContain(previewKey);
@@ -154,7 +153,7 @@ describe('buildManifest storybookFiles', () => {
   it('omits the catch-all entry when every global is synthetic', async () => {
     // The stories entry is the only non-story node here, and it has no file on disk, so there is
     // nothing real to bucket and no empty entry should appear.
-    const { outOfGraph } = createFixture({
+    const { input } = createFixture({
       isAbsent: (candidate) => candidate.includes('storybook-stories.js'),
       fileHashes: { [buttonStory]: 'S1' },
     });
@@ -164,8 +163,7 @@ describe('buildManifest storybookFiles', () => {
           { id: 1, name: buttonStory, reasons: [{ moduleName: './storybook-stories.js' }] },
         ],
       },
-      projectRoot,
-      outOfGraph
+      input
     );
 
     // The version entry is unconditional, so it is the only key left once the catch-all is gone.
@@ -173,7 +171,7 @@ describe('buildManifest storybookFiles', () => {
   });
 
   it('records the installed Storybook version as its own entry, verbatim rather than hashed', async () => {
-    const { outOfGraph } = createFixture({
+    const { input } = createFixture({
       // The value is deliberately legible: the preview core runtime is served outside the module graph
       // on webpack and rspack, so a version is the only signal of a Storybook upgrade there, and
       // keeping it readable means the manifest itself says which Storybook produced the build.
@@ -181,7 +179,7 @@ describe('buildManifest storybookFiles', () => {
       fileHashes: { ...baseHashes },
     });
 
-    const manifest = await buildManifest(makeStats(), projectRoot, outOfGraph);
+    const manifest = await buildManifest(makeStats(), input);
 
     expect(manifest.storybookFileHashes.get('storybookVersion')).toBe('10.6.0-alpha.3');
   });
@@ -189,15 +187,15 @@ describe('buildManifest storybookFiles', () => {
   it('changes the storybookHash when only the Storybook version changes', async () => {
     // A Storybook upgrade that touches no graph file must still force a recapture, which is the
     // whole point of the entry: on webpack and rspack no file hash can see it.
-    const { disk, outOfGraph } = createFixture({
+    const { disk, input } = createFixture({
       fileHashes: { ...baseHashes },
       packageVersions: { storybook: '9.1.19' },
     });
-    const before = await buildManifest(makeStats(), projectRoot, outOfGraph);
+    const before = await buildManifest(makeStats(), input);
 
     disk.fileHashes = { ...baseHashes };
     disk.packageVersions = { storybook: '9.1.20' };
-    const after = await buildManifest(makeStats(), projectRoot, outOfGraph);
+    const after = await buildManifest(makeStats(), input);
 
     expect(after.storybookHash).not.toBe(before.storybookHash);
     // Only the Storybook-wide gate moves; no individual story subtree changed.
@@ -205,10 +203,10 @@ describe('buildManifest storybookFiles', () => {
   });
 
   it('produces identical storybookFiles and storybook hash when building the same stats twice', async () => {
-    const { disk, outOfGraph } = createFixture({ fileHashes: { ...baseHashes } });
-    const first = await buildManifest(makeStats(), projectRoot, outOfGraph);
+    const { disk, input } = createFixture({ fileHashes: { ...baseHashes } });
+    const first = await buildManifest(makeStats(), input);
     disk.fileHashes = { ...baseHashes };
-    const second = await buildManifest(makeStats(), projectRoot, outOfGraph);
+    const second = await buildManifest(makeStats(), input);
 
     expect([...second.storybookFileHashes]).toEqual([...first.storybookFileHashes]);
     expect(second.storybookHash).toBe(first.storybookHash);
@@ -235,19 +233,19 @@ describe('buildManifest out-of-graph inputs', () => {
   }
 
   it('emits a synthetic entry per out-of-graph section', async () => {
-    const { outOfGraph } = fixtureWithAssets();
-    const manifest = await buildManifest(stats, projectRoot, outOfGraph);
+    const { input } = fixtureWithAssets();
+    const manifest = await buildManifest(stats, input);
 
     expect([...manifest.storybookFileHashes.keys()]).toContain('storybookConfigFiles');
     expect([...manifest.storybookFileHashes.keys()]).toContain('staticFiles');
   });
 
   it('moves the storybook hash when main.ts changes, leaving story hashes untouched', async () => {
-    const { disk, outOfGraph } = fixtureWithAssets();
-    const before = await buildManifest(stats, projectRoot, outOfGraph);
+    const { disk, input } = fixtureWithAssets();
+    const before = await buildManifest(stats, input);
 
     disk.fileHashes = { ...disk.fileHashes, [mainConfig]: 'M2' };
-    const after = await buildManifest(stats, projectRoot, outOfGraph);
+    const after = await buildManifest(stats, input);
 
     // This is the v1-parity regression the mechanism exists to close: v1 bails on any configDir
     // edit, while v2 previously produced a byte-identical manifest.
@@ -256,18 +254,18 @@ describe('buildManifest out-of-graph inputs', () => {
   });
 
   it('moves the storybook hash when a static asset changes', async () => {
-    const { disk, outOfGraph } = fixtureWithAssets();
-    const before = await buildManifest(stats, projectRoot, outOfGraph);
+    const { disk, input } = fixtureWithAssets();
+    const before = await buildManifest(stats, input);
 
     disk.fileHashes = { ...disk.fileHashes, [staticAsset]: 'A2' };
-    const after = await buildManifest(stats, projectRoot, outOfGraph);
+    const after = await buildManifest(stats, input);
 
     expect(after.storybookHash).not.toBe(before.storybookHash);
   });
 
   it('moves the storybook hash when a static asset is renamed without changing its bytes', async () => {
-    const { disk, outOfGraph } = fixtureWithAssets();
-    const before = await buildManifest(stats, projectRoot, outOfGraph);
+    const { disk, input } = fixtureWithAssets();
+    const before = await buildManifest(stats, input);
 
     // Static assets are served by URL, so the same bytes at a new path render differently. A
     // content-only roll-up left both `staticFiles` and the storybook hash byte-identical here.
@@ -277,13 +275,13 @@ describe('buildManifest out-of-graph inputs', () => {
     };
     const renamed = '/repo/packages/ui/.storybook/static/sw.js';
     disk.fileHashes = { [story]: 'S', [mainConfig]: 'M', [renamed]: 'A' };
-    const after = await buildManifest(stats, projectRoot, outOfGraph);
+    const after = await buildManifest(stats, input);
 
     expect(after.storybookHash).not.toBe(before.storybookHash);
   });
 
   it('moves the storybook hash when two static assets swap contents', async () => {
-    const { disk, outOfGraph } = fixtureWithAssets();
+    const { disk, input } = fixtureWithAssets();
     disk.directories = {
       '/repo/packages/ui/.storybook': ['main.ts', 'static'],
       '/repo/packages/ui/.storybook/static': ['a.png', 'b.png'],
@@ -293,18 +291,18 @@ describe('buildManifest out-of-graph inputs', () => {
       '/repo/packages/ui/.storybook/static/b.png',
     ];
     disk.fileHashes = { [story]: 'S', [mainConfig]: 'M', [a]: 'A', [b]: 'B' };
-    const before = await buildManifest(stats, projectRoot, outOfGraph);
+    const before = await buildManifest(stats, input);
 
     // The multiset of contents is unchanged, so only path-sensitive hashing sees this.
     disk.fileHashes = { [story]: 'S', [mainConfig]: 'M', [a]: 'B', [b]: 'A' };
-    const after = await buildManifest(stats, projectRoot, outOfGraph);
+    const after = await buildManifest(stats, input);
 
     expect(after.storybookHash).not.toBe(before.storybookHash);
   });
 
   it('keeps out-of-graph files out of files and attribution, so they miss the globals catch-all', async () => {
-    const { outOfGraph } = fixtureWithAssets();
-    const manifest = await buildManifest(stats, projectRoot, outOfGraph);
+    const { input } = fixtureWithAssets();
+    const manifest = await buildManifest(stats, input);
 
     // The catch-all is defined by absence from storyReachable/previewSubtree, which these satisfy by
     // construction — entering `files` would double-hash them into `storybookGlobals`.
@@ -316,8 +314,8 @@ describe('buildManifest out-of-graph inputs', () => {
   });
 
   it('serializes the per-file detail sections for the debug view', async () => {
-    const { outOfGraph } = fixtureWithAssets();
-    const serialized = serializeManifest(await buildManifest(stats, projectRoot, outOfGraph));
+    const { input } = fixtureWithAssets();
+    const serialized = serializeManifest(await buildManifest(stats, input));
 
     expect(serialized.storybookConfigFiles).toEqual({ './.storybook/main.ts': 'M' });
     expect(serialized.staticFiles).toEqual({
@@ -328,17 +326,17 @@ describe('buildManifest out-of-graph inputs', () => {
   });
 
   it('covers a preview.* the builder elided, which has no graph-rolled entry at all', async () => {
-    const { disk, outOfGraph } = fixtureWithAssets();
+    const { disk, input } = fixtureWithAssets();
     // marketing-ui's preview.ts is 0 lines, so vite emits no module for it: v2 had no entry and
     // missed where v1 bails. Hashing the config dir off disk closes that unconditionally.
     disk.directories = { '/repo/packages/ui/.storybook': ['main.ts', 'preview.ts'] };
     const preview = '/repo/packages/ui/.storybook/preview.ts';
     disk.fileHashes = { [story]: 'S', [mainConfig]: 'M', [preview]: 'P1' };
-    const before = await buildManifest(stats, projectRoot, outOfGraph);
+    const before = await buildManifest(stats, input);
     expect(before.storybookFileHashes.has('preview')).toBe(false);
 
     disk.fileHashes = { ...disk.fileHashes, [preview]: 'P2' };
-    const after = await buildManifest(stats, projectRoot, outOfGraph);
+    const after = await buildManifest(stats, input);
 
     expect(after.storybookHash).not.toBe(before.storybookHash);
   });

--- a/node-src/lib/turbosnap/v2/manifest.storybookFiles.test.ts
+++ b/node-src/lib/turbosnap/v2/manifest.storybookFiles.test.ts
@@ -1,0 +1,345 @@
+import { describe, expect, it } from 'vitest';
+
+import { Stats } from '../../../types';
+import { createFixture, projectRoot } from './__fixtures__/manifestFixtures';
+import { buildManifest, serializeManifest } from './manifest';
+
+describe('buildManifest storybookFiles', () => {
+  // Two stories imported straight from the stories entry (Vite style). Button also imports moment,
+  // a per-story dependency. The config entry imports `.storybook/preview.ts`, which imports a
+  // helper — preview and its helper form the preview subtree that no story reaches.
+  const buttonStory = '/repo/packages/ui/src/Button.stories.tsx';
+  const headerStory = '/repo/packages/ui/src/Header.stories.tsx';
+  const moment = '/repo/packages/ui/node_modules/moment/moment.js';
+  const preview = '/repo/packages/ui/.storybook/preview.ts';
+  const previewHelper = '/repo/packages/ui/.storybook/theme.ts';
+  const configEntry = './storybook-config-entry.js';
+  // An orphan global: Storybook wires the framework's preview annotations into the config entry
+  // alongside preview.ts, so it is neither story-reachable nor in the preview subtree.
+  const entryPreview = '/repo/packages/ui/node_modules/@storybook/react/dist/entry-preview.js';
+  const reactDom = '/repo/packages/ui/node_modules/react-dom/index.js';
+
+  const previewKey = 'preview';
+  const globalsKey = 'storybookGlobals';
+
+  function makeStats(): Stats {
+    return {
+      modules: [
+        { id: 1, name: buttonStory, reasons: [{ moduleName: './storybook-stories.js' }] },
+        { id: 2, name: headerStory, reasons: [{ moduleName: './storybook-stories.js' }] },
+        { id: 3, name: moment, reasons: [{ moduleName: buttonStory }] },
+        { id: 4, name: preview, reasons: [{ moduleName: configEntry }] },
+        { id: 5, name: previewHelper, reasons: [{ moduleName: preview }] },
+        { id: 6, name: entryPreview, reasons: [{ moduleName: configEntry }] },
+        { id: 7, name: reactDom, reasons: [{ moduleName: entryPreview }] },
+      ],
+    };
+  }
+
+  const baseHashes = {
+    [buttonStory]: 'S1',
+    [headerStory]: 'S2',
+    [moment]: 'M',
+    [preview]: 'P',
+    [previewHelper]: 'PT',
+    [entryPreview]: 'EP',
+    [reactDom]: 'RD',
+  };
+
+  it('keys the preview subtree under the `preview` category', async () => {
+    const { outOfGraph } = createFixture({ fileHashes: { ...baseHashes } });
+
+    const manifest = await buildManifest(makeStats(), projectRoot, outOfGraph);
+
+    expect([...manifest.storybookFileHashes.keys()]).toContain(previewKey);
+  });
+
+  it('rolls orphan globals into a single catch-all entry', async () => {
+    const { outOfGraph } = createFixture({ fileHashes: { ...baseHashes } });
+
+    const manifest = await buildManifest(makeStats(), projectRoot, outOfGraph);
+
+    expect([...manifest.storybookFileHashes.keys()]).toContain(globalsKey);
+  });
+
+  it('changes the catch-all entry when an orphan global content changes', async () => {
+    const { disk, outOfGraph } = createFixture({ fileHashes: { ...baseHashes } });
+    const before = await buildManifest(makeStats(), projectRoot, outOfGraph);
+
+    // reactDom is reached only via the framework's preview annotations, so it lands in the bucket.
+    disk.fileHashes = { ...baseHashes, [reactDom]: 'RD2' };
+    const after = await buildManifest(makeStats(), projectRoot, outOfGraph);
+
+    expect(after.storybookFileHashes.get(globalsKey)).not.toBe(
+      before.storybookFileHashes.get(globalsKey)
+    );
+  });
+
+  it('changes the storybook hash when the preview config changes, leaving story hashes pure', async () => {
+    const { disk, outOfGraph } = createFixture({ fileHashes: { ...baseHashes } });
+    const before = await buildManifest(makeStats(), projectRoot, outOfGraph);
+
+    disk.fileHashes = { ...baseHashes, [preview]: 'P2' };
+    const after = await buildManifest(makeStats(), projectRoot, outOfGraph);
+
+    expect(after.storybookHash).not.toBe(before.storybookHash);
+    // Pure per-story hashes: a config change must not perturb any individual story's hash. The
+    // backend notices it via storybookHash and drills into storybookFiles instead.
+    expect([...after.storyFileHashes]).toEqual([...before.storyFileHashes]);
+  });
+
+  it('changes the storybook hash when an orphan global changes', async () => {
+    const { disk, outOfGraph } = createFixture({ fileHashes: { ...baseHashes } });
+    const before = await buildManifest(makeStats(), projectRoot, outOfGraph);
+
+    disk.fileHashes = { ...baseHashes, [entryPreview]: 'EP2' };
+    const after = await buildManifest(makeStats(), projectRoot, outOfGraph);
+
+    expect(after.storybookHash).not.toBe(before.storybookHash);
+    expect([...after.storyFileHashes]).toEqual([...before.storyFileHashes]);
+  });
+
+  it('keeps a story dependency out of the catch-all, scoping the change to that story', async () => {
+    const { disk, outOfGraph } = createFixture({ fileHashes: { ...baseHashes } });
+    const before = await buildManifest(makeStats(), projectRoot, outOfGraph);
+
+    // moment lives only in Button's subtree, so it is story-reachable and must not be bucketed.
+    disk.fileHashes = { ...baseHashes, [moment]: 'M2' };
+    const after = await buildManifest(makeStats(), projectRoot, outOfGraph);
+
+    expect(after.storyFileHashes.get('./src/Button.stories.tsx')).not.toBe(
+      before.storyFileHashes.get('./src/Button.stories.tsx')
+    );
+    expect(after.storyFileHashes.get('./src/Header.stories.tsx')).toBe(
+      before.storyFileHashes.get('./src/Header.stories.tsx')
+    );
+    expect(after.storybookFileHashes.get(globalsKey)).toBe(
+      before.storybookFileHashes.get(globalsKey)
+    );
+  });
+
+  it('attributes a preview-subtree change to the preview entry, not the catch-all', async () => {
+    const { disk, outOfGraph } = createFixture({ fileHashes: { ...baseHashes } });
+    const before = await buildManifest(makeStats(), projectRoot, outOfGraph);
+
+    // theme.ts is reached only through preview.ts, so it belongs to the keyed preview entry. Landing
+    // in both would double-count it and destroy the backend's attribution.
+    disk.fileHashes = { ...baseHashes, [previewHelper]: 'PT2' };
+    const after = await buildManifest(makeStats(), projectRoot, outOfGraph);
+
+    expect(after.storybookFileHashes.get(previewKey)).not.toBe(
+      before.storybookFileHashes.get(previewKey)
+    );
+    expect(after.storybookFileHashes.get(globalsKey)).toBe(
+      before.storybookFileHashes.get(globalsKey)
+    );
+  });
+
+  it('omits the preview entry when the graph has no preview config', async () => {
+    // Real case: a Storybook project with no `.storybook/preview.*` in its graph at all.
+    const { outOfGraph } = createFixture({ fileHashes: { [buttonStory]: 'S1' } });
+    const manifest = await buildManifest(
+      {
+        modules: [
+          { id: 1, name: buttonStory, reasons: [{ moduleName: './storybook-stories.js' }] },
+        ],
+      },
+      projectRoot,
+      outOfGraph
+    );
+
+    expect([...manifest.storybookFileHashes.keys()]).not.toContain(previewKey);
+  });
+
+  it('omits the catch-all entry when every global is synthetic', async () => {
+    // The stories entry is the only non-story node here, and it has no file on disk, so there is
+    // nothing real to bucket and no empty entry should appear.
+    const { outOfGraph } = createFixture({
+      isAbsent: (candidate) => candidate.includes('storybook-stories.js'),
+      fileHashes: { [buttonStory]: 'S1' },
+    });
+    const manifest = await buildManifest(
+      {
+        modules: [
+          { id: 1, name: buttonStory, reasons: [{ moduleName: './storybook-stories.js' }] },
+        ],
+      },
+      projectRoot,
+      outOfGraph
+    );
+
+    // The version entry is unconditional, so it is the only key left once the catch-all is gone.
+    expect([...manifest.storybookFileHashes.keys()]).toEqual(['storybookVersion']);
+  });
+
+  it('records the installed Storybook version as its own entry, verbatim rather than hashed', async () => {
+    const { outOfGraph } = createFixture({
+      // The value is deliberately legible: the preview core runtime is served outside the module graph
+      // on webpack and rspack, so a version is the only signal of a Storybook upgrade there, and
+      // keeping it readable means the manifest itself says which Storybook produced the build.
+      packageVersions: { storybook: '10.6.0-alpha.3' },
+      fileHashes: { ...baseHashes },
+    });
+
+    const manifest = await buildManifest(makeStats(), projectRoot, outOfGraph);
+
+    expect(manifest.storybookFileHashes.get('storybookVersion')).toBe('10.6.0-alpha.3');
+  });
+
+  it('changes the storybookHash when only the Storybook version changes', async () => {
+    // A Storybook upgrade that touches no graph file must still force a recapture, which is the
+    // whole point of the entry: on webpack and rspack no file hash can see it.
+    const { disk, outOfGraph } = createFixture({
+      fileHashes: { ...baseHashes },
+      packageVersions: { storybook: '9.1.19' },
+    });
+    const before = await buildManifest(makeStats(), projectRoot, outOfGraph);
+
+    disk.fileHashes = { ...baseHashes };
+    disk.packageVersions = { storybook: '9.1.20' };
+    const after = await buildManifest(makeStats(), projectRoot, outOfGraph);
+
+    expect(after.storybookHash).not.toBe(before.storybookHash);
+    // Only the Storybook-wide gate moves; no individual story subtree changed.
+    expect([...after.storyFileHashes]).toEqual([...before.storyFileHashes]);
+  });
+
+  it('produces identical storybookFiles and storybook hash when building the same stats twice', async () => {
+    const { disk, outOfGraph } = createFixture({ fileHashes: { ...baseHashes } });
+    const first = await buildManifest(makeStats(), projectRoot, outOfGraph);
+    disk.fileHashes = { ...baseHashes };
+    const second = await buildManifest(makeStats(), projectRoot, outOfGraph);
+
+    expect([...second.storybookFileHashes]).toEqual([...first.storybookFileHashes]);
+    expect(second.storybookHash).toBe(first.storybookHash);
+  });
+});
+
+describe('buildManifest out-of-graph inputs', () => {
+  const story = '/repo/packages/ui/src/Button.stories.tsx';
+  const mainConfig = '/repo/packages/ui/.storybook/main.ts';
+  const staticAsset = '/repo/packages/ui/.storybook/static/mockServiceWorker.js';
+
+  const stats: Stats = {
+    modules: [{ id: 1, name: story, reasons: [{ moduleName: './storybook-stories.js' }] }],
+  };
+
+  function fixtureWithAssets() {
+    return createFixture({
+      directories: {
+        '/repo/packages/ui/.storybook': ['main.ts', 'static'],
+        '/repo/packages/ui/.storybook/static': ['mockServiceWorker.js'],
+      },
+      fileHashes: { [story]: 'S', [mainConfig]: 'M', [staticAsset]: 'A' },
+    });
+  }
+
+  it('emits a synthetic entry per out-of-graph section', async () => {
+    const { outOfGraph } = fixtureWithAssets();
+    const manifest = await buildManifest(stats, projectRoot, outOfGraph);
+
+    expect([...manifest.storybookFileHashes.keys()]).toContain('storybookConfigFiles');
+    expect([...manifest.storybookFileHashes.keys()]).toContain('staticFiles');
+  });
+
+  it('moves the storybook hash when main.ts changes, leaving story hashes untouched', async () => {
+    const { disk, outOfGraph } = fixtureWithAssets();
+    const before = await buildManifest(stats, projectRoot, outOfGraph);
+
+    disk.fileHashes = { ...disk.fileHashes, [mainConfig]: 'M2' };
+    const after = await buildManifest(stats, projectRoot, outOfGraph);
+
+    // This is the v1-parity regression the mechanism exists to close: v1 bails on any configDir
+    // edit, while v2 previously produced a byte-identical manifest.
+    expect(after.storybookHash).not.toBe(before.storybookHash);
+    expect(after.storyFileHashes).toEqual(before.storyFileHashes);
+  });
+
+  it('moves the storybook hash when a static asset changes', async () => {
+    const { disk, outOfGraph } = fixtureWithAssets();
+    const before = await buildManifest(stats, projectRoot, outOfGraph);
+
+    disk.fileHashes = { ...disk.fileHashes, [staticAsset]: 'A2' };
+    const after = await buildManifest(stats, projectRoot, outOfGraph);
+
+    expect(after.storybookHash).not.toBe(before.storybookHash);
+  });
+
+  it('moves the storybook hash when a static asset is renamed without changing its bytes', async () => {
+    const { disk, outOfGraph } = fixtureWithAssets();
+    const before = await buildManifest(stats, projectRoot, outOfGraph);
+
+    // Static assets are served by URL, so the same bytes at a new path render differently. A
+    // content-only roll-up left both `staticFiles` and the storybook hash byte-identical here.
+    disk.directories = {
+      '/repo/packages/ui/.storybook': ['main.ts', 'static'],
+      '/repo/packages/ui/.storybook/static': ['sw.js'],
+    };
+    const renamed = '/repo/packages/ui/.storybook/static/sw.js';
+    disk.fileHashes = { [story]: 'S', [mainConfig]: 'M', [renamed]: 'A' };
+    const after = await buildManifest(stats, projectRoot, outOfGraph);
+
+    expect(after.storybookHash).not.toBe(before.storybookHash);
+  });
+
+  it('moves the storybook hash when two static assets swap contents', async () => {
+    const { disk, outOfGraph } = fixtureWithAssets();
+    disk.directories = {
+      '/repo/packages/ui/.storybook': ['main.ts', 'static'],
+      '/repo/packages/ui/.storybook/static': ['a.png', 'b.png'],
+    };
+    const [a, b] = [
+      '/repo/packages/ui/.storybook/static/a.png',
+      '/repo/packages/ui/.storybook/static/b.png',
+    ];
+    disk.fileHashes = { [story]: 'S', [mainConfig]: 'M', [a]: 'A', [b]: 'B' };
+    const before = await buildManifest(stats, projectRoot, outOfGraph);
+
+    // The multiset of contents is unchanged, so only path-sensitive hashing sees this.
+    disk.fileHashes = { [story]: 'S', [mainConfig]: 'M', [a]: 'B', [b]: 'A' };
+    const after = await buildManifest(stats, projectRoot, outOfGraph);
+
+    expect(after.storybookHash).not.toBe(before.storybookHash);
+  });
+
+  it('keeps out-of-graph files out of files and attribution, so they miss the globals catch-all', async () => {
+    const { outOfGraph } = fixtureWithAssets();
+    const manifest = await buildManifest(stats, projectRoot, outOfGraph);
+
+    // The catch-all is defined by absence from storyReachable/previewSubtree, which these satisfy by
+    // construction — entering `files` would double-hash them into `storybookGlobals`.
+    expect(manifest.files.has('./.storybook/main.ts')).toBe(false);
+    expect(manifest.attribution.storybookGlobals.has('./.storybook/main.ts')).toBe(false);
+    expect(
+      manifest.attribution.storybookGlobals.has('./.storybook/static/mockServiceWorker.js')
+    ).toBe(false);
+  });
+
+  it('serializes the per-file detail sections for the debug view', async () => {
+    const { outOfGraph } = fixtureWithAssets();
+    const serialized = serializeManifest(await buildManifest(stats, projectRoot, outOfGraph));
+
+    expect(serialized.storybookConfigFiles).toEqual({ './.storybook/main.ts': 'M' });
+    expect(serialized.staticFiles).toEqual({
+      './.storybook/static/mockServiceWorker.js': 'A',
+    });
+    // eslint-disable-next-line unicorn/prefer-structured-clone
+    expect(JSON.parse(JSON.stringify(serialized))).toEqual(serialized);
+  });
+
+  it('covers a preview.* the builder elided, which has no graph-rolled entry at all', async () => {
+    const { disk, outOfGraph } = fixtureWithAssets();
+    // marketing-ui's preview.ts is 0 lines, so vite emits no module for it: v2 had no entry and
+    // missed where v1 bails. Hashing the config dir off disk closes that unconditionally.
+    disk.directories = { '/repo/packages/ui/.storybook': ['main.ts', 'preview.ts'] };
+    const preview = '/repo/packages/ui/.storybook/preview.ts';
+    disk.fileHashes = { [story]: 'S', [mainConfig]: 'M', [preview]: 'P1' };
+    const before = await buildManifest(stats, projectRoot, outOfGraph);
+    expect(before.storybookFileHashes.has('preview')).toBe(false);
+
+    disk.fileHashes = { ...disk.fileHashes, [preview]: 'P2' };
+    const after = await buildManifest(stats, projectRoot, outOfGraph);
+
+    expect(after.storybookHash).not.toBe(before.storybookHash);
+  });
+});

--- a/node-src/lib/turbosnap/v2/manifest.test.ts
+++ b/node-src/lib/turbosnap/v2/manifest.test.ts
@@ -89,6 +89,35 @@ describe('serializeManifest', () => {
     ]);
   });
 
+  it('keeps synthetic transit nodes in memory while omitting them from serialization', async () => {
+    const story = '/repo/packages/ui/src/Button.stories.tsx';
+    const synthetic = 'virtual:bridge';
+    const helper = '/repo/packages/ui/src/helper.ts';
+    const { outOfGraph } = createFixture({
+      isAbsent: syntheticAbsent,
+      fileHashes: { [story]: 'S', [helper]: 'H' },
+    });
+    const stats: Stats = {
+      modules: [
+        { id: 1, name: story, reasons: [{ moduleName: './storybook-stories.js' }] },
+        { id: 2, name: synthetic, reasons: [{ moduleName: story }] },
+        { id: 3, name: helper, reasons: [{ moduleName: synthetic }] },
+      ],
+    };
+
+    const manifest = await buildManifest(stats, projectRoot, outOfGraph);
+
+    expect(manifest.files.get('./src/Button.stories.tsx')?.dependencies).toContain(synthetic);
+    expect(manifest.files.get(synthetic)?.dependencies).toContain('./src/helper.ts');
+
+    const serialized = serializeManifest(manifest);
+
+    expect(serialized.files).not.toHaveProperty(synthetic);
+    expect(serialized.files['./src/Button.stories.tsx'].dependencies).not.toContain(synthetic);
+    expect(manifest.files.get('./src/Button.stories.tsx')?.dependencies).toContain(synthetic);
+    expect(manifest.files.get(synthetic)?.dependencies).toContain('./src/helper.ts');
+  });
+
   it('prunes dependency references to synthetic nodes after deriving hashes and attribution', async () => {
     const story = '/repo/packages/ui/src/Button.stories.tsx';
     const synthetic = 'virtual:bridge';

--- a/node-src/lib/turbosnap/v2/manifest.test.ts
+++ b/node-src/lib/turbosnap/v2/manifest.test.ts
@@ -158,6 +158,36 @@ describe('serializeManifest', () => {
     expect(after.attribution).toEqual(before.attribution);
   });
 
+  it('keeps a real file reachable only through a synthetic bridge as its own serialized entry', async () => {
+    const story = '/repo/packages/ui/src/Button.stories.tsx';
+    const synthetic = 'virtual:bridge';
+    const helper = '/repo/packages/ui/src/helper.ts';
+    const { outOfGraph } = createFixture({
+      isAbsent: syntheticAbsent,
+      fileHashes: { [story]: 'S', [helper]: 'H' },
+    });
+    // The only path from the story to the helper runs through the synthetic bridge, which pruning
+    // erases. The helper must still surface as its own entry so its hash is published for diffing;
+    // its reachability is carried by the precomputed roll-ups, not by the serialized edges.
+    const stats: Stats = {
+      modules: [
+        { id: 1, name: story, reasons: [{ moduleName: './storybook-stories.js' }] },
+        { id: 2, name: synthetic, reasons: [{ moduleName: story }] },
+        { id: 3, name: helper, reasons: [{ moduleName: synthetic }] },
+      ],
+    };
+
+    const serialized = serializeManifest(await buildManifest(stats, projectRoot, outOfGraph));
+
+    // The helper is published with its own hash, so a debug reader can diff it...
+    expect(serialized.files['./src/helper.ts'].hash).toBe('H');
+    // ...even though no serialized dependency edge reaches it (the bridge that did was pruned).
+    const reachedByAnEdge = Object.values(serialized.files).some((file) =>
+      file.dependencies.includes('./src/helper.ts')
+    );
+    expect(reachedByAnEdge).toBe(false);
+  });
+
   it('counts a synthetic node itself towards the roll-up of the story that reaches it', async () => {
     const story = '/repo/packages/ui/src/Button.stories.tsx';
     const synthetic = 'virtual:bridge';

--- a/node-src/lib/turbosnap/v2/manifest.test.ts
+++ b/node-src/lib/turbosnap/v2/manifest.test.ts
@@ -260,9 +260,7 @@ describe('writeManifest', () => {
 
     writeManifest(manifest, outputDirectory, outOfGraph.projectFiles);
 
-    expect(disk.writtenFiles?.[manifestPath]).toBe(
-      JSON.stringify(serializeManifest(manifest), undefined, 2)
-    );
+    expect(disk.writtenFiles?.[manifestPath]).toBe(JSON.stringify(serializeManifest(manifest)));
   });
 
   it('writes a payload that round-trips through JSON.parse', async () => {

--- a/node-src/lib/turbosnap/v2/manifest.test.ts
+++ b/node-src/lib/turbosnap/v2/manifest.test.ts
@@ -66,6 +66,29 @@ describe('serializeManifest', () => {
     expect(JSON.parse(JSON.stringify(serialized))).toEqual(serialized);
   });
 
+  it('sorts file dependencies regardless of their insertion order', async () => {
+    const story = '/repo/packages/ui/src/Button.stories.tsx';
+    const alpha = '/repo/packages/ui/src/alpha.ts';
+    const zulu = '/repo/packages/ui/src/zulu.ts';
+    const { outOfGraph } = createFixture({
+      fileHashes: { [story]: 'S', [alpha]: 'A', [zulu]: 'Z' },
+    });
+    const stats: Stats = {
+      modules: [
+        { id: 1, name: story, reasons: [{ moduleName: './storybook-stories.js' }] },
+        { id: 2, name: zulu, reasons: [{ moduleName: story }] },
+        { id: 3, name: alpha, reasons: [{ moduleName: story }] },
+      ],
+    };
+
+    const serialized = serializeManifest(await buildManifest(stats, projectRoot, outOfGraph));
+
+    expect(serialized.files['./src/Button.stories.tsx'].dependencies).toEqual([
+      './src/alpha.ts',
+      './src/zulu.ts',
+    ]);
+  });
+
   it('prunes dependency references to synthetic nodes after deriving hashes and attribution', async () => {
     const story = '/repo/packages/ui/src/Button.stories.tsx';
     const synthetic = 'virtual:bridge';

--- a/node-src/lib/turbosnap/v2/manifest.test.ts
+++ b/node-src/lib/turbosnap/v2/manifest.test.ts
@@ -5,14 +5,13 @@ import { Stats } from '../../../types';
 import {
   createFixture,
   manifestWithPreview,
-  projectRoot,
   syntheticAbsent,
 } from './__fixtures__/manifestFixtures';
 import { buildManifest, serializeManifest, writeManifest } from './manifest';
 
 describe('serializeManifest', () => {
   it('converts the manifest maps and sets into JSON-safe objects and arrays', async () => {
-    const { outOfGraph } = createFixture({
+    const { input } = createFixture({
       fileHashes: {
         '/repo/packages/ui/src/Button.stories.tsx': 'S',
         '/repo/packages/ui/src/helper.ts': 'H',
@@ -33,7 +32,7 @@ describe('serializeManifest', () => {
       ],
     };
 
-    const manifest = await buildManifest(stats, projectRoot, outOfGraph);
+    const manifest = await buildManifest(stats, input);
     const serialized = serializeManifest(manifest);
 
     // JSON-safe: storyFiles is a plain object, dependencies is an array.
@@ -48,7 +47,7 @@ describe('serializeManifest', () => {
   it('emits storybookFileHashes as a JSON-safe object', async () => {
     const story = '/repo/packages/ui/src/Button.stories.tsx';
     const preview = '/repo/packages/ui/.storybook/preview.ts';
-    const { outOfGraph } = createFixture({ fileHashes: { [story]: 'S', [preview]: 'P' } });
+    const { input } = createFixture({ fileHashes: { [story]: 'S', [preview]: 'P' } });
     const stats: Stats = {
       modules: [
         { id: 1, name: story, reasons: [{ moduleName: './storybook-stories.js' }] },
@@ -56,7 +55,7 @@ describe('serializeManifest', () => {
       ],
     };
 
-    const manifest = await buildManifest(stats, projectRoot, outOfGraph);
+    const manifest = await buildManifest(stats, input);
     const serialized = serializeManifest(manifest);
 
     expect(serialized.storybookFileHashes.preview).toBe(
@@ -70,7 +69,7 @@ describe('serializeManifest', () => {
     const story = '/repo/packages/ui/src/Button.stories.tsx';
     const alpha = '/repo/packages/ui/src/alpha.ts';
     const zulu = '/repo/packages/ui/src/zulu.ts';
-    const { outOfGraph } = createFixture({
+    const { input } = createFixture({
       fileHashes: { [story]: 'S', [alpha]: 'A', [zulu]: 'Z' },
     });
     const stats: Stats = {
@@ -81,7 +80,7 @@ describe('serializeManifest', () => {
       ],
     };
 
-    const serialized = serializeManifest(await buildManifest(stats, projectRoot, outOfGraph));
+    const serialized = serializeManifest(await buildManifest(stats, input));
 
     expect(serialized.files['./src/Button.stories.tsx'].dependencies).toEqual([
       './src/alpha.ts',
@@ -93,7 +92,7 @@ describe('serializeManifest', () => {
     const story = '/repo/packages/ui/src/Button.stories.tsx';
     const zulu = '/repo/packages/ui/src/zulu.ts';
     const alpha = '/repo/packages/ui/src/alpha.ts';
-    const { outOfGraph } = createFixture({
+    const { input } = createFixture({
       isAbsent: syntheticAbsent,
       fileHashes: { [story]: 'S', [zulu]: 'Z', [alpha]: 'A' },
     });
@@ -105,7 +104,7 @@ describe('serializeManifest', () => {
       ],
     };
 
-    const serialized = serializeManifest(await buildManifest(stats, projectRoot, outOfGraph));
+    const serialized = serializeManifest(await buildManifest(stats, input));
 
     expect(Object.keys(serialized.files)).toEqual([
       './src/alpha.ts',
@@ -118,7 +117,7 @@ describe('serializeManifest', () => {
     const story = '/repo/packages/ui/src/Button.stories.tsx';
     const synthetic = 'virtual:bridge';
     const helper = '/repo/packages/ui/src/helper.ts';
-    const { outOfGraph } = createFixture({
+    const { input } = createFixture({
       isAbsent: syntheticAbsent,
       fileHashes: { [story]: 'S', [helper]: 'H' },
     });
@@ -130,7 +129,7 @@ describe('serializeManifest', () => {
       ],
     };
 
-    const manifest = await buildManifest(stats, projectRoot, outOfGraph);
+    const manifest = await buildManifest(stats, input);
 
     expect(manifest.files.get('./src/Button.stories.tsx')?.dependencies).toContain(synthetic);
     expect(manifest.files.get(synthetic)?.dependencies).toContain('./src/helper.ts');
@@ -147,7 +146,7 @@ describe('serializeManifest', () => {
     const story = '/repo/packages/ui/src/Button.stories.tsx';
     const synthetic = 'virtual:bridge';
     const helper = '/repo/packages/ui/src/helper.ts';
-    const { disk, outOfGraph } = createFixture({
+    const { disk, input } = createFixture({
       isAbsent: syntheticAbsent,
       fileHashes: { [story]: 'S', [helper]: 'H1' },
     });
@@ -159,10 +158,10 @@ describe('serializeManifest', () => {
       ],
     };
 
-    const before = serializeManifest(await buildManifest(stats, projectRoot, outOfGraph));
+    const before = serializeManifest(await buildManifest(stats, input));
 
     disk.fileHashes = { [story]: 'S', [helper]: 'H2' };
-    const after = serializeManifest(await buildManifest(stats, projectRoot, outOfGraph));
+    const after = serializeManifest(await buildManifest(stats, input));
 
     for (const file of Object.values(before.files)) {
       expect(file.dependencies.every((dependency) => dependency in before.files)).toBe(true);
@@ -187,7 +186,7 @@ describe('serializeManifest', () => {
     const story = '/repo/packages/ui/src/Button.stories.tsx';
     const synthetic = 'virtual:bridge';
     const helper = '/repo/packages/ui/src/helper.ts';
-    const { outOfGraph } = createFixture({
+    const { input } = createFixture({
       isAbsent: syntheticAbsent,
       fileHashes: { [story]: 'S', [helper]: 'H' },
     });
@@ -202,7 +201,7 @@ describe('serializeManifest', () => {
       ],
     };
 
-    const serialized = serializeManifest(await buildManifest(stats, projectRoot, outOfGraph));
+    const serialized = serializeManifest(await buildManifest(stats, input));
 
     // The helper is published with its own hash, so a debug reader can diff it...
     expect(serialized.files['./src/helper.ts'].hash).toBe('H');
@@ -217,7 +216,7 @@ describe('serializeManifest', () => {
     const story = '/repo/packages/ui/src/Button.stories.tsx';
     const synthetic = 'virtual:bridge';
     const helper = '/repo/packages/ui/src/helper.ts';
-    const { outOfGraph } = createFixture({
+    const { input } = createFixture({
       isAbsent: syntheticAbsent,
       fileHashes: { [story]: 'S', [helper]: 'H' },
     });
@@ -240,8 +239,8 @@ describe('serializeManifest', () => {
       ],
     };
 
-    const bridged = serializeManifest(await buildManifest(withLeaf, projectRoot, outOfGraph));
-    const plain = serializeManifest(await buildManifest(withoutLeaf, projectRoot, outOfGraph));
+    const bridged = serializeManifest(await buildManifest(withLeaf, input));
+    const plain = serializeManifest(await buildManifest(withoutLeaf, input));
 
     // Identical after pruning, so the story hash is the only place the leaf can show up.
     expect(bridged.files).toEqual(plain.files);
@@ -255,23 +254,19 @@ describe('writeManifest', () => {
   const manifestPath = path.join(outputDirectory, 'turbosnap-manifest.json');
 
   it('writes the serialized manifest as JSON to turbosnap-manifest.json in the output directory', async () => {
-    const { disk, outOfGraph } = createFixture();
+    const { disk, input } = createFixture();
     const manifest = await manifestWithPreview('preview.ts');
 
-    writeManifest(manifest, outputDirectory, outOfGraph.projectFiles);
+    writeManifest(manifest, outputDirectory, input.projectFiles);
 
     expect(disk.writtenFiles?.[manifestPath]).toBe(JSON.stringify(serializeManifest(manifest)));
   });
 
   it('writes a payload that round-trips through JSON.parse', async () => {
-    const { disk, outOfGraph } = createFixture();
+    const { disk, input } = createFixture();
     // The file is uploaded to S3 and read back for debugging, so it has to be valid JSON with the
     // Maps and Sets already flattened.
-    writeManifest(
-      await manifestWithPreview('preview.ts'),
-      outputDirectory,
-      outOfGraph.projectFiles
-    );
+    writeManifest(await manifestWithPreview('preview.ts'), outputDirectory, input.projectFiles);
 
     const payload = disk.writtenFiles?.[manifestPath] ?? '';
 

--- a/node-src/lib/turbosnap/v2/manifest.test.ts
+++ b/node-src/lib/turbosnap/v2/manifest.test.ts
@@ -235,7 +235,9 @@ describe('writeManifest', () => {
 
     writeManifest(manifest, outputDirectory, outOfGraph.projectFiles);
 
-    expect(disk.writtenFiles?.[manifestPath]).toBe(JSON.stringify(serializeManifest(manifest)));
+    expect(disk.writtenFiles?.[manifestPath]).toBe(
+JSON.stringify(serializeManifest(manifest), undefined, 2)
+);
   });
 
   it('writes a payload that round-trips through JSON.parse', async () => {

--- a/node-src/lib/turbosnap/v2/manifest.test.ts
+++ b/node-src/lib/turbosnap/v2/manifest.test.ts
@@ -1,0 +1,173 @@
+import path from 'path';
+import { describe, expect, it } from 'vitest';
+
+import { Stats } from '../../../types';
+import {
+  createFixture,
+  manifestWithPreview,
+  projectRoot,
+  syntheticAbsent,
+} from './__fixtures__/manifestFixtures';
+import { buildManifest, serializeManifest, writeManifest } from './manifest';
+
+describe('serializeManifest', () => {
+  it('converts the manifest maps and sets into JSON-safe objects and arrays', async () => {
+    const { outOfGraph } = createFixture({
+      fileHashes: {
+        '/repo/packages/ui/src/Button.stories.tsx': 'S',
+        '/repo/packages/ui/src/helper.ts': 'H',
+      },
+    });
+    const stats: Stats = {
+      modules: [
+        {
+          id: 1,
+          name: '/repo/packages/ui/src/Button.stories.tsx',
+          reasons: [{ moduleName: './storybook-stories.js' }],
+        },
+        {
+          id: 2,
+          name: '/repo/packages/ui/src/helper.ts',
+          reasons: [{ moduleName: '/repo/packages/ui/src/Button.stories.tsx' }],
+        },
+      ],
+    };
+
+    const manifest = await buildManifest(stats, projectRoot, outOfGraph);
+    const serialized = serializeManifest(manifest);
+
+    // JSON-safe: storyFiles is a plain object, dependencies is an array.
+    expect(serialized.storybookHash).toBe(manifest.storybookHash);
+    expect(serialized.storyFiles).toEqual(Object.fromEntries(manifest.storyFileHashes));
+    expect(serialized.files['./src/Button.stories.tsx'].dependencies).toEqual(['./src/helper.ts']);
+    // structuredClone can hide fields that are not friendly to JSON.parse/JSON>stringify so we test the exact flow instead.
+    // eslint-disable-next-line unicorn/prefer-structured-clone
+    expect(JSON.parse(JSON.stringify(serialized))).toEqual(serialized);
+  });
+
+  it('emits storybookFileHashes as a JSON-safe object', async () => {
+    const story = '/repo/packages/ui/src/Button.stories.tsx';
+    const preview = '/repo/packages/ui/.storybook/preview.ts';
+    const { outOfGraph } = createFixture({ fileHashes: { [story]: 'S', [preview]: 'P' } });
+    const stats: Stats = {
+      modules: [
+        { id: 1, name: story, reasons: [{ moduleName: './storybook-stories.js' }] },
+        { id: 2, name: preview, reasons: [{ moduleName: './storybook-config-entry.js' }] },
+      ],
+    };
+
+    const manifest = await buildManifest(stats, projectRoot, outOfGraph);
+    const serialized = serializeManifest(manifest);
+
+    expect(serialized.storybookFileHashes.preview).toBe(
+      manifest.storybookFileHashes.get('preview')
+    );
+    // eslint-disable-next-line unicorn/prefer-structured-clone
+    expect(JSON.parse(JSON.stringify(serialized))).toEqual(serialized);
+  });
+
+  it('prunes dependency references to synthetic nodes after deriving hashes and attribution', async () => {
+    const story = '/repo/packages/ui/src/Button.stories.tsx';
+    const synthetic = 'virtual:bridge';
+    const helper = '/repo/packages/ui/src/helper.ts';
+    const { disk, outOfGraph } = createFixture({
+      isAbsent: syntheticAbsent,
+      fileHashes: { [story]: 'S', [helper]: 'H1' },
+    });
+    const stats: Stats = {
+      modules: [
+        { id: 1, name: story, reasons: [{ moduleName: './storybook-stories.js' }] },
+        { id: 2, name: synthetic, reasons: [{ moduleName: story }] },
+        { id: 3, name: helper, reasons: [{ moduleName: synthetic }] },
+      ],
+    };
+
+    const before = serializeManifest(await buildManifest(stats, projectRoot, outOfGraph));
+
+    disk.fileHashes = { [story]: 'S', [helper]: 'H2' };
+    const after = serializeManifest(await buildManifest(stats, projectRoot, outOfGraph));
+
+    for (const file of Object.values(before.files)) {
+      expect(file.dependencies.every((dependency) => dependency in before.files)).toBe(true);
+    }
+
+    // The helper remains part of the complete pre-prune graph used for derived values even though
+    // its synthetic bridge is absent from the serialized graph.
+    expect(after.storyFiles['./src/Button.stories.tsx']).not.toBe(
+      before.storyFiles['./src/Button.stories.tsx']
+    );
+    expect(after.storybookFileHashes).toEqual(before.storybookFileHashes);
+    expect(after.storybookHash).not.toBe(before.storybookHash);
+    expect(before.attribution).toEqual({
+      storyReachable: ['./src/Button.stories.tsx', './src/helper.ts'],
+      previewSubtree: [],
+      storybookGlobals: [],
+    });
+    expect(after.attribution).toEqual(before.attribution);
+  });
+
+  it('counts a synthetic node itself towards the roll-up of the story that reaches it', async () => {
+    const story = '/repo/packages/ui/src/Button.stories.tsx';
+    const synthetic = 'virtual:bridge';
+    const helper = '/repo/packages/ui/src/helper.ts';
+    const { outOfGraph } = createFixture({
+      isAbsent: syntheticAbsent,
+      fileHashes: { [story]: 'S', [helper]: 'H' },
+    });
+
+    // The same two real files with the same bytes, once with a synthetic leaf hanging off the story
+    // and once without. The leaf has no file, so pruning erases it and both serialized graphs come
+    // out identical — but it was a member of the story's subtree when the roll-up ran, so it moved
+    // the hash. Pruning any earlier would collapse these two manifests onto the same story hash.
+    const withLeaf: Stats = {
+      modules: [
+        { id: 1, name: story, reasons: [{ moduleName: './storybook-stories.js' }] },
+        { id: 2, name: helper, reasons: [{ moduleName: story }] },
+        { id: 3, name: synthetic, reasons: [{ moduleName: story }] },
+      ],
+    };
+    const withoutLeaf: Stats = {
+      modules: [
+        { id: 1, name: story, reasons: [{ moduleName: './storybook-stories.js' }] },
+        { id: 2, name: helper, reasons: [{ moduleName: story }] },
+      ],
+    };
+
+    const bridged = serializeManifest(await buildManifest(withLeaf, projectRoot, outOfGraph));
+    const plain = serializeManifest(await buildManifest(withoutLeaf, projectRoot, outOfGraph));
+
+    // Identical after pruning, so the story hash is the only place the leaf can show up.
+    expect(bridged.files).toEqual(plain.files);
+    const key = './src/Button.stories.tsx';
+    expect(bridged.storyFiles[key]).not.toBe(plain.storyFiles[key]);
+  });
+});
+
+describe('writeManifest', () => {
+  const outputDirectory = '/repo/packages/ui/chromatic';
+  const manifestPath = path.join(outputDirectory, 'turbosnap-manifest.json');
+
+  it('writes the serialized manifest as JSON to turbosnap-manifest.json in the output directory', async () => {
+    const { disk, outOfGraph } = createFixture();
+    const manifest = await manifestWithPreview('preview.ts');
+
+    writeManifest(manifest, outputDirectory, outOfGraph.projectFiles);
+
+    expect(disk.writtenFiles?.[manifestPath]).toBe(JSON.stringify(serializeManifest(manifest)));
+  });
+
+  it('writes a payload that round-trips through JSON.parse', async () => {
+    const { disk, outOfGraph } = createFixture();
+    // The file is uploaded to S3 and read back for debugging, so it has to be valid JSON with the
+    // Maps and Sets already flattened.
+    writeManifest(
+      await manifestWithPreview('preview.ts'),
+      outputDirectory,
+      outOfGraph.projectFiles
+    );
+
+    const payload = disk.writtenFiles?.[manifestPath] ?? '';
+
+    expect(JSON.parse(payload).storybookFileHashes.preview).toEqual(expect.any(String));
+  });
+});

--- a/node-src/lib/turbosnap/v2/manifest.test.ts
+++ b/node-src/lib/turbosnap/v2/manifest.test.ts
@@ -89,6 +89,31 @@ describe('serializeManifest', () => {
     ]);
   });
 
+  it('sorts the file keys so two builds of the same Storybook serialize identically', async () => {
+    const story = '/repo/packages/ui/src/Button.stories.tsx';
+    const zulu = '/repo/packages/ui/src/zulu.ts';
+    const alpha = '/repo/packages/ui/src/alpha.ts';
+    const { outOfGraph } = createFixture({
+      isAbsent: syntheticAbsent,
+      fileHashes: { [story]: 'S', [zulu]: 'Z', [alpha]: 'A' },
+    });
+    const stats: Stats = {
+      modules: [
+        { id: 1, name: story, reasons: [{ moduleName: './storybook-stories.js' }] },
+        { id: 2, name: zulu, reasons: [{ moduleName: story }] },
+        { id: 3, name: alpha, reasons: [{ moduleName: story }] },
+      ],
+    };
+
+    const serialized = serializeManifest(await buildManifest(stats, projectRoot, outOfGraph));
+
+    expect(Object.keys(serialized.files)).toEqual([
+      './src/alpha.ts',
+      './src/Button.stories.tsx',
+      './src/zulu.ts',
+    ]);
+  });
+
   it('keeps synthetic transit nodes in memory while omitting them from serialization', async () => {
     const story = '/repo/packages/ui/src/Button.stories.tsx';
     const synthetic = 'virtual:bridge';
@@ -236,8 +261,8 @@ describe('writeManifest', () => {
     writeManifest(manifest, outputDirectory, outOfGraph.projectFiles);
 
     expect(disk.writtenFiles?.[manifestPath]).toBe(
-JSON.stringify(serializeManifest(manifest), undefined, 2)
-);
+      JSON.stringify(serializeManifest(manifest), undefined, 2)
+    );
   });
 
   it('writes a payload that round-trips through JSON.parse', async () => {

--- a/node-src/lib/turbosnap/v2/manifest.ts
+++ b/node-src/lib/turbosnap/v2/manifest.ts
@@ -10,12 +10,8 @@ import {
   rollUpFileHashes,
   TurboSnapFile,
 } from './graph';
-import {
-  hashOutOfGraphFiles,
-  OutOfGraphFiles,
-  OutOfGraphInput,
-  rollUpOutOfGraphFiles,
-} from './outOfGraphFiles';
+import { ManifestInput } from './manifestInput';
+import { hashOutOfGraphFiles, OutOfGraphFiles, rollUpOutOfGraphFiles } from './outOfGraphFiles';
 import { normalizeStatsPath } from './paths';
 import { ProjectFiles } from './projectFiles';
 import { readStatsGraph } from './statsGraph';
@@ -81,26 +77,16 @@ interface ManifestFile {
  * {@link readStatsGraph}'s job; everything here works in canonical paths.
  *
  * @param stats The stats file to parse.
- * @param projectRoot The absolute Storybook project root that module paths anchor against.
- * @param outOfGraph Where to find the Storybook inputs that are never bundler inputs; see
- * {@link OutOfGraphInput}.
- * @param statsRoot The absolute directory relative stats paths are named from. Defaults to the
- * project root.
+ * @param input Where the project is and what to read it with; see {@link ManifestInput}.
  *
  * @returns The manifest containing the file hashes, story file hashes, Storybook config file hashes,
  * and Storybook hash.
  */
 export async function buildManifest(
   stats: Stats,
-  projectRoot: string,
-  outOfGraph: OutOfGraphInput,
-  statsRoot = projectRoot
+  input: ManifestInput
 ): Promise<TurboSnapManifest> {
-  const { files, hashes, storyFiles } = await readStatsGraph(stats, {
-    projectRoot,
-    statsRoot,
-    projectFiles: outOfGraph.projectFiles,
-  });
+  const { files, hashes, storyFiles } = await readStatsGraph(stats, input);
 
   const { h64ToString } = await xxHashWasm();
   const storyFileHashes = new Map<FilePath, FileHash>();
@@ -119,7 +105,7 @@ export async function buildManifest(
     files,
     hashes,
     storyReachable,
-    normalizeStatsPath(outOfGraph.configDir, projectRoot),
+    normalizeStatsPath(input.configDir, input.projectRoot),
     h64ToString
   );
 
@@ -127,12 +113,12 @@ export async function buildManifest(
   // upgrade there. Track the version instead; it is a plain string, not a hash.
   storybookFileHashes.set(
     STORYBOOK_VERSION_KEY,
-    resolveStorybookVersion(projectRoot, outOfGraph.projectFiles)
+    resolveStorybookVersion(input.projectRoot, input.projectFiles)
   );
 
   // Storybook's config directory and static assets are never bundler inputs, so nothing above can see
   // them change. They get their own roll-ups; see rollUpOutOfGraphFiles.
-  const outOfGraphFiles = await hashOutOfGraphFiles(outOfGraph, projectRoot);
+  const outOfGraphFiles = await hashOutOfGraphFiles(input);
   for (const [key, hash] of rollUpOutOfGraphFiles(outOfGraphFiles, h64ToString)) {
     storybookFileHashes.set(key, hash);
   }

--- a/node-src/lib/turbosnap/v2/manifest.ts
+++ b/node-src/lib/turbosnap/v2/manifest.ts
@@ -18,7 +18,7 @@ import {
 } from './outOfGraphFiles';
 import { ProjectFiles } from './projectFiles';
 import { readStatsGraph } from './statsGraph';
-import { STORYBOOK_VERSION_KEY } from './storybookFileKeys';
+import { STORYBOOK_VERSION_KEY, StorybookFileKey } from './storybookFileKeys';
 import { collectStorybookFiles, FileAttribution } from './storybookFiles';
 import { resolveStorybookVersion } from './storybookVersion';
 
@@ -37,7 +37,7 @@ export interface TurboSnapManifest {
    * catch-all, the `storybookConfigFiles` and `staticFiles` out-of-graph sweeps, and the Storybook
    * version (the plain version string, not a hash of it).
    */
-  storybookFileHashes: Map<FilePath, FileHash | StorybookVersion>;
+  storybookFileHashes: Map<StorybookFileKey, FileHash | StorybookVersion>;
   /** Rolled-up hash per story file, covering only that story's own transitive subtree. */
   storyFileHashes: Map<FilePath, FileHash>;
   /**
@@ -50,7 +50,10 @@ export interface TurboSnapManifest {
    * `storybookConfigFiles` and `staticFiles` maps.
    */
   outOfGraphFiles: OutOfGraphFiles;
-  /** The list of all files in the Storybook. This is a parsed version of `preview-stats.json` */
+  /**
+   * The unpruned graph parsed from `preview-stats.json`, including synthetic transit nodes used by
+   * roll-ups. Synthetic nodes are omitted only when the manifest is serialized.
+   */
   files: Map<FilePath, TurboSnapFile>;
 }
 
@@ -134,16 +137,13 @@ export async function buildManifest(
     hashEntryIdentities(storyFileHashes) + hashEntryIdentities(storybookFileHashes)
   );
 
-  // Done after hashing so the graph used above is complete.
-  pruneSyntheticFiles(files, hashes);
-
   return {
-    files,
-    storyFileHashes,
-    storybookFileHashes,
     storybookHash,
+    storybookFileHashes,
+    storyFileHashes,
     attribution,
     outOfGraphFiles,
+    files,
   };
 }
 
@@ -164,9 +164,12 @@ export function serializeManifest(manifest: TurboSnapManifest): ManifestFile {
 
   const files: ManifestFile['files'] = {};
   for (const [filePath, file] of manifest.files) {
+    if (file.hash === '') continue;
     files[filePath] = {
       hash: file.hash,
-      dependencies: [...file.dependencies].sort(),
+      dependencies: [...file.dependencies]
+        .filter((dependency) => manifest.files.get(dependency)?.hash)
+        .sort(),
     };
   }
 
@@ -205,29 +208,4 @@ export function writeManifest(
     path.join(outputDirectory, 'turbosnap-manifest.json'),
     JSON.stringify(serializeManifest(manifest))
   );
-}
-
-/**
- * Removes synthetic nodes that have no file on disk (require-context globs, externals) from the
- * manifest, including references to those removed nodes. This runs only after every derived hash
- * and attribution set has been computed from the complete graph, so pruning keeps those values
- * unchanged while limiting the serialized graph to real files.
- *
- * @param files The map of files to their hashes and dependencies, mutated in place.
- * @param hashes The content hashes keyed by canonical file path; a missing entry means no file.
- */
-function pruneSyntheticFiles(files: Map<FilePath, TurboSnapFile>, hashes: Map<FilePath, FileHash>) {
-  for (const file of files.values()) {
-    for (const dependency of file.dependencies) {
-      if (!hashes.has(dependency)) {
-        file.dependencies.delete(dependency);
-      }
-    }
-  }
-
-  for (const filePath of files.keys()) {
-    if (!hashes.has(filePath)) {
-      files.delete(filePath);
-    }
-  }
 }

--- a/node-src/lib/turbosnap/v2/manifest.ts
+++ b/node-src/lib/turbosnap/v2/manifest.ts
@@ -16,6 +16,7 @@ import {
   OutOfGraphInput,
   rollUpOutOfGraphFiles,
 } from './outOfGraphFiles';
+import { normalizeStatsPath } from './paths';
 import { ProjectFiles } from './projectFiles';
 import { readStatsGraph } from './statsGraph';
 import { STORYBOOK_VERSION_KEY, StorybookFileKey } from './storybookFileKeys';
@@ -112,7 +113,7 @@ export async function buildManifest(
     files,
     hashes,
     storyFiles,
-    outOfGraph.configDir,
+    normalizeStatsPath(outOfGraph.configDir, projectRoot),
     h64ToString
   );
 

--- a/node-src/lib/turbosnap/v2/manifest.ts
+++ b/node-src/lib/turbosnap/v2/manifest.ts
@@ -205,6 +205,6 @@ export function writeManifest(
 ) {
   projectFiles.writeFile(
     path.join(outputDirectory, 'turbosnap-manifest.json'),
-    JSON.stringify(serializeManifest(manifest))
+    JSON.stringify(serializeManifest(manifest), undefined, 2)
   );
 }

--- a/node-src/lib/turbosnap/v2/manifest.ts
+++ b/node-src/lib/turbosnap/v2/manifest.ts
@@ -1,0 +1,233 @@
+import path from 'path';
+import xxHashWasm from 'xxhash-wasm';
+
+import { Stats } from '../../../types';
+import {
+  collectTransitiveDependencies,
+  FileHash,
+  FilePath,
+  hashEntryIdentities,
+  rollUpFileHashes,
+  TurboSnapFile,
+} from './graph';
+import {
+  hashOutOfGraphFiles,
+  OutOfGraphFiles,
+  OutOfGraphInput,
+  rollUpOutOfGraphFiles,
+} from './outOfGraphFiles';
+import { ProjectFiles } from './projectFiles';
+import { readStatsGraph } from './statsGraph';
+import { STORYBOOK_VERSION_KEY } from './storybookFileKeys';
+import { collectStorybookFiles, FileAttribution } from './storybookFiles';
+import { resolveStorybookVersion } from './storybookVersion';
+
+type StorybookVersion = string;
+
+/**
+ * The TurboSnap manifest holds the hash of every file in the Storybook project and the dependencies
+ * of each file, along with the derived per-story, Storybook-config and whole-Storybook hashes. This
+ * is uploaded as a static file to S3 for debugging purposes.
+ */
+export interface TurboSnapManifest {
+  /* The rolled-up hash of the entire Storybook, covering every file located in the manifest. */
+  storybookHash: string;
+  /**
+   * A rolled-up hash for each Storybook-wide category: the `preview` subtree, the `storybookGlobals`
+   * catch-all, the `storybookConfigFiles` and `staticFiles` out-of-graph sweeps, and the Storybook
+   * version (the plain version string, not a hash of it).
+   */
+  storybookFileHashes: Map<FilePath, FileHash | StorybookVersion>;
+  /** Rolled-up hash per story file, covering only that story's own transitive subtree. */
+  storyFileHashes: Map<FilePath, FileHash>;
+  /**
+   * Which hashing home each real file landed in (story subtree, preview subtree, or the globals
+   * catch-all). A diagnostic record for the S3 manifest; it feeds no hash.
+   */
+  attribution: FileAttribution;
+  /**
+   * The per-file detail behind the out-of-graph roll-ups, serialized as the top-level
+   * `storybookConfigFiles` and `staticFiles` maps.
+   */
+  outOfGraphFiles: OutOfGraphFiles;
+  /** The list of all files in the Storybook. This is a parsed version of `preview-stats.json` */
+  files: Map<FilePath, TurboSnapFile>;
+}
+
+/**
+ * The manifest shape written to disk: the whole-Storybook hash, the per-story hashes, the
+ * Storybook-config hashes, and the hash and dependencies of every source file.
+ *
+ * Note: This is a separate type than TurboSnapManifest because we're writing to a file and need to
+ * use JSON-safe types like arrays and objects instead of sets and maps.
+ */
+interface ManifestFile {
+  storybookHash: string;
+  storybookFileHashes: Record<FilePath, FileHash | StorybookVersion>;
+  storybookConfigFiles: Record<FilePath, FileHash>;
+  staticFiles: Record<FilePath, FileHash>;
+  storyFiles: Record<FilePath, FileHash>;
+  attribution: Record<keyof FileAttribution, FilePath[]>;
+  files: Record<FilePath, { hash: FileHash; dependencies: FilePath[] }>;
+}
+
+/**
+ * Rolls the graph a stats file describes up into a TurboSnap manifest: the per-story hashes, the
+ * Storybook-wide hashes and the whole-Storybook gate. Reading the stats file is
+ * {@link readStatsGraph}'s job; everything here works in canonical paths.
+ *
+ * @param stats The stats file to parse.
+ * @param projectRoot The absolute Storybook project root that module paths anchor against.
+ * @param outOfGraph Where to find the Storybook inputs that are never bundler inputs; see
+ * {@link OutOfGraphInput}.
+ * @param statsRoot The absolute directory relative stats paths are named from. Defaults to the
+ * project root.
+ *
+ * @returns The manifest containing the file hashes, story file hashes, Storybook config file hashes,
+ * and Storybook hash.
+ */
+export async function buildManifest(
+  stats: Stats,
+  projectRoot: string,
+  outOfGraph: OutOfGraphInput,
+  statsRoot = projectRoot
+): Promise<TurboSnapManifest> {
+  const { files, hashes, storyFiles } = await readStatsGraph(stats, {
+    projectRoot,
+    statsRoot,
+    projectFiles: outOfGraph.projectFiles,
+  });
+
+  const { h64ToString } = await xxHashWasm();
+  const storyFileHashes = new Map<FilePath, FileHash>();
+  for (const storyFile of storyFiles) {
+    const subtree = collectTransitiveDependencies(files, storyFile);
+    storyFileHashes.set(storyFile, rollUpFileHashes(hashes, subtree, h64ToString));
+  }
+
+  const { storybookFileHashes, attribution } = collectStorybookFiles(
+    files,
+    hashes,
+    storyFiles,
+    outOfGraph.configDir,
+    h64ToString
+  );
+
+  // The preview core runtime may not exist in the module graph, so no file hash can see a Storybook
+  // upgrade there. Track the version instead; it is a plain string, not a hash.
+  storybookFileHashes.set(
+    STORYBOOK_VERSION_KEY,
+    resolveStorybookVersion(projectRoot, outOfGraph.projectFiles)
+  );
+
+  // Storybook's config directory and static assets are never bundler inputs, so nothing above can see
+  // them change. They get their own roll-ups; see rollUpOutOfGraphFiles.
+  const outOfGraphFiles = await hashOutOfGraphFiles(outOfGraph, projectRoot);
+  for (const [key, hash] of rollUpOutOfGraphFiles(outOfGraphFiles, h64ToString)) {
+    storybookFileHashes.set(key, hash);
+  }
+
+  // The backend's top-level "did Storybook change at all?" gate: the key and hash of every story
+  // file plus every `storybookFileHashes` entry, so additions, removals and renames are all visible
+  // before the backend drills into the maps.
+  const storybookHash = h64ToString(
+    hashEntryIdentities(storyFileHashes) + hashEntryIdentities(storybookFileHashes)
+  );
+
+  // Done after hashing so the graph used above is complete.
+  pruneSyntheticFiles(files, hashes);
+
+  return {
+    files,
+    storyFileHashes,
+    storybookFileHashes,
+    storybookHash,
+    attribution,
+    outOfGraphFiles,
+  };
+}
+
+/**
+ * Converts the in-memory manifest (which uses Maps and Sets) into the JSON-safe shape written to
+ * disk. Shared by writeManifest and the `turbosnap-manifest` CLI command so both emit an identical
+ * structure.
+ *
+ * @param manifest The manifest to serialize.
+ *
+ * @returns The JSON-safe manifest object.
+ */
+export function serializeManifest(manifest: TurboSnapManifest): ManifestFile {
+  const storyFiles: ManifestFile['storyFiles'] = Object.fromEntries(manifest.storyFileHashes);
+  const storybookFileHashes: ManifestFile['storybookFileHashes'] = Object.fromEntries(
+    manifest.storybookFileHashes
+  );
+
+  const files: ManifestFile['files'] = {};
+  for (const [filePath, file] of manifest.files) {
+    files[filePath] = {
+      hash: file.hash,
+      dependencies: [...file.dependencies],
+    };
+  }
+
+  // Sorted so a manifest diff between two runs shows only real membership changes.
+  const attribution = {
+    storybookGlobals: [...manifest.attribution.storybookGlobals].sort(),
+    previewSubtree: [...manifest.attribution.previewSubtree].sort(),
+    storyReachable: [...manifest.attribution.storyReachable].sort(),
+  };
+
+  return {
+    storybookHash: manifest.storybookHash,
+    storybookFileHashes,
+    storybookConfigFiles: Object.fromEntries(manifest.outOfGraphFiles.storybookConfigFiles),
+    staticFiles: Object.fromEntries(manifest.outOfGraphFiles.staticFiles),
+    storyFiles,
+    attribution,
+    files,
+  };
+}
+
+/**
+ * Writes the entire manifest to a file in the output directory. This is uploaded to S3 for
+ * debugging.
+ *
+ * @param manifest The manifest to write.
+ * @param outputDirectory The directory to write the manifest file to.
+ * @param projectFiles How to write the disk.
+ */
+export function writeManifest(
+  manifest: TurboSnapManifest,
+  outputDirectory: string,
+  projectFiles: ProjectFiles
+) {
+  projectFiles.writeFile(
+    path.join(outputDirectory, 'turbosnap-manifest.json'),
+    JSON.stringify(serializeManifest(manifest))
+  );
+}
+
+/**
+ * Removes synthetic nodes that have no file on disk (require-context globs, externals) from the
+ * manifest, including references to those removed nodes. This runs only after every derived hash
+ * and attribution set has been computed from the complete graph, so pruning keeps those values
+ * unchanged while limiting the serialized graph to real files.
+ *
+ * @param files The map of files to their hashes and dependencies, mutated in place.
+ * @param hashes The content hashes keyed by canonical file path; a missing entry means no file.
+ */
+function pruneSyntheticFiles(files: Map<FilePath, TurboSnapFile>, hashes: Map<FilePath, FileHash>) {
+  for (const file of files.values()) {
+    for (const dependency of file.dependencies) {
+      if (!hashes.has(dependency)) {
+        file.dependencies.delete(dependency);
+      }
+    }
+  }
+
+  for (const filePath of files.keys()) {
+    if (!hashes.has(filePath)) {
+      files.delete(filePath);
+    }
+  }
+}

--- a/node-src/lib/turbosnap/v2/manifest.ts
+++ b/node-src/lib/turbosnap/v2/manifest.ts
@@ -157,37 +157,48 @@ export async function buildManifest(
  * @returns The JSON-safe manifest object.
  */
 export function serializeManifest(manifest: TurboSnapManifest): ManifestFile {
-  const storyFiles: ManifestFile['storyFiles'] = Object.fromEntries(manifest.storyFileHashes);
-  const storybookFileHashes: ManifestFile['storybookFileHashes'] = Object.fromEntries(
-    manifest.storybookFileHashes
-  );
-
-  const files: ManifestFile['files'] = {};
-  for (const [filePath, file] of manifest.files) {
-    if (file.hash === '') continue;
-    files[filePath] = {
-      hash: file.hash,
-      dependencies: [...file.dependencies]
-        .filter((dependency) => manifest.files.get(dependency)?.hash)
-        .sort(),
-    };
-  }
-
-  // Sorted so a manifest diff between two runs shows only real membership changes. Mapped over the
-  // entries rather than named by hand, so a new FileAttribution home can't be silently dropped here.
-  const attribution = Object.fromEntries(
-    Object.entries(manifest.attribution).map(([key, files]) => [key, [...files].sort()])
-  ) as ManifestFile['attribution'];
-
   return {
     storybookHash: manifest.storybookHash,
-    storybookFileHashes,
-    storybookConfigFiles: Object.fromEntries(manifest.outOfGraphFiles.storybookConfigFiles),
-    staticFiles: Object.fromEntries(manifest.outOfGraphFiles.staticFiles),
-    storyFiles,
-    attribution,
-    files,
+    storybookFileHashes: sortByKey(Object.fromEntries(manifest.storybookFileHashes)),
+    storybookConfigFiles: sortByKey(
+      Object.fromEntries(manifest.outOfGraphFiles.storybookConfigFiles)
+    ),
+    staticFiles: sortByKey(Object.fromEntries(manifest.outOfGraphFiles.staticFiles)),
+    storyFiles: sortByKey(Object.fromEntries(manifest.storyFileHashes)),
+    attribution: sortByKey(
+      Object.fromEntries(
+        Object.entries(manifest.attribution).map(([key, filePaths]) => [
+          key,
+          [...filePaths].sort(comparePaths),
+        ])
+      )
+    ) as ManifestFile['attribution'],
+    files: sortByKey(serializeFiles(manifest.files)),
   };
+}
+
+function serializeFiles(files: Map<FilePath, TurboSnapFile>): ManifestFile['files'] {
+  const serialized: ManifestFile['files'] = {};
+  for (const [filePath, file] of files) {
+    if (file.hash === '') {
+      continue;
+    }
+    serialized[filePath] = {
+      hash: file.hash,
+      dependencies: [...file.dependencies]
+        .filter((dependency) => files.get(dependency)?.hash)
+        .sort(comparePaths),
+    };
+  }
+  return serialized;
+}
+
+function sortByKey<Value>(record: Record<string, Value>): Record<string, Value> {
+  return Object.fromEntries(Object.entries(record).sort(([a], [b]) => comparePaths(a, b)));
+}
+
+function comparePaths(a: FilePath, b: FilePath): number {
+  return a.localeCompare(b);
 }
 
 /**

--- a/node-src/lib/turbosnap/v2/manifest.ts
+++ b/node-src/lib/turbosnap/v2/manifest.ts
@@ -173,12 +173,11 @@ export function serializeManifest(manifest: TurboSnapManifest): ManifestFile {
     };
   }
 
-  // Sorted so a manifest diff between two runs shows only real membership changes.
-  const attribution = {
-    storybookGlobals: [...manifest.attribution.storybookGlobals].sort(),
-    previewSubtree: [...manifest.attribution.previewSubtree].sort(),
-    storyReachable: [...manifest.attribution.storyReachable].sort(),
-  };
+  // Sorted so a manifest diff between two runs shows only real membership changes. Mapped over the
+  // entries rather than named by hand, so a new FileAttribution home can't be silently dropped here.
+  const attribution = Object.fromEntries(
+    Object.entries(manifest.attribution).map(([key, files]) => [key, [...files].sort()])
+  ) as ManifestFile['attribution'];
 
   return {
     storybookHash: manifest.storybookHash,

--- a/node-src/lib/turbosnap/v2/manifest.ts
+++ b/node-src/lib/turbosnap/v2/manifest.ts
@@ -217,6 +217,6 @@ export function writeManifest(
 ) {
   projectFiles.writeFile(
     path.join(outputDirectory, 'turbosnap-manifest.json'),
-    JSON.stringify(serializeManifest(manifest), undefined, 2)
+    JSON.stringify(serializeManifest(manifest))
   );
 }

--- a/node-src/lib/turbosnap/v2/manifest.ts
+++ b/node-src/lib/turbosnap/v2/manifest.ts
@@ -104,15 +104,21 @@ export async function buildManifest(
 
   const { h64ToString } = await xxHashWasm();
   const storyFileHashes = new Map<FilePath, FileHash>();
+  const storyReachable = new Set<FilePath>();
+
   for (const storyFile of storyFiles) {
     const subtree = collectTransitiveDependencies(files, storyFile);
     storyFileHashes.set(storyFile, rollUpFileHashes(hashes, subtree, h64ToString));
+
+    for (const filePath of subtree) {
+      storyReachable.add(filePath);
+    }
   }
 
   const { storybookFileHashes, attribution } = collectStorybookFiles(
     files,
     hashes,
-    storyFiles,
+    storyReachable,
     normalizeStatsPath(outOfGraph.configDir, projectRoot),
     h64ToString
   );

--- a/node-src/lib/turbosnap/v2/manifest.ts
+++ b/node-src/lib/turbosnap/v2/manifest.ts
@@ -166,7 +166,7 @@ export function serializeManifest(manifest: TurboSnapManifest): ManifestFile {
   for (const [filePath, file] of manifest.files) {
     files[filePath] = {
       hash: file.hash,
-      dependencies: [...file.dependencies],
+      dependencies: [...file.dependencies].sort(),
     };
   }
 

--- a/node-src/lib/turbosnap/v2/manifestInput.ts
+++ b/node-src/lib/turbosnap/v2/manifestInput.ts
@@ -1,0 +1,25 @@
+import { AbsolutePath } from '../../../types';
+import { ProjectFiles } from './projectFiles';
+
+/**
+ * Everything the manifest pipeline needs from outside itself: where the project is, where the stats
+ * file's paths are named from, where the out-of-graph inputs live, and what to read the disk with.
+ *
+ * One type rather than one per stage, because every stage of building the manifest works against the
+ * same project. Each stage narrows it to the fields it actually uses with a `Pick`.
+ */
+export interface ManifestInput {
+  /** The absolute Storybook project root that canonical manifest keys are relative to. */
+  projectRoot: AbsolutePath;
+  /**
+   * The absolute directory relative stats paths are named from. Defaults to the project root, which
+   * is where a builder usually names them from.
+   */
+  statsRoot?: AbsolutePath;
+  /** How to read the disk; required, so no caller can silently get the real one. */
+  projectFiles: ProjectFiles;
+  /** The absolute Storybook config directory, as it arrives on `ctx.storybook`. */
+  configDir: AbsolutePath;
+  /** The absolute configured static directories. Empty when unset. */
+  staticDirs: AbsolutePath[];
+}

--- a/node-src/lib/turbosnap/v2/outOfGraphFiles.test.ts
+++ b/node-src/lib/turbosnap/v2/outOfGraphFiles.test.ts
@@ -13,6 +13,7 @@ const h64ToString = (value: string) => `h(${value})`;
 // mutates its disk between two sweeps reuses the same input.
 function makeInput(disk: InMemoryDisk, overrides?: Partial<OutOfGraphInput>): OutOfGraphInput {
   return {
+    projectRoot,
     configDir: `${projectRoot}/.storybook`,
     staticDirs: [`${projectRoot}/.storybook/static`],
     projectFiles: inMemoryProjectFiles(disk),
@@ -20,8 +21,8 @@ function makeInput(disk: InMemoryDisk, overrides?: Partial<OutOfGraphInput>): Ou
   };
 }
 
-async function rollUp(input: OutOfGraphInput, theProjectRoot = projectRoot) {
-  return rollUpOutOfGraphFiles(await hashOutOfGraphFiles(input, theProjectRoot), h64ToString);
+async function rollUp(input: OutOfGraphInput) {
+  return rollUpOutOfGraphFiles(await hashOutOfGraphFiles(input), h64ToString);
 }
 
 describe('hashOutOfGraphFiles', () => {
@@ -33,7 +34,7 @@ describe('hashOutOfGraphFiles', () => {
       },
     };
 
-    const { storybookConfigFiles } = await hashOutOfGraphFiles(makeInput(disk), projectRoot);
+    const { storybookConfigFiles } = await hashOutOfGraphFiles(makeInput(disk));
 
     expect([...storybookConfigFiles.keys()]).toEqual([
       './.storybook/main.ts',
@@ -47,7 +48,7 @@ describe('hashOutOfGraphFiles', () => {
       directories: { '/repo/packages/ui/.storybook': ['main.ts', 'preview.ts'] },
     };
 
-    const { storybookConfigFiles } = await hashOutOfGraphFiles(makeInput(disk), projectRoot);
+    const { storybookConfigFiles } = await hashOutOfGraphFiles(makeInput(disk));
 
     // The graph-rolled `.storybook/preview.ts` entry covers its *imports*; this covers its bytes,
     // which is what closes the empty-preview.ts case where the builder elides the module entirely.
@@ -62,10 +63,7 @@ describe('hashOutOfGraphFiles', () => {
       },
     };
 
-    const { storybookConfigFiles, staticFiles } = await hashOutOfGraphFiles(
-      makeInput(disk),
-      projectRoot
-    );
+    const { storybookConfigFiles, staticFiles } = await hashOutOfGraphFiles(makeInput(disk));
 
     // Static wins over the config dir, mirroring v1 testing isStaticFile before isStorybookFile.
     expect([...storybookConfigFiles.keys()]).toEqual(['./.storybook/main.ts']);
@@ -77,10 +75,7 @@ describe('hashOutOfGraphFiles', () => {
       directories: { '/repo/packages/ui/.storybook': ['main.ts'] },
     };
 
-    const { staticFiles } = await hashOutOfGraphFiles(
-      makeInput(disk, { staticDirs: [] }),
-      projectRoot
-    );
+    const { staticFiles } = await hashOutOfGraphFiles(makeInput(disk, { staticDirs: [] }));
 
     expect(staticFiles.size).toBe(0);
   });
@@ -95,8 +90,7 @@ describe('hashOutOfGraphFiles', () => {
     };
 
     const { staticFiles } = await hashOutOfGraphFiles(
-      makeInput(disk, { staticDirs: [`${projectRoot}/public`, `${projectRoot}/assets`] }),
-      projectRoot
+      makeInput(disk, { staticDirs: [`${projectRoot}/public`, `${projectRoot}/assets`] })
     );
 
     expect([...staticFiles.keys()]).toEqual(['./assets/font.woff2', './public/logo.svg']);
@@ -245,10 +239,10 @@ describe('rollUpOutOfGraphFiles', () => {
     };
     const after = await rollUp(
       makeInput(disk, {
+        projectRoot: movedRoot,
         configDir: `${movedRoot}/.storybook`,
         staticDirs: [`${movedRoot}/.storybook/static`],
-      }),
-      movedRoot
+      })
     );
 
     expect(after.get('storybookConfigFiles')).toBe(before.get('storybookConfigFiles'));

--- a/node-src/lib/turbosnap/v2/outOfGraphFiles.test.ts
+++ b/node-src/lib/turbosnap/v2/outOfGraphFiles.test.ts
@@ -1,0 +1,250 @@
+import { describe, expect, it } from 'vitest';
+
+import { hashOutOfGraphFiles, OutOfGraphInput, rollUpOutOfGraphFiles } from './outOfGraphFiles';
+import { InMemoryDisk, inMemoryProjectFiles } from './projectFiles.fake';
+
+const projectRoot = '/repo/packages/ui';
+const h64ToString = (value: string) => `h(${value})`;
+
+// The sweep's input over a disk supplied per test: the tree it walks and the content hash of each
+// file. What the disk *means* — symlinks, cycles, absent and unreadable directories — belongs to the
+// adapter and is pinned against real temporary directories in projectFiles.test.ts, so these tests
+// describe only which files each section claims. The adapter reads the disk live, so a test that
+// mutates its disk between two sweeps reuses the same input.
+function makeInput(disk: InMemoryDisk, overrides?: Partial<OutOfGraphInput>): OutOfGraphInput {
+  return {
+    configDir: '.storybook',
+    staticDirs: ['.storybook/static'],
+    projectFiles: inMemoryProjectFiles(disk),
+    ...overrides,
+  };
+}
+
+async function rollUp(input: OutOfGraphInput, theProjectRoot = projectRoot) {
+  return rollUpOutOfGraphFiles(await hashOutOfGraphFiles(input, theProjectRoot), h64ToString);
+}
+
+describe('hashOutOfGraphFiles', () => {
+  it('hashes every config file recursively, keyed by canonical git-root-relative path', async () => {
+    const disk: InMemoryDisk = {
+      directories: {
+        '/repo/packages/ui/.storybook': ['main.ts', 'preview.ts', 'nested'],
+        '/repo/packages/ui/.storybook/nested': ['helper.ts'],
+      },
+    };
+
+    const { storybookConfigFiles } = await hashOutOfGraphFiles(makeInput(disk), projectRoot);
+
+    expect([...storybookConfigFiles.keys()]).toEqual([
+      './.storybook/main.ts',
+      './.storybook/nested/helper.ts',
+      './.storybook/preview.ts',
+    ]);
+  });
+
+  it('hashes preview.* alongside the rest of the config dir, so its bytes are covered too', async () => {
+    const disk: InMemoryDisk = {
+      directories: { '/repo/packages/ui/.storybook': ['main.ts', 'preview.ts'] },
+    };
+
+    const { storybookConfigFiles } = await hashOutOfGraphFiles(makeInput(disk), projectRoot);
+
+    // The graph-rolled `.storybook/preview.ts` entry covers its *imports*; this covers its bytes,
+    // which is what closes the empty-preview.ts case where the builder elides the module entirely.
+    expect(storybookConfigFiles.has('./.storybook/preview.ts')).toBe(true);
+  });
+
+  it('gives static files their own section, excluding them from the config sweep', async () => {
+    const disk: InMemoryDisk = {
+      directories: {
+        '/repo/packages/ui/.storybook': ['main.ts', 'static'],
+        '/repo/packages/ui/.storybook/static': ['mockServiceWorker.js'],
+      },
+    };
+
+    const { storybookConfigFiles, staticFiles } = await hashOutOfGraphFiles(
+      makeInput(disk),
+      projectRoot
+    );
+
+    // Static wins over the config dir, mirroring v1 testing isStaticFile before isStorybookFile.
+    expect([...storybookConfigFiles.keys()]).toEqual(['./.storybook/main.ts']);
+    expect([...staticFiles.keys()]).toEqual(['./.storybook/static/mockServiceWorker.js']);
+  });
+
+  it('returns an empty static section when staticDirs is unset', async () => {
+    const disk: InMemoryDisk = {
+      directories: { '/repo/packages/ui/.storybook': ['main.ts'] },
+    };
+
+    const { staticFiles } = await hashOutOfGraphFiles(
+      makeInput(disk, { staticDirs: [] }),
+      projectRoot
+    );
+
+    expect(staticFiles.size).toBe(0);
+  });
+
+  it('collects static files from every configured static directory', async () => {
+    const disk: InMemoryDisk = {
+      directories: {
+        '/repo/packages/ui/.storybook': ['main.ts'],
+        '/repo/packages/ui/public': ['logo.svg'],
+        '/repo/packages/ui/assets': ['font.woff2'],
+      },
+    };
+
+    const { staticFiles } = await hashOutOfGraphFiles(
+      makeInput(disk, { staticDirs: ['public', 'assets'] }),
+      projectRoot
+    );
+
+    expect([...staticFiles.keys()]).toEqual(['./assets/font.woff2', './public/logo.svg']);
+  });
+});
+
+describe('rollUpOutOfGraphFiles', () => {
+  it('rolls each section into its own synthetic entry', async () => {
+    const disk: InMemoryDisk = {
+      directories: {
+        '/repo/packages/ui/.storybook': ['main.ts', 'static'],
+        '/repo/packages/ui/.storybook/static': ['logo.svg'],
+      },
+    };
+
+    const rollUps = await rollUp(makeInput(disk));
+
+    expect([...rollUps.keys()]).toEqual(['storybookConfigFiles', 'staticFiles']);
+  });
+
+  it('moves the config roll-up when a config file content changes', async () => {
+    const disk: InMemoryDisk = {
+      directories: { '/repo/packages/ui/.storybook': ['main.ts'] },
+      fileHashes: { '/repo/packages/ui/.storybook/main.ts': 'M1' },
+    };
+    const input = makeInput(disk);
+    const before = await rollUp(input);
+
+    disk.fileHashes = { '/repo/packages/ui/.storybook/main.ts': 'M2' };
+    const after = await rollUp(input);
+
+    expect(after.get('storybookConfigFiles')).not.toBe(before.get('storybookConfigFiles'));
+  });
+
+  it('moves the static roll-up when a static file content changes, leaving the config roll-up alone', async () => {
+    const staticFile = '/repo/packages/ui/.storybook/static/logo.svg';
+    const disk: InMemoryDisk = {
+      directories: {
+        '/repo/packages/ui/.storybook': ['main.ts', 'static'],
+        '/repo/packages/ui/.storybook/static': ['logo.svg'],
+      },
+      fileHashes: { '/repo/packages/ui/.storybook/main.ts': 'M', [staticFile]: 'A1' },
+    };
+    const input = makeInput(disk);
+    const before = await rollUp(input);
+
+    disk.fileHashes = { '/repo/packages/ui/.storybook/main.ts': 'M', [staticFile]: 'A2' };
+    const after = await rollUp(input);
+
+    expect(after.get('staticFiles')).not.toBe(before.get('staticFiles'));
+    expect(after.get('storybookConfigFiles')).toBe(before.get('storybookConfigFiles'));
+  });
+
+  it('moves the static roll-up when an asset is renamed without changing its bytes', async () => {
+    const disk: InMemoryDisk = {
+      directories: {
+        '/repo/packages/ui/.storybook': ['main.ts', 'static'],
+        '/repo/packages/ui/.storybook/static': ['logo.svg'],
+      },
+      fileHashes: { '/repo/packages/ui/.storybook/static/logo.svg': 'A' },
+    };
+    const input = makeInput(disk);
+    const before = await rollUp(input);
+
+    // Same bytes at a different URL renders differently, so the multiset of contents isn't enough.
+    disk.directories = {
+      '/repo/packages/ui/.storybook': ['main.ts', 'static'],
+      '/repo/packages/ui/.storybook/static': ['brand.svg'],
+    };
+    disk.fileHashes = { '/repo/packages/ui/.storybook/static/brand.svg': 'A' };
+    const after = await rollUp(input);
+
+    expect(after.get('staticFiles')).not.toBe(before.get('staticFiles'));
+  });
+
+  it('moves the static roll-up when two assets swap contents', async () => {
+    const [a, b] = [
+      '/repo/packages/ui/.storybook/static/a.png',
+      '/repo/packages/ui/.storybook/static/b.png',
+    ];
+    const disk: InMemoryDisk = {
+      directories: {
+        '/repo/packages/ui/.storybook': ['main.ts', 'static'],
+        '/repo/packages/ui/.storybook/static': ['a.png', 'b.png'],
+      },
+      fileHashes: { [a]: 'A', [b]: 'B' },
+    };
+    const input = makeInput(disk);
+    const before = await rollUp(input);
+
+    // The multiset of contents is identical, but each URL now serves the other's bytes.
+    disk.fileHashes = { [a]: 'B', [b]: 'A' };
+    const after = await rollUp(input);
+
+    expect(after.get('staticFiles')).not.toBe(before.get('staticFiles'));
+  });
+
+  it('moves the config roll-up when a config file is renamed without changing its bytes', async () => {
+    const disk: InMemoryDisk = {
+      directories: { '/repo/packages/ui/.storybook': ['preview-head.html'] },
+      fileHashes: { '/repo/packages/ui/.storybook/preview-head.html': 'H' },
+    };
+    const input = makeInput(disk);
+    const before = await rollUp(input);
+
+    // Storybook loads config files by name, so the same bytes under a new name inject elsewhere.
+    disk.directories = { '/repo/packages/ui/.storybook': ['preview-body.html'] };
+    disk.fileHashes = { '/repo/packages/ui/.storybook/preview-body.html': 'H' };
+    const after = await rollUp(input);
+
+    expect(after.get('storybookConfigFiles')).not.toBe(before.get('storybookConfigFiles'));
+  });
+
+  it('omits a section that has no files, matching how the globals catch-all behaves', async () => {
+    const disk: InMemoryDisk = {
+      directories: { '/repo/packages/ui/.storybook': ['main.ts'] },
+    };
+
+    const rollUps = await rollUp(makeInput(disk));
+
+    expect(rollUps.has('staticFiles')).toBe(false);
+  });
+
+  it('keeps both roll-ups stable when the project moves, since path identity is project-relative', async () => {
+    const disk: InMemoryDisk = {
+      directories: {
+        '/repo/packages/ui/.storybook': ['main.ts', 'static'],
+        '/repo/packages/ui/.storybook/static': ['logo.svg'],
+      },
+      fileHashes: {
+        '/repo/packages/ui/.storybook/main.ts': 'M',
+        '/repo/packages/ui/.storybook/static/logo.svg': 'A',
+      },
+    };
+    const input = makeInput(disk);
+    const before = await rollUp(input);
+
+    disk.directories = {
+      '/repo/apps/web/.storybook': ['main.ts', 'static'],
+      '/repo/apps/web/.storybook/static': ['logo.svg'],
+    };
+    disk.fileHashes = {
+      '/repo/apps/web/.storybook/main.ts': 'M',
+      '/repo/apps/web/.storybook/static/logo.svg': 'A',
+    };
+    const after = await rollUp(input, '/repo/apps/web');
+
+    expect(after.get('storybookConfigFiles')).toBe(before.get('storybookConfigFiles'));
+    expect(after.get('staticFiles')).toBe(before.get('staticFiles'));
+  });
+});

--- a/node-src/lib/turbosnap/v2/outOfGraphFiles.test.ts
+++ b/node-src/lib/turbosnap/v2/outOfGraphFiles.test.ts
@@ -13,8 +13,8 @@ const h64ToString = (value: string) => `h(${value})`;
 // mutates its disk between two sweeps reuses the same input.
 function makeInput(disk: InMemoryDisk, overrides?: Partial<OutOfGraphInput>): OutOfGraphInput {
   return {
-    configDir: '.storybook',
-    staticDirs: ['.storybook/static'],
+    configDir: `${projectRoot}/.storybook`,
+    staticDirs: [`${projectRoot}/.storybook/static`],
     projectFiles: inMemoryProjectFiles(disk),
     ...overrides,
   };
@@ -95,7 +95,7 @@ describe('hashOutOfGraphFiles', () => {
     };
 
     const { staticFiles } = await hashOutOfGraphFiles(
-      makeInput(disk, { staticDirs: ['public', 'assets'] }),
+      makeInput(disk, { staticDirs: [`${projectRoot}/public`, `${projectRoot}/assets`] }),
       projectRoot
     );
 
@@ -231,9 +231,10 @@ describe('rollUpOutOfGraphFiles', () => {
         '/repo/packages/ui/.storybook/static/logo.svg': 'A',
       },
     };
-    const input = makeInput(disk);
-    const before = await rollUp(input);
+    const before = await rollUp(makeInput(disk));
 
+    // The project moved, so its absolute directories moved with it.
+    const movedRoot = '/repo/apps/web';
     disk.directories = {
       '/repo/apps/web/.storybook': ['main.ts', 'static'],
       '/repo/apps/web/.storybook/static': ['logo.svg'],
@@ -242,7 +243,13 @@ describe('rollUpOutOfGraphFiles', () => {
       '/repo/apps/web/.storybook/main.ts': 'M',
       '/repo/apps/web/.storybook/static/logo.svg': 'A',
     };
-    const after = await rollUp(input, '/repo/apps/web');
+    const after = await rollUp(
+      makeInput(disk, {
+        configDir: `${movedRoot}/.storybook`,
+        staticDirs: [`${movedRoot}/.storybook/static`],
+      }),
+      movedRoot
+    );
 
     expect(after.get('storybookConfigFiles')).toBe(before.get('storybookConfigFiles'));
     expect(after.get('staticFiles')).toBe(before.get('staticFiles'));

--- a/node-src/lib/turbosnap/v2/outOfGraphFiles.ts
+++ b/node-src/lib/turbosnap/v2/outOfGraphFiles.ts
@@ -1,21 +1,14 @@
-import { AbsolutePath } from '../../../types';
 import { FileHash, FilePath, rollUpEntryHashes } from './graph';
+import { ManifestInput } from './manifestInput';
 import { normalizeStatsPath } from './paths';
 import { ProjectFiles } from './projectFiles';
 import { STATIC_FILES_KEY, STORYBOOK_CONFIG_KEY, StorybookFileKey } from './storybookFileKeys';
 
-/**
- * Where to look for the out-of-graph inputs, and what to read them with. The directories are
- * absolute, as they arrive on `ctx.storybook`.
- */
-export interface OutOfGraphInput {
-  /** The absolute Storybook config directory. */
-  configDir: AbsolutePath;
-  /** The absolute configured static directories. Empty when unset. */
-  staticDirs: AbsolutePath[];
-  /** How to read the disk; required, so no caller can silently get the real one. */
-  projectFiles: ProjectFiles;
-}
+/** The part of {@link ManifestInput} the out-of-graph sweep reads: where to look, and what with. */
+export type OutOfGraphInput = Pick<
+  ManifestInput,
+  'projectRoot' | 'configDir' | 'staticDirs' | 'projectFiles'
+>;
 
 /**
  * The content hash of every out-of-graph file, keyed by canonical manifest path. These are the S3-only
@@ -47,15 +40,11 @@ export interface OutOfGraphFiles {
  * failure mode this mechanism exists to remove.
  *
  * @param input Where to look and what to read it with; see {@link OutOfGraphInput}.
- * @param projectRoot The absolute Storybook project root used to locate files and name them.
  *
  * @returns The content hash of every config file and every static file, keyed by canonical manifest
  * path.
  */
-export async function hashOutOfGraphFiles(
-  input: OutOfGraphInput,
-  projectRoot: string
-): Promise<OutOfGraphFiles> {
+export async function hashOutOfGraphFiles(input: OutOfGraphInput): Promise<OutOfGraphFiles> {
   const configPaths = input.projectFiles.listTree(input.configDir);
   const staticFilePaths = input.staticDirs.flatMap((directory) =>
     input.projectFiles.listTree(directory)
@@ -68,10 +57,10 @@ export async function hashOutOfGraphFiles(
   return {
     storybookConfigFiles: await hashByManifestPath(
       configPaths.filter((filePath) => !staticFileSet.has(filePath)),
-      projectRoot,
+      input.projectRoot,
       input.projectFiles
     ),
-    staticFiles: await hashByManifestPath(staticFilePaths, projectRoot, input.projectFiles),
+    staticFiles: await hashByManifestPath(staticFilePaths, input.projectRoot, input.projectFiles),
   };
 }
 

--- a/node-src/lib/turbosnap/v2/outOfGraphFiles.ts
+++ b/node-src/lib/turbosnap/v2/outOfGraphFiles.ts
@@ -1,5 +1,4 @@
-import path from 'path';
-
+import { AbsolutePath } from '../../../types';
 import { FileHash, FilePath, rollUpEntryHashes } from './graph';
 import { normalizeStatsPath } from './paths';
 import { ProjectFiles } from './projectFiles';
@@ -7,13 +6,13 @@ import { STATIC_FILES_KEY, STORYBOOK_CONFIG_KEY, StorybookFileKey } from './stor
 
 /**
  * Where to look for the out-of-graph inputs, and what to read them with. The directories are
- * project-root-relative, as they arrive on `ctx.storybook`.
+ * absolute, as they arrive on `ctx.storybook`.
  */
 export interface OutOfGraphInput {
-  /** The Storybook config directory, e.g. `.storybook`. */
-  configDir: string;
-  /** The configured static directories, e.g. `['.storybook/static']`. Empty when unset. */
-  staticDirs: string[];
+  /** The absolute Storybook config directory. */
+  configDir: AbsolutePath;
+  /** The absolute configured static directories. Empty when unset. */
+  staticDirs: AbsolutePath[];
   /** How to read the disk; required, so no caller can silently get the real one. */
   projectFiles: ProjectFiles;
 }
@@ -57,12 +56,8 @@ export async function hashOutOfGraphFiles(
   input: OutOfGraphInput,
   projectRoot: string
 ): Promise<OutOfGraphFiles> {
-  const staticDirectories = input.staticDirs.map((directory) =>
-    path.resolve(projectRoot, directory)
-  );
-
-  const configPaths = input.projectFiles.listTree(path.resolve(projectRoot, input.configDir));
-  const staticFilePaths = staticDirectories.flatMap((directory) =>
+  const configPaths = input.projectFiles.listTree(input.configDir);
+  const staticFilePaths = input.staticDirs.flatMap((directory) =>
     input.projectFiles.listTree(directory)
   );
 

--- a/node-src/lib/turbosnap/v2/outOfGraphFiles.ts
+++ b/node-src/lib/turbosnap/v2/outOfGraphFiles.ts
@@ -1,0 +1,150 @@
+import path from 'path';
+
+import { FileHash, FilePath, rollUpEntryHashes } from './graph';
+import { normalizeStatsPath } from './paths';
+import { ProjectFiles } from './projectFiles';
+import { STATIC_FILES_KEY, STORYBOOK_CONFIG_KEY } from './storybookFileKeys';
+
+/**
+ * Where to look for the out-of-graph inputs, and what to read them with. The directories are
+ * project-root-relative, as they arrive on `ctx.storybook`.
+ */
+export interface OutOfGraphInput {
+  /** The Storybook config directory, e.g. `.storybook`. */
+  configDir: string;
+  /** The configured static directories, e.g. `['.storybook/static']`. Empty when unset. */
+  staticDirs: string[];
+  /** How to read the disk; required, so no caller can silently get the real one. */
+  projectFiles: ProjectFiles;
+}
+
+/**
+ * The content hash of every out-of-graph file, keyed by canonical manifest path. These are the S3-only
+ * debug detail sections behind the {@link STORYBOOK_CONFIG_KEY} and {@link STATIC_FILES_KEY} roll-ups:
+ * the Index does one equality check per roll-up, and the debug view diffs these to name the file that
+ * actually moved.
+ */
+export interface OutOfGraphFiles {
+  storybookConfigFiles: Map<FilePath, FileHash>;
+  staticFiles: Map<FilePath, FileHash>;
+}
+
+/**
+ * Content-hashes every file in the Storybook config directory and every file in the configured static
+ * directories.
+ *
+ * These files are structurally invisible to v2's graph hashing — `.storybook/main.ts` is Node-side
+ * config and static assets are referenced by URL string, so neither is ever a module in
+ * `preview-stats.json`. Without this, an edit to either produces a byte-identical manifest, where
+ * TurboSnap v1 bails and recaptures everything. Hashing bytes off disk covers them regardless of
+ * whether the builder emitted a module, which is also what closes the empty-`preview.ts` case (a
+ * 0-line preview is elided by vite, so it has no graph-rolled entry at all).
+ *
+ * We hash bytes rather than following imports. A change to a file that `main.ts` imports from outside
+ * the config directory is missed — and missed by v1 too, so it is parity — while following those
+ * imports would mean resolving and interpreting Node-side config, which is out of scope.
+ *
+ * Static files are hashed unbounded, with no size or count cap: a cap is a silent gap, which is the
+ * failure mode this mechanism exists to remove.
+ *
+ * @param input Where to look and what to read it with; see {@link OutOfGraphInput}.
+ * @param projectRoot The absolute Storybook project root used to locate files and name them.
+ *
+ * @returns The content hash of every config file and every static file, keyed by canonical manifest
+ * path.
+ */
+export async function hashOutOfGraphFiles(
+  input: OutOfGraphInput,
+  projectRoot: string
+): Promise<OutOfGraphFiles> {
+  const staticDirectories = input.staticDirs.map((directory) =>
+    path.resolve(projectRoot, directory)
+  );
+
+  const [configPaths, staticPaths] = await Promise.all([
+    input.projectFiles.listTree(path.resolve(projectRoot, input.configDir)),
+    // A file can only belong to one section, so collect the static directories first and let them win
+    // below. All the fixtures nest `.storybook/static/`, and v1 tests `isStaticFile` before
+    // `isStorybookFile` for exactly that reason (getDependentStoryFiles.ts:284-292).
+    Promise.all(staticDirectories.map((directory) => input.projectFiles.listTree(directory))),
+  ]);
+
+  const staticFilePaths = staticPaths.flat();
+  const staticFileSet = new Set(staticFilePaths);
+
+  return {
+    storybookConfigFiles: await hashByManifestPath(
+      configPaths.filter((filePath) => !staticFileSet.has(filePath)),
+      projectRoot,
+      input.projectFiles
+    ),
+    staticFiles: await hashByManifestPath(staticFilePaths, projectRoot, input.projectFiles),
+  };
+}
+
+/**
+ * Rolls each out-of-graph section up into the single `storybookFileHashes` entry the Index compares.
+ *
+ * The two sections are deliberately independent of each other and of `.storybook/preview.*`'s
+ * graph-rolled entry: bytes-changed and imports-changed are different failure modes, so `preview.*` is
+ * covered twice on purpose and neither entry has to be complete alone.
+ *
+ * A section with no files contributes no entry at all, matching how the `storybookGlobals` catch-all
+ * is omitted when empty.
+ *
+ * Both roll-ups are path-sensitive, as the graph-rolled entries now are too: a static asset is served
+ * at its path and a config file is loaded by name, so a byte-preserving rename changes what Storybook
+ * renders even though the multiset of contents is untouched. The path identity hashed is the
+ * canonical manifest key, which is project-relative — so a project move leaves both roll-ups still,
+ * the assets being served at the same URLs and the config still loading from the same names, and only
+ * a rename *within* the project is a real change.
+ *
+ * @param outOfGraphFiles The per-file hashes to roll up.
+ * @param h64ToString The hash function.
+ *
+ * @returns The synthetic `storybookFileHashes` entries, keyed by {@link STORYBOOK_CONFIG_KEY} and
+ * {@link STATIC_FILES_KEY}.
+ */
+export function rollUpOutOfGraphFiles(
+  outOfGraphFiles: OutOfGraphFiles,
+  h64ToString: (input: string) => string
+): Map<FilePath, FileHash> {
+  const sections = [
+    [STORYBOOK_CONFIG_KEY, outOfGraphFiles.storybookConfigFiles],
+    [STATIC_FILES_KEY, outOfGraphFiles.staticFiles],
+  ] as const;
+
+  return new Map(
+    sections
+      .filter(([, files]) => files.size > 0)
+      .map(([key, files]) => [key, rollUpEntryHashes([...files], h64ToString)])
+  );
+}
+
+/**
+ * Hashes absolute file paths and keys the result by canonical manifest path, matching how `files` is
+ * keyed so a manifest reader can compare the two.
+ *
+ * @param absolutePaths The absolute paths to hash.
+ * @param projectRoot The absolute Storybook project root canonical keys are relative to.
+ * @param projectFiles How to read the disk.
+ *
+ * @returns The content hash per canonical manifest path.
+ */
+async function hashByManifestPath(
+  absolutePaths: string[],
+  projectRoot: string,
+  projectFiles: ProjectFiles
+): Promise<Map<FilePath, FileHash>> {
+  const hashes = await projectFiles.hashAll(absolutePaths);
+
+  return new Map(
+    absolutePaths
+      .map((absolutePath): [FilePath, FileHash] => [
+        normalizeStatsPath(absolutePath, projectRoot),
+        hashes[absolutePath],
+      ])
+      // Sorted so the debug detail section reads in path order rather than directory-walk order.
+      .sort(([a], [b]) => a.localeCompare(b))
+  );
+}

--- a/node-src/lib/turbosnap/v2/outOfGraphFiles.ts
+++ b/node-src/lib/turbosnap/v2/outOfGraphFiles.ts
@@ -65,7 +65,7 @@ export async function hashOutOfGraphFiles(
     input.projectFiles.listTree(path.resolve(projectRoot, input.configDir)),
     // A file can only belong to one section, so collect the static directories first and let them win
     // below. All the fixtures nest `.storybook/static/`, and v1 tests `isStaticFile` before
-    // `isStorybookFile` for exactly that reason (getDependentStoryFiles.ts:284-292).
+    // `isStorybookFile` for exactly that reason.
     Promise.all(staticDirectories.map((directory) => input.projectFiles.listTree(directory))),
   ]);
 

--- a/node-src/lib/turbosnap/v2/outOfGraphFiles.ts
+++ b/node-src/lib/turbosnap/v2/outOfGraphFiles.ts
@@ -61,15 +61,13 @@ export async function hashOutOfGraphFiles(
     path.resolve(projectRoot, directory)
   );
 
-  const [configPaths, staticPaths] = await Promise.all([
-    input.projectFiles.listTree(path.resolve(projectRoot, input.configDir)),
-    // A file can only belong to one section, so collect the static directories first and let them win
-    // below. All the fixtures nest `.storybook/static/`, and v1 tests `isStaticFile` before
-    // `isStorybookFile` for exactly that reason.
-    Promise.all(staticDirectories.map((directory) => input.projectFiles.listTree(directory))),
-  ]);
+  const configPaths = input.projectFiles.listTree(path.resolve(projectRoot, input.configDir));
+  const staticFilePaths = staticDirectories.flatMap((directory) =>
+    input.projectFiles.listTree(directory)
+  );
 
-  const staticFilePaths = staticPaths.flat();
+  // A file can only belong to one section, so collect the static directories first and filter them
+  // out later.
   const staticFileSet = new Set(staticFilePaths);
 
   return {

--- a/node-src/lib/turbosnap/v2/outOfGraphFiles.ts
+++ b/node-src/lib/turbosnap/v2/outOfGraphFiles.ts
@@ -3,7 +3,7 @@ import path from 'path';
 import { FileHash, FilePath, rollUpEntryHashes } from './graph';
 import { normalizeStatsPath } from './paths';
 import { ProjectFiles } from './projectFiles';
-import { STATIC_FILES_KEY, STORYBOOK_CONFIG_KEY } from './storybookFileKeys';
+import { STATIC_FILES_KEY, STORYBOOK_CONFIG_KEY, StorybookFileKey } from './storybookFileKeys';
 
 /**
  * Where to look for the out-of-graph inputs, and what to read them with. The directories are
@@ -108,7 +108,7 @@ export async function hashOutOfGraphFiles(
 export function rollUpOutOfGraphFiles(
   outOfGraphFiles: OutOfGraphFiles,
   h64ToString: (input: string) => string
-): Map<FilePath, FileHash> {
+): Map<StorybookFileKey, FileHash> {
   const sections = [
     [STORYBOOK_CONFIG_KEY, outOfGraphFiles.storybookConfigFiles],
     [STATIC_FILES_KEY, outOfGraphFiles.staticFiles],

--- a/node-src/lib/turbosnap/v2/paths.test.ts
+++ b/node-src/lib/turbosnap/v2/paths.test.ts
@@ -1,8 +1,113 @@
 import { describe, expect, it } from 'vitest';
 
-import { normalizeStatsPath, resolveStatsPath } from './paths';
+import { Module } from '../../../types';
+import { moduleFileNames, normalizeStatsPath, resolveStatsPath, rootFilePath } from './paths';
 
 const projectRoot = '/repo/packages/ui';
+
+function module(module: Partial<Module>): Module {
+  return { id: 0, name: '', ...module };
+}
+
+describe('moduleFileNames', () => {
+  it('names a plain module by itself', () => {
+    expect(moduleFileNames(module({ name: './src/Button.tsx' }))).toEqual(['./src/Button.tsx']);
+  });
+
+  it('prefers nameForCondition over name', () => {
+    expect(
+      moduleFileNames(
+        module({ name: './src/Button.tsx', nameForCondition: '/repo/src/Button.tsx' })
+      )
+    ).toEqual(['/repo/src/Button.tsx']);
+  });
+
+  it('lists the root first, then the concatenated members', () => {
+    expect(
+      moduleFileNames(
+        module({
+          name: './src/Button.stories.tsx + 1 modules',
+          modules: [{ name: './src/Button.stories.tsx' }, { name: './src/Button.tsx' }],
+        })
+      )
+    ).toEqual(['./src/Button.stories.tsx', './src/Button.tsx']);
+  });
+
+  it("roots at the module's own name, never at modules[0]", () => {
+    // storybook-builder-rsbuild 3.3.0/3.3.1 fills `modules` with the record's require-contexts (a
+    // glob) rather than its concatenated files. The root must still come from the module's own name,
+    // or the glob would become the root and promote the whole record to a story importer.
+    expect(
+      moduleFileNames(
+        module({
+          name: './src/Button.stories.tsx',
+          modules: [{ name: String.raw`./src sync recursive \.stories\.tsx$` }],
+        })
+      )[0]
+    ).toBe('./src/Button.stories.tsx');
+  });
+
+  it('strips the concatenation suffix from the root and every member', () => {
+    expect(
+      moduleFileNames(
+        module({
+          name: './src/a.ts + 2 modules',
+          modules: [{ name: './src/b.ts + 1 module' }, { name: './src/c.ts' }],
+        })
+      )
+    ).toEqual(['./src/a.ts', './src/b.ts', './src/c.ts']);
+  });
+
+  it('drops duplicates so a suffixed root never repeats a member spelling the same file', () => {
+    expect(
+      moduleFileNames(
+        module({
+          name: './src/a.ts + 1 modules',
+          modules: [{ name: './src/a.ts' }, { name: './src/b.ts' }],
+        })
+      )
+    ).toEqual(['./src/a.ts', './src/b.ts']);
+  });
+
+  it('drops empty names', () => {
+    expect(
+      moduleFileNames(
+        module({ name: './src/a.ts', modules: [{ name: '' }, { name: './src/b.ts' }] })
+      )
+    ).toEqual(['./src/a.ts', './src/b.ts']);
+  });
+
+  it('returns nothing when the module names no files', () => {
+    expect(moduleFileNames(module({ name: '' }))).toEqual([]);
+  });
+});
+
+describe('rootFilePath', () => {
+  it('normalizes the root name against the project root', () => {
+    expect(
+      rootFilePath(module({ name: '/repo/packages/ui/src/Button.tsx' }), projectRoot, projectRoot)
+    ).toBe('./src/Button.tsx');
+  });
+
+  it("takes the root from the module's own name, not a require-context glob in modules", () => {
+    // Same rsbuild quirk as moduleFileNames: the glob in `modules` has no file on disk, so rooting
+    // there would resolve to a phantom path instead of the real story file.
+    expect(
+      rootFilePath(
+        module({
+          name: './src/Button.stories.tsx',
+          modules: [{ name: String.raw`./src sync recursive \.stories\.tsx$` }],
+        }),
+        projectRoot,
+        projectRoot
+      )
+    ).toBe('./src/Button.stories.tsx');
+  });
+
+  it('returns undefined when the module names no files', () => {
+    expect(rootFilePath(module({ name: '' }), projectRoot, projectRoot)).toBeUndefined();
+  });
+});
 
 describe('normalizeStatsPath', () => {
   it('keeps a project-relative path as-is, with its ./ prefix', () => {

--- a/node-src/lib/turbosnap/v2/paths.test.ts
+++ b/node-src/lib/turbosnap/v2/paths.test.ts
@@ -1,7 +1,14 @@
 import { describe, expect, it } from 'vitest';
 
 import { Module } from '../../../types';
-import { moduleFileNames, normalizeStatsPath, resolveStatsPath, rootFilePath } from './paths';
+import {
+  canonicalFileNames,
+  canonicalImporters,
+  moduleFileNames,
+  normalizeStatsPath,
+  resolveStatsPath,
+  rootFilePath,
+} from './paths';
 
 const projectRoot = '/repo/packages/ui';
 
@@ -106,6 +113,63 @@ describe('rootFilePath', () => {
 
   it('returns undefined when the module names no files', () => {
     expect(rootFilePath(module({ name: '' }), projectRoot, projectRoot)).toBeUndefined();
+  });
+});
+
+describe('canonicalFileNames', () => {
+  it.each([
+    {
+      name: 'a module that names no files',
+      module: module({ name: '' }),
+      expected: [],
+    },
+    {
+      name: 'a plain module',
+      module: module({ name: '/repo/packages/ui/src/Button.tsx' }),
+      expected: ['./src/Button.tsx'],
+    },
+    {
+      name: 'a concatenated module, root first',
+      module: module({
+        name: '/repo/packages/ui/src/Button.stories.tsx + 1 modules',
+        modules: [
+          { name: '/repo/packages/ui/src/Button.stories.tsx' },
+          { name: '/repo/packages/ui/src/Button.tsx' },
+        ],
+      }),
+      expected: ['./src/Button.stories.tsx', './src/Button.tsx'],
+    },
+  ])('normalizes the file names of $name', ({ module: input, expected }) => {
+    expect(canonicalFileNames(input, projectRoot, projectRoot)).toEqual(expected);
+  });
+});
+
+describe('canonicalImporters', () => {
+  it.each([
+    {
+      name: 'drops reasons with a null moduleName',
+      module: module({
+        reasons: [{ moduleName: null }, { moduleName: '/repo/packages/ui/src/Button.tsx' }],
+      }),
+      expected: ['./src/Button.tsx'],
+    },
+    {
+      name: 'normalizes string moduleNames',
+      module: module({
+        reasons: [
+          { moduleName: '/repo/packages/ui/src/a.ts' },
+          { moduleName: '/repo/packages/shared/theme.ts' },
+        ],
+      }),
+      expected: ['./src/a.ts', '../shared/theme.ts'],
+    },
+    {
+      name: 'returns nothing when the module has no reasons',
+      module: module({ name: './src/Button.tsx' }),
+      expected: [],
+    },
+  ])('$name', ({ module: input, expected }) => {
+    expect(canonicalImporters(input, projectRoot, projectRoot)).toEqual(expected);
   });
 });
 

--- a/node-src/lib/turbosnap/v2/paths.test.ts
+++ b/node-src/lib/turbosnap/v2/paths.test.ts
@@ -11,6 +11,7 @@ import {
 } from './paths';
 
 const projectRoot = '/repo/packages/ui';
+const roots = { projectRoot, statsRoot: projectRoot };
 
 function module(module: Partial<Module>): Module {
   return { id: 0, name: '', ...module };
@@ -91,9 +92,9 @@ describe('moduleFileNames', () => {
 
 describe('rootFilePath', () => {
   it('normalizes the root name against the project root', () => {
-    expect(
-      rootFilePath(module({ name: '/repo/packages/ui/src/Button.tsx' }), projectRoot, projectRoot)
-    ).toBe('./src/Button.tsx');
+    expect(rootFilePath(module({ name: '/repo/packages/ui/src/Button.tsx' }), roots)).toBe(
+      './src/Button.tsx'
+    );
   });
 
   it("takes the root from the module's own name, not a require-context glob in modules", () => {
@@ -105,14 +106,13 @@ describe('rootFilePath', () => {
           name: './src/Button.stories.tsx',
           modules: [{ name: String.raw`./src sync recursive \.stories\.tsx$` }],
         }),
-        projectRoot,
-        projectRoot
+        roots
       )
     ).toBe('./src/Button.stories.tsx');
   });
 
   it('returns undefined when the module names no files', () => {
-    expect(rootFilePath(module({ name: '' }), projectRoot, projectRoot)).toBeUndefined();
+    expect(rootFilePath(module({ name: '' }), roots)).toBeUndefined();
   });
 });
 
@@ -140,7 +140,7 @@ describe('canonicalFileNames', () => {
       expected: ['./src/Button.stories.tsx', './src/Button.tsx'],
     },
   ])('normalizes the file names of $name', ({ module: input, expected }) => {
-    expect(canonicalFileNames(input, projectRoot, projectRoot)).toEqual(expected);
+    expect(canonicalFileNames(input, roots)).toEqual(expected);
   });
 });
 
@@ -169,7 +169,7 @@ describe('canonicalImporters', () => {
       expected: [],
     },
   ])('$name', ({ module: input, expected }) => {
-    expect(canonicalImporters(input, projectRoot, projectRoot)).toEqual(expected);
+    expect(canonicalImporters(input, roots)).toEqual(expected);
   });
 });
 

--- a/node-src/lib/turbosnap/v2/paths.ts
+++ b/node-src/lib/turbosnap/v2/paths.ts
@@ -5,22 +5,28 @@ import { relativeTo } from '../../getStorybookProjectRoot';
 import { FilePath } from './graph';
 
 /**
- * The source file names a stats module stands for. A concatenated module's `name` is a group label
- * (e.g. `./x.stories.tsx + 1 modules`), so its real files are read from the inner `modules`; a
- * plain module names itself.
+ * The source file names a stats module stands for, root first. Webpack/rspack concatenate modules
+ * and expose the combined files in `module.modules`; a plain module names only itself.
  *
- * webpack and rspack both carry the real (absolute) source path in `nameForCondition`, so it is
- * preferred over `name` where present.
+ * The root is always the module's own name, never the first entry of `module.modules`: only the own
+ * name is guaranteed to spell the file the record stands for. `storybook-builder-rsbuild` 3.3.0/3.3.1
+ * fills `modules` with the record's require-contexts instead of its concatenated files, so reading the
+ * root from there yields a glob — which has no file on disk and would promote the whole record to a
+ * story importer. webpack and rspack both carry the real (absolute) source path in `nameForCondition`,
+ * so it is preferred over `name`. The concatenation suffix is stripped from every name and duplicates
+ * are dropped, so the root never duplicates a member that spells the same file without it.
  *
  * @param module The stats module to read the file names of.
  *
- * @returns The source file names, with empty entries dropped.
+ * @returns The source file names, root first, with empty entries and duplicates dropped.
  */
-function moduleFileNames(module: Module): FilePath[] {
-  const names = module.modules?.length
-    ? module.modules.map((inner) => inner.nameForCondition ?? inner.name)
-    : [module.nameForCondition ?? module.name];
-  return names.filter(Boolean);
+export function moduleFileNames(module: Module): FilePath[] {
+  const root = module.nameForCondition ?? module.name;
+  const names = [
+    root,
+    ...(module.modules ?? []).map((inner) => inner.nameForCondition ?? inner.name),
+  ];
+  return [...new Set(names.filter(Boolean).map((name) => stripConcatenatedModuleSuffix(name)))];
 }
 
 /**

--- a/node-src/lib/turbosnap/v2/paths.ts
+++ b/node-src/lib/turbosnap/v2/paths.ts
@@ -30,9 +30,50 @@ export function moduleFileNames(module: Module): FilePath[] {
 }
 
 /**
- * The canonical path of a stats module's root source file: the first of its {@link moduleFileNames},
- * normalized. Only the root identifies the module and matches it against importers; the other inner
- * names of a concatenation group are its descendants.
+ * The canonical paths of a stats module's source files: its {@link moduleFileNames}, each normalized,
+ * root first. The single place the "canonical file names" rule lives, so every walk over
+ * `stats.modules` reads the same definition.
+ *
+ * @param module The stats module.
+ * @param projectRoot The absolute Storybook project root to anchor against.
+ * @param statsRoot The directory relative stats paths are named from.
+ *
+ * @returns The canonical file paths, root first, with empty entries and duplicates dropped.
+ */
+export function canonicalFileNames(
+  module: Module,
+  projectRoot: AbsolutePath,
+  statsRoot: AbsolutePath
+): FilePath[] {
+  return moduleFileNames(module).map((name) => normalizeStatsPath(name, projectRoot, statsRoot));
+}
+
+/**
+ * The canonical paths that import a stats module: its `reasons` mapped to `moduleName`, entry reasons
+ * (null `moduleName`) dropped, each normalized. The single place the "canonical importers" rule lives,
+ * so `readStatsGraph` and story detection cannot drift apart.
+ *
+ * @param module The stats module.
+ * @param projectRoot The absolute Storybook project root to anchor against.
+ * @param statsRoot The directory relative stats paths are named from.
+ *
+ * @returns The canonical importer paths.
+ */
+export function canonicalImporters(
+  module: Module,
+  projectRoot: AbsolutePath,
+  statsRoot: AbsolutePath
+): FilePath[] {
+  return (module.reasons ?? [])
+    .map((reason) => reason.moduleName)
+    .filter((name): name is FilePath => typeof name === 'string')
+    .map((name) => normalizeStatsPath(name, projectRoot, statsRoot));
+}
+
+/**
+ * The canonical path of a stats module's root source file: the first of its {@link canonicalFileNames}.
+ * Only the root identifies the module and matches it against importers; the other inner names of a
+ * concatenation group are its descendants.
  *
  * @param module The stats module.
  * @param projectRoot The absolute Storybook project root to anchor against.
@@ -45,8 +86,7 @@ export function rootFilePath(
   projectRoot: AbsolutePath,
   statsRoot: AbsolutePath
 ): FilePath | undefined {
-  const [rootName] = moduleFileNames(module);
-  return rootName === undefined ? undefined : normalizeStatsPath(rootName, projectRoot, statsRoot);
+  return canonicalFileNames(module, projectRoot, statsRoot)[0];
 }
 
 /**

--- a/node-src/lib/turbosnap/v2/paths.ts
+++ b/node-src/lib/turbosnap/v2/paths.ts
@@ -30,22 +30,31 @@ export function moduleFileNames(module: Module): FilePath[] {
 }
 
 /**
+ * The two roots that anchor a stats module path. They always travel together through
+ * canonicalization: {@link normalizeStatsPath} resolves a relative stats path from `statsRoot`, then
+ * names it relative to `projectRoot`.
+ */
+export interface StatsRoots {
+  /** The absolute Storybook project root that canonical manifest keys are relative to. */
+  projectRoot: AbsolutePath;
+  /** The absolute directory relative stats paths are named from. */
+  statsRoot: AbsolutePath;
+}
+
+/**
  * The canonical paths of a stats module's source files: its {@link moduleFileNames}, each normalized,
  * root first. The single place the "canonical file names" rule lives, so every walk over
  * `stats.modules` reads the same definition.
  *
  * @param module The stats module.
- * @param projectRoot The absolute Storybook project root to anchor against.
- * @param statsRoot The directory relative stats paths are named from.
+ * @param roots The roots to anchor against. See {@link StatsRoots}.
  *
  * @returns The canonical file paths, root first, with empty entries and duplicates dropped.
  */
-export function canonicalFileNames(
-  module: Module,
-  projectRoot: AbsolutePath,
-  statsRoot: AbsolutePath
-): FilePath[] {
-  return moduleFileNames(module).map((name) => normalizeStatsPath(name, projectRoot, statsRoot));
+export function canonicalFileNames(module: Module, roots: StatsRoots): FilePath[] {
+  return moduleFileNames(module).map((name) =>
+    normalizeStatsPath(name, roots.projectRoot, roots.statsRoot)
+  );
 }
 
 /**
@@ -54,20 +63,15 @@ export function canonicalFileNames(
  * so `readStatsGraph` and story detection cannot drift apart.
  *
  * @param module The stats module.
- * @param projectRoot The absolute Storybook project root to anchor against.
- * @param statsRoot The directory relative stats paths are named from.
+ * @param roots The roots to anchor against. See {@link StatsRoots}.
  *
  * @returns The canonical importer paths.
  */
-export function canonicalImporters(
-  module: Module,
-  projectRoot: AbsolutePath,
-  statsRoot: AbsolutePath
-): FilePath[] {
+export function canonicalImporters(module: Module, roots: StatsRoots): FilePath[] {
   return (module.reasons ?? [])
     .map((reason) => reason.moduleName)
     .filter((name): name is FilePath => typeof name === 'string')
-    .map((name) => normalizeStatsPath(name, projectRoot, statsRoot));
+    .map((name) => normalizeStatsPath(name, roots.projectRoot, roots.statsRoot));
 }
 
 /**
@@ -76,17 +80,12 @@ export function canonicalImporters(
  * concatenation group are its descendants.
  *
  * @param module The stats module.
- * @param projectRoot The absolute Storybook project root to anchor against.
- * @param statsRoot The directory relative stats paths are named from.
+ * @param roots The roots to anchor against. See {@link StatsRoots}.
  *
  * @returns The canonical root path, or undefined when the module names no files.
  */
-export function rootFilePath(
-  module: Module,
-  projectRoot: AbsolutePath,
-  statsRoot: AbsolutePath
-): FilePath | undefined {
-  return canonicalFileNames(module, projectRoot, statsRoot)[0];
+export function rootFilePath(module: Module, roots: StatsRoots): FilePath | undefined {
+  return canonicalFileNames(module, roots)[0];
 }
 
 /**

--- a/node-src/lib/turbosnap/v2/projectFiles.fake.ts
+++ b/node-src/lib/turbosnap/v2/projectFiles.fake.ts
@@ -20,6 +20,8 @@ export interface InMemoryDisk {
    * having to list every source file its stats fixture names.
    */
   isAbsent?: (absolutePath: AbsolutePath) => boolean;
+  /** Contents written by `writeFile`, keyed by absolute path, so a suite can read them back. */
+  writtenFiles?: Record<AbsolutePath, string>;
 }
 
 /**
@@ -72,5 +74,9 @@ export function inMemoryProjectFiles(disk: InMemoryDisk): ProjectFiles {
       );
     },
     listTree,
+    writeFile: (absolutePath: AbsolutePath, contents: string) => {
+      disk.writtenFiles ??= {};
+      disk.writtenFiles[absolutePath] = contents;
+    },
   };
 }

--- a/node-src/lib/turbosnap/v2/projectFiles.test.ts
+++ b/node-src/lib/turbosnap/v2/projectFiles.test.ts
@@ -121,6 +121,24 @@ describe('realProjectFiles listTree', () => {
     ]);
   });
 
+  it('lists the same target through every symlink alias and reflects alias removal', async () => {
+    const root = temporaryDirectory();
+    write(root, 'vendor/assets/logo.svg');
+    mkdirSync(path.join(root, 'static'));
+    symlinkSync(path.join(root, 'vendor/assets'), path.join(root, 'static/brand'));
+    symlinkSync(path.join(root, 'vendor/assets'), path.join(root, 'static/legacy'));
+
+    const before = realProjectFiles().listTree(path.join(root, 'static'));
+    rmSync(path.join(root, 'static/legacy'));
+    const after = realProjectFiles().listTree(path.join(root, 'static'));
+
+    expect(before.sort()).toEqual([
+      path.join(root, 'static/brand/logo.svg'),
+      path.join(root, 'static/legacy/logo.svg'),
+    ]);
+    expect(after).toEqual([path.join(root, 'static/brand/logo.svg')]);
+  });
+
   it('contributes nothing for a broken symlink, finishing the rest of the sweep', async () => {
     const root = temporaryDirectory();
     write(root, 'static/keep.svg');

--- a/node-src/lib/turbosnap/v2/projectFiles.test.ts
+++ b/node-src/lib/turbosnap/v2/projectFiles.test.ts
@@ -1,4 +1,12 @@
-import { chmodSync, mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'fs';
+import {
+  chmodSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from 'fs';
 import { tmpdir } from 'os';
 import path from 'path';
 import { afterEach, describe, expect, it } from 'vitest';
@@ -232,6 +240,26 @@ describe('realProjectFiles hashAll', () => {
     }
 
     expect(err?.message).toContain(unreadable);
+  });
+});
+
+describe('realProjectFiles writeFile', () => {
+  it('writes the contents to the path, readable back as the same bytes', () => {
+    const root = temporaryDirectory();
+    const filePath = path.join(root, 'turbosnap-manifest.json');
+
+    realProjectFiles().writeFile(filePath, '{"storybookHash":"abc"}');
+
+    expect(readFileSync(filePath, 'utf8')).toBe('{"storybookHash":"abc"}');
+  });
+
+  it('overwrites an existing file rather than appending', () => {
+    const root = temporaryDirectory();
+    const filePath = write(root, 'turbosnap-manifest.json', 'stale');
+
+    realProjectFiles().writeFile(filePath, 'fresh');
+
+    expect(readFileSync(filePath, 'utf8')).toBe('fresh');
   });
 });
 

--- a/node-src/lib/turbosnap/v2/projectFiles.ts
+++ b/node-src/lib/turbosnap/v2/projectFiles.ts
@@ -105,13 +105,14 @@ function namePathThatFailed(error: any, absolutePaths: AbsolutePath[]): string {
  * v1 never matches such a path either. The same holds for a broken symlink, whose target can't be read.
  *
  * @param directory The absolute directory to walk.
- * @param visitedDirectories Resolved real paths already walked, so a symlink cycle terminates.
+ * @param ancestorDirectories Resolved real paths in the current branch, so a symlink cycle
+ * terminates without suppressing sibling aliases to the same directory.
  *
  * @returns The absolute path of every file found.
  */
 function listFilesRecursively(
   directory: AbsolutePath,
-  visitedDirectories = new Set<AbsolutePath>()
+  ancestorDirectories = new Set<AbsolutePath>()
 ): AbsolutePath[] {
   let realDirectory;
   try {
@@ -120,37 +121,41 @@ function listFilesRecursively(
     return [];
   }
 
-  if (visitedDirectories.has(realDirectory)) {
+  if (ancestorDirectories.has(realDirectory)) {
     return [];
   }
-  visitedDirectories.add(realDirectory);
+  ancestorDirectories.add(realDirectory);
 
-  let entries;
   try {
-    entries = readdirSync(directory, { withFileTypes: true });
-  } catch {
-    return [];
-  }
-
-  return entries.flatMap((entry) => {
-    const entryPath = path.join(directory, entry.name);
-    if (entry.isDirectory()) {
-      return listFilesRecursively(entryPath, visitedDirectories);
-    }
-    if (entry.isFile()) {
-      return [entryPath];
-    }
-
-    // A symlink is neither, so ask `stat`, which follows it. Anything else with no bytes of its own
-    // — a socket, a device, a broken link — contributes nothing.
+    let entries;
     try {
-      const stats = statSync(entryPath);
-      if (stats.isDirectory()) {
-        return listFilesRecursively(entryPath, visitedDirectories);
-      }
-      return stats.isFile() ? [entryPath] : [];
+      entries = readdirSync(directory, { withFileTypes: true });
     } catch {
       return [];
     }
-  });
+
+    return entries.flatMap((entry) => {
+      const entryPath = path.join(directory, entry.name);
+      if (entry.isDirectory()) {
+        return listFilesRecursively(entryPath, ancestorDirectories);
+      }
+      if (entry.isFile()) {
+        return [entryPath];
+      }
+
+      // A symlink is neither, so ask `stat`, which follows it. Anything else with no bytes of its own
+      // — a socket, a device, a broken link — contributes nothing.
+      try {
+        const stats = statSync(entryPath);
+        if (stats.isDirectory()) {
+          return listFilesRecursively(entryPath, ancestorDirectories);
+        }
+        return stats.isFile() ? [entryPath] : [];
+      } catch {
+        return [];
+      }
+    });
+  } finally {
+    ancestorDirectories.delete(realDirectory);
+  }
 }

--- a/node-src/lib/turbosnap/v2/projectFiles.ts
+++ b/node-src/lib/turbosnap/v2/projectFiles.ts
@@ -1,4 +1,4 @@
-import { readdirSync, readFileSync, realpathSync, statSync } from 'fs';
+import { readdirSync, readFileSync, realpathSync, statSync, writeFileSync } from 'fs';
 import { createRequire } from 'module';
 import path from 'path';
 
@@ -22,6 +22,8 @@ export interface ProjectFiles {
   ): Promise<Record<AbsolutePath, FileHash>>;
   /** Follows symlinks, names files by the link path, terminates on a cycle, empty when absent. */
   listTree(absoluteDirectory: AbsolutePath): AbsolutePath[];
+  /** Writes the contents to the file, creating or overwriting it. */
+  writeFile(absolutePath: AbsolutePath, contents: string): void;
 }
 
 /**
@@ -39,6 +41,8 @@ export function realProjectFiles(): ProjectFiles {
     packageVersion: readPackageVersion,
     hashAll: hashFileContents,
     listTree: (absoluteDirectory: AbsolutePath) => listFilesRecursively(absoluteDirectory),
+    writeFile: (absolutePath: AbsolutePath, contents: string) =>
+      writeFileSync(absolutePath, contents),
   };
 }
 

--- a/node-src/lib/turbosnap/v2/statsGraph.test.ts
+++ b/node-src/lib/turbosnap/v2/statsGraph.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import { Stats } from '../../../types';
 import { createFixture } from './__fixtures__/manifestFixtures';
-import { countNodeModulesFiles, readStatsGraph } from './statsGraph';
+import { readStatsGraph } from './statsGraph';
 
 // These suites are about builder spellings: what webpack, rspack and Vite each call the same file,
 // and what the graph reader makes of it. They assert on the graph, not on a hash — that the right
@@ -305,66 +305,5 @@ describe('readStatsGraph hashing failures', () => {
     }
 
     expect(err?.message).toContain(story);
-  });
-});
-
-describe('countNodeModulesFiles', () => {
-  it('counts zero for a first-party-only graph', () => {
-    const stats: Stats = {
-      modules: [
-        { id: 1, name: './src/Button.stories.tsx' },
-        { id: 2, name: './src/Button.tsx' },
-        { id: 3, name: './.storybook/preview.ts' },
-      ],
-    };
-
-    expect(countNodeModulesFiles(stats)).toBe(0);
-  });
-
-  it('does not count file names and context expressions that only mention node_modules', () => {
-    const stats: Stats = {
-      modules: [
-        { id: 1, name: './src/node_modules-helper.ts' },
-        {
-          id: 2,
-          name: String.raw`./src|lazy|/^\.\/.*$/|include: /(?!.*node_modules)/|namespace object`,
-        },
-      ],
-    };
-
-    expect(countNodeModulesFiles(stats)).toBe(0);
-  });
-
-  it('counts installed dependency files however the builder spells them', () => {
-    const stats: Stats = {
-      // One relative (Vite), two absolute (webpack on POSIX and Windows), one via
-      // `nameForCondition` (rspack).
-      modules: [
-        { id: 1, name: './src/Button.tsx' },
-        { id: 2, name: './../../node_modules/@storybook/react/dist/entry-preview.js' },
-        { id: 3, name: '/repo/node_modules/storybook/dist/csf/index.js' },
-        { id: 4, name: 'dependency group', nameForCondition: '/repo/node_modules/react/index.js' },
-        { id: 5, name: String.raw`C:\repo\node_modules\react-dom\index.js` },
-      ],
-    };
-
-    expect(countNodeModulesFiles(stats)).toBe(4);
-  });
-
-  it('counts the concatenated children of a dependency group', () => {
-    const stats: Stats = {
-      modules: [
-        {
-          id: 1,
-          name: './../../node_modules/storybook/dist/csf/index.js + 1 modules',
-          modules: [
-            { name: './../../node_modules/storybook/dist/csf/index.js' },
-            { name: './../../node_modules/storybook/dist/csf/toId.js' },
-          ],
-        },
-      ],
-    };
-
-    expect(countNodeModulesFiles(stats)).toBe(2);
   });
 });

--- a/node-src/lib/turbosnap/v2/statsGraph.test.ts
+++ b/node-src/lib/turbosnap/v2/statsGraph.test.ts
@@ -1,0 +1,354 @@
+import { describe, expect, it } from 'vitest';
+
+import { Stats } from '../../../types';
+import { createFixture } from './__fixtures__/manifestFixtures';
+import { countNodeModulesFiles, readStatsGraph } from './statsGraph';
+
+// These suites are about builder spellings: what webpack, rspack and Vite each call the same file,
+// and what the graph reader makes of it. They assert on the graph, not on a hash — that the right
+// edge exists and the right bytes were hashed. Whether an edge reaches a roll-up is graph.test.ts's
+// job, and end-to-end in manifest.hashing.test.ts.
+
+describe('readStatsGraph concatenated modules', () => {
+  // Webpack/rspack concatenate the story and its local imports into one module: the module name
+  // carries a ` + N modules` suffix and the real files live in `module.modules`.
+  const concatenatedStory: Stats = {
+    modules: [
+      {
+        id: 1,
+        name: '/repo/packages/ui/src/Button.stories.tsx + 1 modules',
+        modules: [
+          { name: '/repo/packages/ui/src/Button.stories.tsx' },
+          { name: '/repo/packages/ui/src/Button.tsx' },
+        ],
+        reasons: [{ moduleName: './storybook-stories.js' }],
+      },
+    ],
+  };
+
+  it('keys the story by its root file, stripping the concatenation suffix', async () => {
+    const { statsContext } = createFixture({
+      fileHashes: {
+        '/repo/packages/ui/src/Button.stories.tsx': 'S',
+        '/repo/packages/ui/src/Button.tsx': 'B',
+      },
+    });
+    const graph = await readStatsGraph(concatenatedStory, statsContext);
+
+    expect([...graph.storyFiles]).toEqual(['./src/Button.stories.tsx']);
+  });
+
+  it('records each concatenated sub-file as a dependency of the root file, hashed by its own bytes', async () => {
+    const { statsContext } = createFixture({
+      fileHashes: {
+        '/repo/packages/ui/src/Button.stories.tsx': 'S',
+        '/repo/packages/ui/src/Button.tsx': 'B',
+      },
+    });
+    const graph = await readStatsGraph(concatenatedStory, statsContext);
+
+    expect([...(graph.files.get('./src/Button.stories.tsx')?.dependencies ?? [])]).toContain(
+      './src/Button.tsx'
+    );
+    expect(graph.hashes.get('./src/Button.tsx')).toBe('B');
+  });
+
+  // `storybook-builder-rsbuild` 3.3.0/3.3.1 fill `modules` with the record's require-contexts rather
+  // than its concatenated files, and omit the root file. Reading the root from `modules` then yields
+  // a glob, which has no file on disk, so the whole record is promoted to a story importer and every
+  // module that imports it becomes a story file.
+  const contextsInModules: Stats = {
+    modules: [
+      {
+        id: 1,
+        name: './node_modules/storybook/dist/csf/index.js + 11 modules',
+        modules: [{ name: './node_modules/storybook/dist/csf/*.js' }],
+        reasons: [{ moduleName: './storybook-config-entry.js' }],
+      },
+      {
+        id: 2,
+        name: './node_modules/storybook/dist/instrumenter/index.js',
+        reasons: [{ moduleName: './node_modules/storybook/dist/csf/index.js + 11 modules' }],
+      },
+    ],
+  };
+
+  it('roots a module at its own name when `modules` holds contexts rather than concatenated files', async () => {
+    // The glob has no file on disk, which is what would promote the record to a story importer if
+    // the root were read from `modules`.
+    const { statsContext } = createFixture({
+      isAbsent: (candidate) => candidate.includes('*.js'),
+      fileHashes: {
+        '/repo/packages/ui/node_modules/storybook/dist/csf/index.js': 'C',
+        '/repo/packages/ui/node_modules/storybook/dist/instrumenter/index.js': 'I',
+      },
+    });
+
+    const graph = await readStatsGraph(contextsInModules, statsContext);
+
+    // The record keys by its own name, so it stays a real file rather than becoming a story
+    // importer, and the module it imports is not a story file.
+    expect(graph.files.has('./node_modules/storybook/dist/csf/index.js')).toBe(true);
+    expect([...graph.storyFiles]).toEqual([]);
+  });
+});
+
+describe('readStatsGraph unhashable paths', () => {
+  it('skips a module named after a directory rather than failing the read', async () => {
+    const story = '/repo/packages/ui/src/Button.stories.tsx';
+    // rspack names one record after a directory on `storybook-builder-rsbuild` 3.3.0/3.3.1. Reading
+    // it throws EISDIR, which would fail the whole manifest to an internalError bail.
+    const directory = '/repo/packages/ui/node_modules/@storybook/react/dist/';
+
+    const { statsContext } = createFixture({
+      fileHashes: { [story]: 'S' },
+      // The record's `modules` entry is a directory on disk; reading it throws EISDIR, so the adapter
+      // reports it as not a file and the sweep skips it.
+      directories: { [directory]: [] },
+    });
+    const graph = await readStatsGraph(
+      {
+        modules: [
+          { id: 1, name: story, reasons: [{ moduleName: './storybook-stories.js' }] },
+          { id: 2, name: story, modules: [{ name: directory }], reasons: [] },
+        ],
+      },
+      statsContext
+    );
+
+    expect([...graph.storyFiles]).toEqual(['./src/Button.stories.tsx']);
+    expect(graph.hashes.has('./node_modules/@storybook/react/dist')).toBe(false);
+  });
+});
+
+describe('readStatsGraph suffix-equivalent story importer identity', () => {
+  it('reads the same graph when only the story-entry reason gains a concatenation suffix', async () => {
+    const story = '/repo/packages/ui/src/Button.stories.tsx';
+    const stats = (storyImporter: string): Stats => ({
+      modules: [{ id: 1, name: story, reasons: [{ moduleName: storyImporter }] }],
+    });
+    const { statsContext } = createFixture({ fileHashes: { [story]: 'S' } });
+
+    const plain = await readStatsGraph(stats('./storybook-stories.js'), statsContext);
+    const concatenated = await readStatsGraph(
+      stats('./storybook-stories.js + 1 modules'),
+      statsContext
+    );
+
+    expect(concatenated).toEqual(plain);
+  });
+});
+
+describe('readStatsGraph concatenated modules with rspack-style child names', () => {
+  // rspack labels a concatenated child's `name` with the parent group name (e.g.
+  // `./Button.stories.tsx + 1 modules`) rather than the child's own file. The real path is only in
+  // `nameForCondition`. Without reading `nameForCondition` the child collapses onto the root file
+  // and its content is never hashed.
+  const rspackConcatenatedStory: Stats = {
+    modules: [
+      {
+        id: 1,
+        name: '/repo/packages/ui/src/Button.stories.tsx + 1 modules',
+        nameForCondition: '/repo/packages/ui/src/Button.stories.tsx',
+        modules: [
+          {
+            name: '/repo/packages/ui/src/Button.stories.tsx',
+            nameForCondition: '/repo/packages/ui/src/Button.stories.tsx',
+          },
+          {
+            // The buggy child: `name` is the group label, real file is in nameForCondition.
+            name: '/repo/packages/ui/src/Button.stories.tsx + 1 modules',
+            nameForCondition: '/repo/packages/ui/src/Button.tsx',
+          },
+        ],
+        reasons: [{ moduleName: './storybook-stories.js' }],
+      },
+    ],
+  };
+
+  it('recovers the concatenated child file from nameForCondition and hashes its own bytes', async () => {
+    const { statsContext } = createFixture({
+      fileHashes: {
+        '/repo/packages/ui/src/Button.stories.tsx': 'S',
+        '/repo/packages/ui/src/Button.tsx': 'B',
+      },
+    });
+    const graph = await readStatsGraph(rspackConcatenatedStory, statsContext);
+
+    expect([...graph.storyFiles]).toEqual(['./src/Button.stories.tsx']);
+    expect([...(graph.files.get('./src/Button.stories.tsx')?.dependencies ?? [])]).toContain(
+      './src/Button.tsx'
+    );
+    expect(graph.hashes.get('./src/Button.tsx')).toBe('B');
+  });
+
+  it('reads the same graph as minimal stats that re-emit the concatenated files by usable name', async () => {
+    const story = '/repo/packages/ui/src/Button.stories.tsx';
+    const implementation = '/repo/packages/ui/src/Button.tsx';
+    const shimmedStats: Stats = {
+      modules: [
+        { id: 1, name: story, reasons: [{ moduleName: './storybook-stories.js' }] },
+        { id: 2, name: implementation, reasons: [{ moduleName: story }] },
+      ],
+    };
+    const { statsContext } = createFixture({ fileHashes: { [story]: 'S', [implementation]: 'B' } });
+
+    const full = await readStatsGraph(rspackConcatenatedStory, statsContext);
+    const shimmed = await readStatsGraph(shimmedStats, statsContext);
+
+    expect(shimmed).toEqual(full);
+  });
+});
+
+describe('readStatsGraph missing names', () => {
+  it('skips reasons with a null moduleName without dropping the story', async () => {
+    const { statsContext } = createFixture({
+      fileHashes: { '/repo/packages/ui/src/Button.stories.tsx': 'S' },
+    });
+    const stats: Stats = {
+      modules: [
+        {
+          id: 1,
+          name: '/repo/packages/ui/src/Button.stories.tsx',
+          // An entry reason carries `moduleName: null`; the stories-entry reason must still apply.
+          reasons: [
+            { moduleName: null as unknown as string },
+            { moduleName: './storybook-stories.js' },
+          ],
+        },
+      ],
+    };
+
+    const graph = await readStatsGraph(stats, statsContext);
+
+    expect([...graph.storyFiles]).toEqual(['./src/Button.stories.tsx']);
+  });
+
+  it('uses module.modules when module.name is absent', async () => {
+    const { statsContext } = createFixture({
+      fileHashes: {
+        '/repo/packages/ui/src/Button.stories.tsx': 'S',
+        '/repo/packages/ui/src/Button.tsx': 'B',
+      },
+    });
+    const stats: Stats = {
+      modules: [
+        {
+          id: 1,
+          name: null as unknown as string,
+          modules: [
+            { name: '/repo/packages/ui/src/Button.stories.tsx' },
+            { name: '/repo/packages/ui/src/Button.tsx' },
+          ],
+          reasons: [{ moduleName: './storybook-stories.js' }],
+        },
+      ],
+    };
+
+    const graph = await readStatsGraph(stats, statsContext);
+
+    expect([...graph.storyFiles]).toEqual(['./src/Button.stories.tsx']);
+    expect([...(graph.files.get('./src/Button.stories.tsx')?.dependencies ?? [])]).toContain(
+      './src/Button.tsx'
+    );
+  });
+});
+
+describe('readStatsGraph unhashable files', () => {
+  it('leaves a file missing on disk out of the hashes and gives its node an empty hash', async () => {
+    const story = '/repo/packages/ui/src/Button.stories.tsx';
+    const missing = '/repo/packages/ui/src/missing.ts';
+
+    const { statsContext } = createFixture({
+      isAbsent: (candidate) => candidate === missing,
+      // The missing file has a content hash on the fixture disk, so this pins that absence wins
+      // over the bytes: a name with no file contributes nothing, whatever it would have hashed to.
+      fileHashes: { [story]: 'S', [missing]: 'WOULD-BE-A' },
+    });
+    const graph = await readStatsGraph(
+      {
+        modules: [
+          { id: 1, name: story, reasons: [{ moduleName: './storybook-stories.js' }] },
+          { id: 2, name: missing, reasons: [{ moduleName: story }] },
+        ],
+      },
+      statsContext
+    );
+
+    expect(graph.hashes.has('./src/missing.ts')).toBe(false);
+    expect(graph.files.get('./src/missing.ts')?.hash).toBe('');
+  });
+});
+
+describe('readStatsGraph hashing failures', () => {
+  it('fails the read rather than returning a graph missing a file it could not read', async () => {
+    // Unreadability is a bug, not an answer: a manifest built without those bytes would silently
+    // under-capture, so this propagates to the entry point and bails TurboSnap to v1.
+    const { statsContext } = createFixture();
+    const story = '/repo/packages/ui/src/Button.stories.tsx';
+    const unreadable = new Error(`Could not hash ${story}: EACCES: permission denied`);
+
+    let err: Error | undefined;
+    try {
+      await readStatsGraph(
+        { modules: [{ id: 1, name: story, reasons: [{ moduleName: './storybook-stories.js' }] }] },
+        {
+          ...statsContext,
+          projectFiles: {
+            ...statsContext.projectFiles,
+            hashAll: () => Promise.reject(unreadable),
+          },
+        }
+      );
+    } catch (error) {
+      err = error as Error;
+    }
+
+    expect(err?.message).toContain(story);
+  });
+});
+
+describe('countNodeModulesFiles', () => {
+  it('counts zero for a first-party-only graph', () => {
+    const stats: Stats = {
+      modules: [
+        { id: 1, name: './src/Button.stories.tsx' },
+        { id: 2, name: './src/Button.tsx' },
+        { id: 3, name: './.storybook/preview.ts' },
+      ],
+    };
+
+    expect(countNodeModulesFiles(stats)).toBe(0);
+  });
+
+  it('counts installed dependency files however the builder spells them', () => {
+    const stats: Stats = {
+      // One relative (Vite), one absolute (webpack), one via `nameForCondition` (rspack).
+      modules: [
+        { id: 1, name: './src/Button.tsx' },
+        { id: 2, name: './../../node_modules/@storybook/react/dist/entry-preview.js' },
+        { id: 3, name: '/repo/node_modules/storybook/dist/csf/index.js' },
+        { id: 4, name: 'dependency group', nameForCondition: '/repo/node_modules/react/index.js' },
+      ],
+    };
+
+    expect(countNodeModulesFiles(stats)).toBe(3);
+  });
+
+  it('counts the concatenated children of a dependency group', () => {
+    const stats: Stats = {
+      modules: [
+        {
+          id: 1,
+          name: './../../node_modules/storybook/dist/csf/index.js + 1 modules',
+          modules: [
+            { name: './../../node_modules/storybook/dist/csf/index.js' },
+            { name: './../../node_modules/storybook/dist/csf/toId.js' },
+          ],
+        },
+      ],
+    };
+
+    expect(countNodeModulesFiles(stats)).toBe(2);
+  });
+});

--- a/node-src/lib/turbosnap/v2/statsGraph.test.ts
+++ b/node-src/lib/turbosnap/v2/statsGraph.test.ts
@@ -27,25 +27,25 @@ describe('readStatsGraph concatenated modules', () => {
   };
 
   it('keys the story by its root file, stripping the concatenation suffix', async () => {
-    const { statsContext } = createFixture({
+    const { input } = createFixture({
       fileHashes: {
         '/repo/packages/ui/src/Button.stories.tsx': 'S',
         '/repo/packages/ui/src/Button.tsx': 'B',
       },
     });
-    const graph = await readStatsGraph(concatenatedStory, statsContext);
+    const graph = await readStatsGraph(concatenatedStory, input);
 
     expect([...graph.storyFiles]).toEqual(['./src/Button.stories.tsx']);
   });
 
   it('records each concatenated sub-file as a dependency of the root file, hashed by its own bytes', async () => {
-    const { statsContext } = createFixture({
+    const { input } = createFixture({
       fileHashes: {
         '/repo/packages/ui/src/Button.stories.tsx': 'S',
         '/repo/packages/ui/src/Button.tsx': 'B',
       },
     });
-    const graph = await readStatsGraph(concatenatedStory, statsContext);
+    const graph = await readStatsGraph(concatenatedStory, input);
 
     expect([...(graph.files.get('./src/Button.stories.tsx')?.dependencies ?? [])]).toContain(
       './src/Button.tsx'
@@ -76,7 +76,7 @@ describe('readStatsGraph concatenated modules', () => {
   it('roots a module at its own name when `modules` holds contexts rather than concatenated files', async () => {
     // The glob has no file on disk, which is what would promote the record to a story importer if
     // the root were read from `modules`.
-    const { statsContext } = createFixture({
+    const { input } = createFixture({
       isAbsent: (candidate) => candidate.includes('*.js'),
       fileHashes: {
         '/repo/packages/ui/node_modules/storybook/dist/csf/index.js': 'C',
@@ -84,7 +84,7 @@ describe('readStatsGraph concatenated modules', () => {
       },
     });
 
-    const graph = await readStatsGraph(contextsInModules, statsContext);
+    const graph = await readStatsGraph(contextsInModules, input);
 
     // The record keys by its own name, so it stays a real file rather than becoming a story
     // importer, and the module it imports is not a story file.
@@ -100,7 +100,7 @@ describe('readStatsGraph unhashable paths', () => {
     // it throws EISDIR, which would fail the whole manifest to an internalError bail.
     const directory = '/repo/packages/ui/node_modules/@storybook/react/dist/';
 
-    const { statsContext } = createFixture({
+    const { input } = createFixture({
       fileHashes: { [story]: 'S' },
       // The record's `modules` entry is a directory on disk; reading it throws EISDIR, so the adapter
       // reports it as not a file and the sweep skips it.
@@ -113,7 +113,7 @@ describe('readStatsGraph unhashable paths', () => {
           { id: 2, name: story, modules: [{ name: directory }], reasons: [] },
         ],
       },
-      statsContext
+      input
     );
 
     expect([...graph.storyFiles]).toEqual(['./src/Button.stories.tsx']);
@@ -127,13 +127,10 @@ describe('readStatsGraph suffix-equivalent story importer identity', () => {
     const stats = (storyImporter: string): Stats => ({
       modules: [{ id: 1, name: story, reasons: [{ moduleName: storyImporter }] }],
     });
-    const { statsContext } = createFixture({ fileHashes: { [story]: 'S' } });
+    const { input } = createFixture({ fileHashes: { [story]: 'S' } });
 
-    const plain = await readStatsGraph(stats('./storybook-stories.js'), statsContext);
-    const concatenated = await readStatsGraph(
-      stats('./storybook-stories.js + 1 modules'),
-      statsContext
-    );
+    const plain = await readStatsGraph(stats('./storybook-stories.js'), input);
+    const concatenated = await readStatsGraph(stats('./storybook-stories.js + 1 modules'), input);
 
     expect(concatenated).toEqual(plain);
   });
@@ -167,13 +164,13 @@ describe('readStatsGraph concatenated modules with rspack-style child names', ()
   };
 
   it('recovers the concatenated child file from nameForCondition and hashes its own bytes', async () => {
-    const { statsContext } = createFixture({
+    const { input } = createFixture({
       fileHashes: {
         '/repo/packages/ui/src/Button.stories.tsx': 'S',
         '/repo/packages/ui/src/Button.tsx': 'B',
       },
     });
-    const graph = await readStatsGraph(rspackConcatenatedStory, statsContext);
+    const graph = await readStatsGraph(rspackConcatenatedStory, input);
 
     expect([...graph.storyFiles]).toEqual(['./src/Button.stories.tsx']);
     expect([...(graph.files.get('./src/Button.stories.tsx')?.dependencies ?? [])]).toContain(
@@ -191,10 +188,10 @@ describe('readStatsGraph concatenated modules with rspack-style child names', ()
         { id: 2, name: implementation, reasons: [{ moduleName: story }] },
       ],
     };
-    const { statsContext } = createFixture({ fileHashes: { [story]: 'S', [implementation]: 'B' } });
+    const { input } = createFixture({ fileHashes: { [story]: 'S', [implementation]: 'B' } });
 
-    const full = await readStatsGraph(rspackConcatenatedStory, statsContext);
-    const shimmed = await readStatsGraph(shimmedStats, statsContext);
+    const full = await readStatsGraph(rspackConcatenatedStory, input);
+    const shimmed = await readStatsGraph(shimmedStats, input);
 
     expect(shimmed).toEqual(full);
   });
@@ -202,7 +199,7 @@ describe('readStatsGraph concatenated modules with rspack-style child names', ()
 
 describe('readStatsGraph missing names', () => {
   it('skips reasons with a null moduleName without dropping the story', async () => {
-    const { statsContext } = createFixture({
+    const { input } = createFixture({
       fileHashes: { '/repo/packages/ui/src/Button.stories.tsx': 'S' },
     });
     const stats: Stats = {
@@ -219,13 +216,13 @@ describe('readStatsGraph missing names', () => {
       ],
     };
 
-    const graph = await readStatsGraph(stats, statsContext);
+    const graph = await readStatsGraph(stats, input);
 
     expect([...graph.storyFiles]).toEqual(['./src/Button.stories.tsx']);
   });
 
   it('uses module.modules when module.name is absent', async () => {
-    const { statsContext } = createFixture({
+    const { input } = createFixture({
       fileHashes: {
         '/repo/packages/ui/src/Button.stories.tsx': 'S',
         '/repo/packages/ui/src/Button.tsx': 'B',
@@ -245,7 +242,7 @@ describe('readStatsGraph missing names', () => {
       ],
     };
 
-    const graph = await readStatsGraph(stats, statsContext);
+    const graph = await readStatsGraph(stats, input);
 
     expect([...graph.storyFiles]).toEqual(['./src/Button.stories.tsx']);
     expect([...(graph.files.get('./src/Button.stories.tsx')?.dependencies ?? [])]).toContain(
@@ -259,7 +256,7 @@ describe('readStatsGraph unhashable files', () => {
     const story = '/repo/packages/ui/src/Button.stories.tsx';
     const missing = '/repo/packages/ui/src/missing.ts';
 
-    const { statsContext } = createFixture({
+    const { input } = createFixture({
       isAbsent: (candidate) => candidate === missing,
       // The missing file has a content hash on the fixture disk, so this pins that absence wins
       // over the bytes: a name with no file contributes nothing, whatever it would have hashed to.
@@ -272,7 +269,7 @@ describe('readStatsGraph unhashable files', () => {
           { id: 2, name: missing, reasons: [{ moduleName: story }] },
         ],
       },
-      statsContext
+      input
     );
 
     expect(graph.hashes.has('./src/missing.ts')).toBe(false);
@@ -283,14 +280,14 @@ describe('readStatsGraph unhashable files', () => {
 describe('readStatsGraph hashing failures', () => {
   it('treats a file omitted from the hash result as not real', async () => {
     const story = '/repo/packages/ui/src/Button.stories.tsx';
-    const { statsContext } = createFixture();
+    const { input } = createFixture();
 
     const graph = await readStatsGraph(
       { modules: [{ id: 1, name: story, reasons: [{ moduleName: './storybook-stories.js' }] }] },
       {
-        ...statsContext,
+        ...input,
         projectFiles: {
-          ...statsContext.projectFiles,
+          ...input.projectFiles,
           hashAll: async () => ({}),
         },
       }
@@ -304,7 +301,7 @@ describe('readStatsGraph hashing failures', () => {
   it('fails the read rather than returning a graph missing a file it could not read', async () => {
     // Unreadability is a bug, not an answer: a manifest built without those bytes would silently
     // under-capture, so this propagates to the entry point and bails TurboSnap to v1.
-    const { statsContext } = createFixture();
+    const { input } = createFixture();
     const story = '/repo/packages/ui/src/Button.stories.tsx';
     const unreadable = new Error(`Could not hash ${story}: EACCES: permission denied`);
 
@@ -313,9 +310,9 @@ describe('readStatsGraph hashing failures', () => {
       await readStatsGraph(
         { modules: [{ id: 1, name: story, reasons: [{ moduleName: './storybook-stories.js' }] }] },
         {
-          ...statsContext,
+          ...input,
           projectFiles: {
-            ...statsContext.projectFiles,
+            ...input.projectFiles,
             hashAll: () => Promise.reject(unreadable),
           },
         }

--- a/node-src/lib/turbosnap/v2/statsGraph.test.ts
+++ b/node-src/lib/turbosnap/v2/statsGraph.test.ts
@@ -321,18 +321,34 @@ describe('countNodeModulesFiles', () => {
     expect(countNodeModulesFiles(stats)).toBe(0);
   });
 
+  it('does not count file names and context expressions that only mention node_modules', () => {
+    const stats: Stats = {
+      modules: [
+        { id: 1, name: './src/node_modules-helper.ts' },
+        {
+          id: 2,
+          name: String.raw`./src|lazy|/^\.\/.*$/|include: /(?!.*node_modules)/|namespace object`,
+        },
+      ],
+    };
+
+    expect(countNodeModulesFiles(stats)).toBe(0);
+  });
+
   it('counts installed dependency files however the builder spells them', () => {
     const stats: Stats = {
-      // One relative (Vite), one absolute (webpack), one via `nameForCondition` (rspack).
+      // One relative (Vite), two absolute (webpack on POSIX and Windows), one via
+      // `nameForCondition` (rspack).
       modules: [
         { id: 1, name: './src/Button.tsx' },
         { id: 2, name: './../../node_modules/@storybook/react/dist/entry-preview.js' },
         { id: 3, name: '/repo/node_modules/storybook/dist/csf/index.js' },
         { id: 4, name: 'dependency group', nameForCondition: '/repo/node_modules/react/index.js' },
+        { id: 5, name: String.raw`C:\repo\node_modules\react-dom\index.js` },
       ],
     };
 
-    expect(countNodeModulesFiles(stats)).toBe(3);
+    expect(countNodeModulesFiles(stats)).toBe(4);
   });
 
   it('counts the concatenated children of a dependency group', () => {

--- a/node-src/lib/turbosnap/v2/statsGraph.test.ts
+++ b/node-src/lib/turbosnap/v2/statsGraph.test.ts
@@ -281,6 +281,26 @@ describe('readStatsGraph unhashable files', () => {
 });
 
 describe('readStatsGraph hashing failures', () => {
+  it('treats a file omitted from the hash result as not real', async () => {
+    const story = '/repo/packages/ui/src/Button.stories.tsx';
+    const { statsContext } = createFixture();
+
+    const graph = await readStatsGraph(
+      { modules: [{ id: 1, name: story, reasons: [{ moduleName: './storybook-stories.js' }] }] },
+      {
+        ...statsContext,
+        projectFiles: {
+          ...statsContext.projectFiles,
+          hashAll: async () => ({}),
+        },
+      }
+    );
+
+    expect(graph.hashes.has('./src/Button.stories.tsx')).toBe(false);
+    expect(graph.files.get('./src/Button.stories.tsx')?.hash).toBe('');
+    expect([...graph.storyFiles]).toEqual([]);
+  });
+
   it('fails the read rather than returning a graph missing a file it could not read', async () => {
     // Unreadability is a bug, not an answer: a manifest built without those bytes would silently
     // under-capture, so this propagates to the entry point and bails TurboSnap to v1.

--- a/node-src/lib/turbosnap/v2/statsGraph.ts
+++ b/node-src/lib/turbosnap/v2/statsGraph.ts
@@ -1,15 +1,18 @@
 import { Stats } from '../../../types';
 import { FileHash, FilePath, TurboSnapFile } from './graph';
+import { ManifestInput } from './manifestInput';
 import {
   canonicalFileNames,
   canonicalImporters,
   moduleFileNames,
   normalizeStatsPath,
   resolveStatsPath,
-  StatsRoots,
 } from './paths';
 import { ProjectFiles } from './projectFiles';
 import { detectStoryFiles } from './storyDetection';
+
+/** The part of {@link ManifestInput} reading the stats file needs: the two roots, and the disk. */
+export type StatsContext = Pick<ManifestInput, 'projectRoot' | 'statsRoot' | 'projectFiles'>;
 
 /**
  * What the builder's stats file says it emitted, read into one canonical graph. Builder spellings —
@@ -38,18 +41,13 @@ export interface StatsGraph {
  * is what the hashes answer.
  *
  * @param stats The stats file to parse.
- * @param context The context the stats file was built in, which is needed to resolve module paths to absolute files
- * @param context.projectRoot The absolute Storybook project root that module paths anchor against.
- * @param context.statsRoot The absolute directory relative stats paths are named from.
- * @param context.projectFiles How to read the disk.
+ * @param context The context the stats file was built in, which is needed to resolve module paths to
+ * absolute files; see {@link StatsContext}.
  *
  * @returns The unpruned graph; see {@link StatsGraph}.
  */
-export async function readStatsGraph(
-  stats: Stats,
-  context: StatsRoots & { projectFiles: ProjectFiles }
-): Promise<StatsGraph> {
-  const { projectRoot, statsRoot, projectFiles } = context;
+export async function readStatsGraph(stats: Stats, context: StatsContext): Promise<StatsGraph> {
+  const { projectRoot, statsRoot = projectRoot, projectFiles } = context;
   const roots = { projectRoot, statsRoot };
   const hashes = await hashFiles(stats, projectRoot, statsRoot, projectFiles);
 

--- a/node-src/lib/turbosnap/v2/statsGraph.ts
+++ b/node-src/lib/turbosnap/v2/statsGraph.ts
@@ -4,8 +4,6 @@ import { moduleFileNames, normalizeStatsPath, resolveStatsPath } from './paths';
 import { ProjectFiles } from './projectFiles';
 import { detectStoryFiles } from './storyDetection';
 
-const nodeModulesPathSegment = /(?:^|[\\/])node_modules(?:[\\/]|$)/;
-
 /**
  * What the builder's stats file says it emitted, read into one canonical graph. Builder spellings —
  * webpack, rspack and Vite each name the same file differently — stop mattering at this value; every
@@ -78,22 +76,6 @@ export async function readStatsGraph(
   }
 
   return { files, hashes, storyFiles };
-}
-
-/**
- * Counts the graph's `node_modules` file names. Read off the stats file rather than the manifest,
- * because it is a property of the builder's output rather than of what we derived from it.
- *
- * @param stats The stats file to parse.
- *
- * @returns The number of `node_modules` file names across all modules.
- */
-export function countNodeModulesFiles(stats: Stats): number {
-  let count = 0;
-  for (const module of stats.modules) {
-    count += moduleFileNames(module).filter((name) => nodeModulesPathSegment.test(name)).length;
-  }
-  return count;
 }
 
 /**

--- a/node-src/lib/turbosnap/v2/statsGraph.ts
+++ b/node-src/lib/turbosnap/v2/statsGraph.ts
@@ -45,11 +45,14 @@ export async function readStatsGraph(
   const { projectRoot, statsRoot, projectFiles } = context;
   const hashes = await hashFiles(stats, projectRoot, statsRoot, projectFiles);
 
-  const storyFiles = detectStoryFiles(stats, {
-    projectRoot,
-    statsRoot,
-    realFiles: hashes,
-  });
+  const storyFiles = detectStoryFiles(
+    {
+      projectRoot,
+      statsRoot,
+      onDiskFiles: hashes,
+    },
+    stats
+  );
 
   const files = new Map<FilePath, TurboSnapFile>();
   for (const module of stats.modules) {

--- a/node-src/lib/turbosnap/v2/statsGraph.ts
+++ b/node-src/lib/turbosnap/v2/statsGraph.ts
@@ -1,6 +1,12 @@
 import { Stats } from '../../../types';
 import { FileHash, FilePath, TurboSnapFile } from './graph';
-import { moduleFileNames, normalizeStatsPath, resolveStatsPath } from './paths';
+import {
+  canonicalFileNames,
+  canonicalImporters,
+  moduleFileNames,
+  normalizeStatsPath,
+  resolveStatsPath,
+} from './paths';
 import { ProjectFiles } from './projectFiles';
 import { detectStoryFiles } from './storyDetection';
 
@@ -58,18 +64,12 @@ export async function readStatsGraph(
   for (const module of stats.modules) {
     // A module may bundle several real files (webpack/rspack module concatenation), so resolve its
     // canonical file paths, root first. Modules with no usable name (e.g. externals) are skipped.
-    const fileNames = moduleFileNames(module).map((name) =>
-      normalizeStatsPath(name, projectRoot, statsRoot)
-    );
+    const fileNames = canonicalFileNames(module, projectRoot, statsRoot);
     if (fileNames.length === 0) continue;
     const [sourceFilePath, ...concatenated] = fileNames;
 
-    // Canonicalised so a dependency edge names the same key wherever the builder spells it. Entry
-    // reasons carry a null moduleName, so drop those.
-    const importers = (module.reasons ?? [])
-      .map((reason) => reason.moduleName)
-      .filter((name): name is FilePath => typeof name === 'string')
-      .map((name) => normalizeStatsPath(name, projectRoot, statsRoot));
+    // Canonicalised so a dependency edge names the same key wherever the builder spells it.
+    const importers = canonicalImporters(module, projectRoot, statsRoot);
 
     linkConcatenatedFiles(files, sourceFilePath, concatenated, hashes);
 

--- a/node-src/lib/turbosnap/v2/statsGraph.ts
+++ b/node-src/lib/turbosnap/v2/statsGraph.ts
@@ -11,7 +11,7 @@ import { detectStoryFiles } from './storyDetection';
  *
  * The graph is *unpruned*: synthetic nodes with no file on disk (require-context globs, externals,
  * virtual modules) are still members, because they are members of the subtrees the roll-ups walk.
- * See `pruneSyntheticFiles` in ./manifest.
+ * {@link serializeManifest} filters them only when the manifest is written.
  */
 export interface StatsGraph {
   /** Every module path, with its content hash and the paths it depends on. */
@@ -180,7 +180,8 @@ async function hashFiles(
 
   const hashes = new Map<FilePath, FileHash>();
   for (const [normalizedName, absolutePath] of normalizedToAbsolute) {
-    hashes.set(normalizedName, fileHashes[absolutePath]);
+    const hash = fileHashes[absolutePath];
+    if (hash) hashes.set(normalizedName, hash);
   }
 
   return hashes;

--- a/node-src/lib/turbosnap/v2/statsGraph.ts
+++ b/node-src/lib/turbosnap/v2/statsGraph.ts
@@ -6,6 +6,7 @@ import {
   moduleFileNames,
   normalizeStatsPath,
   resolveStatsPath,
+  StatsRoots,
 } from './paths';
 import { ProjectFiles } from './projectFiles';
 import { detectStoryFiles } from './storyDetection';
@@ -46,30 +47,24 @@ export interface StatsGraph {
  */
 export async function readStatsGraph(
   stats: Stats,
-  context: { projectRoot: string; statsRoot: string; projectFiles: ProjectFiles }
+  context: StatsRoots & { projectFiles: ProjectFiles }
 ): Promise<StatsGraph> {
   const { projectRoot, statsRoot, projectFiles } = context;
+  const roots = { projectRoot, statsRoot };
   const hashes = await hashFiles(stats, projectRoot, statsRoot, projectFiles);
 
-  const storyFiles = detectStoryFiles(
-    {
-      projectRoot,
-      statsRoot,
-      onDiskFiles: hashes,
-    },
-    stats
-  );
+  const storyFiles = detectStoryFiles({ ...roots, onDiskFiles: hashes }, stats);
 
   const files = new Map<FilePath, TurboSnapFile>();
   for (const module of stats.modules) {
     // A module may bundle several real files (webpack/rspack module concatenation), so resolve its
     // canonical file paths, root first. Modules with no usable name (e.g. externals) are skipped.
-    const fileNames = canonicalFileNames(module, projectRoot, statsRoot);
+    const fileNames = canonicalFileNames(module, roots);
     if (fileNames.length === 0) continue;
     const [sourceFilePath, ...concatenated] = fileNames;
 
     // Canonicalised so a dependency edge names the same key wherever the builder spells it.
-    const importers = canonicalImporters(module, projectRoot, statsRoot);
+    const importers = canonicalImporters(module, roots);
 
     linkConcatenatedFiles(files, sourceFilePath, concatenated, hashes);
 

--- a/node-src/lib/turbosnap/v2/statsGraph.ts
+++ b/node-src/lib/turbosnap/v2/statsGraph.ts
@@ -1,0 +1,203 @@
+import { Stats } from '../../../types';
+import { FileHash, FilePath, TurboSnapFile } from './graph';
+import { moduleFileNames, normalizeStatsPath, resolveStatsPath } from './paths';
+import { ProjectFiles } from './projectFiles';
+import { detectStoryFiles } from './storyDetection';
+
+/**
+ * What the builder's stats file says it emitted, read into one canonical graph. Builder spellings —
+ * webpack, rspack and Vite each name the same file differently — stop mattering at this value; every
+ * roll-up downstream sees canonical paths only.
+ *
+ * The graph is *unpruned*: synthetic nodes with no file on disk (require-context globs, externals,
+ * virtual modules) are still members, because they are members of the subtrees the roll-ups walk.
+ * See `pruneSyntheticFiles` in ./manifest.
+ */
+export interface StatsGraph {
+  /** Every module path, with its content hash and the paths it depends on. */
+  files: Map<FilePath, TurboSnapFile>;
+  /** Content hashes keyed by canonical path; a missing entry means there is no file on disk. */
+  hashes: Map<FilePath, FileHash>;
+  /** The canonical paths the builder's entries identify as story files. */
+  storyFiles: Set<FilePath>;
+}
+
+/**
+ * Reads a stats file into the graph the manifest rolls up: what each module is, what it depends on,
+ * what it hashes to and which modules are story files.
+ *
+ * Hashing happens here rather than in the caller because story detection depends on it: telling a
+ * story file apart from a require-context glob is asking whether there is a real file on disk, which
+ * is what the hashes answer.
+ *
+ * @param stats The stats file to parse.
+ * @param context The context the stats file was built in, which is needed to resolve module paths to absolute files
+ * @param context.projectRoot The absolute Storybook project root that module paths anchor against.
+ * @param context.statsRoot The absolute directory relative stats paths are named from.
+ * @param context.projectFiles How to read the disk.
+ *
+ * @returns The unpruned graph; see {@link StatsGraph}.
+ */
+export async function readStatsGraph(
+  stats: Stats,
+  context: { projectRoot: string; statsRoot: string; projectFiles: ProjectFiles }
+): Promise<StatsGraph> {
+  const { projectRoot, statsRoot, projectFiles } = context;
+  const hashes = await hashFiles(stats, projectRoot, statsRoot, projectFiles);
+
+  const storyFiles = detectStoryFiles(stats, {
+    projectRoot,
+    statsRoot,
+    realFiles: hashes,
+  });
+
+  const files = new Map<FilePath, TurboSnapFile>();
+  for (const module of stats.modules) {
+    // A module may bundle several real files (webpack/rspack module concatenation), so resolve its
+    // canonical file paths, root first. Modules with no usable name (e.g. externals) are skipped.
+    const fileNames = moduleFileNames(module).map((name) =>
+      normalizeStatsPath(name, projectRoot, statsRoot)
+    );
+    if (fileNames.length === 0) continue;
+    const [sourceFilePath, ...concatenated] = fileNames;
+
+    // Canonicalised so a dependency edge names the same key wherever the builder spells it. Entry
+    // reasons carry a null moduleName, so drop those.
+    const importers = (module.reasons ?? [])
+      .map((reason) => reason.moduleName)
+      .filter((name): name is FilePath => typeof name === 'string')
+      .map((name) => normalizeStatsPath(name, projectRoot, statsRoot));
+
+    linkConcatenatedFiles(files, sourceFilePath, concatenated, hashes);
+
+    for (const importer of importers) {
+      ensureFile(files, importer, hashes).dependencies.add(sourceFilePath);
+    }
+  }
+
+  return { files, hashes, storyFiles };
+}
+
+/**
+ * Counts the graph's `node_modules` file names. Read off the stats file rather than the manifest,
+ * because it is a property of the builder's output rather than of what we derived from it.
+ *
+ * @param stats The stats file to parse.
+ *
+ * @returns The number of `node_modules` file names across all modules.
+ */
+export function countNodeModulesFiles(stats: Stats): number {
+  let count = 0;
+  for (const module of stats.modules) {
+    count += moduleFileNames(module).filter((name) => name.includes('node_modules')).length;
+  }
+  return count;
+}
+
+/**
+ * Records the internal edges of a concatenated module: webpack/rspack bundle several real files into
+ * one module, so the other files become dependencies of the concatenation root. Each of them also gets
+ * an entry of its own, so no dependency reference names a file the serialized graph omits.
+ *
+ * @param files The map of files to their hashes and dependencies, mutated in place.
+ * @param rootPath The canonical path of the concatenation root.
+ * @param concatenated The canonical paths of the other files bundled into the same module.
+ * @param hashes The content hashes keyed by canonical file path.
+ */
+function linkConcatenatedFiles(
+  files: Map<FilePath, TurboSnapFile>,
+  rootPath: FilePath,
+  concatenated: FilePath[],
+  hashes: Map<FilePath, FileHash>
+) {
+  const rootFile = ensureFile(files, rootPath, hashes);
+  for (const dependency of concatenated) {
+    rootFile.dependencies.add(dependency);
+    ensureFile(files, dependency, hashes);
+  }
+}
+
+/**
+ * Gets the graph entry for a file, creating it (seeded with the file's content hash) if absent.
+ *
+ * @param files The map of files to their hashes and dependencies.
+ * @param filePath The file to get or create an entry for.
+ * @param hashes The content hashes keyed by canonical file path.
+ *
+ * @returns The file's graph entry.
+ */
+function ensureFile(
+  files: Map<FilePath, TurboSnapFile>,
+  filePath: FilePath,
+  hashes: Map<FilePath, FileHash>
+): TurboSnapFile {
+  let file = files.get(filePath);
+  if (!file) {
+    file = { hash: hashes.get(filePath) ?? '', dependencies: new Set() };
+    files.set(filePath, file);
+  }
+  return file;
+}
+
+/**
+ * Resolves a stats module path to the absolute on-disk file to hash, or undefined when there is
+ * nothing hashable there.
+ *
+ * Virtual modules (e.g. Vite's `virtual:` entries) have no on-disk location. Skipping them is stats
+ * policy, which is why it is asked here rather than of the disk. Beyond that, only a regular file is
+ * hashable, and what counts as one is the module's rule; see {@link ProjectFiles.isFile}. Skipping a
+ * name with no file loses no evidence, because such a name is never a source file and so can never be
+ * edited as one.
+ *
+ * @param rawPath The module name from the stats file.
+ * @param statsRoot The directory relative stats paths are named from.
+ * @param projectFiles How to read the disk.
+ *
+ * @returns The absolute path to hash, or undefined if there is no hashable file.
+ */
+function hashableAbsolutePath(
+  rawPath: FilePath,
+  statsRoot: string,
+  projectFiles: ProjectFiles
+): string | undefined {
+  if (rawPath.includes('virtual:')) return undefined;
+  const absolutePath = resolveStatsPath(rawPath, statsRoot);
+  return projectFiles.isFile(absolutePath) ? absolutePath : undefined;
+}
+
+async function hashFiles(
+  stats: Stats,
+  projectRoot: string,
+  statsRoot: string,
+  projectFiles: ProjectFiles
+): Promise<Map<FilePath, FileHash>> {
+  // Collect every referenced module path once, expanding concatenated modules into their real
+  // files and skipping importers with a null moduleName.
+  const rawPaths = new Set<FilePath>();
+  for (const module of stats.modules) {
+    for (const name of moduleFileNames(module)) {
+      rawPaths.add(name);
+    }
+    for (const reason of module.reasons ?? []) {
+      if (reason.moduleName) rawPaths.add(reason.moduleName);
+    }
+  }
+
+  // Map each hashable file's canonical project-relative name to its absolute on-disk path.
+  const normalizedToAbsolute = new Map<FilePath, string>();
+  for (const rawPath of rawPaths) {
+    const absolutePath = hashableAbsolutePath(rawPath, statsRoot, projectFiles);
+    if (absolutePath) {
+      normalizedToAbsolute.set(normalizeStatsPath(rawPath, projectRoot, statsRoot), absolutePath);
+    }
+  }
+
+  const fileHashes = await projectFiles.hashAll([...normalizedToAbsolute.values()]);
+
+  const hashes = new Map<FilePath, FileHash>();
+  for (const [normalizedName, absolutePath] of normalizedToAbsolute) {
+    hashes.set(normalizedName, fileHashes[absolutePath]);
+  }
+
+  return hashes;
+}

--- a/node-src/lib/turbosnap/v2/statsGraph.ts
+++ b/node-src/lib/turbosnap/v2/statsGraph.ts
@@ -4,6 +4,8 @@ import { moduleFileNames, normalizeStatsPath, resolveStatsPath } from './paths';
 import { ProjectFiles } from './projectFiles';
 import { detectStoryFiles } from './storyDetection';
 
+const nodeModulesPathSegment = /(?:^|[\\/])node_modules(?:[\\/]|$)/;
+
 /**
  * What the builder's stats file says it emitted, read into one canonical graph. Builder spellings —
  * webpack, rspack and Vite each name the same file differently — stop mattering at this value; every
@@ -89,7 +91,7 @@ export async function readStatsGraph(
 export function countNodeModulesFiles(stats: Stats): number {
   let count = 0;
   for (const module of stats.modules) {
-    count += moduleFileNames(module).filter((name) => name.includes('node_modules')).length;
+    count += moduleFileNames(module).filter((name) => nodeModulesPathSegment.test(name)).length;
   }
   return count;
 }

--- a/node-src/lib/turbosnap/v2/storyDetection.ts
+++ b/node-src/lib/turbosnap/v2/storyDetection.ts
@@ -1,6 +1,6 @@
-import { AbsolutePath, Stats } from '../../../types';
+import { Stats } from '../../../types';
 import { FilePath } from './graph';
-import { canonicalImporters, normalizeStatsPath, rootFilePath } from './paths';
+import { canonicalImporters, normalizeStatsPath, rootFilePath, StatsRoots } from './paths';
 
 /**
  * Whether a canonical path has a real file on disk. You can use things that adhere to this
@@ -14,11 +14,7 @@ export interface OnDiskFiles {
  * What story detection needs to resolve stats paths and tell real files apart from the
  * require-context glob.
  */
-interface StoryDetectionContext {
-  // The absolute Storybook project root that module paths anchor against.
-  projectRoot: AbsolutePath;
-  // The directory relative stats paths are named from.
-  statsRoot: AbsolutePath;
+interface StoryDetectionContext extends StatsRoots {
   // Which canonical paths have a real file on disk.
   onDiskFiles: OnDiskFiles;
 }
@@ -123,7 +119,7 @@ interface ProcessedModule {
  * @returns The processed modules.
  */
 function processModules(context: StoryDetectionContext, stats: Stats): ProcessedModule[] {
-  const { projectRoot, statsRoot, onDiskFiles } = context;
+  const { onDiskFiles } = context;
   const processed: ProcessedModule[] = [];
 
   for (const module of stats.modules) {
@@ -132,12 +128,12 @@ function processModules(context: StoryDetectionContext, stats: Stats): Processed
       continue;
     }
 
-    const filePath = rootFilePath(module, projectRoot, statsRoot);
+    const filePath = rootFilePath(module, context);
     if (!filePath) {
       continue;
     }
 
-    const importers = canonicalImporters(module, projectRoot, statsRoot);
+    const importers = canonicalImporters(module, context);
 
     processed.push({
       rawName: module.name,

--- a/node-src/lib/turbosnap/v2/storyDetection.ts
+++ b/node-src/lib/turbosnap/v2/storyDetection.ts
@@ -1,6 +1,6 @@
 import { AbsolutePath, Stats } from '../../../types';
 import { FilePath } from './graph';
-import { normalizeStatsPath, rootFilePath } from './paths';
+import { canonicalImporters, normalizeStatsPath, rootFilePath } from './paths';
 
 /**
  * Whether a canonical path has a real file on disk. You can use things that adhere to this
@@ -137,11 +137,7 @@ function processModules(context: StoryDetectionContext, stats: Stats): Processed
       continue;
     }
 
-    // Entry reasons carry a null moduleName, so drop those before canonicalising.
-    const importers = (module.reasons ?? [])
-      .map((reason) => reason.moduleName)
-      .filter((name): name is FilePath => typeof name === 'string')
-      .map((name) => normalizeStatsPath(name, projectRoot, statsRoot));
+    const importers = canonicalImporters(module, projectRoot, statsRoot);
 
     processed.push({
       rawName: module.name,

--- a/node-src/lib/turbosnap/v2/storybookFileKeys.ts
+++ b/node-src/lib/turbosnap/v2/storybookFileKeys.ts
@@ -34,3 +34,14 @@ export const STORYBOOK_CONFIG_KEY = 'storybookConfigFiles';
 
 /** The static directories; see {@link STORYBOOK_CONFIG_KEY}. */
 export const STATIC_FILES_KEY = 'staticFiles';
+
+/**
+ * Every synthetic key in `storybookFileHashes`. A canonical file path always starts `./` or `../`,
+ * so none of these bare names can collide with one; see the note at the top of this file.
+ */
+export type StorybookFileKey =
+  | typeof STORYBOOK_PREVIEW_KEY
+  | typeof STORYBOOK_GLOBALS_KEY
+  | typeof STORYBOOK_VERSION_KEY
+  | typeof STORYBOOK_CONFIG_KEY
+  | typeof STATIC_FILES_KEY;

--- a/node-src/lib/turbosnap/v2/storybookFileKeys.ts
+++ b/node-src/lib/turbosnap/v2/storybookFileKeys.ts
@@ -1,0 +1,36 @@
+/**
+ * The synthetic keys in the manifest's `storybookFileHashes` map. They share one namespace and one
+ * invariant, so they are declared together: a canonical relative path always starts with `./` or
+ * `../`, so none of these bare names can collide with a real file.
+ */
+
+/**
+ * Every `<configDir>/preview.*` subtree, unioned and rolled up; see {@link collectStorybookFiles}.
+ * One category entry rather than one entry per preview path, so the map stays a homogeneous set of
+ * category roll-ups.
+ */
+export const STORYBOOK_PREVIEW_KEY = 'preview';
+
+/** Every orphan global, rolled up; see {@link collectStorybookFiles}. */
+export const STORYBOOK_GLOBALS_KEY = 'storybookGlobals';
+
+/**
+ * The installed Storybook version. Unlike every other entry this is a version string rather than a
+ * hash, because the preview core runtime is served outside the module graph on webpack and rspack;
+ * see {@link resolveStorybookVersion}.
+ */
+export const STORYBOOK_VERSION_KEY = 'storybookVersion';
+
+/**
+ * The Storybook config directory and the static directories: Storybook inputs that are never bundler
+ * inputs, so no module hash can see them change.
+ *
+ * `package.json` and lockfiles deliberately have no key here, even though they are also not modules.
+ * v1 diffed them only to derive changed package *names*; v2 content-hashes the installed files that
+ * are in the graph, which covers a dependency change more precisely. Hashing manifest bytes on top
+ * would recapture everything on lockfile churn that v1 correctly captures nothing for.
+ */
+export const STORYBOOK_CONFIG_KEY = 'storybookConfigFiles';
+
+/** The static directories; see {@link STORYBOOK_CONFIG_KEY}. */
+export const STATIC_FILES_KEY = 'staticFiles';

--- a/node-src/lib/turbosnap/v2/storybookFiles.test.ts
+++ b/node-src/lib/turbosnap/v2/storybookFiles.test.ts
@@ -1,0 +1,279 @@
+import { describe, expect, it } from 'vitest';
+
+import { FileHash, FilePath, TurboSnapFile } from './graph';
+import { STORYBOOK_GLOBALS_KEY, STORYBOOK_PREVIEW_KEY } from './storybookFileKeys';
+import { collectStorybookFiles } from './storybookFiles';
+
+// The config dir most tests don't care about; only the configDir-specific tests below vary it.
+const DEFAULT_CONFIG_DIR = '.storybook';
+
+// An identity "hash" so a roll-up is readable as the set of paths that went into it, which is what
+// makes the contents of the shared `preview` roll-up visible.
+function identity(input: string): string {
+  return input;
+}
+
+function makeFiles(graph: Record<FilePath, FilePath[]>): Map<FilePath, TurboSnapFile> {
+  return new Map(
+    Object.entries(graph).map(([filePath, dependencies]) => [
+      filePath,
+      { hash: `hash-${filePath}`, dependencies: new Set(dependencies) },
+    ])
+  );
+}
+
+function makeHashes(filePaths: FilePath[]): Map<FilePath, FileHash> {
+  return new Map(filePaths.map((filePath) => [filePath, `hash-${filePath}`]));
+}
+
+describe('collectStorybookFiles', () => {
+  it('keys the preview subtree under the `preview` category', () => {
+    const files = makeFiles({ './.storybook/preview.ts': [], './src/a.stories.tsx': [] });
+    const hashes = makeHashes(['./.storybook/preview.ts', './src/a.stories.tsx']);
+
+    const { storybookFileHashes } = collectStorybookFiles(
+      files,
+      hashes,
+      new Set(['./src/a.stories.tsx']),
+      DEFAULT_CONFIG_DIR,
+      identity
+    );
+
+    expect([...storybookFileHashes.keys()]).toContain(STORYBOOK_PREVIEW_KEY);
+    expect([...storybookFileHashes.keys()]).not.toContain('./.storybook/preview.ts');
+  });
+
+  it('matches every preview config extension Storybook accepts', () => {
+    const previews = [
+      './.storybook/preview.ts',
+      './.storybook/preview.tsx',
+      './.storybook/preview.js',
+      './.storybook/preview.jsx',
+      './.storybook/preview.mjs',
+      './.storybook/preview.cjs',
+    ];
+    const { storybookFileHashes, attribution } = collectStorybookFiles(
+      makeFiles(Object.fromEntries(previews.map((p) => [p, []]))),
+      makeHashes(previews),
+      new Set(),
+      DEFAULT_CONFIG_DIR,
+      identity
+    );
+
+    // Every extension lands in the one shared `preview` home, so all six show up in its subtree.
+    expect([...storybookFileHashes.keys()]).toEqual([STORYBOOK_PREVIEW_KEY]);
+    expect([...attribution.previewSubtree].sort()).toEqual([...previews].sort());
+  });
+
+  it('does not treat a file merely named preview outside the config dir as a config', () => {
+    const files = makeFiles({ './src/preview.ts': [] });
+
+    const { storybookFileHashes, attribution } = collectStorybookFiles(
+      files,
+      makeHashes(['./src/preview.ts']),
+      new Set(),
+      DEFAULT_CONFIG_DIR,
+      identity
+    );
+
+    expect([...storybookFileHashes.keys()]).toEqual([STORYBOOK_GLOBALS_KEY]);
+    expect([...attribution.storybookGlobals]).toEqual(['./src/preview.ts']);
+  });
+
+  it('finds the preview under a non-default config dir', () => {
+    // A project with `-c src` has no `.storybook` at all; the preview lives at `./src/preview.ts` and
+    // must be found there, not missed for not being literally named `.storybook`.
+    const files = makeFiles({ './src/preview.ts': [] });
+
+    const { storybookFileHashes, attribution } = collectStorybookFiles(
+      files,
+      makeHashes(['./src/preview.ts']),
+      new Set(),
+      'src',
+      identity
+    );
+
+    expect([...storybookFileHashes.keys()]).toEqual([STORYBOOK_PREVIEW_KEY]);
+    expect([...attribution.previewSubtree]).toEqual(['./src/preview.ts']);
+  });
+
+  it('rolls a file the preview and one story both import into the preview subtree, not just the story', () => {
+    // Reproduces the audit's synthetic repro: a theme shared between the preview and Button.stories,
+    // under a non-default config dir. Missing this would make the theme storyReachable only, so
+    // editing it moves Button's hash but not the preview's, and Badge (which never imports it) is
+    // never recaptured despite the preview affecting every story.
+    const shared = './src/theme.ts';
+    const files = makeFiles({
+      './config/preview.ts': [shared],
+      [shared]: [],
+      './src/Button.stories.tsx': [shared],
+      './src/Badge.stories.tsx': [],
+    });
+    const hashes = makeHashes([...files.keys()]);
+
+    const { attribution } = collectStorybookFiles(
+      files,
+      hashes,
+      new Set(['./src/Button.stories.tsx', './src/Badge.stories.tsx']),
+      'config',
+      identity
+    );
+
+    expect(attribution.previewSubtree.has(shared)).toBe(true);
+    expect(attribution.storyReachable.has(shared)).toBe(true);
+  });
+
+  it('unions every preview subtree into the one `preview` roll-up', () => {
+    // The `preview` entry covers all preview configs together, so both subtrees feed the single
+    // rolled-up hash and a change to either moves it.
+    const files = makeFiles({
+      './.storybook/preview.ts': ['./.storybook/themeA.ts'],
+      './.storybook/themeA.ts': [],
+      './packages/other/.storybook/preview.ts': ['./packages/other/.storybook/themeB.ts'],
+      './packages/other/.storybook/themeB.ts': [],
+    });
+    const hashes = makeHashes([...files.keys()]);
+
+    const { storybookFileHashes } = collectStorybookFiles(
+      files,
+      hashes,
+      new Set(),
+      DEFAULT_CONFIG_DIR,
+      identity
+    );
+
+    expect([...storybookFileHashes.keys()]).toEqual([STORYBOOK_PREVIEW_KEY]);
+    // The identity hash makes the roll-up read as the paths that went into it: both themes are there.
+    expect(storybookFileHashes.get(STORYBOOK_PREVIEW_KEY)).toContain('themeA');
+    expect(storybookFileHashes.get(STORYBOOK_PREVIEW_KEY)).toContain('themeB');
+  });
+
+  it('rolls files reached by no story and no preview into the catch-all', () => {
+    const files = makeFiles({ './node_modules/react-dom/index.js': [] });
+
+    const { storybookFileHashes, attribution } = collectStorybookFiles(
+      files,
+      makeHashes(['./node_modules/react-dom/index.js']),
+      new Set(),
+      DEFAULT_CONFIG_DIR,
+      identity
+    );
+
+    expect([...storybookFileHashes.keys()]).toEqual([STORYBOOK_GLOBALS_KEY]);
+    expect([...attribution.storybookGlobals]).toEqual(['./node_modules/react-dom/index.js']);
+  });
+
+  it('omits the catch-all entirely when every file has a home', () => {
+    const files = makeFiles({
+      './src/a.stories.tsx': ['./src/button.tsx'],
+      './src/button.tsx': [],
+    });
+
+    const { storybookFileHashes } = collectStorybookFiles(
+      files,
+      makeHashes(['./src/a.stories.tsx', './src/button.tsx']),
+      new Set(['./src/a.stories.tsx']),
+      DEFAULT_CONFIG_DIR,
+      identity
+    );
+
+    expect([...storybookFileHashes.keys()]).toEqual([]);
+  });
+
+  it('rolls a file hashed but absent from the graph into the catch-all', () => {
+    // A file inside a concatenated module is hashed but recorded only under the concatenation root,
+    // so deriving the catch-all from `files` rather than `hashes` would leave it hashed nowhere.
+    const { attribution } = collectStorybookFiles(
+      makeFiles({}),
+      makeHashes(['./src/inlined.ts']),
+      new Set(),
+      DEFAULT_CONFIG_DIR,
+      identity
+    );
+
+    expect([...attribution.storybookGlobals]).toEqual(['./src/inlined.ts']);
+  });
+
+  it('partitions every hashed file into at least one home', () => {
+    const files = makeFiles({
+      './src/a.stories.tsx': ['./src/button.tsx'],
+      './src/button.tsx': [],
+      './.storybook/preview.ts': ['./.storybook/theme.ts'],
+      './.storybook/theme.ts': [],
+      './node_modules/react-dom/index.js': [],
+    });
+    const hashes = makeHashes([...files.keys()]);
+
+    const { attribution } = collectStorybookFiles(
+      files,
+      hashes,
+      new Set(['./src/a.stories.tsx']),
+      DEFAULT_CONFIG_DIR,
+      identity
+    );
+
+    const homed = new Set([
+      ...attribution.storyReachable,
+      ...attribution.previewSubtree,
+      ...attribution.storybookGlobals,
+    ]);
+    expect([...homed].sort()).toEqual([...hashes.keys()].sort());
+  });
+
+  it('reports a file in both a story subtree and a preview subtree under both homes', () => {
+    // The two named homes are not mutually exclusive; only the catch-all is defined by absence.
+    const shared = './src/tokens.ts';
+    const files = makeFiles({
+      './src/a.stories.tsx': [shared],
+      './.storybook/preview.ts': [shared],
+      [shared]: [],
+    });
+
+    const { attribution } = collectStorybookFiles(
+      files,
+      makeHashes([...files.keys()]),
+      new Set(['./src/a.stories.tsx']),
+      DEFAULT_CONFIG_DIR,
+      identity
+    );
+
+    expect(attribution.storyReachable.has(shared)).toBe(true);
+    expect(attribution.previewSubtree.has(shared)).toBe(true);
+    expect(attribution.storybookGlobals.has(shared)).toBe(false);
+  });
+
+  it('leaves synthetic nodes out of the attribution, since they are never hashed', () => {
+    // The walks pass through globs, externals and virtual modules; only real files are reported.
+    const files = makeFiles({
+      './src/a.stories.tsx': ['virtual:stories'],
+      'virtual:stories': [],
+      './.storybook/preview.ts': ['glob:./src/**'],
+      'glob:./src/**': [],
+    });
+
+    const { attribution } = collectStorybookFiles(
+      files,
+      makeHashes(['./src/a.stories.tsx', './.storybook/preview.ts']),
+      new Set(['./src/a.stories.tsx']),
+      DEFAULT_CONFIG_DIR,
+      identity
+    );
+
+    expect([...attribution.storyReachable]).toEqual(['./src/a.stories.tsx']);
+    expect([...attribution.previewSubtree]).toEqual(['./.storybook/preview.ts']);
+  });
+
+  it('skips a preview config that has no content hash', () => {
+    const files = makeFiles({ './.storybook/preview.ts': [] });
+
+    const { storybookFileHashes } = collectStorybookFiles(
+      files,
+      new Map(),
+      new Set(),
+      DEFAULT_CONFIG_DIR,
+      identity
+    );
+
+    expect([...storybookFileHashes.keys()]).toEqual([]);
+  });
+});

--- a/node-src/lib/turbosnap/v2/storybookFiles.test.ts
+++ b/node-src/lib/turbosnap/v2/storybookFiles.test.ts
@@ -80,6 +80,26 @@ describe('collectStorybookFiles', () => {
     expect([...attribution.storybookGlobals]).toEqual(['./src/preview.ts']);
   });
 
+  it('does not treat a preview config under node_modules as the project preview', () => {
+    const vendoredPreview = './node_modules/some-addon/.storybook/preview.ts';
+    const vendoredTheme = './node_modules/some-addon/.storybook/theme.ts';
+    const files = makeFiles({ [vendoredPreview]: [vendoredTheme], [vendoredTheme]: [] });
+
+    const { storybookFileHashes, attribution } = collectStorybookFiles(
+      files,
+      makeHashes([...files.keys()]),
+      new Set(),
+      DEFAULT_CONFIG_DIR,
+      identity
+    );
+
+    expect([...storybookFileHashes.keys()]).toEqual([STORYBOOK_GLOBALS_KEY]);
+    expect([...attribution.previewSubtree]).toEqual([]);
+    expect([...attribution.storybookGlobals].sort()).toEqual(
+      [vendoredPreview, vendoredTheme].sort()
+    );
+  });
+
   it('finds the preview under a non-default config dir', () => {
     // A project with `-c src` has no `.storybook` at all; the preview lives at `./src/preview.ts` and
     // must be found there, not missed for not being literally named `.storybook`.
@@ -129,8 +149,8 @@ describe('collectStorybookFiles', () => {
     const files = makeFiles({
       './.storybook/preview.ts': ['./.storybook/themeA.ts'],
       './.storybook/themeA.ts': [],
-      './packages/other/.storybook/preview.ts': ['./packages/other/.storybook/themeB.ts'],
-      './packages/other/.storybook/themeB.ts': [],
+      './.storybook/preview.js': ['./.storybook/themeB.ts'],
+      './.storybook/themeB.ts': [],
     });
     const hashes = makeHashes([...files.keys()]);
 

--- a/node-src/lib/turbosnap/v2/storybookFiles.test.ts
+++ b/node-src/lib/turbosnap/v2/storybookFiles.test.ts
@@ -5,7 +5,7 @@ import { STORYBOOK_GLOBALS_KEY, STORYBOOK_PREVIEW_KEY } from './storybookFileKey
 import { collectStorybookFiles } from './storybookFiles';
 
 // The config dir most tests don't care about; only the configDir-specific tests below vary it.
-const DEFAULT_CONFIG_DIR = '.storybook';
+const DEFAULT_CONFIG_DIR = './.storybook';
 
 // An identity "hash" so a roll-up is readable as the set of paths that went into it, which is what
 // makes the contents of the shared `preview` roll-up visible.
@@ -109,7 +109,7 @@ describe('collectStorybookFiles', () => {
       files,
       makeHashes(['./src/preview.ts']),
       new Set(),
-      'src',
+      './src',
       identity
     );
 
@@ -135,7 +135,7 @@ describe('collectStorybookFiles', () => {
       files,
       hashes,
       new Set(['./src/Button.stories.tsx', './src/Badge.stories.tsx']),
-      'config',
+      './config',
       identity
     );
 

--- a/node-src/lib/turbosnap/v2/storybookFiles.test.ts
+++ b/node-src/lib/turbosnap/v2/storybookFiles.test.ts
@@ -134,7 +134,7 @@ describe('collectStorybookFiles', () => {
     const { attribution } = collectStorybookFiles(
       files,
       hashes,
-      new Set(['./src/Button.stories.tsx', './src/Badge.stories.tsx']),
+      new Set(['./src/Button.stories.tsx', './src/Badge.stories.tsx', shared]),
       './config',
       identity
     );
@@ -192,7 +192,7 @@ describe('collectStorybookFiles', () => {
     const { storybookFileHashes } = collectStorybookFiles(
       files,
       makeHashes(['./src/a.stories.tsx', './src/button.tsx']),
-      new Set(['./src/a.stories.tsx']),
+      new Set(['./src/a.stories.tsx', './src/button.tsx']),
       DEFAULT_CONFIG_DIR,
       identity
     );
@@ -227,7 +227,7 @@ describe('collectStorybookFiles', () => {
     const { attribution } = collectStorybookFiles(
       files,
       hashes,
-      new Set(['./src/a.stories.tsx']),
+      new Set(['./src/a.stories.tsx', './src/button.tsx']),
       DEFAULT_CONFIG_DIR,
       identity
     );
@@ -252,7 +252,7 @@ describe('collectStorybookFiles', () => {
     const { attribution } = collectStorybookFiles(
       files,
       makeHashes([...files.keys()]),
-      new Set(['./src/a.stories.tsx']),
+      new Set(['./src/a.stories.tsx', shared]),
       DEFAULT_CONFIG_DIR,
       identity
     );
@@ -274,7 +274,7 @@ describe('collectStorybookFiles', () => {
     const { attribution } = collectStorybookFiles(
       files,
       makeHashes(['./src/a.stories.tsx', './.storybook/preview.ts']),
-      new Set(['./src/a.stories.tsx']),
+      new Set(['./src/a.stories.tsx', 'virtual:stories']),
       DEFAULT_CONFIG_DIR,
       identity
     );

--- a/node-src/lib/turbosnap/v2/storybookFiles.ts
+++ b/node-src/lib/turbosnap/v2/storybookFiles.ts
@@ -22,13 +22,13 @@ import {
  * detached root). `configDir` is a project setting, not always `.storybook`.
  *
  * @param filePath The canonical manifest path to test.
- * @param configDirectory The project's Storybook config directory, project-root-relative.
+ * @param configDirectory The canonical manifest path of the project's Storybook config directory.
  *
  * @returns Whether the path is the project's preview config file.
  */
-function isPreviewConfig(filePath: FilePath, configDirectory: string): boolean {
+function isPreviewConfig(filePath: FilePath, configDirectory: FilePath): boolean {
   const { dir, base } = path.posix.parse(filePath);
-  return dir === `./${configDirectory}` && PREVIEW_CONFIG_PATTERN.test(base);
+  return dir === configDirectory && PREVIEW_CONFIG_PATTERN.test(base);
 }
 
 /**
@@ -59,8 +59,8 @@ export interface FileAttribution {
  * @param files The map of files to their hashes and dependencies.
  * @param hashes The content hashes keyed by canonical file path; a missing entry means no real file.
  * @param storyFileNames The detected story files.
- * @param configDirectory The project's Storybook config directory, project-root-relative (e.g.
- * `.storybook`).
+ * @param configDirectory The canonical manifest path of the project's Storybook config directory
+ * (e.g. `./.storybook`).
  * @param h64ToString The hash function.
  *
  * @returns The rolled-up hash per Storybook config file, and the {@link FileAttribution} recording
@@ -70,7 +70,7 @@ export function collectStorybookFiles(
   files: Map<FilePath, TurboSnapFile>,
   hashes: Map<FilePath, FileHash>,
   storyFileNames: Set<FilePath>,
-  configDirectory: string,
+  configDirectory: FilePath,
   h64ToString: (input: string) => string
 ): { storybookFileHashes: Map<StorybookFileKey, FileHash>; attribution: FileAttribution } {
   // The union of every story's subtree, used to tell Storybook globals apart from story code.

--- a/node-src/lib/turbosnap/v2/storybookFiles.ts
+++ b/node-src/lib/turbosnap/v2/storybookFiles.ts
@@ -1,0 +1,114 @@
+import {
+  collectTransitiveDependencies,
+  FileHash,
+  FilePath,
+  rollUpFileHashes,
+  TurboSnapFile,
+} from './graph';
+import { STORYBOOK_GLOBALS_KEY, STORYBOOK_PREVIEW_KEY } from './storybookFileKeys';
+
+// Matches `<configDir>/preview.*` on a canonical manifest path. Path matching is the only consistent
+// way to find the preview config: the config-entry import edge is spelled three incompatible ways
+// across builders (vite has no such edge at all, leaving preview a detached root). `configDir` is a
+// project setting, not always `.storybook`, so the pattern is built per call rather than hardcoded.
+function previewConfigPattern(configDirectory: string): RegExp {
+  const escapedConfigDirectory = configDirectory.replaceAll(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`);
+  return new RegExp(String.raw`(^|/)${escapedConfigDirectory}/preview\.[cm]?[jt]sx?$`);
+}
+
+/**
+ * Which of the three hashing homes each real file landed in, recorded by the same pass that builds
+ * the hashes. The graph in `files` is pruned of synthetic nodes after hashing, so a reachability walk
+ * over the written manifest cannot reconstruct these sets — it reports attributed files as orphans.
+ *
+ * The sets are closed over `hashes`: every hashed file lands in a home, and `storybookGlobals` holds
+ * exactly the ones in neither of the others. A file can be both story-reachable and in a preview
+ * subtree, so the two named homes are not mutually exclusive.
+ */
+export interface FileAttribution {
+  /** Files in neither of the above, rolled into the {@link STORYBOOK_GLOBALS_KEY} catch-all. */
+  storybookGlobals: Set<FilePath>;
+  /** Files in a `.storybook/preview.*` subtree, hashed into the shared `preview` `storybookFileHashes` entry. */
+  previewSubtree: Set<FilePath>;
+  /** Files in some story's transitive subtree, hashed into that story's `storyFiles` entry. */
+  storyReachable: Set<FilePath>;
+}
+
+/**
+ * Builds the file-hash entries of the `storybookFileHashes` section: a rolled-up hash for each Storybook
+ * config file that no story imports. Every hashable file lands in exactly one hashing home — a
+ * story's own subtree, the shared {@link STORYBOOK_PREVIEW_KEY} entry, or the {@link STORYBOOK_GLOBALS_KEY}
+ * catch-all — so nothing goes unhashed and the backend can still attribute a change to the preview
+ * config or to a Storybook/framework global.
+ *
+ * @param files The map of files to their hashes and dependencies.
+ * @param hashes The content hashes keyed by canonical file path; a missing entry means no real file.
+ * @param storyFileNames The detected story files.
+ * @param configDirectory The project's Storybook config directory, project-root-relative (e.g.
+ * `.storybook`).
+ * @param h64ToString The hash function.
+ *
+ * @returns The rolled-up hash per Storybook config file, and the {@link FileAttribution} recording
+ * which of the three hashing homes each real file landed in.
+ */
+export function collectStorybookFiles(
+  files: Map<FilePath, TurboSnapFile>,
+  hashes: Map<FilePath, FileHash>,
+  storyFileNames: Set<FilePath>,
+  configDirectory: string,
+  h64ToString: (input: string) => string
+): { storybookFileHashes: Map<FilePath, FileHash>; attribution: FileAttribution } {
+  // The union of every story's subtree, used to tell Storybook globals apart from story code.
+  const storyReachable = new Set<FilePath>();
+  for (const storyFile of storyFileNames) {
+    collectTransitiveDependencies(files, storyFile, storyReachable);
+  }
+
+  // Every preview config subtree, unioned into one `preview` roll-up rather than one entry per path,
+  // so the map stays a homogeneous set of category roll-ups (preview, globals, config, static). The
+  // shared accumulator is safe because every preview feeds the same hash, so there is no cross-preview
+  // leak to keep apart.
+  const previewConfig = previewConfigPattern(configDirectory);
+  const storybookFileHashes = new Map<FilePath, FileHash>();
+  const previewSubtree = new Set<FilePath>();
+  let hasPreview = false;
+  for (const filePath of files.keys()) {
+    if (!hashes.has(filePath) || !previewConfig.test(filePath)) continue;
+    hasPreview = true;
+    collectTransitiveDependencies(files, filePath, previewSubtree);
+  }
+  if (hasPreview) {
+    storybookFileHashes.set(
+      STORYBOOK_PREVIEW_KEY,
+      rollUpFileHashes(hashes, previewSubtree, h64ToString)
+    );
+  }
+
+  // Everything else real goes in one catch-all bucket. Membership is defined by *absence* from the
+  // story graph and the preview subtree rather than by an import edge, because those edges are
+  // unreliable — vite has no config-to-preview edge and rspack drops importer edges. Framework
+  // preview annotations and the React runtime land here, and they affect rendering, so leaving them
+  // unhashed would be a real blind spot.
+  // Derived from `hashes`, not from `files`: a file inside a concatenated module is hashed but only
+  // recorded as a dependency of the concatenation root, so filtering `files` would hash it nowhere.
+  const orphanGlobals = [...hashes.keys()].filter(
+    (filePath) => !storyReachable.has(filePath) && !previewSubtree.has(filePath)
+  );
+  if (orphanGlobals.length > 0) {
+    storybookFileHashes.set(
+      STORYBOOK_GLOBALS_KEY,
+      rollUpFileHashes(hashes, orphanGlobals, h64ToString)
+    );
+  }
+
+  // Report only real files, matching how the catch-all is defined, so the three sets cover exactly
+  // the hashed files. The walks pass through synthetic nodes (globs, externals, virtual modules),
+  // which have no hash. A file can be both story-reachable and in a preview subtree.
+  const attribution: FileAttribution = {
+    storyReachable: new Set([...storyReachable].filter((filePath) => hashes.has(filePath))),
+    previewSubtree: new Set([...previewSubtree].filter((filePath) => hashes.has(filePath))),
+    storybookGlobals: new Set(orphanGlobals),
+  };
+
+  return { storybookFileHashes, attribution };
+}

--- a/node-src/lib/turbosnap/v2/storybookFiles.ts
+++ b/node-src/lib/turbosnap/v2/storybookFiles.ts
@@ -58,7 +58,9 @@ export interface FileAttribution {
  *
  * @param files The map of files to their hashes and dependencies.
  * @param hashes The content hashes keyed by canonical file path; a missing entry means no real file.
- * @param storyFileNames The detected story files.
+ * @param storyReachable The union of every story's transitive subtree. The caller unions these as it
+ * hashes each story, so the story graph is walked once rather than here again. Synthetic nodes are
+ * filtered out of the attribution below.
  * @param configDirectory The canonical manifest path of the project's Storybook config directory
  * (e.g. `./.storybook`).
  * @param h64ToString The hash function.
@@ -69,16 +71,10 @@ export interface FileAttribution {
 export function collectStorybookFiles(
   files: Map<FilePath, TurboSnapFile>,
   hashes: Map<FilePath, FileHash>,
-  storyFileNames: Set<FilePath>,
+  storyReachable: Set<FilePath>,
   configDirectory: FilePath,
   h64ToString: (input: string) => string
 ): { storybookFileHashes: Map<StorybookFileKey, FileHash>; attribution: FileAttribution } {
-  // The union of every story's subtree, used to tell Storybook globals apart from story code.
-  const storyReachable = new Set<FilePath>();
-  for (const storyFile of storyFileNames) {
-    collectTransitiveDependencies(files, storyFile, storyReachable);
-  }
-
   // Every preview config subtree, unioned into one `preview` roll-up rather than one entry per path,
   // so the map stays a homogeneous set of category roll-ups (preview, globals, config, static). The
   // shared accumulator is safe because every preview feeds the same hash, so there is no cross-preview

--- a/node-src/lib/turbosnap/v2/storybookFiles.ts
+++ b/node-src/lib/turbosnap/v2/storybookFiles.ts
@@ -5,7 +5,11 @@ import {
   rollUpFileHashes,
   TurboSnapFile,
 } from './graph';
-import { STORYBOOK_GLOBALS_KEY, STORYBOOK_PREVIEW_KEY } from './storybookFileKeys';
+import {
+  STORYBOOK_GLOBALS_KEY,
+  STORYBOOK_PREVIEW_KEY,
+  StorybookFileKey,
+} from './storybookFileKeys';
 
 // Matches the project-root `<configDir>/preview.*` on a canonical manifest path (whose in-project
 // keys start `./`), so a preview under node_modules is not treated as the project's preview config.
@@ -19,8 +23,8 @@ function previewConfigPattern(configDirectory: string): RegExp {
 
 /**
  * Which of the three hashing homes each real file landed in, recorded by the same pass that builds
- * the hashes. The graph in `files` is pruned of synthetic nodes after hashing, so a reachability walk
- * over the written manifest cannot reconstruct these sets — it reports attributed files as orphans.
+ * the hashes. Serialization prunes synthetic nodes from the written graph, so a reachability walk
+ * over that graph cannot reconstruct these sets — it reports attributed files as orphans.
  *
  * The sets are closed over `hashes`: every hashed file lands in a home, and `storybookGlobals` holds
  * exactly the ones in neither of the others. A file can be both story-reachable and in a preview
@@ -58,7 +62,7 @@ export function collectStorybookFiles(
   storyFileNames: Set<FilePath>,
   configDirectory: string,
   h64ToString: (input: string) => string
-): { storybookFileHashes: Map<FilePath, FileHash>; attribution: FileAttribution } {
+): { storybookFileHashes: Map<StorybookFileKey, FileHash>; attribution: FileAttribution } {
   // The union of every story's subtree, used to tell Storybook globals apart from story code.
   const storyReachable = new Set<FilePath>();
   for (const storyFile of storyFileNames) {
@@ -70,7 +74,7 @@ export function collectStorybookFiles(
   // shared accumulator is safe because every preview feeds the same hash, so there is no cross-preview
   // leak to keep apart.
   const previewConfig = previewConfigPattern(configDirectory);
-  const storybookFileHashes = new Map<FilePath, FileHash>();
+  const storybookFileHashes = new Map<StorybookFileKey, FileHash>();
   const previewSubtree = new Set<FilePath>();
   let hasPreview = false;
   for (const filePath of files.keys()) {

--- a/node-src/lib/turbosnap/v2/storybookFiles.ts
+++ b/node-src/lib/turbosnap/v2/storybookFiles.ts
@@ -1,3 +1,6 @@
+import path from 'path';
+
+import { PREVIEW_CONFIG_PATTERN } from '../../getStorybookMetadata';
 import {
   collectTransitiveDependencies,
   FileHash,
@@ -11,16 +14,21 @@ import {
   StorybookFileKey,
 } from './storybookFileKeys';
 
-// Matches the project-root `<configDir>/preview.*` on a canonical manifest path (whose in-project
-// keys start `./`), so a preview under node_modules is not treated as the project's preview config.
-// Path matching is the only consistent way to find it: the config-entry import edge is spelled three
-// incompatible ways across builders (vite has no such edge at all, leaving preview a detached root).
-// `configDir` is a project setting, not always `.storybook`, so the pattern is built per call.
-function previewConfigPattern(configDirectory: string): RegExp {
-  const escapedConfigDirectory = configDirectory.replaceAll(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`);
-  // The only interpolated part is regex-escaped just above, so the pattern is safe.
-  // eslint-disable-next-line security/detect-non-literal-regexp
-  return new RegExp(String.raw`^\./${escapedConfigDirectory}/preview\.[cm]?[jt]sx?$`);
+/**
+ * Whether a canonical manifest path is the project's `<configDir>/preview.*` config file. Canonical
+ * in-project keys start `./`, so a preview under node_modules (keyed elsewhere) is not mistaken for
+ * the project's. Path matching is the only consistent way to find it: the config-entry import edge is
+ * spelled three incompatible ways across builders (vite has no such edge at all, leaving preview a
+ * detached root). `configDir` is a project setting, not always `.storybook`.
+ *
+ * @param filePath The canonical manifest path to test.
+ * @param configDirectory The project's Storybook config directory, project-root-relative.
+ *
+ * @returns Whether the path is the project's preview config file.
+ */
+function isPreviewConfig(filePath: FilePath, configDirectory: string): boolean {
+  const { dir, base } = path.posix.parse(filePath);
+  return dir === `./${configDirectory}` && PREVIEW_CONFIG_PATTERN.test(base);
 }
 
 /**
@@ -75,12 +83,11 @@ export function collectStorybookFiles(
   // so the map stays a homogeneous set of category roll-ups (preview, globals, config, static). The
   // shared accumulator is safe because every preview feeds the same hash, so there is no cross-preview
   // leak to keep apart.
-  const previewConfig = previewConfigPattern(configDirectory);
   const storybookFileHashes = new Map<StorybookFileKey, FileHash>();
   const previewSubtree = new Set<FilePath>();
   let hasPreview = false;
   for (const filePath of files.keys()) {
-    if (!hashes.has(filePath) || !previewConfig.test(filePath)) continue;
+    if (!hashes.has(filePath) || !isPreviewConfig(filePath, configDirectory)) continue;
     hasPreview = true;
     collectTransitiveDependencies(files, filePath, previewSubtree);
   }

--- a/node-src/lib/turbosnap/v2/storybookFiles.ts
+++ b/node-src/lib/turbosnap/v2/storybookFiles.ts
@@ -18,6 +18,8 @@ import {
 // `configDir` is a project setting, not always `.storybook`, so the pattern is built per call.
 function previewConfigPattern(configDirectory: string): RegExp {
   const escapedConfigDirectory = configDirectory.replaceAll(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`);
+  // The only interpolated part is regex-escaped just above, so the pattern is safe.
+  // eslint-disable-next-line security/detect-non-literal-regexp
   return new RegExp(String.raw`^\./${escapedConfigDirectory}/preview\.[cm]?[jt]sx?$`);
 }
 

--- a/node-src/lib/turbosnap/v2/storybookFiles.ts
+++ b/node-src/lib/turbosnap/v2/storybookFiles.ts
@@ -7,13 +7,14 @@ import {
 } from './graph';
 import { STORYBOOK_GLOBALS_KEY, STORYBOOK_PREVIEW_KEY } from './storybookFileKeys';
 
-// Matches `<configDir>/preview.*` on a canonical manifest path. Path matching is the only consistent
-// way to find the preview config: the config-entry import edge is spelled three incompatible ways
-// across builders (vite has no such edge at all, leaving preview a detached root). `configDir` is a
-// project setting, not always `.storybook`, so the pattern is built per call rather than hardcoded.
+// Matches the project-root `<configDir>/preview.*` on a canonical manifest path (whose in-project
+// keys start `./`), so a preview under node_modules is not treated as the project's preview config.
+// Path matching is the only consistent way to find it: the config-entry import edge is spelled three
+// incompatible ways across builders (vite has no such edge at all, leaving preview a detached root).
+// `configDir` is a project setting, not always `.storybook`, so the pattern is built per call.
 function previewConfigPattern(configDirectory: string): RegExp {
   const escapedConfigDirectory = configDirectory.replaceAll(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`);
-  return new RegExp(String.raw`(^|/)${escapedConfigDirectory}/preview\.[cm]?[jt]sx?$`);
+  return new RegExp(String.raw`^\./${escapedConfigDirectory}/preview\.[cm]?[jt]sx?$`);
 }
 
 /**

--- a/node-src/lib/uploadMetadataFiles.ts
+++ b/node-src/lib/uploadMetadataFiles.ts
@@ -7,7 +7,11 @@ import { main as trimStatsFile } from '../../bin-src/trimStatsFile';
 import { Context, FileDesc } from '../types';
 import metadataHtml from '../ui/html/metadata.html';
 import uploadingMetadata from '../ui/messages/info/uploadingMetadata';
-import { findStorybookConfigFile, MAIN_CONFIG_PATTERN } from './getStorybookMetadata';
+import {
+  findStorybookConfigFile,
+  MAIN_CONFIG_PATTERN,
+  PREVIEW_CONFIG_PATTERN,
+} from './getStorybookMetadata';
 import { uploadMetadata } from './upload';
 
 const fileSize = (path: string): Promise<number> =>
@@ -35,7 +39,7 @@ export async function uploadMetadataFiles(ctx: Context) {
         await findStorybookConfigFile(ctx.options.storybookConfigDir, MAIN_CONFIG_PATTERN).catch(
           () => undefined
         ),
-        await findStorybookConfigFile(ctx.options.storybookConfigDir, /^preview\.[jt]sx?$/).catch(
+        await findStorybookConfigFile(ctx.options.storybookConfigDir, PREVIEW_CONFIG_PATTERN).catch(
           () => undefined
         ),
         ctx.fileInfo?.statsPath && (await trimStatsFile([ctx.fileInfo.statsPath])),


### PR DESCRIPTION
Relates to CAP-4864

> [!NOTE]
> This is a sizable PR but all these changes felt related enough to include in a single PR. Our goal is to get this version of TurboSnap 2.0 into a testing phase and make adjustments later so I'm opening this PR a little early because it's built against a working version of the algorithm.

This builds the remaining functions to produce the TurboSnap manifest. This manifest is what is then uploaded to the Index service which determines what changed based on the baseline's version of the manifest.

It looks something like:

```
{
  "storybookHash": "<a single hash of the entire storybook>",
  "storybookFilesHashes": {
    "storybookGlobals": "<a single hash of all globals>",
    "storybookVersion": "<storybook version string>",
    "storybookConfigFiles": "<a single hash of all config files",
    "staticFiles": "<a single hash of all static files>"
  },
  "storybookConfigFiles": {
    <file path of config files>: <hash of that source file>
  },
  "staticFiles": {
    <file path of static files>: <hash of that source file>
  },
  "storyFiles": {
    <file path of story files>: <hash of that source file>
  },
  "unrecognizedStoryEntries": [],
  "attribution": {
    "storyReachable": [<list of files that link to a story>],
    "previewSubtree": [<list of files that link to .storybook/preview.ts> (or the configured dir if it's not default)],
    "storybookGlobals": [<list of files that don't link to a story but are floating in the preview-stats.json>],
  },
  "files": {
    <file path>: {
      "hash": "<hash of source file>",
      "dependencies": [<list of dependencies for the file>],
    }
    ...
  }
}
```

The main entrypoint is going to be `manifest.ts` which orchestrates all the `preview-stats.json` operations. The caller will eventually:
1. `buildManifest()`
2. `serializeManifest()`
3. `writeManifest()`

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>18.6.1--canary.1442.32890865792.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@18.6.1--canary.1442.32890865792.0
  # or 
  yarn add chromatic@18.6.1--canary.1442.32890865792.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
