### PR TITLE
Filter `.storybook/*.md` and `.storybook/*.txt` changes from TurboSnap

### DIFF
--- a/node-src/lib/turbosnap/v1/getDependentStoryFiles.test.ts
+++ b/node-src/lib/turbosnap/v1/getDependentStoryFiles.test.ts
@@ -586,6 +586,63 @@ describe('getDependentStoryFiles', () => {
     );
   });
 
+  it.each([
+    'path/to/storybook-config/README.md',
+    'path/to/storybook-config/docs/guidelines.md',
+    'path/to/storybook-config/notes.txt',
+  ])(
+    'does not bail on changed documentation file %s in the Storybook config dir',
+    async (documentationFile) => {
+      const changedFiles = ['src/foo.stories.js', documentationFile];
+      const modules = [
+        {
+          id: './src/foo.stories.js',
+          name: './src/foo.stories.js',
+          reasons: [{ moduleName: CSF_GLOB }],
+        },
+        {
+          id: CSF_GLOB,
+          name: CSF_GLOB,
+          reasons: [{ moduleName: './path/to/storybook-config/generated-stories-entry.js' }],
+        },
+      ];
+      const ctx = getContext({ configDir: 'path/to/storybook-config' });
+      const result = await getDependentStoryFiles(ctx, { modules }, statsPath, changedFiles);
+      expect(result.turboSnap.bailReason).toBeUndefined();
+      expect(result).toMatchObject({
+        status: 'traced',
+        onlyStoryFiles: {
+          './src/foo.stories.js': ['src/foo.stories.js'],
+        },
+      });
+    }
+  );
+
+  it('still bails on a real config change when a documentation file changed alongside it', async () => {
+    const changedFiles = [
+      'path/to/storybook-config/README.md',
+      'path/to/storybook-config/preview.js',
+    ];
+    const modules = [
+      {
+        id: './path/to/storybook-config/preview.js',
+        name: './path/to/storybook-config/preview.js',
+        reasons: [{ moduleName: './path/to/storybook-config/generated-stories-entry.js' }],
+      },
+      {
+        id: CSF_GLOB,
+        name: CSF_GLOB,
+        reasons: [{ moduleName: './path/to/storybook-config/generated-stories-entry.js' }],
+      },
+    ];
+    const ctx = getContext({ configDir: 'path/to/storybook-config' });
+    const result = await getDependentStoryFiles(ctx, { modules }, statsPath, changedFiles);
+    expect(result.status).toBe('bailed');
+    expect(result.turboSnap.bailReason).toEqual({
+      changedStorybookFiles: ['path/to/storybook-config/preview.js'],
+    });
+  });
+
   it('does not bail on changed external Storybook config file', async () => {
     const changedFiles = ['src/foo.stories.js', 'path/to/other-storybook/.storybook/file.js'];
     const modules = [

--- a/node-src/lib/turbosnap/v1/getDependentStoryFiles.ts
+++ b/node-src/lib/turbosnap/v1/getDependentStoryFiles.ts
@@ -18,6 +18,12 @@ const INTERNALS = [/\/webpack\/runtime\//, /^\(webpack\)/];
 
 const isPackageLockFile = (name: string) =>
   SUPPORTED_LOCK_FILES.some((lockfile) => name.endsWith(lockfile));
+
+// Documentation files inside the config dir (e.g. `.storybook/README.md`) don't affect the built
+// Storybook, so a change to them shouldn't trigger a full rebuild.
+const isDocumentationFile = (name: string) =>
+  ['.md', '.txt'].some((extension) => name.toLowerCase().endsWith(extension));
+
 const isUserModule = (module_: Module | Reason) =>
   (module_ as Module).id !== undefined &&
   (module_ as Module).id !== null &&
@@ -146,7 +152,10 @@ export async function getDependentStoryFiles(
   const csfGlobsByName = new Set<NormalizedName>();
 
   const isStorybookFile = (name: string) =>
-    name && name.startsWith(`${storybookDirectory}/`) && !storiesEntryFiles.includes(name);
+    name &&
+    name.startsWith(`${storybookDirectory}/`) &&
+    !storiesEntryFiles.includes(name) &&
+    !isDocumentationFile(name);
 
   stats.modules
     .filter((module_) => isUserModule(module_))


### PR DESCRIPTION
Some projects put doc files within `.storybook` to keep the documentation with their configs. TurboSnap looks at any changes within `.storybook` as a config change which bails and recaptures everything.

This filters out `*.md` and `*.txt` files from that list to prevent bailing unnecessarily.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>18.3.1--canary.1446.32161765690.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@18.3.1--canary.1446.32161765690.0
  # or 
  yarn add chromatic@18.3.1--canary.1446.32161765690.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
