### PR TITLE
Ignore Claude worktrees

### DIFF
--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -1,9 +1,10 @@
 import tsconfigPaths from 'vite-tsconfig-paths';
-import { defineConfig, Plugin } from 'vitest/config';
+import { defaultExclude, defineConfig, Plugin } from 'vitest/config';
 
 export default defineConfig({
   test: {
     clearMocks: true, // Clear all mocks between each test
+    exclude: ['**/.claude/worktrees/**', ...defaultExclude],
     coverage: {
       include: ['{bin,node}-src/**/*.{ts,tsx}', 'isChromatic.{mjs,js}'],
       exclude: [


### PR DESCRIPTION
If you ever run worktrees in Claude, it dumps the worktree in `.claude/worktrees` which then gets picked up in Vitest. Let's ignore those!

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>18.6.1--canary.1448.32890852898.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@18.6.1--canary.1448.32890852898.0
  # or 
  yarn add chromatic@18.6.1--canary.1448.32890852898.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
