### PR TITLE
[TurboSnap v2] Validate TurboSnap v2 stats inputs

### DIFF
--- a/node-src/lib/turbosnap/v2/classifyUploadHashesFailure.test.ts
+++ b/node-src/lib/turbosnap/v2/classifyUploadHashesFailure.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from 'vitest';
+
+import { classifyUploadHashesFailure } from './classifyUploadHashesFailure';
+
+describe('classifyUploadHashesFailure', () => {
+  it('names nothing when the response carries the success member', () => {
+    expect(
+      classifyUploadHashesFailure({
+        build: { turboSnapStatus: 'APPLIED', turboSnapMechanism: 'HASH_BASED' },
+      })
+    ).toBeUndefined();
+  });
+
+  it('names invalid story file hashes as our own malformed request', () => {
+    const failure = classifyUploadHashesFailure({
+      errors: [
+        { __typename: 'InvalidStoryFileHashesError', message: 'Invalid story file hashes.' },
+      ],
+    });
+
+    expect(failure?.bailSubreason).toBe('invalidStoryFileHashes');
+    expect(failure?.error.message).toContain('Invalid story file hashes.');
+  });
+
+  it('names invalid storybook config hashes as our own malformed request', () => {
+    const failure = classifyUploadHashesFailure({
+      errors: [
+        {
+          __typename: 'InvalidStorybookConfigHashesError',
+          message: 'Invalid storybook config hashes.',
+        },
+      ],
+    });
+
+    expect(failure?.bailSubreason).toBe('invalidStorybookConfigHashes');
+    expect(failure?.error.message).toContain('Invalid storybook config hashes.');
+  });
+
+  it('names an invalid build status as calling at the wrong point in the lifecycle', () => {
+    const failure = classifyUploadHashesFailure({
+      errors: [
+        {
+          __typename: 'InvalidUploadHashesBuildStatusError',
+          message: 'Uploading hashes is only allowed for announced builds.',
+        },
+      ],
+    });
+
+    expect(failure?.bailSubreason).toBe('invalidBuildStatus');
+  });
+
+  it('groups an unrecognized error typename under schema drift', () => {
+    const failure = classifyUploadHashesFailure({
+      errors: [{ __typename: 'UnknownMutationError', message: 'Something went wrong.' }],
+    });
+
+    expect(failure?.bailSubreason).toBe('invalidResponse');
+    expect(failure?.error.message).toContain('Something went wrong.');
+  });
+
+  it('names a response matching neither union member, which is otherwise indistinguishable from success', () => {
+    const failure = classifyUploadHashesFailure({});
+
+    expect(failure?.bailSubreason).toBe('invalidResponse');
+    expect(failure?.error.message).toContain('neither member');
+  });
+
+  it('names a missing payload as schema drift too', () => {
+    expect(classifyUploadHashesFailure(undefined)?.bailSubreason).toBe('invalidResponse');
+  });
+
+  it('treats an empty errors array as matching neither member', () => {
+    expect(classifyUploadHashesFailure({ errors: [] })?.bailSubreason).toBe('invalidResponse');
+  });
+
+  it('groups an unrecognized error typename under schema drift', () => {
+    const failure = classifyUploadHashesFailure({
+      errors: [{ __typename: 'SomeNewError', message: 'Something else went wrong.' }],
+    });
+
+    expect(failure?.bailSubreason).toBe('invalidResponse');
+    expect(failure?.error.message).toContain('SomeNewError: Something else went wrong.');
+  });
+
+  it('reports every error message when the Index returns several', () => {
+    const failure = classifyUploadHashesFailure({
+      errors: [
+        { __typename: 'SomeNewError' },
+        { __typename: 'InvalidStoryFileHashesError', message: 'Invalid story file hashes.' },
+      ],
+    });
+
+    expect(failure?.bailSubreason).toBe('invalidStoryFileHashes');
+    expect(failure?.error.message).toContain('SomeNewError');
+    expect(failure?.error.message).toContain('Invalid story file hashes.');
+  });
+});

--- a/node-src/lib/turbosnap/v2/classifyUploadHashesFailure.ts
+++ b/node-src/lib/turbosnap/v2/classifyUploadHashesFailure.ts
@@ -1,0 +1,66 @@
+import type { TurboSnapIndexContractViolationSubreason } from '../../../types';
+import type { BuildUploadHashesError, BuildUploadHashesResponse } from './uploadHashes';
+
+/**
+ * A rejection the CLI caused: we sent bad data, called at the wrong point in the build lifecycle, or
+ * are talking to a schema we no longer understand. Each subreason is its own Sentry fingerprint.
+ */
+export interface UploadHashesFailure {
+  bailSubreason: TurboSnapIndexContractViolationSubreason;
+  error: Error;
+}
+
+// Index error typenames, matching the `BuildUploadHashesError` union in the webapp schema. Any other
+// typename (including the schema's `UnknownMutationError` catch-all) falls through to `invalidResponse`.
+const SUBREASON_BY_ERROR_TYPENAME = new Map<string, TurboSnapIndexContractViolationSubreason>([
+  ['InvalidStoryFileHashesError', 'invalidStoryFileHashes'],
+  ['InvalidStorybookConfigHashesError', 'invalidStorybookConfigHashes'],
+  ['InvalidUploadHashesBuildStatusError', 'invalidBuildStatus'],
+]);
+
+/**
+ * Names the self-inflicted half of the hash upload contract. The mutation resolves rather than
+ * throws on rejection, so without this check a server-side rejection is indistinguishable from
+ * success. Transport failures throw and are classified by the caller instead.
+ *
+ * @param response The `buildUploadHashes` payload, or `undefined` when the field is missing entirely.
+ *
+ * @returns The named failure, or `undefined` when the response is a well-formed success.
+ */
+export function classifyUploadHashesFailure(
+  response: BuildUploadHashesResponse | undefined
+): UploadHashesFailure | undefined {
+  const errors = response?.errors;
+  if (errors && errors.length > 0) {
+    const bailSubreason = selectErrorSubreason(errors);
+    return {
+      bailSubreason,
+      error: new Error(`Index rejected the hash upload: ${describeErrors(errors)}`),
+    };
+  }
+
+  if (response?.build) return undefined;
+
+  return {
+    bailSubreason: 'invalidResponse',
+    error: new Error('Hash upload response matched neither member of the mutation union'),
+  };
+}
+
+// An errors array we cannot name is schema drift just as much as a response matching neither member,
+// so it groups under the same fingerprint.
+function selectErrorSubreason(
+  errors: BuildUploadHashesError[]
+): TurboSnapIndexContractViolationSubreason {
+  for (const error of errors) {
+    const subreason = error.__typename && SUBREASON_BY_ERROR_TYPENAME.get(error.__typename);
+    if (subreason) return subreason;
+  }
+  return 'invalidResponse';
+}
+
+function describeErrors(errors: BuildUploadHashesError[]): string {
+  return errors
+    .map((error) => [error.__typename, error.message].filter(Boolean).join(': ') || 'unknown error')
+    .join('; ');
+}

--- a/node-src/lib/turbosnap/v2/index.test.ts
+++ b/node-src/lib/turbosnap/v2/index.test.ts
@@ -427,12 +427,12 @@ function diskWhere(overrides: Partial<ProjectFiles>): ProjectFiles {
   return { ...projectFiles, ...overrides };
 }
 
-/** The mutation input the Index received, or undefined when nothing was uploaded. */
+// The mutation input the Index received, or undefined when nothing was uploaded.
 function uploaded() {
   return runQuery.mock.calls[0]?.[1]?.input;
 }
 
