### PR TITLE
[TurboSnap v2] Upload TurboSnap manifest to Index

### DIFF
--- a/node-src/lib/turbosnap/v2/manifest.attribution.test.ts
+++ b/node-src/lib/turbosnap/v2/manifest.attribution.test.ts
@@ -242,8 +242,8 @@ describe('buildManifest attribution closure', () => {
     const after = await buildManifest(stats, input);
 
     // Editing the inner file used to leave the manifest byte-identical.
-    expect(after.storybookFileHashes.get(globalsKey)).not.toBe(
-      before.storybookFileHashes.get(globalsKey)
+    expect(after.storybookConfigHashes.get(globalsKey)).not.toBe(
+      before.storybookConfigHashes.get(globalsKey)
     );
     expect(after.storybookHash).not.toBe(before.storybookHash);
   });
@@ -318,8 +318,8 @@ describe('buildManifest attribution of swept node_modules stories', () => {
     disk.fileHashes = { [story]: 'S', [swept]: 'W', [shared]: 'R2' };
     const after = await buildManifest(stats, input);
 
-    expect(after.storybookFileHashes.get('storybookGlobals')).not.toBe(
-      before.storybookFileHashes.get('storybookGlobals')
+    expect(after.storybookConfigHashes.get('storybookGlobals')).not.toBe(
+      before.storybookConfigHashes.get('storybookGlobals')
     );
   });
 });

--- a/node-src/lib/turbosnap/v2/manifest.golden.test.ts
+++ b/node-src/lib/turbosnap/v2/manifest.golden.test.ts
@@ -118,10 +118,10 @@ describe('manifest golden hashes', () => {
     expect(Object.fromEntries(manifest.storyFileHashes)).toEqual(GOLDEN_STORY_FILES);
   });
 
-  it('publishes the same storybookFileHashes for the frozen fixture', async () => {
+  it('publishes the same storybookConfigHashes for the frozen fixture', async () => {
     const { input } = goldenFixture();
     const manifest = await buildManifest(GOLDEN_STATS, input);
 
-    expect(Object.fromEntries(manifest.storybookFileHashes)).toEqual(GOLDEN_STORYBOOK_FILES);
+    expect(Object.fromEntries(manifest.storybookConfigHashes)).toEqual(GOLDEN_STORYBOOK_FILES);
   });
 });

