### PR TITLE
Remove `actions/checkout` version from logs

### DIFF
--- a/node-src/ui/messages/errors/gitOneCommit.ts
+++ b/node-src/ui/messages/errors/gitOneCommit.ts
@@ -9,9 +9,9 @@ export default (isGithubAction = false) =>
     ? dedent(chalk`
       ${error} {bold Found only one commit}
       This typically means you have ran into one of the following scenarios:
-      - You've checked out a shallow copy of the Git repository, which {bold actions/checkout@v2} does by default.
+      - You've checked out a shallow copy of the Git repository, which {bold actions/checkout} does by default.
         In order for Chromatic to correctly determine baseline commits, we need access to the full Git history graph.
-        With {bold actions/checkout@v2}, you can enable this by setting 'fetch-depth: 0'.
+        With {bold actions/checkout}, you can enable this by setting 'fetch-depth: 0'.
         ${info} Read more at ${link('https://www.chromatic.com/docs/github-actions')}
       - You've only made a single commit so far. 
         Please make at least one additional commit in order for Chromatic to be able to detect what's changed. 


### PR DESCRIPTION
Looks like our logs were showing `actions/checkout@v2` which is WAY out of date. This simply removes the version from the log.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>18.6.1--canary.1447.32890880115.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@18.6.1--canary.1447.32890880115.0
  # or 
  yarn add chromatic@18.6.1--canary.1447.32890880115.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