-/** The diagnostic manifest as written, or undefined when none was written. */
+// The diagnostic manifest as written, or undefined when none was written.
 function writtenManifest() {
   const contents =
     disk.writtenFiles?.[path.join(manifestOutputDirectory, 'turbosnap-manifest.json')];

--- a/node-src/lib/turbosnap/v2/index.test.ts
+++ b/node-src/lib/turbosnap/v2/index.test.ts
@@ -1,0 +1,440 @@
+import * as Sentry from '@sentry/node';
+import path from 'path';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import GraphQLClient from '../../../io/graphqlClient';
+import { Stats } from '../../../types';
+import { captureBailException } from '../v1/captureBailException';
+import { traceChangedFiles } from './index';
+import { ProjectFiles } from './projectFiles';
+import { InMemoryDisk, inMemoryProjectFiles } from './projectFiles.fake';
+
+// Only the two boundaries the module cannot describe as a value stay mocked: error reporting, whose
+// whole job is a side effect, and the network, faked through the injected client rather than the api
+// module so the mutation input the Index receives is the thing asserted. Everything below
+// traceChangedFiles — the manifest and the emptiness guards — runs for real against the disk
+// described in `disk`.
+vi.mock('@sentry/node', () => ({
+  captureException: vi.fn(),
+  setContext: vi.fn(),
+}));
+
+vi.mock('../v1/captureBailException', () => ({
+  captureBailException: vi.fn(() => 'sentry-event-id'),
+}));
+
+const projectRoot = '/repo/packages/ui';
+const configDirectory = `${projectRoot}/.storybook`;
+
+const STORY = './src/Button.stories.tsx';
+const COMPONENT = './src/Button.tsx';
+const PREVIEW = './.storybook/preview.ts';
+const DEPENDENCY = './node_modules/react/index.js';
+const STORIES_ENTRY = './storybook-stories.js';
+const CONFIG_ENTRY = './storybook-config-entry.js';
+
+// The names a builder generates have no file on disk; everything else the stats mention does, which
+// is what keeps a test from having to list every source file its stats name.
+const SYNTHETIC = ['storybook-stories.js', 'storybook-config-entry.js', '|lazy|'];
+
+// The manifest write goes through ProjectFiles, so the fake records it into `disk.writtenFiles`;
+// reading those bytes back is a stronger assertion than a spy on writeManifest. See writtenManifest.
+const manifestOutputDirectory = '/repo/packages/ui/storybook-static';
+
+// A fresh disk describing a healthy project and the adapter that reads it, rebuilt for each test so
+// none leaks into the next; see createFixture in __fixtures__/manifestFixtures.ts.
+let disk: InMemoryDisk;
+let projectFiles: ProjectFiles;
+let runQuery: ReturnType<typeof vi.fn>;
+
+/**
+ * Builds a fresh in-memory disk describing a healthy project and the adapter that reads it, so each
+ * test owns its own state.
+ *
+ * @param overrides Disk fields to replace on top of the healthy defaults.
+ *
+ * @returns The disk and the adapter that reads it.
+ */
+function createFixture(overrides: InMemoryDisk = {}) {
+  const nextDisk: InMemoryDisk = {
+    directories: {
+      [configDirectory]: ['main.ts', 'preview.ts', 'static'],
+      [`${configDirectory}/static`]: ['logo.svg'],
+    },
+    packageVersions: { storybook: '9.1.20' },
+    isAbsent: (candidate) => SYNTHETIC.some((name) => candidate.includes(name)),
+    ...overrides,
+  };
+  return { disk: nextDisk, projectFiles: inMemoryProjectFiles(nextDisk) };
+}
+
+beforeEach(() => {
+  ({ disk, projectFiles } = createFixture());
+  runQuery = vi.fn().mockResolvedValue({
+    buildUploadHashes: { build: { turboSnapStatus: 'APPLIED', turboSnapMechanism: 'HASH_BASED' } },
+  });
+});
+
+describe('traceChangedFiles', () => {
+  it('uploads and writes a manifest when the stats build a healthy manifest', async () => {
+    await expect(trace()).resolves.toEqual({ status: 'fallback' });
+
+    expect(uploaded()).toEqual({
+      buildId: 'build-id',
+      storybookHash: expect.any(String),
+      storybookConfigHashes: {
+        preview: expect.any(String),
+        storybookVersion: '9.1.20',
+        storybookConfigFiles: expect.any(String),
+        staticFiles: expect.any(String),
+      },
+      storyFileHashes: { [STORY]: expect.any(String) },
+    });
+    // The three out-of-graph sections the Index gates on, plus the graph-rolled preview entry.
+    expect(writtenManifest().storybookFileHashes).toEqual({
+      preview: expect.any(String),
+      storybookVersion: '9.1.20',
+      storybookConfigFiles: expect.any(String),
+      staticFiles: expect.any(String),
+    });
+    expect(writtenManifest().storybookConfigFiles).toEqual({
+      './.storybook/main.ts': expect.any(String),
+      [PREVIEW]: expect.any(String),
+    });
+    expect(writtenManifest().staticFiles).toEqual({
+      './.storybook/static/logo.svg': expect.any(String),
+    });
+  });
+
+  it('bails with indexUnavailable when the Index request times out', async () => {
+    runQuery.mockRejectedValue(
+      Object.assign(new Error('request timed out'), { code: 'ETIMEDOUT' })
+    );
+
+    await expect(trace()).resolves.toEqual({
+      status: 'bailed',
+      turboSnap: {
+        bailReason: {
+          indexUnavailable: true,
+          bailSubreason: 'networkError',
+        },
+      },
+    });
+    expect(writtenManifest().storyFiles).toEqual({ [STORY]: expect.any(String) });
+    expect(captureBailException).not.toHaveBeenCalled();
+  });
+
+  it('leaves the indexUnavailable subreason absent when the request error is unclassified', async () => {
+    runQuery.mockRejectedValue(new Error('request failed unexpectedly'));
+
+    await expect(trace()).resolves.toEqual({
+      status: 'bailed',
+      turboSnap: { bailReason: { indexUnavailable: true } },
+    });
+    expect(captureBailException).not.toHaveBeenCalled();
+    expect(Sentry.captureException).not.toHaveBeenCalled();
+  });
+
+  it('bails with a fingerprinted Sentry event when the Index rejects our story file hashes', async () => {
+    runQuery.mockResolvedValue({
+      buildUploadHashes: {
+        errors: [
+          { __typename: 'InvalidStoryFileHashesError', message: 'Invalid story file hashes.' },
+        ],
+      },
+    });
+
+    await expect(trace()).resolves.toEqual({
+      status: 'bailed',
+      turboSnap: {
+        bailReason: {
+          indexContractViolation: true,
+          bailSubreason: 'invalidStoryFileHashes',
+          sentryEventId: 'sentry-event-id',
+        },
+      },
+    });
+    expect(captureBailException).toHaveBeenCalledWith(expect.any(Error), {
+      bailSubreason: 'invalidStoryFileHashes',
+      bailPath: 'uploadHashes',
+    });
+    expect(writtenManifest().storyFiles).toEqual({ [STORY]: expect.any(String) });
+  });
+
+  it('bails with a fingerprinted Sentry event when we upload at the wrong build status', async () => {
+    runQuery.mockResolvedValue({
+      buildUploadHashes: {
+        errors: [
+          {
+            __typename: 'InvalidUploadHashesBuildStatusError',
+            message: 'Uploading hashes is only allowed for announced builds.',
+          },
+        ],
+      },
+    });
+
+    await expect(trace()).resolves.toEqual({
+      status: 'bailed',
+      turboSnap: {
+        bailReason: {
+          indexContractViolation: true,
+          bailSubreason: 'invalidBuildStatus',
+          sentryEventId: 'sentry-event-id',
+        },
+      },
+    });
+    expect(captureBailException).toHaveBeenCalledWith(expect.any(Error), {
+      bailSubreason: 'invalidBuildStatus',
+      bailPath: 'uploadHashes',
+    });
+  });
+
+  it('bails with a fingerprinted Sentry event when the response matches neither union member', async () => {
+    runQuery.mockResolvedValue({ buildUploadHashes: {} });
+
+    await expect(trace()).resolves.toEqual({
+      status: 'bailed',
+      turboSnap: {
+        bailReason: {
+          indexContractViolation: true,
+          bailSubreason: 'invalidResponse',
+          sentryEventId: 'sentry-event-id',
+        },
+      },
+    });
+    expect(captureBailException).toHaveBeenCalledWith(expect.any(Error), {
+      bailSubreason: 'invalidResponse',
+      bailPath: 'uploadHashes',
+    });
+  });
+
+  it('bails with a Sentry ID when manifest construction fails', async () => {
+    // A file the sweep found and then could not read is the one unreadability the module treats as a
+    // bug rather than an answer; see ProjectFiles.
+    const error = new Error('Could not hash /repo/packages/ui/src/Button.stories.tsx');
+
+    await expect(
+      trace({
+        projectFiles: diskWhere({
+          hashAll: () => {
+            throw error;
+          },
+        }),
+      })
+    ).resolves.toEqual({
+      status: 'bailed',
+      turboSnap: {
+        bailReason: {
+          internalError: true,
+          bailSubreason: 'manifestBuildFailed',
+          sentryEventId: 'sentry-event-id',
+        },
+      },
+    });
+    expect(captureBailException).toHaveBeenCalledWith(error, {
+      bailSubreason: 'manifestBuildFailed',
+      bailPath: 'buildManifest',
+    });
+    expect(runQuery).not.toHaveBeenCalled();
+  });
+
+  it('bails without uploading when the config directory resolves to zero files', async () => {
+    disk.directories = {};
+
+    const result = await trace();
+
+    expect(result).toEqual({
+      status: 'bailed',
+      turboSnap: {
+        bailReason: {
+          noStorybookConfigFiles: true,
+        },
+      },
+    });
+    expect(runQuery).not.toHaveBeenCalled();
+    expect(writtenManifest().storybookConfigFiles).toEqual({});
+  });
+
+  it('bails when the prebuilt metadata declares static directories that source did not resolve', async () => {
+    const result = await trace({ staticDirs: [] });
+
+    expect(result).toEqual({
+      status: 'bailed',
+      turboSnap: {
+        bailReason: {
+          unresolvedStaticDirectories: true,
+        },
+      },
+    });
+    expect(writtenManifest()).toBeUndefined();
+    expect(runQuery).not.toHaveBeenCalled();
+  });
+
+  it('reports the empty config directory rather than the empty graph when both hold', async () => {
+    disk.directories = {};
+
+    await expect(trace({ stats: stats({ stories: false }) })).resolves.toEqual({
+      status: 'bailed',
+      turboSnap: { bailReason: { noStorybookConfigFiles: true } },
+    });
+  });
+
+  it('bails without uploading when configured static directories resolve to zero files', async () => {
+    disk.directories = { [configDirectory]: ['main.ts', 'preview.ts'] };
+
+    const result = await trace();
+
+    expect(result).toEqual({
+      status: 'bailed',
+      turboSnap: {
+        bailReason: {
+          noStaticFiles: true,
+        },
+      },
+    });
+    expect(runQuery).not.toHaveBeenCalled();
+    expect(writtenManifest().staticFiles).toEqual({});
+  });
+
+  it('allows an empty static section when no static directories are configured', async () => {
+    await expect(trace({ staticDirs: [], staticDirsDeclared: false })).resolves.toEqual({
+      status: 'fallback',
+    });
+
+    expect(uploaded().storyFileHashes).toEqual({ [STORY]: expect.any(String) });
+    expect(writtenManifest().storybookFileHashes['staticFiles']).toBeUndefined();
+  });
+
+  it('bails without uploading when the graph contains no node_modules files', async () => {
+    const result = await trace({ stats: stats({ dependency: false }) });
+
+    expect(result).toEqual({
+      status: 'bailed',
+      turboSnap: {
+        bailReason: {
+          noNodeModulesFiles: true,
+        },
+      },
+    });
+    expect(runQuery).not.toHaveBeenCalled();
+    expect(writtenManifest().storyFiles).toEqual({ [STORY]: expect.any(String) });
+  });
+
+  it('reports the empty config directory rather than the missing dependencies when both hold', async () => {
+    disk.directories = {};
+
+    await expect(trace({ stats: stats({ dependency: false }) })).resolves.toEqual({
+      status: 'bailed',
+      turboSnap: { bailReason: { noStorybookConfigFiles: true } },
+    });
+  });
+
+  it('reports the missing dependencies rather than the empty graph when both hold', async () => {
+    await expect(trace({ stats: stats({ stories: false, dependency: false }) })).resolves.toEqual({
+      status: 'bailed',
+      turboSnap: { bailReason: { noNodeModulesFiles: true } },
+    });
+  });
+
+  it('bails without uploading when the graph contains no story files', async () => {
+    const result = await trace({ stats: stats({ stories: false }) });
+
+    expect(result).toEqual({
+      status: 'bailed',
+      turboSnap: {
+        bailReason: {
+          noStoryFiles: true,
+        },
+      },
+    });
+    expect(runQuery).not.toHaveBeenCalled();
+    expect(writtenManifest().storyFiles).toEqual({});
+  });
+
+  it('preserves the no-story bail when writing its diagnostic manifest fails', async () => {
+    await expect(
+      trace({
+        stats: stats({ stories: false }),
+        projectFiles: diskWhere({
+          writeFile: () => {
+            throw new Error('the manifest directory is gone');
+          },
+        }),
+      })
+    ).resolves.toEqual({
+      status: 'bailed',
+      turboSnap: { bailReason: { noStoryFiles: true } },
+    });
+    expect(Sentry.captureException).toHaveBeenCalledWith(expect.any(Error), {
+      tags: { turbo_snap_v2_diagnostic: 'writeManifest' },
+    });
+  });
+});
+
+/**
+ * Runs the entry point against the disk in `disk`, with the fake client as its only network.
+ *
+ * @param overrides The input fields this test's assertion turns on.
+ *
+ * @returns The TurboSnap result.
+ */
+function trace(overrides: Partial<Parameters<typeof traceChangedFiles>[0]> = {}) {
+  return traceChangedFiles({
+    graphqlClient: { runQuery } as unknown as GraphQLClient,
+    buildId: 'build-id',
+    stats: stats(),
+    manifestOutputDirectory,
+    projectRoot,
+    configDir: '.storybook',
+    staticDirs: ['.storybook/static'],
+    staticDirsDeclared: true,
+    projectFiles,
+    ...overrides,
+  });
+}
+
+/**
+ * A stats file describing the project on disk.
+ *
+ * @param options Which properties of a healthy graph to keep.
+ * @param options.stories Whether the source module is imported by the stories entry, which is what
+ * makes it a story file rather than plain source.
+ * @param options.dependency Whether the graph names the one `node_modules` file that makes a
+ * dependency upgrade visible.
+ *
+ * @returns The stats file.
+ */
+function stats({ stories = true, dependency = true } = {}): Stats {
+  const source = stories ? STORY : COMPONENT;
+
+  return {
+    modules: [
+      { id: 1, name: source, reasons: [{ moduleName: stories ? STORIES_ENTRY : PREVIEW }] },
+      { id: 2, name: PREVIEW, reasons: [{ moduleName: CONFIG_ENTRY }] },
+      ...(dependency ? [{ id: 3, name: DEPENDENCY, reasons: [{ moduleName: source }] }] : []),
+    ],
+  };
+}
+
+/**
+ * The disk with some methods replaced, for the paths that only a failing read reaches.
+ *
+ * @param overrides The methods to replace.
+ *
+ * @returns The adapter.
+ */
+function diskWhere(overrides: Partial<ProjectFiles>): ProjectFiles {
+  return { ...projectFiles, ...overrides };
+}
+
+/** The mutation input the Index received, or undefined when nothing was uploaded. */
+function uploaded() {
+  return runQuery.mock.calls[0]?.[1]?.input;
+}
+
+/** The diagnostic manifest as written, or undefined when none was written. */
+function writtenManifest() {
+  const contents =
+    disk.writtenFiles?.[path.join(manifestOutputDirectory, 'turbosnap-manifest.json')];
+  return contents === undefined ? undefined : JSON.parse(contents);
+}

--- a/node-src/lib/turbosnap/v2/index.ts
+++ b/node-src/lib/turbosnap/v2/index.ts
@@ -1,0 +1,214 @@
+import * as Sentry from '@sentry/node';
+
+import GraphQLClient from '../../../io/graphqlClient';
+import type { Stats, TurboSnapBailReason, TurboSnapInternalErrorSubreason } from '../../../types';
+import { TraceChangedFilesResult } from '../types';
+import { captureBailException } from '../v1/captureBailException';
+import { isNetworkError } from '../v1/errors';
+import { classifyUploadHashesFailure } from './classifyUploadHashesFailure';
+import { buildManifest, TurboSnapManifest, writeManifest } from './manifest';
+import { ProjectFiles } from './projectFiles';
+import { countNodeModulesFiles } from './statsGraph';
+import { uploadHashes } from './uploadHashes';
+
+interface TraceChangedFilesInput {
+  graphqlClient: GraphQLClient;
+  buildId: string;
+  stats: Stats;
+  manifestOutputDirectory: string;
+  projectRoot: string;
+  configDir: string;
+  staticDirs: string[];
+  staticDirsDeclared: boolean;
+  projectFiles: ProjectFiles;
+}
+
+/**
+ * The result of running TurboSnap v2. In addition to the shared trace statuses, v2 can return
+ * 'fallback' to tell the caller it can't be trusted to trace this build and v1 should run instead.
+ */
+export type TraceChangedFilesV2Result = TraceChangedFilesResult | { status: 'fallback' };
+
+/**
+ * Determines which story files are affected by the changed source file hashes, bailing out of
+ * TurboSnap when necessary.
+ *
+ * @param input The input to run TurboSnap 2.0.
+ * @param input.stats The preview stats file, read by the caller because v1 traces the same one.
+ * @param input.manifestOutputDirectory The directory to write the manifest file to.
+ * @param input.projectRoot The absolute Storybook project root used to read source files off disk
+ * and to anchor manifest keys.
+ * @param input.configDir The project-relative Storybook config directory, hashed off disk because it
+ * is never a bundler input.
+ * @param input.staticDirs The project-relative static directories, hashed off disk for the same reason.
+ * @param input.staticDirsDeclared Whether the prebuilt Storybook reports that its source config
+ * declared static directories.
+ * @param input.projectFiles How to read the disk; see {@link ProjectFiles}. Required rather than
+ * defaulted, so a caller cannot silently reach the real disk.
+ *
+ * @returns The TurboSnap result.
+ */
+export async function traceChangedFiles(
+  input: TraceChangedFilesInput
+): Promise<TraceChangedFilesV2Result> {
+  const { stats } = input;
+
+  const staticDirectoriesBail = getStaticDirectoriesBail(input);
+  if (staticDirectoriesBail) return staticDirectoriesBail;
+
+  let manifest;
+  try {
+    manifest = await buildManifest(stats, input.projectRoot, {
+      configDir: input.configDir,
+      staticDirs: input.staticDirs,
+      projectFiles: input.projectFiles,
+    });
+  } catch (error) {
+    return internalErrorBail(error, 'manifestBuildFailed', 'buildManifest');
+  }
+
+  // Written here rather than at each exit below, because every one of them writes it: a bail is
+  // exactly when the manifest is worth inspecting, and a degenerate graph still has to be debuggable.
+  writeDiagnosticManifest(manifest, input.manifestOutputDirectory, input.projectFiles);
+
+  const emptySectionBail = getEmptySectionBail(manifest, stats, input.staticDirs);
+  if (emptySectionBail) return emptySectionBail;
+
+  let response;
+  try {
+    response = await uploadHashes(input.graphqlClient, input.buildId, manifest);
+  } catch (error) {
+    // A thrown error is a transport failure, already retried. It is expected volume rather than a
+    // bug, so it gets a named reason and no Sentry event.
+    return bailWith({
+      indexUnavailable: true,
+      ...(isNetworkError(error) && { bailSubreason: 'networkError' as const }),
+    });
+  }
+
+  // The mutation resolves with its failure member rather than throwing, so a rejection is only
+  // visible by inspecting the response. Each of these is our own bug and is worth a Sentry event.
+  const uploadFailure = classifyUploadHashesFailure(response);
+  if (uploadFailure) {
+    return bailWith({
+      indexContractViolation: true,
+      bailSubreason: uploadFailure.bailSubreason,
+      sentryEventId: captureBailException(uploadFailure.error, {
+        bailSubreason: uploadFailure.bailSubreason,
+        bailPath: 'uploadHashes',
+      }),
+    });
+  }
+
+  // Until we want to lean on the v2 output, we always fallback to v1.
+  return { status: 'fallback' };
+}
+
+/** Wraps a bail reason in the result shape the caller expects. */
+function bailWith(bailReason: TurboSnapBailReason): TraceChangedFilesResult {
+  return { status: 'bailed', turboSnap: { bailReason } };
+}
+
+/**
+ * Bails on a thrown error from one of our own checks, reporting it to Sentry under `bailPath`.
+ *
+ * @param error The thrown value.
+ * @param bailSubreason The classified subreason, which is also the Sentry fingerprint.
+ * @param bailPath A stable identifier for the bail site.
+ *
+ * @returns The internal-error bail result.
+ */
+function internalErrorBail(
+  error: unknown,
+  bailSubreason: TurboSnapInternalErrorSubreason,
+  bailPath: string
+): TraceChangedFilesResult {
+  return bailWith({
+    internalError: true,
+    bailSubreason,
+    sentryEventId: captureBailException(error, { bailSubreason, bailPath }),
+  });
+}
+
+function writeDiagnosticManifest(
+  manifest: TurboSnapManifest,
+  outputDirectory: string,
+  projectFiles: ProjectFiles
+) {
+  try {
+    writeManifest(manifest, outputDirectory, projectFiles);
+  } catch (error) {
+    Sentry.captureException(error, {
+      tags: { turbo_snap_v2_diagnostic: 'writeManifest' },
+    });
+  }
+}
+
+/**
+ * A prebuilt Storybook's project.json records whether static directories were declared, while their
+ * paths must still be derived from the checked-out source. If those two sources disagree, continuing
+ * would silently omit `staticFiles` even though we know the section should exist.
+ */
+function getStaticDirectoriesBail(
+  input: Pick<TraceChangedFilesInput, 'staticDirs' | 'staticDirsDeclared'>
+): TraceChangedFilesResult | undefined {
+  if (!input.staticDirsDeclared || input.staticDirs.length > 0) return undefined;
+  return bailWith({ unresolvedStaticDirectories: true });
+}
+
+/**
+ * Bails when a section that should never be empty is empty, in diagnosis order. An empty section is
+ * evidence that the input we derived is wrong rather than that the project genuinely lacks it.
+ *
+ * @param manifest The manifest built from the stats.
+ * @param stats The stats file the manifest was built from.
+ * @param staticDirectories The project-relative static directories.
+ *
+ * @returns The bail result, or undefined when every section that should be populated is.
+ */
+function getEmptySectionBail(
+  manifest: TurboSnapManifest,
+  stats: Stats,
+  staticDirectories: string[]
+): TraceChangedFilesResult | undefined {
+  // A real Storybook always has a non-empty config directory, so resolving zero files there says the
+  // input derivation is wrong rather than that the project has no config. It remains the first and
+  // most actionable diagnosis when several manifest sections are empty.
+  if (manifest.outOfGraphFiles.storybookConfigFiles.size === 0) {
+    return bailWith({ noStorybookConfigFiles: true });
+  }
+
+  // An empty static section is only suspicious when static directories were explicitly configured.
+  // A configured-but-empty directory deliberately bails in the safe direction rather than sharing
+  // the same silent evidence as a missing or unreadable directory.
+  if (staticDirectories.length > 0 && manifest.outOfGraphFiles.staticFiles.size === 0) {
+    return bailWith({ noStaticFiles: true });
+  }
+
+  // Content-hashing the `node_modules` files that are in the graph is v2's entire dependency
+  // coverage, so a graph containing none of them covers no dependency change at all: an upgrade
+  // would leave the manifest byte-identical and capture nothing. This is the precise condition
+  // under which v1 declares the stats incomplete and bails (`nodeModulesMissingInStats`), except
+  // that reading it needs no changed-file list — it is a self-contained property of the stats.
+  //
+  // Zero is the whole test, with no threshold to tune: the lowest count across the ten harness
+  // fixtures is 17 (`ui-sb8`), and Vite's pre-bundling does not erase them (`ui` has 30).
+  if (countNodeModulesFiles(stats) === 0) {
+    return bailWith({ noNodeModulesFiles: true });
+  }
+
+  return getNoStoryFilesBail(manifest);
+}
+
+/**
+ * Explains a graph we found no stories in, which can only ever recapture everything through
+ * `storybookGlobals` — wider than v1.
+ *
+ * @param manifest The manifest built from the stats.
+ *
+ * @returns The bail result, or undefined when the graph contains story files.
+ */
+function getNoStoryFilesBail(manifest: TurboSnapManifest): TraceChangedFilesResult | undefined {
+  if (manifest.storyFileHashes.size > 0) return undefined;
+  return bailWith({ noStoryFiles: true });
+}

--- a/node-src/lib/turbosnap/v2/index.ts
+++ b/node-src/lib/turbosnap/v2/index.ts
@@ -104,7 +104,7 @@ export async function traceChangedFiles(
   return { status: 'fallback' };
 }
 
-/** Wraps a bail reason in the result shape the caller expects. */
+// Wraps a bail reason in the result shape the caller expects.
 function bailWith(bailReason: TurboSnapBailReason): TraceChangedFilesResult {
   return { status: 'bailed', turboSnap: { bailReason } };
 }
@@ -148,6 +148,12 @@ function writeDiagnosticManifest(
  * A prebuilt Storybook's project.json records whether static directories were declared, while their
  * paths must still be derived from the checked-out source. If those two sources disagree, continuing
  * would silently omit `staticFiles` even though we know the section should exist.
+ *
+ * @param input The static directory inputs to reconcile.
+ * @param input.staticDirs The project-relative static directories derived from the source.
+ * @param input.staticDirsDeclared Whether the prebuilt Storybook reports static directories were declared.
+ *
+ * @returns The bail result, or undefined when the two sources agree.
  */
 function getStaticDirectoriesBail(
   input: Pick<TraceChangedFilesInput, 'staticDirs' | 'staticDirsDeclared'>

--- a/node-src/lib/turbosnap/v2/paths.ts
+++ b/node-src/lib/turbosnap/v2/paths.ts
@@ -88,6 +88,24 @@ export function rootFilePath(module: Module, roots: StatsRoots): FilePath | unde
   return canonicalFileNames(module, roots)[0];
 }
 
+// A `node_modules` segment anywhere in a path. Matched segment-wise rather than by substring so a
+// file merely named `…node_modules…` is not mistaken for one inside the directory. Tolerant of both
+// separators and of the segment being terminal, so it reads raw stats names (Windows backslashes)
+// and canonical keys alike.
+const NODE_MODULES_SEGMENT = /(?:^|[\\/])node_modules(?:[\\/]|$)/;
+
+/**
+ * Whether a path passes through a `node_modules` directory. The single definition of that question,
+ * so raw-stats walks and canonical-key walks cannot drift apart.
+ *
+ * @param filePath The path to test, raw or canonical.
+ *
+ * @returns Whether the path contains a `node_modules` segment.
+ */
+export function isNodeModulesPath(filePath: string): boolean {
+  return NODE_MODULES_SEGMENT.test(filePath);
+}
+
 /**
  * Strips a trailing ` + N modules` suffix from a concatenated module's name, leaving the root file.
  *

--- a/node-src/lib/turbosnap/v2/statsAnchor.test.ts
+++ b/node-src/lib/turbosnap/v2/statsAnchor.test.ts
@@ -1,0 +1,425 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import path from 'path';
+import { afterAll, describe, expect, it, vi } from 'vitest';
+
+import { Stats } from '../../../types';
+import { buildManifest } from './manifest';
+import { realProjectFiles } from './projectFiles';
+import { AnchorInput, getAnchorMismatchReason, getSourceModuleResolution } from './statsAnchor';
+
+// The fixtures below are real directories on disk — the anchor damage is only visible against real
+// bytes — but they install no Storybook, and resolving its version is the one thing that would throw.
+vi.mock('./storybookVersion', () => ({
+  resolveStorybookVersion: () => '9.1.20',
+}));
+
+// A vite-shaped graph: relative module names only, no `nameForCondition`, so the anchor is the sole
+// thing deciding which files get hashed. Both fixture packages below satisfy every path in it.
+const VITE_STATS: Stats = {
+  modules: [
+    { id: 1, name: './iframe.html', reasons: [] },
+    {
+      id: 2,
+      name: '/virtual:/@storybook/builder-vite/storybook-stories.js',
+      reasons: [{ moduleName: './iframe.html' }],
+    },
+    {
+      id: 3,
+      name: './src/lib/Badge/Badge.stories.tsx',
+      reasons: [{ moduleName: '/virtual:/@storybook/builder-vite/storybook-stories.js' }],
+    },
+    {
+      id: 4,
+      name: './src/lib/Badge/Badge.tsx',
+      reasons: [{ moduleName: './src/lib/Badge/Badge.stories.tsx' }],
+    },
+    { id: 5, name: './.storybook/preview.ts', reasons: [{ moduleName: './iframe.html' }] },
+  ],
+} as unknown as Stats;
+
+const temporaryDirectories: string[] = [];
+
+afterAll(() => {
+  for (const directory of temporaryDirectories) rmSync(directory, { recursive: true, force: true });
+});
+
+/**
+ * Builds a monorepo of near-identical sibling packages, which is what makes a wrong anchor dangerous:
+ * every path in the stats resolves under either one. `badge` is the only content that differs, so a
+ * hash read off the wrong sibling is visible.
+ *
+ * @param packages
+ *
+ * @returns
+ */
+function givenSiblingPackages(packages: Record<string, { badge: string }>) {
+  const repository = mkdtempSync(path.join(tmpdir(), 'anchor-'));
+  temporaryDirectories.push(repository);
+  writeFileSync(path.join(repository, 'package.json'), JSON.stringify({ name: 'repo' }));
+
+  const roots: Record<string, string> = {};
+  for (const [name, { badge }] of Object.entries(packages)) {
+    const root = path.join(repository, 'packages', name);
+    mkdirSync(path.join(root, 'src/lib/Badge'), { recursive: true });
+    mkdirSync(path.join(root, '.storybook'), { recursive: true });
+    mkdirSync(path.join(root, 'storybook-static'), { recursive: true });
+    writeFileSync(path.join(root, 'package.json'), JSON.stringify({ name }));
+    writeFileSync(path.join(root, 'src/lib/Badge/Badge.tsx'), badge);
+    writeFileSync(
+      path.join(root, 'src/lib/Badge/Badge.stories.tsx'),
+      `import { Badge } from './Badge';\nexport default { component: Badge };\n`
+    );
+    writeFileSync(path.join(root, '.storybook/preview.ts'), 'export const parameters = {};\n');
+    writeFileSync(
+      path.join(root, 'storybook-static/preview-stats.json'),
+      JSON.stringify(VITE_STATS)
+    );
+    roots[name] = root;
+  }
+
+  return { repository, roots };
+}
+
+/** An anchor named only by the part a case is about; the rest is what production always supplies. */
+type AnchorOverrides = Partial<AnchorInput> & Pick<AnchorInput, 'projectRoot'>;
+
+/**
+ * Completes an anchor. The defaults live here rather than in the module under test, where a default
+ * could mask a wiring bug instead of failing.
+ *
+ * @param overrides The anchor fields the case names.
+ *
+ * @returns The complete anchor.
+ */
+function anchorInput(overrides: AnchorOverrides): AnchorInput {
+  return {
+    repositoryRoot: overrides.projectRoot,
+    statsPath: statsPathFor(overrides.projectRoot),
+    configDir: '.storybook',
+    // The fixtures are real directories, so the real disk is the disk under test.
+    projectFiles: realProjectFiles(),
+    ...overrides,
+  };
+}
+
+// The production caller resolves the stats root once and hands it to the anchor check, so the tests
+// exercise the same pairing.
+function anchorMismatchFor(stats: Stats, overrides: AnchorOverrides) {
+  const input = anchorInput(overrides);
+  return getAnchorMismatchReason(stats, input, getSourceModuleResolution(stats, input));
+}
+
+function statsPathFor(projectRoot: string) {
+  return path.join(projectRoot, 'storybook-static/preview-stats.json');
+}
+
+describe('getAnchorMismatchReason', () => {
+  it('accepts the anchor the stats file belongs to', () => {
+    const { roots } = givenSiblingPackages({
+      ui: { badge: 'export const Badge = () => "ui";\n' },
+      'marketing-ui': { badge: 'export const Badge = () => "marketing";\n' },
+    });
+
+    expect(
+      anchorMismatchFor(VITE_STATS, {
+        projectRoot: roots.ui,
+        builderName: '@storybook/react-vite',
+      })
+    ).toBeUndefined();
+  });
+
+  it('refuses a structurally similar sibling, which no emptiness guard can detect', async () => {
+    const { roots } = givenSiblingPackages({
+      ui: { badge: 'export const Badge = () => "ui";\n' },
+      'marketing-ui': { badge: 'export const Badge = () => "marketing";\n' },
+    });
+    const statsPath = statsPathFor(roots.ui);
+
+    // First, the damage: with the wrong sibling as the anchor the manifest is complete — a story is
+    // found and nothing is empty — but its hashes are read off the other package's bytes.
+    const outOfGraph = {
+      configDir: '.storybook',
+      staticDirs: [],
+      projectFiles: realProjectFiles(),
+    };
+    const correct = await buildManifest(VITE_STATS, roots.ui, outOfGraph);
+    const wrong = await buildManifest(VITE_STATS, roots['marketing-ui'], outOfGraph);
+    const storyFile = './src/lib/Badge/Badge.stories.tsx';
+    expect(correct.storyFileHashes.get(storyFile)).toBeDefined();
+    expect(wrong.storyFileHashes.get(storyFile)).toBeDefined();
+    expect(wrong.storyFileHashes.get(storyFile)).not.toBe(correct.storyFileHashes.get(storyFile));
+
+    // Which is what the guard refuses to build.
+    expect(
+      anchorMismatchFor(VITE_STATS, {
+        projectRoot: roots['marketing-ui'],
+        statsPath,
+        builderName: '@storybook/react-vite',
+      })
+    ).toMatchObject({ subreason: 'statsFileOutsideProject' });
+  });
+
+  it('accepts a stats file built into a directory above the project', () => {
+    const { repository, roots } = givenSiblingPackages({
+      ui: { badge: 'export const Badge = () => "ui";\n' },
+    });
+    const statsPath = path.join(repository, 'dist/storybook/preview-stats.json');
+    mkdirSync(path.dirname(statsPath), { recursive: true });
+    writeFileSync(statsPath, JSON.stringify(VITE_STATS));
+
+    expect(
+      anchorMismatchFor(VITE_STATS, {
+        projectRoot: roots.ui,
+        statsPath,
+        builderName: '@storybook/react-vite',
+      })
+    ).toBeUndefined();
+  });
+
+  it('accepts a stats file with no owning package, as the CLI’s own temporary build has', () => {
+    const { roots } = givenSiblingPackages({ ui: { badge: 'export const Badge = () => "ui";\n' } });
+    const buildDirectory = mkdtempSync(path.join(tmpdir(), 'chromatic-'));
+    temporaryDirectories.push(buildDirectory);
+    const statsPath = path.join(buildDirectory, 'preview-stats.json');
+    writeFileSync(statsPath, JSON.stringify(VITE_STATS));
+
+    expect(
+      anchorMismatchFor(VITE_STATS, {
+        projectRoot: roots.ui,
+        statsPath,
+        builderName: '@storybook/react-vite',
+      })
+    ).toBeUndefined();
+  });
+
+  it('does not treat a plain file named like the config directory as an owning project', () => {
+    const { roots } = givenSiblingPackages({ ui: { badge: 'export const Badge = () => "ui";\n' } });
+    const buildDirectory = mkdtempSync(path.join(tmpdir(), 'chromatic-'));
+    temporaryDirectories.push(buildDirectory);
+    const statsPath = path.join(buildDirectory, 'preview-stats.json');
+    writeFileSync(statsPath, JSON.stringify(VITE_STATS));
+    // The walk looks for a config *directory*. A file of the same name holds no Storybook config, so
+    // it cannot make this directory the project the stats belong to.
+    writeFileSync(path.join(buildDirectory, '.storybook'), '');
+
+    expect(
+      anchorMismatchFor(VITE_STATS, {
+        projectRoot: roots.ui,
+        statsPath,
+        builderName: '@storybook/react-vite',
+      })
+    ).toBeUndefined();
+  });
+
+  describe('the builder the stats were produced by', () => {
+    it('refuses vite stats anchored at a project that declares webpack', () => {
+      const { roots } = givenSiblingPackages({
+        ui: { badge: 'export const Badge = () => "ui";\n' },
+      });
+
+      expect(
+        anchorMismatchFor(VITE_STATS, {
+          projectRoot: roots.ui,
+          builderName: '@storybook/react-webpack5',
+        })
+      ).toMatchObject({ subreason: 'builderMismatch' });
+    });
+
+    it('refuses non-vite stats anchored at a project that declares vite', () => {
+      const { roots } = givenSiblingPackages({
+        ui: { badge: 'export const Badge = () => "ui";\n' },
+      });
+      const webpackStats = {
+        modules: [
+          { id: 1, name: './storybook-stories.js', reasons: [] },
+          {
+            id: 2,
+            name: './src/lib/Badge/Badge.stories.tsx',
+            reasons: [{ moduleName: './storybook-stories.js' }],
+          },
+        ],
+      } as unknown as Stats;
+
+      expect(
+        anchorMismatchFor(webpackStats, {
+          projectRoot: roots.ui,
+          builderName: '@storybook/react-vite',
+        })
+      ).toMatchObject({ subreason: 'builderMismatch' });
+    });
+
+    it('gives no verdict for a framework whose name does not name its builder', () => {
+      const { roots } = givenSiblingPackages({
+        ui: { badge: 'export const Badge = () => "ui";\n' },
+      });
+
+      expect(
+        anchorMismatchFor(VITE_STATS, {
+          projectRoot: roots.ui,
+          builderName: '@storybook/nextjs',
+        })
+      ).toBeUndefined();
+    });
+  });
+
+  it('accepts a builder entry that exists outside the project', () => {
+    const { repository, roots } = givenSiblingPackages({
+      ui: { badge: 'export const Badge = () => "ui";\n' },
+    });
+    const entry = path.join(
+      repository,
+      'node_modules/.cache/storybook-rsbuild-builder/storybook-config-entry.js'
+    );
+    mkdirSync(path.dirname(entry), { recursive: true });
+    writeFileSync(entry, '');
+    const rsbuildStats = {
+      modules: [
+        {
+          id: 1,
+          name: './storybook-config-entry.js',
+          nameForCondition: entry,
+          reasons: [],
+        },
+        {
+          id: 2,
+          name: './src/lib/Badge/Badge.stories.tsx',
+          reasons: [{ moduleName: './storybook-config-entry.js' }],
+        },
+      ],
+    } as unknown as Stats;
+
+    expect(
+      anchorMismatchFor(rsbuildStats, {
+        projectRoot: roots.ui,
+        builderName: 'storybook-react-rsbuild',
+      })
+    ).toBeUndefined();
+  });
+
+  it('refuses an unrelated anchor where no source module resolves, as v1 does', () => {
+    const { repository } = givenSiblingPackages({
+      ui: { badge: 'export const Badge = () => "ui";\n' },
+    });
+    const unrelated = path.join(repository, 'packages/empty');
+    mkdirSync(unrelated, { recursive: true });
+
+    // The default stats path sits under the unrelated root and owns no config directory, so this is
+    // the predicate under test rather than the stats file's location.
+    expect(
+      anchorMismatchFor(VITE_STATS, {
+        projectRoot: unrelated,
+        builderName: '@storybook/react-vite',
+      })
+    ).toMatchObject({ subreason: 'unresolvedSourceModules' });
+  });
+
+  it('refuses an anchor witnessed only by the config directory, which every project has', () => {
+    const { repository } = givenSiblingPackages({
+      ui: { badge: 'export const Badge = () => "ui";\n' },
+    });
+    // A decoy root: it has the boilerplate `.storybook/preview.ts` every project has at the same
+    // path, but none of the real source files the stats also name.
+    const decoy = path.join(repository, 'packages/decoy');
+    mkdirSync(path.join(decoy, '.storybook'), { recursive: true });
+    writeFileSync(path.join(decoy, '.storybook/preview.ts'), 'export const parameters = {};\n');
+
+    expect(
+      anchorMismatchFor(VITE_STATS, {
+        projectRoot: decoy,
+        builderName: '@storybook/react-vite',
+      })
+    ).toMatchObject({ subreason: 'unresolvedSourceModules' });
+  });
+
+  it('refuses an anchor whose only matches are directories named like source files', () => {
+    const { repository } = givenSiblingPackages({
+      ui: { badge: 'export const Badge = () => "ui";\n' },
+    });
+    // Every source module the stats name resolves here, but each one lands on a directory. Reading
+    // such a path throws EISDIR, so it is not evidence that the anchor owns those modules.
+    const decoy = path.join(repository, 'packages/decoy');
+    mkdirSync(path.join(decoy, 'src/lib/Badge/Badge.stories.tsx'), { recursive: true });
+    mkdirSync(path.join(decoy, 'src/lib/Badge/Badge.tsx'), { recursive: true });
+
+    expect(
+      anchorMismatchFor(VITE_STATS, {
+        projectRoot: decoy,
+        builderName: '@storybook/react-vite',
+      })
+    ).toMatchObject({ subreason: 'unresolvedSourceModules' });
+  });
+
+  it('refuses an anchor where every source module is absolute-spelled and points elsewhere', () => {
+    const { roots } = givenSiblingPackages({
+      ui: { badge: 'export const Badge = () => "ui";\n' },
+    });
+    // Every name is absolute and lives under a different package entirely — none can resolve under
+    // `ui`, so this must count as missing evidence rather than being discarded before counting.
+    const otherPackage = path.join(roots.ui, '..', 'other-package');
+    const absoluteStats = {
+      modules: [
+        { id: 1, name: path.join(otherPackage, 'src/lib/Badge/Badge.stories.tsx'), reasons: [] },
+        {
+          id: 2,
+          name: path.join(otherPackage, 'src/lib/Badge/Badge.tsx'),
+          reasons: [{ moduleName: path.join(otherPackage, 'src/lib/Badge/Badge.stories.tsx') }],
+        },
+      ],
+    } as unknown as Stats;
+
+    expect(
+      anchorMismatchFor(absoluteStats, {
+        projectRoot: roots.ui,
+        builderName: '@storybook/react-webpack5',
+      })
+    ).toMatchObject({ subreason: 'unresolvedSourceModules' });
+  });
+
+  describe('modules bundled by concatenation', () => {
+    // Webpack and rspack fold several real files into one module and expose them in `module.modules`.
+    // The wrapper's own name is a synthetic label that resolves nowhere, so the anchor evidence lives
+    // only on the children — a check that read the wrapper alone would see no source modules at all.
+    const concatenatedStats = {
+      modules: [
+        {
+          id: 1,
+          name: './src/lib/Badge/Badge.stories.tsx + 1 modules',
+          modules: [
+            { name: './src/lib/Badge/Badge.stories.tsx' },
+            { name: './src/lib/Badge/Badge.tsx' },
+          ],
+          reasons: [{ moduleName: './storybook-stories.js' }],
+        },
+      ],
+    } as unknown as Stats;
+
+    it('accepts an anchor witnessed only by a concatenated child', () => {
+      const { roots } = givenSiblingPackages({
+        ui: { badge: 'export const Badge = () => "ui";\n' },
+      });
+
+      expect(
+        anchorMismatchFor(concatenatedStats, {
+          projectRoot: roots.ui,
+          builderName: '@storybook/react-webpack5',
+        })
+      ).toBeUndefined();
+    });
+
+    it('counts concatenated children as source modules when none of them resolve', () => {
+      const { repository } = givenSiblingPackages({
+        ui: { badge: 'export const Badge = () => "ui";\n' },
+      });
+      const unrelated = path.join(repository, 'packages/empty');
+      mkdirSync(unrelated, { recursive: true });
+
+      expect(
+        anchorMismatchFor(concatenatedStats, {
+          projectRoot: unrelated,
+          builderName: '@storybook/react-webpack5',
+        })
+      ).toMatchObject({ subreason: 'unresolvedSourceModules' });
+    });
+  });
+});

--- a/node-src/lib/turbosnap/v2/statsAnchor.ts
+++ b/node-src/lib/turbosnap/v2/statsAnchor.ts
@@ -1,0 +1,291 @@
+import path from 'path';
+
+import { Module, Stats, TurboSnapAnchorMismatchSubreason } from '../../../types';
+import { resolveStatsPath, stripConcatenatedModuleSuffix } from './paths';
+import { ProjectFiles } from './projectFiles';
+
+const BUILDER_VITE_PACKAGE = '@storybook/builder-vite';
+
+export interface AnchorMismatchReason {
+  /** Why the pairing was refused; see {@link TurboSnapAnchorMismatchSubreason}. */
+  subreason: TurboSnapAnchorMismatchSubreason;
+  /** The evidence, reported to Sentry for whoever investigates the bail. */
+  detail: string;
+}
+
+export interface SourceModuleResolution {
+  /** How many distinctive source modules the stats name. */
+  sourceModuleCount: number;
+  /** The root those names resolve from, absent when none of them resolve at all. */
+  statsRoot?: string;
+}
+
+const SOURCE_MODULE_EXTENSIONS = /\.(js|jsx|ts|tsx)$/;
+
+/**
+ * Returns why the stats file cannot be shown to belong to the project at `projectRoot`, or undefined
+ * when nothing contradicts the pairing.
+ *
+ * Nothing else asks this question. Every other guard detects an *absence* — no config files, no
+ * static files, no stories — and a wrong-but-structurally-similar anchor leaves nothing empty: paths
+ * resolve, stories are found, and the manifest is complete with hashes read off another package's
+ * files. So the check has to compare identities rather than count resolutions.
+ *
+ * @param stats The preview stats file.
+ * @param input The anchor and the builder the project declares.
+ * @param input.projectRoot The absolute Storybook project root the manifest anchors against.
+ * @param input.repositoryRoot The repository root, tried when relative stats paths do not resolve
+ * from the project root.
+ * @param input.builderName The builder named by the project's own Storybook config, read from the
+ * config directory rather than from the anchor, which is what makes it independent evidence.
+ * @param input.statsPath The path the stats file was read from.
+ * @param input.configDir The project-relative Storybook config directory.
+ * @param input.projectFiles How to read the disk; see {@link ProjectFiles}.
+ * @param resolution The stats-root resolution, computed once per build by the caller because the
+ * manifest needs the same answer.
+ *
+ * @returns The structured anchor-mismatch reason, if any.
+ */
+export function getAnchorMismatchReason(
+  stats: Stats,
+  input: AnchorInput,
+  resolution: SourceModuleResolution
+): AnchorMismatchReason | undefined {
+  return (
+    getBuilderMismatch(stats, input.builderName) ??
+    getStatsFileOutsideProject(input) ??
+    getUnresolvedSourceModules(input.projectRoot, resolution)
+  );
+}
+
+/** What the caller guarantees about the anchor; only the builder can genuinely be unknown. */
+export interface AnchorInput {
+  projectRoot: string;
+  repositoryRoot: string;
+  statsPath: string;
+  configDir: string;
+  /** Required rather than defaulted, so a caller cannot silently reach the real disk. */
+  projectFiles: ProjectFiles;
+  builderName?: string;
+}
+
+/**
+ * Resolves the root relative stats paths are named from, and counts the source modules the verdict
+ * rests on. The project root remains the default and wins whenever any source module resolves there;
+ * the repository root is a fallback for builders that relativise names from the command's working
+ * directory.
+ *
+ * This is a full pass over every name in the stats, so the caller runs it once and hands the result
+ * to both the anchor check and the manifest.
+ *
+ * @param stats The preview stats file.
+ * @param input The anchor the stats are resolved against.
+ * @param input.projectRoot The absolute Storybook project root.
+ * @param input.repositoryRoot The repository root, tried when names do not resolve from the project
+ * root.
+ * @param input.configDir The project-relative Storybook config directory.
+ * @param input.projectFiles How to read the disk; see {@link ProjectFiles}.
+ *
+ * @returns The resolved stats root, if any, and the source module count.
+ */
+export function getSourceModuleResolution(
+  stats: Stats,
+  {
+    projectRoot,
+    repositoryRoot,
+    configDir: configDirectory,
+    projectFiles,
+  }: Pick<AnchorInput, 'projectRoot' | 'repositoryRoot' | 'configDir' | 'projectFiles'>
+): SourceModuleResolution {
+  const sourceModules = statsPaths(stats).filter((name) => {
+    if (name.includes('node_modules') || !SOURCE_MODULE_EXTENSIONS.test(name)) return false;
+    return !isConfigDirectoryEntry(name, configDirectory);
+  });
+
+  for (const statsRoot of new Set([projectRoot, repositoryRoot])) {
+    if (
+      sourceModules.some((name) => {
+        const absolutePath = resolveStatsPath(name, statsRoot);
+        // A file, not merely something: a directory named like a source module is not a module the
+        // anchor could have built, and reading one throws EISDIR.
+        return isInside(projectRoot, absolutePath) && projectFiles.isFile(absolutePath);
+      })
+    ) {
+      return { sourceModuleCount: sourceModules.length, statsRoot };
+    }
+  }
+
+  return { sourceModuleCount: sourceModules.length };
+}
+
+/**
+ * Compares the builder that produced the stats against the builder the project declares. Only Vite
+ * is asserted in either direction: `isBuilderViteStats` identifies a stats contract with a proven
+ * correctness defect, while webpack and rspack intentionally share the non-Vite bucket because both
+ * satisfy the contract consumed here. Rspack's `rspackVersion` is a reliable signature, but without
+ * a known contract defect it does not justify another bail. A framework whose name says nothing
+ * about its builder (`@storybook/nextjs`) yields no verdict rather than a guess, so an unrecognised
+ * project never bails here.
+ */
+function getBuilderMismatch(
+  stats: Stats,
+  builderName: string | undefined
+): AnchorMismatchReason | undefined {
+  const projectUsesVite = declaresVite(builderName);
+  if (projectUsesVite === undefined) return undefined;
+
+  const statsAreVite = isBuilderViteStats(stats);
+  if (statsAreVite === projectUsesVite) return undefined;
+
+  return {
+    subreason: 'builderMismatch',
+    detail: `stats were produced by ${statsAreVite ? 'Vite' : 'a non-Vite builder'}, but the project declares ${builderName}`,
+  };
+}
+
+function declaresVite(builderName: string | undefined): boolean | undefined {
+  if (!builderName) return undefined;
+  if (builderName.includes('vite')) return true;
+  if (/webpack|rsbuild|rspack/.test(builderName)) return false;
+  return undefined;
+}
+
+/**
+ * Asks which project the stats *file* lives in. This is the only witness that separates two siblings
+ * built by the same builder, whose module names can be byte-identical: a prebuilt Storybook's stats
+ * sit inside the project they describe.
+ *
+ * The owning project is the nearest ancestor of the stats file holding a config directory. Asking for
+ * the config directory rather than a `package.json` is deliberate: the vite builder writes its own
+ * `package.json` into `storybook-static`, so a package walk stops at the build output.
+ *
+ * A verdict needs the owning project to be disjoint from the anchor. An output directory *above* the
+ * project (`dist/storybook` at a monorepo root) is a normal layout and says nothing, and a stats file
+ * the CLI built into a temporary directory has no owning project at all.
+ */
+function getStatsFileOutsideProject({
+  projectRoot,
+  statsPath,
+  configDir: configDirectory,
+  projectFiles,
+}: AnchorInput): AnchorMismatchReason | undefined {
+  const owningProject = findOwningProject(
+    path.dirname(path.resolve(statsPath)),
+    configDirectory,
+    projectFiles
+  );
+  if (!owningProject || !isDisjoint(owningProject, projectRoot)) return undefined;
+
+  return {
+    subreason: 'statsFileOutsideProject',
+    detail: `the stats file lives in the Storybook project ${owningProject}, which is not ${projectRoot}`,
+  };
+}
+
+/**
+ * Walks up from a directory to the nearest ancestor holding the Storybook config directory.
+ */
+function findOwningProject(
+  directory: string,
+  configDirectory: string,
+  projectFiles: ProjectFiles
+): string | undefined {
+  let current = directory;
+  for (;;) {
+    if (projectFiles.isDirectory(path.join(current, configDirectory))) return current;
+    const parent = path.dirname(current);
+    if (parent === current) return undefined;
+    current = parent;
+  }
+}
+
+/**
+ * v1's `checkStorybookBaseDirectory` predicate, ported: at least one non-`node_modules` source module
+ * from the stats must exist under either known spelling root. The project root is tried first; the
+ * repository root covers builders that relativise stats names from the command's working directory.
+ *
+ * This is the gross-mismatch case — an unrelated anchor. A 2026-08-06 audit found that v2 did not, in
+ * fact, survive it by accident: an anchor with one universal match (`.storybook/preview.ts`, present
+ * at the same path in every project) produced a complete manifest with hashes read off the wrong
+ * package, and `noStoryFiles` never fired. The evidence base now excludes config-directory entries —
+ * they are not distinctive — and no longer discards absolute-spelled names before counting them as
+ * missing, so a single boilerplate match or an all-absolute stats file can no longer pass for a
+ * verdict.
+ */
+function getUnresolvedSourceModules(
+  projectRoot: string,
+  { sourceModuleCount, statsRoot }: SourceModuleResolution
+): AnchorMismatchReason | undefined {
+  if (sourceModuleCount === 0 || statsRoot) return undefined;
+
+  return {
+    subreason: 'unresolvedSourceModules',
+    detail: `none of the ${sourceModuleCount} source modules in the stats exist under ${projectRoot}`,
+  };
+}
+
+/**
+ * Every file name the stats mention: each module's own names plus the names of its importers.
+ *
+ * Deliberately not shared with `moduleFileNames` in manifest.ts, which enumerates the same stats to
+ * build the graph and so returns each file once. This takes every spelling of every module,
+ * including both `name` and `nameForCondition`, because the anchor checks only ask whether any one
+ * name witnesses a mismatch — over-inclusion costs nothing and a missed spelling hides evidence.
+ */
+function statsPaths(stats: Stats): string[] {
+  return stats.modules.flatMap((module: Module) =>
+    [
+      module.name,
+      module.nameForCondition,
+      ...(module.modules ?? []).flatMap((inner) => [inner.name, inner.nameForCondition]),
+      ...(module.reasons ?? []).map((reason) => reason.moduleName),
+    ]
+      .filter(Boolean)
+      .map((name) => stripConcatenatedModuleSuffix(name as string))
+      .filter((name) => !name.includes('virtual:'))
+  );
+}
+
+/**
+ * Whether a stats-named module is the project's own config entrypoint (e.g. `.storybook/preview.ts`)
+ * rather than project-identifying source. Every Storybook project has one at the same relative path,
+ * so a lone match against it is not distinctive evidence for `getUnresolvedSourceModules` — the
+ * predicate needs a real source or story file to confirm the anchor.
+ */
+function isConfigDirectoryEntry(name: string, configDirectory: string): boolean {
+  const relativeName = name.replace(/^\.\//, '');
+  return relativeName === configDirectory || relativeName.startsWith(`${configDirectory}/`);
+}
+
+function isInside(directory: string, filePath: string): boolean {
+  const relative = path.relative(directory, filePath);
+  return relative !== '' && !relative.startsWith('..') && !path.isAbsolute(relative);
+}
+
+/**
+ * Whether two directories are unrelated: not the same, and neither contains the other.
+ */
+function isDisjoint(one: string, other: string): boolean {
+  return (
+    !isInside(one, other) && !isInside(other, one) && path.resolve(one) !== path.resolve(other)
+  );
+}
+
+/**
+ * Whether these stats were produced by builder-vite, told by the builder's own modules appearing in
+ * the graph. Used to check the stats against the builder the project declares; see
+ * {@link getBuilderMismatch}.
+ *
+ * @param stats The preview stats file.
+ *
+ * @returns Whether the stats are builder-vite's.
+ */
+function isBuilderViteStats(stats: Stats): boolean {
+  return stats.modules.some((module) =>
+    [
+      module.name,
+      module.nameForCondition,
+      ...(module.reasons ?? []).map((reason) => reason.moduleName),
+    ].some((name) => name?.includes(`${BUILDER_VITE_PACKAGE}/`))
+  );
+}

--- a/node-src/lib/turbosnap/v2/statsGraph.test.ts
+++ b/node-src/lib/turbosnap/v2/statsGraph.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import { Stats } from '../../../types';
 import { createFixture } from './__fixtures__/manifestFixtures';
-import { readStatsGraph } from './statsGraph';
+import { countNodeModulesFiles, readStatsGraph } from './statsGraph';
 
 // These suites are about builder spellings: what webpack, rspack and Vite each call the same file,
 // and what the graph reader makes of it. They assert on the graph, not on a hash — that the right
@@ -325,5 +325,66 @@ describe('readStatsGraph hashing failures', () => {
     }
 
     expect(err?.message).toContain(story);
+  });
+});
+
+describe('countNodeModulesFiles', () => {
+  it('counts zero for a first-party-only graph', () => {
+    const stats: Stats = {
+      modules: [
+        { id: 1, name: './src/Button.stories.tsx' },
+        { id: 2, name: './src/Button.tsx' },
+        { id: 3, name: './.storybook/preview.ts' },
+      ],
+    };
+
+    expect(countNodeModulesFiles(stats)).toBe(0);
+  });
+
+  it('does not count file names and context expressions that only mention node_modules', () => {
+    const stats: Stats = {
+      modules: [
+        { id: 1, name: './src/node_modules-helper.ts' },
+        {
+          id: 2,
+          name: String.raw`./src|lazy|/^\.\/.*$/|include: /(?!.*node_modules)/|namespace object`,
+        },
+      ],
+    };
+
+    expect(countNodeModulesFiles(stats)).toBe(0);
+  });
+
+  it('counts installed dependency files however the builder spells them', () => {
+    const stats: Stats = {
+      // One relative (Vite), two absolute (webpack on POSIX and Windows), one via
+      // `nameForCondition` (rspack).
+      modules: [
+        { id: 1, name: './src/Button.tsx' },
+        { id: 2, name: './../../node_modules/@storybook/react/dist/entry-preview.js' },
+        { id: 3, name: '/repo/node_modules/storybook/dist/csf/index.js' },
+        { id: 4, name: 'dependency group', nameForCondition: '/repo/node_modules/react/index.js' },
+        { id: 5, name: String.raw`C:\repo\node_modules\react-dom\index.js` },
+      ],
+    };
+
+    expect(countNodeModulesFiles(stats)).toBe(4);
+  });
+
+  it('counts the concatenated children of a dependency group', () => {
+    const stats: Stats = {
+      modules: [
+        {
+          id: 1,
+          name: './../../node_modules/storybook/dist/csf/index.js + 1 modules',
+          modules: [
+            { name: './../../node_modules/storybook/dist/csf/index.js' },
+            { name: './../../node_modules/storybook/dist/csf/toId.js' },
+          ],
+        },
+      ],
+    };
+
+    expect(countNodeModulesFiles(stats)).toBe(2);
   });
 });