--- a/node-src/lib/turbosnap/v2/manifest.hashing.test.ts
+++ b/node-src/lib/turbosnap/v2/manifest.hashing.test.ts
@@ -126,8 +126,8 @@ describe('buildManifest relocation stability', () => {
 
     // The `preview` roll-up folds in each file's path as well as its bytes, so renaming preview.ts to
     // preview.tsx moves the rolled-up value even though its key stays `preview`...
-    expect(after.storybookFileHashes.get('preview')).not.toBe(
-      before.storybookFileHashes.get('preview')
+    expect(after.storybookConfigHashes.get('preview')).not.toBe(
+      before.storybookConfigHashes.get('preview')
     );
     // ...and that value feeds the gate, so the rename shows up in the storybook hash too.
     expect(after.storybookHash).not.toBe(before.storybookHash);

--- a/node-src/lib/turbosnap/v2/manifest.storybookFiles.test.ts
+++ b/node-src/lib/turbosnap/v2/manifest.storybookFiles.test.ts
@@ -51,7 +51,7 @@ describe('buildManifest storybookFiles', () => {
 
     const manifest = await buildManifest(makeStats(), input);
 
-    expect([...manifest.storybookFileHashes.keys()]).toContain(previewKey);
+    expect([...manifest.storybookConfigHashes.keys()]).toContain(previewKey);
   });
 
   it('rolls orphan globals into a single catch-all entry', async () => {
@@ -59,7 +59,7 @@ describe('buildManifest storybookFiles', () => {
 
     const manifest = await buildManifest(makeStats(), input);
 
-    expect([...manifest.storybookFileHashes.keys()]).toContain(globalsKey);
+    expect([...manifest.storybookConfigHashes.keys()]).toContain(globalsKey);
   });
 
   it('changes the catch-all entry when an orphan global content changes', async () => {
@@ -70,8 +70,8 @@ describe('buildManifest storybookFiles', () => {
     disk.fileHashes = { ...baseHashes, [reactDom]: 'RD2' };
     const after = await buildManifest(makeStats(), input);
 
-    expect(after.storybookFileHashes.get(globalsKey)).not.toBe(
-      before.storybookFileHashes.get(globalsKey)
+    expect(after.storybookConfigHashes.get(globalsKey)).not.toBe(
+      before.storybookConfigHashes.get(globalsKey)
     );
   });
 
@@ -113,8 +113,8 @@ describe('buildManifest storybookFiles', () => {
     expect(after.storyFileHashes.get('./src/Header.stories.tsx')).toBe(
       before.storyFileHashes.get('./src/Header.stories.tsx')
     );
-    expect(after.storybookFileHashes.get(globalsKey)).toBe(
-      before.storybookFileHashes.get(globalsKey)
+    expect(after.storybookConfigHashes.get(globalsKey)).toBe(
+      before.storybookConfigHashes.get(globalsKey)
     );
   });
 
@@ -127,11 +127,11 @@ describe('buildManifest storybookFiles', () => {
     disk.fileHashes = { ...baseHashes, [previewHelper]: 'PT2' };
     const after = await buildManifest(makeStats(), input);
 
-    expect(after.storybookFileHashes.get(previewKey)).not.toBe(
-      before.storybookFileHashes.get(previewKey)
+    expect(after.storybookConfigHashes.get(previewKey)).not.toBe(
+      before.storybookConfigHashes.get(previewKey)
     );
-    expect(after.storybookFileHashes.get(globalsKey)).toBe(
-      before.storybookFileHashes.get(globalsKey)
+    expect(after.storybookConfigHashes.get(globalsKey)).toBe(
+      before.storybookConfigHashes.get(globalsKey)
     );
   });
 
@@ -147,7 +147,7 @@ describe('buildManifest storybookFiles', () => {
       input
     );
 
-    expect([...manifest.storybookFileHashes.keys()]).not.toContain(previewKey);
+    expect([...manifest.storybookConfigHashes.keys()]).not.toContain(previewKey);
   });
 
   it('omits the catch-all entry when every global is synthetic', async () => {
@@ -167,7 +167,7 @@ describe('buildManifest storybookFiles', () => {
     );
 
     // The version entry is unconditional, so it is the only key left once the catch-all is gone.
-    expect([...manifest.storybookFileHashes.keys()]).toEqual(['storybookVersion']);
+    expect([...manifest.storybookConfigHashes.keys()]).toEqual(['storybookVersion']);
   });
 
   it('records the installed Storybook version as its own entry, verbatim rather than hashed', async () => {
@@ -181,7 +181,7 @@ describe('buildManifest storybookFiles', () => {
 
     const manifest = await buildManifest(makeStats(), input);
 
-    expect(manifest.storybookFileHashes.get('storybookVersion')).toBe('10.6.0-alpha.3');
+    expect(manifest.storybookConfigHashes.get('storybookVersion')).toBe('10.6.0-alpha.3');
   });
 
   it('changes the storybookHash when only the Storybook version changes', async () => {
@@ -208,7 +208,7 @@ describe('buildManifest storybookFiles', () => {
     disk.fileHashes = { ...baseHashes };
     const second = await buildManifest(makeStats(), input);
 
-    expect([...second.storybookFileHashes]).toEqual([...first.storybookFileHashes]);
+    expect([...second.storybookConfigHashes]).toEqual([...first.storybookConfigHashes]);
     expect(second.storybookHash).toBe(first.storybookHash);
   });
 });
@@ -236,8 +236,8 @@ describe('buildManifest out-of-graph inputs', () => {
     const { input } = fixtureWithAssets();
     const manifest = await buildManifest(stats, input);
 
-    expect([...manifest.storybookFileHashes.keys()]).toContain('storybookConfigFiles');
-    expect([...manifest.storybookFileHashes.keys()]).toContain('staticFiles');
+    expect([...manifest.storybookConfigHashes.keys()]).toContain('storybookConfigFiles');
+    expect([...manifest.storybookConfigHashes.keys()]).toContain('staticFiles');
   });
 
   it('moves the storybook hash when main.ts changes, leaving story hashes untouched', async () => {
@@ -333,7 +333,7 @@ describe('buildManifest out-of-graph inputs', () => {
     const preview = '/repo/packages/ui/.storybook/preview.ts';
     disk.fileHashes = { [story]: 'S', [mainConfig]: 'M', [preview]: 'P1' };
     const before = await buildManifest(stats, input);
-    expect(before.storybookFileHashes.has('preview')).toBe(false);
+    expect(before.storybookConfigHashes.has('preview')).toBe(false);
 
     disk.fileHashes = { ...disk.fileHashes, [preview]: 'P2' };
     const after = await buildManifest(stats, input);

--- a/node-src/lib/turbosnap/v2/manifest.test.ts
+++ b/node-src/lib/turbosnap/v2/manifest.test.ts
@@ -44,7 +44,7 @@ describe('serializeManifest', () => {
     expect(JSON.parse(JSON.stringify(serialized))).toEqual(serialized);
   });
 
-  it('emits storybookFileHashes as a JSON-safe object', async () => {
+  it('emits storybookConfigHashes as a JSON-safe object', async () => {
     const story = '/repo/packages/ui/src/Button.stories.tsx';
     const preview = '/repo/packages/ui/.storybook/preview.ts';
     const { input } = createFixture({ fileHashes: { [story]: 'S', [preview]: 'P' } });
@@ -58,8 +58,8 @@ describe('serializeManifest', () => {
     const manifest = await buildManifest(stats, input);
     const serialized = serializeManifest(manifest);
 
-    expect(serialized.storybookFileHashes.preview).toBe(
-      manifest.storybookFileHashes.get('preview')
+    expect(serialized.storybookConfigHashes.preview).toBe(
+      manifest.storybookConfigHashes.get('preview')
     );
     // eslint-disable-next-line unicorn/prefer-structured-clone
     expect(JSON.parse(JSON.stringify(serialized))).toEqual(serialized);
@@ -172,7 +172,7 @@ describe('serializeManifest', () => {
     expect(after.storyFiles['./src/Button.stories.tsx']).not.toBe(
       before.storyFiles['./src/Button.stories.tsx']
     );
-    expect(after.storybookFileHashes).toEqual(before.storybookFileHashes);
+    expect(after.storybookConfigHashes).toEqual(before.storybookConfigHashes);
     expect(after.storybookHash).not.toBe(before.storybookHash);
     expect(before.attribution).toEqual({
       storyReachable: ['./src/Button.stories.tsx', './src/helper.ts'],
@@ -270,6 +270,6 @@ describe('writeManifest', () => {
 
     const payload = disk.writtenFiles?.[manifestPath] ?? '';
 
-    expect(JSON.parse(payload).storybookFileHashes.preview).toEqual(expect.any(String));
+    expect(JSON.parse(payload).storybookConfigHashes.preview).toEqual(expect.any(String));
   });
 });

--- a/node-src/lib/turbosnap/v2/manifest.ts
+++ b/node-src/lib/turbosnap/v2/manifest.ts
@@ -34,7 +34,7 @@ export interface TurboSnapManifest {
    * catch-all, the `storybookConfigFiles` and `staticFiles` out-of-graph sweeps, and the Storybook
    * version (the plain version string, not a hash of it).
    */
-  storybookFileHashes: Map<StorybookFileKey, FileHash | StorybookVersion>;
+  storybookConfigHashes: Map<StorybookFileKey, FileHash | StorybookVersion>;
   /** Rolled-up hash per story file, covering only that story's own transitive subtree. */
   storyFileHashes: Map<FilePath, FileHash>;
   /**
@@ -63,7 +63,7 @@ export interface TurboSnapManifest {
  */
 interface ManifestFile {
   storybookHash: string;
-  storybookFileHashes: Record<FilePath, FileHash | StorybookVersion>;
+  storybookConfigHashes: Record<FilePath, FileHash | StorybookVersion>;
   storybookConfigFiles: Record<FilePath, FileHash>;
   staticFiles: Record<FilePath, FileHash>;
   storyFiles: Record<FilePath, FileHash>;
@@ -101,7 +101,7 @@ export async function buildManifest(
     }
   }
 
-  const { storybookFileHashes, attribution } = collectStorybookFiles(
+  const { storybookConfigHashes, attribution } = collectStorybookFiles(
     files,
     hashes,
     storyReachable,
@@ -111,7 +111,7 @@ export async function buildManifest(
 
   // The preview core runtime may not exist in the module graph, so no file hash can see a Storybook
   // upgrade there. Track the version instead; it is a plain string, not a hash.
-  storybookFileHashes.set(
+  storybookConfigHashes.set(
     STORYBOOK_VERSION_KEY,
     resolveStorybookVersion(input.projectRoot, input.projectFiles)
   );
@@ -120,19 +120,19 @@ export async function buildManifest(
   // them change. They get their own roll-ups; see rollUpOutOfGraphFiles.
   const outOfGraphFiles = await hashOutOfGraphFiles(input);
   for (const [key, hash] of rollUpOutOfGraphFiles(outOfGraphFiles, h64ToString)) {
-    storybookFileHashes.set(key, hash);
+    storybookConfigHashes.set(key, hash);
   }
 
   // The backend's top-level "did Storybook change at all?" gate: the key and hash of every story
-  // file plus every `storybookFileHashes` entry, so additions, removals and renames are all visible
+  // file plus every `storybookConfigHashes` entry, so additions, removals and renames are all visible
   // before the backend drills into the maps.
   const storybookHash = h64ToString(
-    hashEntryIdentities(storyFileHashes) + hashEntryIdentities(storybookFileHashes)
+    hashEntryIdentities(storyFileHashes) + hashEntryIdentities(storybookConfigHashes)
   );
 
   return {
     storybookHash,
-    storybookFileHashes,
+    storybookConfigHashes,
     storyFileHashes,
     attribution,
     outOfGraphFiles,
@@ -152,7 +152,7 @@ export async function buildManifest(
 export function serializeManifest(manifest: TurboSnapManifest): ManifestFile {
   return {
     storybookHash: manifest.storybookHash,
-    storybookFileHashes: sortByKey(Object.fromEntries(manifest.storybookFileHashes)),
+    storybookConfigHashes: sortByKey(Object.fromEntries(manifest.storybookConfigHashes)),
     storybookConfigFiles: sortByKey(
       Object.fromEntries(manifest.outOfGraphFiles.storybookConfigFiles)
     ),

--- a/node-src/lib/turbosnap/v2/outOfGraphFiles.ts
+++ b/node-src/lib/turbosnap/v2/outOfGraphFiles.ts
@@ -65,7 +65,7 @@ export async function hashOutOfGraphFiles(input: OutOfGraphInput): Promise<OutOf
 }
 
 /**
- * Rolls each out-of-graph section up into the single `storybookFileHashes` entry the Index compares.
+ * Rolls each out-of-graph section up into the single `storybookConfigHashes` entry the Index compares.
  *
  * The two sections are deliberately independent of each other and of `.storybook/preview.*`'s
  * graph-rolled entry: bytes-changed and imports-changed are different failure modes, so `preview.*` is
@@ -84,7 +84,7 @@ export async function hashOutOfGraphFiles(input: OutOfGraphInput): Promise<OutOf
  * @param outOfGraphFiles The per-file hashes to roll up.
  * @param h64ToString The hash function.
  *
- * @returns The synthetic `storybookFileHashes` entries, keyed by {@link STORYBOOK_CONFIG_KEY} and
+ * @returns The synthetic `storybookConfigHashes` entries, keyed by {@link STORYBOOK_CONFIG_KEY} and
  * {@link STATIC_FILES_KEY}.
  */
 export function rollUpOutOfGraphFiles(

--- a/node-src/lib/turbosnap/v2/paths.test.ts
+++ b/node-src/lib/turbosnap/v2/paths.test.ts
@@ -4,6 +4,7 @@ import { Module } from '../../../types';
 import {
   canonicalFileNames,
   canonicalImporters,
+  isNodeModulesPath,
   moduleFileNames,
   normalizeStatsPath,
   resolveStatsPath,
@@ -237,5 +238,30 @@ describe('resolveStatsPath', () => {
     expect(resolveStatsPath('/repo/packages/shared/theme.ts', projectRoot)).toBe(
       '/repo/packages/shared/theme.ts'
     );
+  });
+});
+
+describe('isNodeModulesPath', () => {
+  it.each([
+    ['canonical project-relative path', './node_modules/react/index.js'],
+    ['bare relative path', 'node_modules/react/index.js'],
+    ['absolute POSIX path', '/repo/node_modules/react/index.js'],
+    ['nested node_modules', './node_modules/a/node_modules/b/index.js'],
+    ['Windows backslash separators', String.raw`C:\repo\node_modules\react\index.js`],
+    ['segment at the end of the path', './packages/ui/node_modules'],
+    ['segment at the start of the path', 'node_modules'],
+  ])('is true for a %s', (_description, filePath) => {
+    expect(isNodeModulesPath(filePath)).toBe(true);
+  });
+
+  it.each([
+    ['a project source file', './src/Button.stories.tsx'],
+    ['an absolute source file', '/repo/packages/ui/src/Button.tsx'],
+    ['a file merely named node_modules', './src/node_modules.ts'],
+    ['a segment that only starts with node_modules', './src/node_modules_backup/x.ts'],
+    ['a segment that only ends with node_modules', './src/my_node_modules/x.ts'],
+    ['an empty path', ''],
+  ])('is false for %s', (_description, filePath) => {
+    expect(isNodeModulesPath(filePath)).toBe(false);
   });
 });

--- a/node-src/lib/turbosnap/v2/paths.ts
+++ b/node-src/lib/turbosnap/v2/paths.ts
@@ -88,6 +88,23 @@ export function rootFilePath(module: Module, roots: StatsRoots): FilePath | unde
   return canonicalFileNames(module, roots)[0];
 }
 
+// A `node_modules` segment anywhere in a path. Matched segment-wise rather than by substring so a
+// file merely named `node_modules` is not mistaken for one inside the directory. Tolerant of both
+// separators and of the segment being terminal, so it reads raw stats names (Windows backslashes)
+// and canonical keys alike.
+const NODE_MODULES_SEGMENT = /(?:^|[\\/])node_modules(?:[\\/]|$)/;
+
+/**
+ * Whether a path passes through a `node_modules` directory.
+ *
+ * @param filePath The path to test, raw or canonical.
+ *
+ * @returns Whether the path contains a `node_modules` segment.
+ */
+export function isNodeModulesPath(filePath: string): boolean {
+  return NODE_MODULES_SEGMENT.test(filePath);
+}
+
 /**
  * Strips a trailing ` + N modules` suffix from a concatenated module's name, leaving the root file.
  *

--- a/node-src/lib/turbosnap/v2/statsGraph.test.ts
+++ b/node-src/lib/turbosnap/v2/statsGraph.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import { Stats } from '../../../types';
 import { createFixture } from './__fixtures__/manifestFixtures';
-import { readStatsGraph } from './statsGraph';
+import { countNodeModulesFiles, readStatsGraph } from './statsGraph';
 
 // These suites are about builder spellings: what webpack, rspack and Vite each call the same file,
 // and what the graph reader makes of it. They assert on the graph, not on a hash — that the right
@@ -322,5 +322,66 @@ describe('readStatsGraph hashing failures', () => {
     }
 
     expect(err?.message).toContain(story);
+  });
+});
+
+describe('countNodeModulesFiles', () => {
+  it('counts zero for a first-party-only graph', () => {
+    const stats: Stats = {
+      modules: [
+        { id: 1, name: './src/Button.stories.tsx' },
+        { id: 2, name: './src/Button.tsx' },
+        { id: 3, name: './.storybook/preview.ts' },
+      ],
+    };
+
+    expect(countNodeModulesFiles(stats)).toBe(0);
+  });
+
+  it('does not count file names and context expressions that only mention node_modules', () => {
+    const stats: Stats = {
+      modules: [
+        { id: 1, name: './src/node_modules-helper.ts' },
+        {
+          id: 2,
+          name: String.raw`./src|lazy|/^\.\/.*$/|include: /(?!.*node_modules)/|namespace object`,
+        },
+      ],
+    };
+
+    expect(countNodeModulesFiles(stats)).toBe(0);
+  });
+
+  it('counts installed dependency files however the builder spells them', () => {
+    const stats: Stats = {
+      // One relative (Vite), two absolute (webpack on POSIX and Windows), one via
+      // `nameForCondition` (rspack).
+      modules: [
+        { id: 1, name: './src/Button.tsx' },
+        { id: 2, name: './../../node_modules/@storybook/react/dist/entry-preview.js' },
+        { id: 3, name: '/repo/node_modules/storybook/dist/csf/index.js' },
+        { id: 4, name: 'dependency group', nameForCondition: '/repo/node_modules/react/index.js' },
+        { id: 5, name: String.raw`C:\repo\node_modules\react-dom\index.js` },
+      ],
+    };
+
+    expect(countNodeModulesFiles(stats)).toBe(4);
+  });
+
+  it('counts the concatenated children of a dependency group', () => {
+    const stats: Stats = {
+      modules: [
+        {
+          id: 1,
+          name: './../../node_modules/storybook/dist/csf/index.js + 1 modules',
+          modules: [
+            { name: './../../node_modules/storybook/dist/csf/index.js' },
+            { name: './../../node_modules/storybook/dist/csf/toId.js' },
+          ],
+        },
+      ],
+    };
+
+    expect(countNodeModulesFiles(stats)).toBe(2);
   });
 });

--- a/node-src/lib/turbosnap/v2/statsGraph.ts
+++ b/node-src/lib/turbosnap/v2/statsGraph.ts
@@ -4,6 +4,7 @@ import { ManifestInput } from './manifestInput';
 import {
   canonicalFileNames,
   canonicalImporters,
+  isNodeModulesPath,
   moduleFileNames,
   normalizeStatsPath,
   resolveStatsPath,
@@ -72,6 +73,22 @@ export async function readStatsGraph(stats: Stats, context: StatsContext): Promi
   }
 
   return { files, hashes, storyFiles };
+}
+
+/**
+ * Counts the graph's `node_modules` file names. Read off the stats file rather than the manifest,
+ * because it is a property of the builder's output rather than of what we derived from it.
+ *
+ * @param stats The stats file to parse.
+ *
+ * @returns The number of `node_modules` file names across all modules.
+ */
+export function countNodeModulesFiles(stats: Stats): number {
+  let count = 0;
+  for (const module of stats.modules) {
+    count += moduleFileNames(module).filter((name) => isNodeModulesPath(name)).length;
+  }
+  return count;
 }
 
 /**

--- a/node-src/lib/turbosnap/v2/storyDetection.ts
+++ b/node-src/lib/turbosnap/v2/storyDetection.ts
@@ -1,6 +1,12 @@
 import { Stats } from '../../../types';
 import { FilePath } from './graph';
-import { canonicalImporters, normalizeStatsPath, rootFilePath, StatsRoots } from './paths';
+import {
+  canonicalImporters,
+  isNodeModulesPath,
+  normalizeStatsPath,
+  rootFilePath,
+  StatsRoots,
+} from './paths';
 
 /**
  * Whether a canonical path has a real file on disk. You can use things that adhere to this
@@ -48,11 +54,6 @@ const CONFIG_ENTRY_FILES = new Set([
 // Webpack/rspack name a module the bundle does not own `external "<request>"` (e.g. Storybook's
 // preview runtime globals). It has no on-disk file and imports nothing.
 const EXTERNAL_MODULE = /^external "/;
-
-// A `node_modules` segment anywhere in a path. Matched segment-wise rather than by substring because
-// a canonical key may reach a hoisted install through `../`, and because a context's own name embeds
-// the literal text `node_modules` inside its include regex.
-const NODE_MODULES_SEGMENT = /(^|\/)node_modules\//;
 
 // Webpack spells contexts with ` lazy `; rspack delimits the same marker with pipes.
 const LAZY_CONTEXT_MARKER = / lazy |\|lazy\|/;
@@ -171,7 +172,7 @@ function isStoryFile(
   if (matchedStoryImporters.length === 0) {
     return false;
   }
-  if (!NODE_MODULES_SEGMENT.test(filePath)) {
+  if (!isNodeModulesPath(filePath)) {
     return true;
   }
   return !matchedStoryImporters.every((importer) => contextsExcludingNodeModules.has(importer));
@@ -250,5 +251,5 @@ function isLazyContext(moduleName: string): boolean {
  * @returns Whether the context's glob excluded `node_modules`.
  */
 function excludesNodeModules(contextName: string): boolean {
-  return !NODE_MODULES_SEGMENT.test(contextName.split(LAZY_CONTEXT_MARKER)[0]);
+  return !isNodeModulesPath(contextName.split(LAZY_CONTEXT_MARKER)[0]);
 }

--- a/node-src/lib/turbosnap/v2/storybookFileKeys.ts
+++ b/node-src/lib/turbosnap/v2/storybookFileKeys.ts
@@ -1,5 +1,5 @@
 /**
- * The synthetic keys in the manifest's `storybookFileHashes` map. They share one namespace and one
+ * The synthetic keys in the manifest's `storybookConfigHashes` map. They share one namespace and one
  * invariant, so they are declared together: a canonical relative path always starts with `./` or
  * `../`, so none of these bare names can collide with a real file.
  */
@@ -36,7 +36,7 @@ export const STORYBOOK_CONFIG_KEY = 'storybookConfigFiles';
 export const STATIC_FILES_KEY = 'staticFiles';
 
 /**
- * Every synthetic key in `storybookFileHashes`. A canonical file path always starts `./` or `../`,
+ * Every synthetic key in `storybookConfigHashes`. A canonical file path always starts `./` or `../`,
  * so none of these bare names can collide with one; see the note at the top of this file.
  */
 export type StorybookFileKey =

--- a/node-src/lib/turbosnap/v2/storybookFiles.test.ts
+++ b/node-src/lib/turbosnap/v2/storybookFiles.test.ts
@@ -31,7 +31,7 @@ describe('collectStorybookFiles', () => {
     const files = makeFiles({ './.storybook/preview.ts': [], './src/a.stories.tsx': [] });
     const hashes = makeHashes(['./.storybook/preview.ts', './src/a.stories.tsx']);
 
-    const { storybookFileHashes } = collectStorybookFiles(
+    const { storybookConfigHashes } = collectStorybookFiles(
       files,
       hashes,
       new Set(['./src/a.stories.tsx']),
@@ -39,8 +39,8 @@ describe('collectStorybookFiles', () => {
       identity
     );
 
-    expect([...storybookFileHashes.keys()]).toContain(STORYBOOK_PREVIEW_KEY);
-    expect([...storybookFileHashes.keys()]).not.toContain('./.storybook/preview.ts');
+    expect([...storybookConfigHashes.keys()]).toContain(STORYBOOK_PREVIEW_KEY);
+    expect([...storybookConfigHashes.keys()]).not.toContain('./.storybook/preview.ts');
   });
 
   it('matches every preview config extension Storybook accepts', () => {
@@ -52,7 +52,7 @@ describe('collectStorybookFiles', () => {
       './.storybook/preview.mjs',
       './.storybook/preview.cjs',
     ];
-    const { storybookFileHashes, attribution } = collectStorybookFiles(
+    const { storybookConfigHashes, attribution } = collectStorybookFiles(
       makeFiles(Object.fromEntries(previews.map((p) => [p, []]))),
       makeHashes(previews),
       new Set(),
@@ -61,14 +61,14 @@ describe('collectStorybookFiles', () => {
     );
 
     // Every extension lands in the one shared `preview` home, so all six show up in its subtree.
-    expect([...storybookFileHashes.keys()]).toEqual([STORYBOOK_PREVIEW_KEY]);
+    expect([...storybookConfigHashes.keys()]).toEqual([STORYBOOK_PREVIEW_KEY]);
     expect([...attribution.previewSubtree].sort()).toEqual([...previews].sort());
   });
 
   it('does not treat a file merely named preview outside the config dir as a config', () => {
     const files = makeFiles({ './src/preview.ts': [] });
 
-    const { storybookFileHashes, attribution } = collectStorybookFiles(
+    const { storybookConfigHashes, attribution } = collectStorybookFiles(
       files,
       makeHashes(['./src/preview.ts']),
       new Set(),
@@ -76,7 +76,7 @@ describe('collectStorybookFiles', () => {
       identity
     );
 
-    expect([...storybookFileHashes.keys()]).toEqual([STORYBOOK_GLOBALS_KEY]);
+    expect([...storybookConfigHashes.keys()]).toEqual([STORYBOOK_GLOBALS_KEY]);
     expect([...attribution.storybookGlobals]).toEqual(['./src/preview.ts']);
   });
 
@@ -85,7 +85,7 @@ describe('collectStorybookFiles', () => {
     const vendoredTheme = './node_modules/some-addon/.storybook/theme.ts';
     const files = makeFiles({ [vendoredPreview]: [vendoredTheme], [vendoredTheme]: [] });
 
-    const { storybookFileHashes, attribution } = collectStorybookFiles(
+    const { storybookConfigHashes, attribution } = collectStorybookFiles(
       files,
       makeHashes([...files.keys()]),
       new Set(),
@@ -93,7 +93,7 @@ describe('collectStorybookFiles', () => {
       identity
     );
 
-    expect([...storybookFileHashes.keys()]).toEqual([STORYBOOK_GLOBALS_KEY]);
+    expect([...storybookConfigHashes.keys()]).toEqual([STORYBOOK_GLOBALS_KEY]);
     expect([...attribution.previewSubtree]).toEqual([]);
     expect([...attribution.storybookGlobals].sort()).toEqual(
       [vendoredPreview, vendoredTheme].sort()
@@ -105,7 +105,7 @@ describe('collectStorybookFiles', () => {
     // must be found there, not missed for not being literally named `.storybook`.
     const files = makeFiles({ './src/preview.ts': [] });
 
-    const { storybookFileHashes, attribution } = collectStorybookFiles(
+    const { storybookConfigHashes, attribution } = collectStorybookFiles(
       files,
       makeHashes(['./src/preview.ts']),
       new Set(),
@@ -113,7 +113,7 @@ describe('collectStorybookFiles', () => {
       identity
     );
 
-    expect([...storybookFileHashes.keys()]).toEqual([STORYBOOK_PREVIEW_KEY]);
+    expect([...storybookConfigHashes.keys()]).toEqual([STORYBOOK_PREVIEW_KEY]);
     expect([...attribution.previewSubtree]).toEqual(['./src/preview.ts']);
   });
 
@@ -154,7 +154,7 @@ describe('collectStorybookFiles', () => {
     });
     const hashes = makeHashes([...files.keys()]);
 
-    const { storybookFileHashes } = collectStorybookFiles(
+    const { storybookConfigHashes } = collectStorybookFiles(
       files,
       hashes,
       new Set(),
@@ -162,16 +162,16 @@ describe('collectStorybookFiles', () => {
       identity
     );
 
-    expect([...storybookFileHashes.keys()]).toEqual([STORYBOOK_PREVIEW_KEY]);
+    expect([...storybookConfigHashes.keys()]).toEqual([STORYBOOK_PREVIEW_KEY]);
     // The identity hash makes the roll-up read as the paths that went into it: both themes are there.
-    expect(storybookFileHashes.get(STORYBOOK_PREVIEW_KEY)).toContain('themeA');
-    expect(storybookFileHashes.get(STORYBOOK_PREVIEW_KEY)).toContain('themeB');
+    expect(storybookConfigHashes.get(STORYBOOK_PREVIEW_KEY)).toContain('themeA');
+    expect(storybookConfigHashes.get(STORYBOOK_PREVIEW_KEY)).toContain('themeB');
   });
 
   it('rolls files reached by no story and no preview into the catch-all', () => {
     const files = makeFiles({ './node_modules/react-dom/index.js': [] });
 
-    const { storybookFileHashes, attribution } = collectStorybookFiles(
+    const { storybookConfigHashes, attribution } = collectStorybookFiles(
       files,
       makeHashes(['./node_modules/react-dom/index.js']),
       new Set(),
@@ -179,7 +179,7 @@ describe('collectStorybookFiles', () => {
       identity
     );
 
-    expect([...storybookFileHashes.keys()]).toEqual([STORYBOOK_GLOBALS_KEY]);
+    expect([...storybookConfigHashes.keys()]).toEqual([STORYBOOK_GLOBALS_KEY]);
     expect([...attribution.storybookGlobals]).toEqual(['./node_modules/react-dom/index.js']);
   });
 
@@ -189,7 +189,7 @@ describe('collectStorybookFiles', () => {
       './src/button.tsx': [],
     });
 
-    const { storybookFileHashes } = collectStorybookFiles(
+    const { storybookConfigHashes } = collectStorybookFiles(
       files,
       makeHashes(['./src/a.stories.tsx', './src/button.tsx']),
       new Set(['./src/a.stories.tsx', './src/button.tsx']),
@@ -197,7 +197,7 @@ describe('collectStorybookFiles', () => {
       identity
     );
 
-    expect([...storybookFileHashes.keys()]).toEqual([]);
+    expect([...storybookConfigHashes.keys()]).toEqual([]);
   });
 
   it('rolls a file hashed but absent from the graph into the catch-all', () => {
@@ -286,7 +286,7 @@ describe('collectStorybookFiles', () => {
   it('skips a preview config that has no content hash', () => {
     const files = makeFiles({ './.storybook/preview.ts': [] });
 
-    const { storybookFileHashes } = collectStorybookFiles(
+    const { storybookConfigHashes } = collectStorybookFiles(
       files,
       new Map(),
       new Set(),
@@ -294,6 +294,6 @@ describe('collectStorybookFiles', () => {
       identity
     );
 
-    expect([...storybookFileHashes.keys()]).toEqual([]);
+    expect([...storybookConfigHashes.keys()]).toEqual([]);
   });
 });

--- a/node-src/lib/turbosnap/v2/storybookFiles.ts
+++ b/node-src/lib/turbosnap/v2/storybookFiles.ts
@@ -43,14 +43,14 @@ function isPreviewConfig(filePath: FilePath, configDirectory: FilePath): boolean
 export interface FileAttribution {
   /** Files in neither of the above, rolled into the {@link STORYBOOK_GLOBALS_KEY} catch-all. */
   storybookGlobals: Set<FilePath>;
-  /** Files in a `.storybook/preview.*` subtree, hashed into the shared `preview` `storybookFileHashes` entry. */
+  /** Files in a `.storybook/preview.*` subtree, hashed into the shared `preview` `storybookConfigHashes` entry. */
   previewSubtree: Set<FilePath>;
   /** Files in some story's transitive subtree, hashed into that story's `storyFiles` entry. */
   storyReachable: Set<FilePath>;
 }
 
 /**
- * Builds the file-hash entries of the `storybookFileHashes` section: a rolled-up hash for each Storybook
+ * Builds the file-hash entries of the `storybookConfigHashes` section: a rolled-up hash for each Storybook
  * config file that no story imports. Every hashable file lands in exactly one hashing home — a
  * story's own subtree, the shared {@link STORYBOOK_PREVIEW_KEY} entry, or the {@link STORYBOOK_GLOBALS_KEY}
  * catch-all — so nothing goes unhashed and the backend can still attribute a change to the preview
@@ -74,12 +74,12 @@ export function collectStorybookFiles(
   storyReachable: Set<FilePath>,
   configDirectory: FilePath,
   h64ToString: (input: string) => string
-): { storybookFileHashes: Map<StorybookFileKey, FileHash>; attribution: FileAttribution } {
+): { storybookConfigHashes: Map<StorybookFileKey, FileHash>; attribution: FileAttribution } {
   // Every preview config subtree, unioned into one `preview` roll-up rather than one entry per path,
   // so the map stays a homogeneous set of category roll-ups (preview, globals, config, static). The
   // shared accumulator is safe because every preview feeds the same hash, so there is no cross-preview
   // leak to keep apart.
-  const storybookFileHashes = new Map<StorybookFileKey, FileHash>();
+  const storybookConfigHashes = new Map<StorybookFileKey, FileHash>();
   const previewSubtree = new Set<FilePath>();
   let hasPreview = false;
   for (const filePath of files.keys()) {
@@ -88,7 +88,7 @@ export function collectStorybookFiles(
     collectTransitiveDependencies(files, filePath, previewSubtree);
   }
   if (hasPreview) {
-    storybookFileHashes.set(
+    storybookConfigHashes.set(
       STORYBOOK_PREVIEW_KEY,
       rollUpFileHashes(hashes, previewSubtree, h64ToString)
     );
@@ -105,7 +105,7 @@ export function collectStorybookFiles(
     (filePath) => !storyReachable.has(filePath) && !previewSubtree.has(filePath)
   );
   if (orphanGlobals.length > 0) {
-    storybookFileHashes.set(
+    storybookConfigHashes.set(
       STORYBOOK_GLOBALS_KEY,
       rollUpFileHashes(hashes, orphanGlobals, h64ToString)
     );
@@ -120,5 +120,5 @@ export function collectStorybookFiles(
     storybookGlobals: new Set(orphanGlobals),
   };
 
-  return { storybookFileHashes, attribution };
+  return { storybookConfigHashes, attribution };
 }

--- a/node-src/lib/turbosnap/v2/uploadHashes.test.ts
+++ b/node-src/lib/turbosnap/v2/uploadHashes.test.ts
@@ -11,7 +11,7 @@ const graphqlClient = client as unknown as GraphQLClient;
 const manifest: TurboSnapManifest = {
   files: new Map(),
   storyFileHashes: new Map([['./src/Button.stories.ts', 'story-hash']]),
-  storybookFileHashes: new Map([
+  storybookConfigHashes: new Map([
     [STORYBOOK_PREVIEW_KEY, 'preview-hash'],
     [STORYBOOK_GLOBALS_KEY, 'globals-hash'],
   ]),
@@ -21,7 +21,6 @@ const manifest: TurboSnapManifest = {
     previewSubtree: new Set(['./.storybook/preview.ts']),
     storybookGlobals: new Set(),
   },
-  // Present on the manifest for the S3 debug file, but deliberately not uploaded to the Index.
   outOfGraphFiles: { storybookConfigFiles: new Map(), staticFiles: new Map() },
 };
 
@@ -47,23 +46,6 @@ describe('uploadHashes', () => {
       },
       { retries: 3 }
     );
-  });
-
-  it('sends storybookFileHashes under the storybookConfigHashes input field', async () => {
-    await uploadHashes(graphqlClient, 'build-id', manifest);
-
-    const [, variables] = client.runQuery.mock.calls[0];
-    expect(variables.input.storybookConfigHashes).toEqual(
-      Object.fromEntries(manifest.storybookFileHashes)
-    );
-  });
-
-  it('selects both members of the response union', async () => {
-    await uploadHashes(graphqlClient, 'build-id', manifest);
-
-    const [mutation] = client.runQuery.mock.calls[0];
-    expect(mutation).toContain('... on BuildUploadHashesSuccess');
-    expect(mutation).toContain('... on BuildUploadHashesFailure');
   });
 
   it('returns the mechanism the Index decided by, so a caller can tell it decided at all', async () => {

--- a/node-src/lib/turbosnap/v2/uploadHashes.test.ts
+++ b/node-src/lib/turbosnap/v2/uploadHashes.test.ts
@@ -1,0 +1,88 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import GraphQLClient from '../../../io/graphqlClient';
+import { TurboSnapManifest } from './manifest';
+import { STORYBOOK_GLOBALS_KEY, STORYBOOK_PREVIEW_KEY } from './storybookFileKeys';
+import { uploadHashes } from './uploadHashes';
+
+const client = { runQuery: vi.fn() };
+const graphqlClient = client as unknown as GraphQLClient;
+
+const manifest: TurboSnapManifest = {
+  files: new Map(),
+  storyFileHashes: new Map([['./src/Button.stories.ts', 'story-hash']]),
+  storybookFileHashes: new Map([
+    [STORYBOOK_PREVIEW_KEY, 'preview-hash'],
+    [STORYBOOK_GLOBALS_KEY, 'globals-hash'],
+  ]),
+  storybookHash: 'storybook-hash',
+  attribution: {
+    storyReachable: new Set(['./src/Button.stories.ts']),
+    previewSubtree: new Set(['./.storybook/preview.ts']),
+    storybookGlobals: new Set(),
+  },
+  // Present on the manifest for the S3 debug file, but deliberately not uploaded to the Index.
+  outOfGraphFiles: { storybookConfigFiles: new Map(), staticFiles: new Map() },
+};
+
+beforeEach(() => {
+  client.runQuery.mockResolvedValue({
+    buildUploadHashes: { build: { turboSnapStatus: 'APPLIED', turboSnapMechanism: 'HASH_BASED' } },
+  });
+});
+
+describe('uploadHashes', () => {
+  it('uploads the Storybook hash, the config hashes, and the story file hashes', async () => {
+    await uploadHashes(graphqlClient, 'build-id', manifest);
+
+    expect(client.runQuery).toHaveBeenCalledWith(
+      expect.stringContaining('buildUploadHashes'),
+      {
+        input: {
+          buildId: 'build-id',
+          storybookHash: 'storybook-hash',
+          storybookConfigHashes: { preview: 'preview-hash', storybookGlobals: 'globals-hash' },
+          storyFileHashes: { './src/Button.stories.ts': 'story-hash' },
+        },
+      },
+      { retries: 3 }
+    );
+  });
+
+  it('sends storybookFileHashes under the storybookConfigHashes input field', async () => {
+    await uploadHashes(graphqlClient, 'build-id', manifest);
+
+    const [, variables] = client.runQuery.mock.calls[0];
+    expect(variables.input.storybookConfigHashes).toEqual(
+      Object.fromEntries(manifest.storybookFileHashes)
+    );
+  });
+
+  it('selects both members of the response union', async () => {
+    await uploadHashes(graphqlClient, 'build-id', manifest);
+
+    const [mutation] = client.runQuery.mock.calls[0];
+    expect(mutation).toContain('... on BuildUploadHashesSuccess');
+    expect(mutation).toContain('... on BuildUploadHashesFailure');
+  });
+
+  it('returns the mechanism the Index decided by, so a caller can tell it decided at all', async () => {
+    const result = await uploadHashes(graphqlClient, 'build-id', manifest);
+
+    expect(result.build?.turboSnapMechanism).toBe('HASH_BASED');
+  });
+
+  it('returns the errors the Index reported when the upload fails', async () => {
+    client.runQuery.mockResolvedValue({
+      buildUploadHashes: {
+        errors: [{ message: 'Uploading hashes is only allowed for announced builds.' }],
+      },
+    });
+
+    const result = await uploadHashes(graphqlClient, 'build-id', manifest);
+
+    expect(result.errors).toEqual([
+      { message: 'Uploading hashes is only allowed for announced builds.' },
+    ]);
+  });
+});

--- a/node-src/lib/turbosnap/v2/uploadHashes.ts
+++ b/node-src/lib/turbosnap/v2/uploadHashes.ts
@@ -77,7 +77,7 @@ export async function uploadHashes(
   const input: BuildUploadHashesInput = {
     buildId,
     storybookHash: manifest.storybookHash,
-    storybookConfigHashes: Object.fromEntries(manifest.storybookFileHashes),
+    storybookConfigHashes: Object.fromEntries(manifest.storybookConfigHashes),
     storyFileHashes: Object.fromEntries(manifest.storyFileHashes),
   };
 

--- a/node-src/lib/turbosnap/v2/uploadHashes.ts
+++ b/node-src/lib/turbosnap/v2/uploadHashes.ts
@@ -1,0 +1,91 @@
+import GraphQLClient from '../../../io/graphqlClient';
+import { TurboSnapManifest } from './manifest';
+
+const BuildUploadHashesMutation = `
+  mutation BuildUploadHashes($input: BuildUploadHashesInput!) {
+    buildUploadHashes(input: $input) {
+      ... on BuildUploadHashesSuccess {
+        build {
+          turboSnapStatus
+          turboSnapMechanism
+        }
+      }
+      ... on BuildUploadHashesFailure {
+        errors {
+          ... on MutationError {
+            message
+          }
+        }
+      }
+    }
+  }
+`;
+
+/** How the Index decided `onlyStoryFiles`. Absent means it did not decide by hash. */
+type TurboSnapMechanism = 'GIT_BASED' | 'HASH_BASED';
+
+/**
+ * The `BuildUploadHashesInput` the CLI sends. It mirrors the Index's input type so a schema change
+ * on that side surfaces here as a type error rather than a runtime rejection.
+ *
+ * `storybookConfigHashes` is a map of Storybook-wide category roll-ups to their hashes. The Index
+ * requires `storybookVersion` and `storybookConfigFiles`; the remaining categories (`preview`,
+ * `storybookGlobals`, `staticFiles`) ride its catch-all. Every value is a string, so the manifest's
+ * `FileHash | StorybookVersion` entries map onto it directly.
+ */
+interface BuildUploadHashesInput {
+  buildId: string;
+  storybookHash: string;
+  storybookConfigHashes: Record<string, string>;
+  storyFileHashes: Record<string, string>;
+}
+
+/**
+ * The mutation payload: the updated build on success, or the errors that prevented the upload. We do
+ * not distinguish the individual error types, only whether the upload failed and what it reported.
+ */
+export interface BuildUploadHashesResponse {
+  /** Present on success. The Index sets these itself; the CLI does not send them. */
+  build?: {
+    turboSnapStatus?: string;
+    turboSnapMechanism?: TurboSnapMechanism;
+  };
+  /** Present on failure. */
+  errors?: { message?: string }[];
+}
+
+interface BuildUploadHashesResult {
+  buildUploadHashes: BuildUploadHashesResponse;
+}
+
+/**
+ * Sends the whole-Storybook hash and the per-story hashes from the TurboSnap manifest to the Index,
+ * which compares them against the build's ancestors to determine which stories need to be
+ * recaptured.
+ *
+ * @param graphqlClient The GraphQL client to use.
+ * @param buildId The build ID associated with the manifest.
+ * @param manifest The manifest whose Storybook and story file hashes are sent to the Index.
+ *
+ * @returns The mutation result: the updated build on success, or the errors that prevented the upload.
+ */
+export async function uploadHashes(
+  graphqlClient: GraphQLClient,
+  buildId: string,
+  manifest: TurboSnapManifest
+): Promise<BuildUploadHashesResponse> {
+  const input: BuildUploadHashesInput = {
+    buildId,
+    storybookHash: manifest.storybookHash,
+    storybookConfigHashes: Object.fromEntries(manifest.storybookFileHashes),
+    storyFileHashes: Object.fromEntries(manifest.storyFileHashes),
+  };
+
+  const { buildUploadHashes } = await graphqlClient.runQuery<BuildUploadHashesResult>(
+    BuildUploadHashesMutation,
+    { input },
+    { retries: 3 }
+  );
+
+  return buildUploadHashes;
+}


### PR DESCRIPTION
Relates to CAP-4864

This takes the built manifest file and uploads pieces to the Index for analysis. The Index then decides which stories need to be retested.

I also noticed some duplication when checking for files within `node_modules` directories so I cleaned that up while I was in there.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>18.6.1--canary.1444.32890875728.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@18.6.1--canary.1444.32890875728.0
  # or 
  yarn add chromatic@18.6.1--canary.1444.32890875728.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
