### PR TITLE
Add --first-parent-baseline flag

### DIFF
--- a/action-src/main.ts
+++ b/action-src/main.ts
@@ -113,6 +113,7 @@ async function run() {
     const exitZeroOnChanges = getInput('exitZeroOnChanges');
     const externals = getMultilineInput('externals');
     const fileHashing = getInput('fileHashing');
+    const firstParentBaseline = getInput('firstParentBaseline');
     const forceRebuild = getInput('forceRebuild');
     const ignoreLastBuildOnBranch = getInput('ignoreLastBuildOnBranch');
     const logFile = getInput('logFile');
@@ -180,6 +181,7 @@ async function run() {
         exitZeroOnChanges: maybe(exitZeroOnChanges, !isMergeQueueBuild),
         externals: maybe(externals),
         fileHashing: maybe(fileHashing, true),
+        firstParentBaseline: maybe(firstParentBaseline),
         forceRebuild: maybe(forceRebuild),
         ignoreLastBuildOnBranch: maybe(ignoreLastBuildOnBranch),
         interactive: false,

--- a/action.yml
+++ b/action.yml
@@ -47,6 +47,9 @@ inputs:
   fileHashing:
     description: 'Whether to apply file hashing to skip uploading unchanged files (default: true)'
     required: false
+  firstParentBaseline:
+    description: 'Resolve the baseline by walking only the first-parent (mainline) history: boolean or branch name/glob'
+    required: false
   forceRebuild:
     description: 'Do not skip build when a rebuild is detected'
     required: false

--- a/node-src/git/getParentCommits.test.ts
+++ b/node-src/git/getParentCommits.test.ts
@@ -812,4 +812,33 @@ describe('getParentCommits', () => {
       expectCommitsToEqualNames(parentCommits, ['E', 'D'], repository);
     });
   });
+
+  describe('firstParentBaseline', () => {
+    it('follows only the first-parent mainline, excluding second-parent ancestors', async () => {
+      //  A - B - C -[D]-(F)  [main]   F = merge(D, E); D is F's first parent
+      //            \   /
+      //             [E]      [branch]  reachable only via F's second parent
+      const repository = repositories.simpleLoop;
+      await checkoutCommit('F', 'main', repository);
+      const client = createClient({
+        repository,
+        builds: [
+          ['D', 'main'],
+          ['E', 'branch'],
+        ],
+      });
+      const git = { branch: 'main', ...(await getCommit(ctx)) };
+
+      // Without the option, E is a genuine ancestor of F, so it is included.
+      const defaultParents = await getParentCommits({ client, log, options } as any, withGit(git));
+      expectCommitsToEqualNames(defaultParents, ['E', 'D'], repository);
+
+      // With the option, the rev-list walk never descends into E (the second parent).
+      const firstParentParents = await getParentCommits(
+        { client, log, options } as any,
+        withGit(git, { firstParentBaseline: true })
+      );
+      expectCommitsToEqualNames(firstParentParents, ['D'], repository);
+    });
+  });
 });

--- a/node-src/git/getParentCommits.ts
+++ b/node-src/git/getParentCommits.ts
@@ -95,10 +95,12 @@ async function nextCommits(
     firstCommittedAtSeconds,
     commitsWithBuilds,
     commitsWithoutBuilds,
+    firstParentBaseline,
   }: {
     firstCommittedAtSeconds: number;
     commitsWithBuilds: string[];
     commitsWithoutBuilds: string[];
+    firstParentBaseline?: boolean;
   }
 ) {
   // We want the next limit commits that aren't "covered" by `commitsWithBuilds`
@@ -106,6 +108,7 @@ async function nextCommits(
   // so we ask enough that we'll definitely get `limit` unknown commits
   const command = `git rev-list HEAD \
       ${firstCommittedAtSeconds ? `--since ${firstCommittedAtSeconds}` : ''} \
+      ${firstParentBaseline ? '--first-parent' : ''} \
       -n ${limit + commitsWithoutBuilds.length} --not ${commitsForCLI(commitsWithBuilds)}`;
   const commitsString = await execGitCommand(deps, command);
   const commits = commitsString?.split('\n').filter(Boolean);
@@ -133,10 +136,12 @@ async function step(
     firstCommittedAtSeconds,
     commitsWithBuilds,
     commitsWithoutBuilds,
+    firstParentBaseline,
   }: {
     firstCommittedAtSeconds: number;
     commitsWithBuilds: string[];
     commitsWithoutBuilds: string[];
+    firstParentBaseline?: boolean;
   }
 ) {
   const { options, client, log } = deps;
@@ -151,6 +156,7 @@ async function step(
       firstCommittedAtSeconds,
       commitsWithBuilds,
       commitsWithoutBuilds,
+      firstParentBaseline,
     }
   );
 
@@ -180,6 +186,7 @@ async function step(
     firstCommittedAtSeconds,
     commitsWithBuilds: [...commitsWithBuilds, ...newCommitsWithBuilds],
     commitsWithoutBuilds: [...commitsWithoutBuilds, ...(newCommitsWithoutBuilds || [])],
+    firstParentBaseline,
   });
 }
 