--- a/node-src/lib/turbosnap/v2/statsGraph.ts
+++ b/node-src/lib/turbosnap/v2/statsGraph.ts
@@ -11,6 +11,8 @@ import {
 import { ProjectFiles } from './projectFiles';
 import { detectStoryFiles } from './storyDetection';
 
+const nodeModulesPathSegment = /(?:^|[\\/])node_modules(?:[\\/]|$)/;
+
 /**
  * What the builder's stats file says it emitted, read into one canonical graph. Builder spellings —
  * webpack, rspack and Vite each name the same file differently — stop mattering at this value; every
@@ -74,6 +76,22 @@ export async function readStatsGraph(
   }
 
   return { files, hashes, storyFiles };
+}
+
+/**
+ * Counts the graph's `node_modules` file names. Read off the stats file rather than the manifest,
+ * because it is a property of the builder's output rather than of what we derived from it.
+ *
+ * @param stats The stats file to parse.
+ *
+ * @returns The number of `node_modules` file names across all modules.
+ */
+export function countNodeModulesFiles(stats: Stats): number {
+  let count = 0;
+  for (const module of stats.modules) {
+    count += moduleFileNames(module).filter((name) => nodeModulesPathSegment.test(name)).length;
+  }
+  return count;
 }
 
 /**

--- a/node-src/lib/turbosnap/v2/statsGraph.ts
+++ b/node-src/lib/turbosnap/v2/statsGraph.ts
@@ -3,6 +3,7 @@ import { FileHash, FilePath, TurboSnapFile } from './graph';
 import {
   canonicalFileNames,
   canonicalImporters,
+  isNodeModulesPath,
   moduleFileNames,
   normalizeStatsPath,
   resolveStatsPath,
@@ -10,8 +11,6 @@ import {
 } from './paths';
 import { ProjectFiles } from './projectFiles';
 import { detectStoryFiles } from './storyDetection';
-
-const nodeModulesPathSegment = /(?:^|[\\/])node_modules(?:[\\/]|$)/;
 
 /**
  * What the builder's stats file says it emitted, read into one canonical graph. Builder spellings —
@@ -89,7 +88,7 @@ export async function readStatsGraph(
 export function countNodeModulesFiles(stats: Stats): number {
   let count = 0;
   for (const module of stats.modules) {
-    count += moduleFileNames(module).filter((name) => nodeModulesPathSegment.test(name)).length;
+    count += moduleFileNames(module).filter((name) => isNodeModulesPath(name)).length;
   }
   return count;
 }

--- a/node-src/lib/turbosnap/v2/storyDetection.ts
+++ b/node-src/lib/turbosnap/v2/storyDetection.ts
@@ -1,6 +1,12 @@
 import { Stats } from '../../../types';
 import { FilePath } from './graph';
-import { canonicalImporters, normalizeStatsPath, rootFilePath, StatsRoots } from './paths';
+import {
+  canonicalImporters,
+  isNodeModulesPath,
+  normalizeStatsPath,
+  rootFilePath,
+  StatsRoots,
+} from './paths';
 
 /**
  * Whether a canonical path has a real file on disk. You can use things that adhere to this
@@ -48,11 +54,6 @@ const CONFIG_ENTRY_FILES = new Set([
 // Webpack/rspack name a module the bundle does not own `external "<request>"` (e.g. Storybook's
 // preview runtime globals). It has no on-disk file and imports nothing.
 const EXTERNAL_MODULE = /^external "/;
-
-// A `node_modules` segment anywhere in a path. Matched segment-wise rather than by substring because
-// a canonical key may reach a hoisted install through `../`, and because a context's own name embeds
-// the literal text `node_modules` inside its include regex.
-const NODE_MODULES_SEGMENT = /(^|\/)node_modules\//;
 
 // Webpack spells contexts with ` lazy `; rspack delimits the same marker with pipes.
 const LAZY_CONTEXT_MARKER = / lazy |\|lazy\|/;
@@ -171,7 +172,7 @@ function isStoryFile(
   if (matchedStoryImporters.length === 0) {
     return false;
   }
-  if (!NODE_MODULES_SEGMENT.test(filePath)) {
+  if (!isNodeModulesPath(filePath)) {
     return true;
   }
   return !matchedStoryImporters.every((importer) => contextsExcludingNodeModules.has(importer));
@@ -250,5 +251,5 @@ function isLazyContext(moduleName: string): boolean {
  * @returns Whether the context's glob excluded `node_modules`.
  */
 function excludesNodeModules(contextName: string): boolean {
-  return !NODE_MODULES_SEGMENT.test(contextName.split(LAZY_CONTEXT_MARKER)[0]);
+  return !isNodeModulesPath(contextName.split(LAZY_CONTEXT_MARKER)[0]);
 }

--- a/node-src/lib/turbosnap/v2/uploadHashes.test.ts
+++ b/node-src/lib/turbosnap/v2/uploadHashes.test.ts
@@ -1,0 +1,101 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import GraphQLClient from '../../../io/graphqlClient';
+import { TurboSnapManifest } from './manifest';
+import { STORYBOOK_GLOBALS_KEY, STORYBOOK_PREVIEW_KEY } from './storybookFileKeys';
+import { uploadHashes } from './uploadHashes';
+
+const client = { runQuery: vi.fn() };
+const graphqlClient = client as unknown as GraphQLClient;
+
+const manifest: TurboSnapManifest = {
+  files: new Map(),
+  storyFileHashes: new Map([['./src/Button.stories.ts', 'story-hash']]),
+  storybookFileHashes: new Map([
+    [STORYBOOK_PREVIEW_KEY, 'preview-hash'],
+    [STORYBOOK_GLOBALS_KEY, 'globals-hash'],
+  ]),
+  storybookHash: 'storybook-hash',
+  attribution: {
+    storyReachable: new Set(['./src/Button.stories.ts']),
+    previewSubtree: new Set(['./.storybook/preview.ts']),
+    storybookGlobals: new Set(),
+  },
+  // Present on the manifest for the S3 debug file, but deliberately not uploaded to the Index.
+  outOfGraphFiles: { storybookConfigFiles: new Map(), staticFiles: new Map() },
+};
+
+beforeEach(() => {
+  client.runQuery.mockResolvedValue({
+    buildUploadHashes: { build: { turboSnapStatus: 'APPLIED', turboSnapMechanism: 'HASH_BASED' } },
+  });
+});
+
+describe('uploadHashes', () => {
+  it('uploads the Storybook hash, the config hashes, and the story file hashes under a nested input', async () => {
+    await uploadHashes(graphqlClient, 'build-id', manifest);
+
+    expect(client.runQuery).toHaveBeenCalledWith(
+      expect.stringContaining('buildUploadHashes'),
+      {
+        input: {
+          buildId: 'build-id',
+          storybookHash: 'storybook-hash',
+          storybookConfigHashes: { preview: 'preview-hash', storybookGlobals: 'globals-hash' },
+          storyFileHashes: { './src/Button.stories.ts': 'story-hash' },
+        },
+      },
+      { retries: 3 }
+    );
+  });
+
+  it('sends storybookFileHashes under the storybookConfigHashes input field', async () => {
+    await uploadHashes(graphqlClient, 'build-id', manifest);
+
+    const [, variables] = client.runQuery.mock.calls[0];
+    expect(variables.input.storybookConfigHashes).toEqual(
+      Object.fromEntries(manifest.storybookFileHashes)
+    );
+  });
+
+  it('selects both members of the response union', async () => {
+    await uploadHashes(graphqlClient, 'build-id', manifest);
+
+    const [mutation] = client.runQuery.mock.calls[0];
+    expect(mutation).toContain('... on BuildUploadHashesSuccess');
+    expect(mutation).toContain('... on BuildUploadHashesFailure');
+  });
+
+  it('returns the mechanism the Index decided by, so a caller can tell it decided at all', async () => {
+    const result = await uploadHashes(graphqlClient, 'build-id', manifest);
+
+    expect(result.build?.turboSnapMechanism).toBe('HASH_BASED');
+  });
+
+  it('returns the errors when the upload fails', async () => {
+    client.runQuery.mockResolvedValue({
+      buildUploadHashes: {
+        errors: [{ message: 'Uploading hashes is only allowed for announced builds.' }],
+      },
+    });
+
+    const result = await uploadHashes(graphqlClient, 'build-id', manifest);
+
+    expect(result.errors).toEqual([
+      { message: 'Uploading hashes is only allowed for announced builds.' },
+    ]);
+  });
+
+  it('sends an empty map of story hashes as an empty object', async () => {
+    await uploadHashes(graphqlClient, 'build-id', {
+      ...manifest,
+      storyFileHashes: new Map(),
+    });
+
+    expect(client.runQuery).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ input: expect.objectContaining({ storyFileHashes: {} }) }),
+      expect.anything()
+    );
+  });
+});

