### PR TITLE
Grab correct version of `@storybook/angular-vite`

### DIFF
--- a/node-src/lib/viewLayers.ts
+++ b/node-src/lib/viewLayers.ts
@@ -3,6 +3,7 @@ export const viewLayers = {
   '@storybook/vue': 'vue',
   '@storybook/vue3': 'vue3',
   '@storybook/angular': 'angular',
+  '@storybook/angular-vite': 'angular',
   '@storybook/html': 'html',
   '@storybook/web-components': 'web-components',
   '@storybook/polymer': 'polymer',


### PR DESCRIPTION
Fixes chromaui/chromatic-cli#1439

It appears we weren't grabbing the correct Storybook version within Angular project so it was passing the wrong flag to the Storybook build command. This fixes that!

<details><summary>📦 Published PR as canary version: 18.2.1--canary.1445.32048821324.0</summary>

✨ Test out this PR locally via:

```bash
npm install chromatic@18.2.1--canary.1445.32048821324.0
# or 
yarn add chromatic@18.2.1--canary.1445.32048821324.0
```

</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>18.3.1--canary.1445.32161764504.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@18.3.1--canary.1445.32161764504.0
  # or 
  yarn add chromatic@18.3.1--canary.1445.32161764504.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