@@ -207,6 +214,8 @@ async function maximallyDescendentCommits(deps: GitDeps, commits: string[]) {
  * @param deps Dependencies (log, client, options).
  * @param options Additional options for changing function flow.
  * @param options.git Git information for the current build.
+ * @param options.firstParentBaseline Only walk the first-parent (mainline) history when looking
+ * for ancestor commits with builds.
  * @param options.ignoreLastBuildOnBranch Ignore the last Chromatic build associated with this
  * branch.
  *
@@ -216,7 +225,11 @@ async function maximallyDescendentCommits(deps: GitDeps, commits: string[]) {
 // eslint-disable-next-line complexity, max-statements
 export async function getParentCommits(
   deps: Pick<Deps, 'options' | 'client' | 'log'>,
-  { git, ignoreLastBuildOnBranch = false }: { git: Git; ignoreLastBuildOnBranch?: boolean | string }
+  {
+    git,
+    firstParentBaseline = false,
+    ignoreLastBuildOnBranch = false,
+  }: { git: Git; firstParentBaseline?: boolean; ignoreLastBuildOnBranch?: boolean | string }
 ) {
   const { options, client, log } = deps;
   const { branch, committedAt } = git;
@@ -275,6 +288,7 @@ export async function getParentCommits(
       firstCommittedAtSeconds: firstBuild.committedAt && firstBuild.committedAt / 1000,
       commitsWithBuilds: initialCommitsWithBuilds,
       commitsWithoutBuilds: [],
+      firstParentBaseline,
     }
   );
 

--- a/node-src/lib/getConfiguration.ts
+++ b/node-src/lib/getConfiguration.ts
@@ -28,6 +28,7 @@ const configurationSchema = z
     autoAcceptChanges: z.union([z.string(), z.boolean()]),
     exitZeroOnChanges: z.union([z.string(), z.boolean()]),
     exitOnceUploaded: z.union([z.string(), z.boolean()]),
+    firstParentBaseline: z.union([z.string(), z.boolean()]),
     ignoreLastBuildOnBranch: z.string(),
     gitTimeout: z.number().min(MINIMUM_GIT_TIMEOUT_SECONDS).optional(),
 

--- a/node-src/lib/getOptions.test.ts
+++ b/node-src/lib/getOptions.test.ts
@@ -56,6 +56,7 @@ describe('getOptions', () => {
       junitReport: undefined,
       zip: undefined,
 
+      firstParentBaseline: undefined,
       ignoreLastBuildOnBranch: undefined,
       preserveMissingSpecs: undefined,
 
@@ -122,6 +123,15 @@ describe('getOptions', () => {
       debug: true,
       interactive: false,
       storybookLogFile: false,
+    });
+  });
+
+  it('accepts a branch glob or a bare flag for --first-parent-baseline', async () => {
+    expect(getOptions(getContext(['--first-parent-baseline', 'main']))).toMatchObject({
+      firstParentBaseline: 'main',
+    });
+    expect(getOptions(getContext(['--first-parent-baseline']))).toMatchObject({
+      firstParentBaseline: true,
     });
   });
 

--- a/node-src/lib/getOptions.ts
+++ b/node-src/lib/getOptions.ts
@@ -93,6 +93,7 @@ export const getPartialOptions = (ctx: InitialContext): Partial<Options> => {
     zip: undefined,
     skipUpdateCheck: undefined,
 
+    firstParentBaseline: undefined,
     ignoreLastBuildOnBranch: undefined,
     preserveMissingSpecs: undefined,
 
@@ -147,6 +148,7 @@ export const getPartialOptions = (ctx: InitialContext): Partial<Options> => {
     autoAcceptChanges: trueIfSet(flags.autoAcceptChanges),
     exitZeroOnChanges: trueIfSet(flags.exitZeroOnChanges),
     exitOnceUploaded: trueIfSet(flags.exitOnceUploaded),
+    firstParentBaseline: trueIfSet(flags.firstParentBaseline),
     ignoreLastBuildOnBranch: flags.ignoreLastBuildOnBranch,
     // deprecated
     preserveMissingSpecs: flags.preserveMissing,

--- a/node-src/lib/parseArguments.ts
+++ b/node-src/lib/parseArguments.ts
@@ -36,6 +36,7 @@ export default function parseArguments(argv: string[]) {
       --exit-once-uploaded [branch]             Exit with 0 once the built version has been published to Chromatic. Only for [branch], if specified. Globs are supported via picomatch.
       --exit-zero-on-changes [branch]           If all snapshots render but there are visual changes, exit with code 0 rather than the usual exit code 1. Only for [branch], if specified. Globs are supported via picomatch.
       --externals <filepath>                    Disable TurboSnap when any of these files have changed since the baseline build. Globs are supported via picomatch. This flag can be specified multiple times. Requires --only-changed.
+      --first-parent-baseline [branch]          Resolve the baseline by walking only the first-parent (mainline) history, so ancestry never descends into merged-in branch histories. Only for [branch], if specified. Globs are supported via picomatch.
       --ignore-last-build-on-branch <branch>    Do not use the last build on this branch as a baseline if it is no longer in history (i.e. branch was rebased). Globs are supported via picomatch.
       --only-changed [branch]                   Enables TurboSnap: Only run stories affected by files changed since the baseline build. Only for [branch], if specified. Globs are supported via picomatch. All other snapshots will be inherited from the prior commit.
       --only-story-files <filepath>             Only run a single story or a subset of stories by their filename(s). Specify the full path to the story file relative to the root of your Storybook project. Globs are supported via picomatch. This flag can be specified multiple times.
@@ -96,6 +97,7 @@ export default function parseArguments(argv: string[]) {
         exitOnceUploaded: { type: 'string' },
         exitZeroOnChanges: { type: 'string' },
         externals: { type: 'string', isMultiple: true },
+        firstParentBaseline: { type: 'string' },
         ignoreLastBuildOnBranch: { type: 'string' },
         onlyChanged: { type: 'string' },
         onlyStoryFiles: { type: 'string', isMultiple: true },

--- a/node-src/tasks/gitInfo.ts
+++ b/node-src/tasks/gitInfo.ts
@@ -53,6 +53,7 @@ export interface GitInfoInput {
   interactive: boolean;
   isLocalBuild: boolean;
   skip: boolean | string;
+  firstParentBaseline?: boolean | string;
   ignoreLastBuildOnBranch?: string;
   onlyChanged: boolean | string;
   externals?: string[];
@@ -145,6 +146,7 @@ export async function gatherGitInfo(
     interactive,
     isLocalBuild,
     skip,
+    firstParentBaseline,
     ignoreLastBuildOnBranch,
     onlyChanged,
     externals,
@@ -231,6 +233,7 @@ export async function gatherGitInfo(
     { log, client, options },
     {
       git,
+      firstParentBaseline: git.matchesBranch(firstParentBaseline || false),
       ignoreLastBuildOnBranch: git.matchesBranch(ignoreLastBuildOnBranch || false),
     }
   );
@@ -428,6 +431,7 @@ export const extractGitInfoInput = (ctx: Context): GitInfoInput => ({
   interactive: ctx.options.interactive,
   isLocalBuild: ctx.options.isLocalBuild,
   skip: ctx.options.skip,
+  firstParentBaseline: ctx.options.firstParentBaseline,
   ignoreLastBuildOnBranch: ctx.options.ignoreLastBuildOnBranch,
   onlyChanged: ctx.options.onlyChanged,
   externals: ctx.options.externals,

--- a/node-src/types.ts
+++ b/node-src/types.ts
@@ -32,6 +32,7 @@ export interface Flags {
   exitOnceUploaded?: string;
   exitZeroOnChanges?: string;
   externals?: string[];
+  firstParentBaseline?: string;
   ignoreLastBuildOnBranch?: string;
   onlyChanged?: string;
   onlyStoryFiles?: string[];
@@ -107,6 +108,7 @@ export interface Options extends Configuration {
   exitZeroOnChanges: boolean | string;
   exitOnceUploaded: boolean | string;
   isLocalBuild: boolean;
+  firstParentBaseline: boolean | string;
   ignoreLastBuildOnBranch: Flags['ignoreLastBuildOnBranch'];
   preserveMissingSpecs: boolean;
   originalArgv: string[];


### PR DESCRIPTION
Adds an opt-in `--first-parent-baseline [branch]` flag that passes `--first-parent` to the `git rev-list` ancestry walk in `nextCommits`, so baseline resolution stays on the mainline instead of descending into merged-in branch histories.

Context and motivation: #1449. This is the smaller of the two flags proposed there, and it carries the plumbing that the second one (`--ignore-merged-pr-builds`) builds on, so it goes first.

## Behaviour

Default (flag unset) behaviour is byte-identical to today — the flag only ever adds `--first-parent` to the `rev-list` invocation.

Branch-glob scoped, following `--ignore-last-build-on-branch` exactly, so it can be enabled on the trunk only while PR builds keep the default base-branch baseline:

```yaml
# .github/workflows/…
with:
  firstParentBaseline: master
```

```jsonc
// chromatic.config.json
{ "firstParentBaseline": "master" }
```

`--first-parent-baseline` with no value means `true` (via `trueIfSet`), matching `--auto-accept-changes` and friends.

## Implementation

Standard option plumbing, one change per file:

| File | Change |
| --- | --- |
| `node-src/lib/parseArguments.ts` | Help text under **Chromatic options** (alphabetical) and `flags` entry |
| `node-src/types.ts` | `Flags.firstParentBaseline`, `Options.firstParentBaseline` |
| `node-src/lib/getOptions.ts` | `defaultOptions` entry + `trueIfSet(flags.firstParentBaseline)` |
| `node-src/lib/getConfiguration.ts` | Zod `z.union([z.string(), z.boolean()])` |
| `action.yml` | `firstParentBaseline` input (alphabetical) |
| `action-src/main.ts` | `getInput` + `runNode` flags entry |
| `node-src/tasks/gitInfo.ts` | `GitInfoInput` + `extractGitInfoInput`, resolved via `git.matchesBranch(firstParentBaseline \|\| false)` |
| `node-src/git/getParentCommits.ts` | Boolean threaded `getParentCommits` → `step` → `nextCommits`, interpolated into the `rev-list` command |

The glob is resolved in the `gitInfo` task and `getParentCommits` receives a plain boolean, so `node-src/git/` stays glob-unaware — same seam `ignoreLastBuildOnBranch` uses.

## Testing

- `node-src/git/getParentCommits.test.ts`: new `firstParentBaseline` case on the `simpleLoop` fixture (`F = merge(D, E)`, `D` is `F`'s first parent) asserting both halves in one test — without the option `E` is included (it is a genuine ancestor), with the option the walk never reaches it. Because this suite runs `getParentCommits` against real generated git repositories, the assertion only holds if `--first-parent` actually reaches `git rev-list`.
- `node-src/lib/getOptions.test.ts`: flag → option for the glob form, and the bare-flag `trueIfSet` path; plus `firstParentBaseline: undefined` added to the defaults assertion.
- `yarn typescript:check`, `yarn lint`, `yarn build`, `yarn test` all clean locally (1007 passing).

## Labels

Requesting `minor` + `release` — I don't have permission to set them.