--- a/node-src/lib/turbosnap/v2/uploadHashes.ts
+++ b/node-src/lib/turbosnap/v2/uploadHashes.ts
@@ -1,0 +1,113 @@
+import GraphQLClient from '../../../io/graphqlClient';
+import { TurboSnapManifest } from './manifest';
+
+const BuildUploadHashesMutation = `
+  mutation BuildUploadHashes($input: BuildUploadHashesInput!) {
+    buildUploadHashes(input: $input) {
+      ... on BuildUploadHashesSuccess {
+        build {
+          turboSnapStatus
+          turboSnapMechanism
+        }
+      }
+      ... on BuildUploadHashesFailure {
+        errors {
+          __typename
+          ... on MutationError {
+            message
+          }
+        }
+      }
+    }
+  }
+`;
+
+/** How the Index decided `onlyStoryFiles`. Absent means it did not decide by hash. */
+type TurboSnapMechanism = 'GIT_BASED' | 'HASH_BASED';
+
+/**
+ * The `BuildUploadHashesInput` the CLI sends. It mirrors the Index's input type so a schema change
+ * on that side surfaces here as a type error rather than a runtime rejection.
+ *
+ * `storybookConfigHashes` is a map of Storybook-wide category roll-ups to their hashes. The Index
+ * requires `storybookVersion` and `storybookConfigFiles`; the remaining categories (`preview`,
+ * `storybookGlobals`, `staticFiles`) ride its catch-all. Every value is a string, so the manifest's
+ * `FileHash | StorybookVersion` entries map onto it directly.
+ */
+interface BuildUploadHashesInput {
+  buildId: string;
+  storybookHash: string;
+  storybookConfigHashes: Record<string, string>;
+  storyFileHashes: Record<string, string>;
+}
+
+/** One entry of the failure member. `__typename` is what tells the rejections apart. */
+export interface BuildUploadHashesError {
+  __typename?: string;
+  message?: string;
+}
+
+/**
+ * The mutation payload. Both members are optional because a response matching neither is a real
+ * case the CLI has to name rather than assume away.
+ */
+export interface BuildUploadHashesResponse {
+  /** Present on success. The Index sets these itself; the CLI does not send them. */
+  build?: {
+    turboSnapStatus?: string;
+    turboSnapMechanism?: TurboSnapMechanism;
+  };
+  /** Present on failure. */
+  errors?: BuildUploadHashesError[];
+}
+
+interface BuildUploadHashesResult {
+  buildUploadHashes: BuildUploadHashesResponse;
+}
+
+/**
+ * Sends the whole-Storybook hash and the per-story hashes to the Index, which compares them against
+ * the build's ancestors and writes `onlyStoryFiles` onto the build itself. The changed files are
+ * therefore never returned to the CLI — only whether the Index took the decision, via
+ * `turboSnapMechanism: HASH_BASED`.
+ *
+ * `storybookHash` is the Index's top-level gate: if it is unchanged nothing in Storybook changed and
+ * no story needs recapturing. When it moves, the Index drills into `storyFileHashes` to attribute the
+ * change to individual stories.
+ *
+ * `storybookFileHashes` is sent as the `storybookConfigHashes` input. The Index compares it against
+ * the baselines and, when it differs, bails with a configuration change rather than trusting the
+ * per-story diff. This covers a change confined to a `storybookFileHashes` entry — a static asset,
+ * `main.ts`, a `preview.*` edit, a Storybook upgrade — that moves `storybookHash` while matching no
+ * story, which earlier Index versions had no field for.
+ *
+ * The manifest's `outOfGraphFiles` sections stay out of the request, though:
+ * they exist to name *which* file moved for the S3 debug view, and the Index only ever needs the one
+ * roll-up value per section.
+ *
+ * @param graphqlClient The GraphQL client to use.
+ * @param buildId The build ID associated with the manifest.
+ * @param manifest The manifest whose Storybook and story file hashes are sent to the Index.
+ *
+ * @returns The mutation result: the updated build on success, or the errors that prevented the upload.
+ */
+export async function uploadHashes(
+  graphqlClient: GraphQLClient,
+  buildId: string,
+  manifest: TurboSnapManifest
+): Promise<BuildUploadHashesResponse> {
+  const input: BuildUploadHashesInput = {
+    buildId,
+    storybookHash: manifest.storybookHash,
+    storybookConfigHashes: Object.fromEntries(manifest.storybookFileHashes),
+    storyFileHashes: Object.fromEntries(manifest.storyFileHashes),
+  };
+
+  const { buildUploadHashes } = await graphqlClient.runQuery<BuildUploadHashesResult>(
+    BuildUploadHashesMutation,
+    { input },
+    { retries: 3 }
+  );
+
+  return buildUploadHashes;
+}

--- a/node-src/types.ts
+++ b/node-src/types.ts
@@ -610,12 +610,21 @@ export interface TargetInfo {
   formFields: Record<string, string>;
 }
 
+// The flag-only bail reasons, which are deliberately not mutually exclusive: they are a pre-existing
+// shape, and `BailFamily` below already makes the field-carrying reasons exclusive where analytics
+// depend on it.
 interface TurboSnapBailReasonBase {
   changedStorybookFiles?: string[];
   changedStaticFiles?: string[];
   changedExternalFiles?: string[];
+  noStoryFiles?: true;
+  noStorybookConfigFiles?: true;
+  noStaticFiles?: true;
+  noNodeModulesFiles?: true;
+  unresolvedStaticDirectories?: true;
   noAncestorBuild?: true;
   rebuild?: true;
+  sentryEventId?: string;
 }
 
 export type TurboSnapChangedPackageFilesSubreason =
@@ -631,36 +640,74 @@ export type TurboSnapInvalidChangedFilesSubreason =
   | 'networkError'
   | 'gitCommandFailed';
 
+export type TurboSnapIndexContractViolationSubreason =
+  | 'invalidStoryFileHashes'
+  | 'invalidStorybookConfigHashes'
+  | 'invalidBuildStatus'
+  | 'invalidResponse';
+
+/** Which of our own checks threw; each one is also the Sentry fingerprint for the bail. */
+export type TurboSnapInternalErrorSubreason = 'manifestBuildFailed';
+
+export type TurboSnapIndexUnavailableSubreason = 'networkError';
+
 export type TurboSnapBailSubreason =
   | TurboSnapChangedPackageFilesSubreason
-  | TurboSnapInvalidChangedFilesSubreason;
+  | TurboSnapInvalidChangedFilesSubreason
+  | TurboSnapIndexContractViolationSubreason
+  | TurboSnapIndexUnavailableSubreason
+  | TurboSnapInternalErrorSubreason;
+
+// The bail reasons that carry fields of their own. Each one owns exactly one of these flags, so the
+// others are pinned to `never` by `BailFamily` below.
+interface TurboSnapBailFamilyFlags {
+  changedPackageFiles: string[];
+  invalidChangedFiles: true;
+  indexContractViolation: true;
+  indexUnavailable: true;
+  internalError: true;
+}
+
+type BailFamily<Flag extends keyof TurboSnapBailFamilyFlags> = TurboSnapBailReasonBase &
+  Pick<TurboSnapBailFamilyFlags, Flag> &
+  Partial<Record<Exclude<keyof TurboSnapBailFamilyFlags, Flag>, never>>;
 
 // All additional fields allowed for the `changedPackageFiles` bail reason
-export type ChangedPackageFilesBailReason = TurboSnapBailReasonBase & {
-  changedPackageFiles: string[];
-  invalidChangedFiles?: never;
+export type ChangedPackageFilesBailReason = BailFamily<'changedPackageFiles'> & {
   bailSubreason?: TurboSnapChangedPackageFilesSubreason;
   lockfileKind?: string;
   lockfileSizeBytes?: number;
-  sentryEventId?: string;
 };
 
 // All additional fields allowed for the `invalidChangedFiles` bail reason
-export type InvalidChangedFilesBailReason = TurboSnapBailReasonBase & {
-  changedPackageFiles?: never;
-  invalidChangedFiles: true;
+export type InvalidChangedFilesBailReason = BailFamily<'invalidChangedFiles'> & {
   bailSubreason?: TurboSnapInvalidChangedFilesSubreason;
-  sentryEventId?: string;
+};
+
+// All additional fields allowed for the `indexContractViolation` bail reason
+export type IndexContractViolationBailReason = BailFamily<'indexContractViolation'> & {
+  bailSubreason: TurboSnapIndexContractViolationSubreason;
+};
+
+// All additional fields allowed for the `indexUnavailable` bail reason. The subreason is optional
+// because it is only set when the transport failure is a recognised network error.
+export type IndexUnavailableBailReason = BailFamily<'indexUnavailable'> & {
+  bailSubreason?: TurboSnapIndexUnavailableSubreason;
+};
+
+// All additional fields allowed for the `internalError` bail reason
+export type InternalErrorBailReason = BailFamily<'internalError'> & {
+  bailSubreason: TurboSnapInternalErrorSubreason;
 };
 
 export type TurboSnapBailReason =
   | ChangedPackageFilesBailReason
   | InvalidChangedFilesBailReason
+  | IndexContractViolationBailReason
+  | IndexUnavailableBailReason
+  | InternalErrorBailReason
   // All remaining bail reasons
-  | (TurboSnapBailReasonBase & {
-      changedPackageFiles?: never;
-      invalidChangedFiles?: never;
-    });
+  | (TurboSnapBailReasonBase & Partial<Record<keyof TurboSnapBailFamilyFlags, never>>);
 
 export interface UntracedFile {
   filepath: string;


### PR DESCRIPTION
Relates to CAP-4864

This validates the output of `preview-stats.json` to determine which package it was built from. This is useful for prebuilt Storybooks (then using `-d` to specify which directory Chromatic should run against).

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>18.5.1--canary.1443.32299319578.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@18.5.1--canary.1443.32299319578.0
  # or 
  yarn add chromatic@18.5.1--canary.1443.32299319578.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
