### PR TITLE
Add --ignore-merged-pr-builds flag

### DIFF
--- a/action-src/main.ts
+++ b/action-src/main.ts
@@ -115,6 +115,7 @@ async function run() {
     const fileHashing = getInput('fileHashing');
     const forceRebuild = getInput('forceRebuild');
     const ignoreLastBuildOnBranch = getInput('ignoreLastBuildOnBranch');
+    const ignoreMergedPrBuilds = getInput('ignoreMergedPrBuilds');
     const logFile = getInput('logFile');
     const logLevel = getInput('logLevel');
     const logPrefix = getInput('logPrefix');
@@ -182,6 +183,7 @@ async function run() {
         fileHashing: maybe(fileHashing, true),
         forceRebuild: maybe(forceRebuild),
         ignoreLastBuildOnBranch: maybe(ignoreLastBuildOnBranch),
+        ignoreMergedPrBuilds: maybe(ignoreMergedPrBuilds),
         interactive: false,
         logFile: maybe(logFile),
         logLevel: maybe(logLevel),

--- a/action.yml
+++ b/action.yml
@@ -53,6 +53,9 @@ inputs:
   ignoreLastBuildOnBranch:
     description: 'Do not use the last build on this branch as a baseline if it is no longer in history (i.e. branch was rebased)'
     required: false
+  ignoreMergedPrBuilds:
+    description: 'Do not consider builds on the head branches of merged pull requests as baseline candidates: boolean or branch name/glob'
+    required: false
   logFile:
     description: 'Write CLI logs to a file'
     required: false

--- a/node-src/git/getParentCommits.test.ts
+++ b/node-src/git/getParentCommits.test.ts
@@ -989,4 +989,103 @@ describe('getParentCommits', () => {
       expect(visited[commitMap.C.hash].isShallowBoundary).toBe(false);
     });
   });
+
+  describe('ignoreMergedPrBuilds', () => {
+    it('does not inject the head build of a merged PR that is missing from the index', async () => {
+      // []: has build, <>: is squash merge, (): current commit
+      //
+      //  [MISSING]     [branch]  no longer in the repository
+      //
+      //  [A]- C -<(D)> [main]    D is the squash merge commit for "branch"
+      const repository = repositories.twoRoots;
+      await checkoutCommit('D', 'main', repository);
+      const client = createClient({
+        repository,
+        builds: [
+          ['A', 'main'],
+          ['MISSING', 'branch'],
+        ],
+        prs: [['D', 'branch']],
+      });
+      const git = { branch: 'main', ...(await getCommit(ctx)) };
+
+      // Without the option, the merged-PR block appends the missing head build commit.
+      const { ancestorCommits: defaultParents } = await getParentCommits(
+        { client, log, options } as any,
+        withGit(git)
+      );
+      expectCommitsToEqualNames(defaultParents, ['MISSING', 'A'], repository);
+
+      // With the option, MISSING is not injected.
+      const { ancestorCommits: parentCommits } = await getParentCommits(
+        { client, log, options } as any,
+        withGit(git, { ignoreMergedPrBuilds: true })
+      );
+      expectCommitsToEqualNames(parentCommits, ['A'], repository);
+    });
+
+    it('does not inject the head build of a merged PR that is not an ancestor of HEAD', async () => {
+      // []: has build, <>: is squash merge, (): current commit
+      //
+      //  [B]           [branch]  in the repository, but not an ancestor of D
+      //
+      //  [A]- C -<(D)> [main]    D is the squash merge commit for "branch"
+      const repository = repositories.twoRoots;
+      await checkoutCommit('D', 'main', repository);
+      const client = createClient({
+        repository,
+        builds: [
+          ['A', 'main'],
+          ['B', 'branch'],
+        ],
+        prs: [['D', 'branch']],
+      });
+      const git = { branch: 'main', ...(await getCommit(ctx)) };
+
+      // Without the option, B is injected even though it is not reachable from HEAD.
+      const { ancestorCommits: defaultParents } = await getParentCommits(
+        { client, log, options } as any,
+        withGit(git)
+      );
+      expectCommitsToEqualNames(defaultParents, ['B', 'A'], repository);
+
+      // With the option, only the genuine mainline ancestor remains.
+      const { ancestorCommits: parentCommits } = await getParentCommits(
+        { client, log, options } as any,
+        withGit(git, { ignoreMergedPrBuilds: true })
+      );
+      expectCommitsToEqualNames(parentCommits, ['A'], repository);
+    });
+
+    it('still reports the PR merge commit as isMergePoint', async () => {
+      // The option suppresses merged-PR baselines only; merge-point metadata is unaffected.
+      //  A - B -[C]      [main]
+      //            \
+      //            (E)   [main, squash merge of branch]
+      //           /
+      //         [D]      [branch]
+      const repository = repositories.simpleLoop;
+      await checkoutCommit('E', 'main', repository);
+      const client = createClient({
+        repository,
+        builds: [
+          ['C', 'main'],
+          ['D', 'branch'],
+        ],
+        prs: [['E', 'branch']],
+      });
+      const git = { branch: 'main', ...(await getCommit(ctx)) };
+
+      const { visitedCommits } = await getParentCommits(
+        { client, log, options } as any,
+        withGit(git, { ignoreMergedPrBuilds: true })
+      );
+
+      const { commitMap } = repository;
+      const visited = Object.fromEntries(visitedCommits.map((v) => [v.commit, v]));
+
+      expect(visited[commitMap.E.hash].isMergePoint).toBe(true);
+      expect(visited[commitMap.C.hash].isMergePoint).toBe(false);
+    });
+  });
 });

--- a/node-src/git/getParentCommits.ts
+++ b/node-src/git/getParentCommits.ts
@@ -216,6 +216,8 @@ async function maximallyDescendentCommits(deps: GitDeps, commits: string[]) {
  * @param options.git Git information for the current build.
  * @param options.ignoreLastBuildOnBranch Ignore the last Chromatic build associated with this
  * branch.
+ * @param options.ignoreMergedPrBuilds Do not consider builds on the head branches of merged pull
+ * requests as baseline candidates.
  *
  * @returns An object with:
  *   - `ancestorCommits` – the baseline parent commits to pass to the Chromatic build.
@@ -227,7 +229,15 @@ async function maximallyDescendentCommits(deps: GitDeps, commits: string[]) {
 // eslint-disable-next-line complexity, max-statements
 export async function getParentCommits(
   deps: Pick<Deps, 'options' | 'client' | 'log'>,
-  { git, ignoreLastBuildOnBranch = false }: { git: Git; ignoreLastBuildOnBranch?: boolean | string }
+  {
+    git,
+    ignoreLastBuildOnBranch = false,
+    ignoreMergedPrBuilds = false,
+  }: {
+    git: Git;
+    ignoreLastBuildOnBranch?: boolean | string;
+    ignoreMergedPrBuilds?: boolean;
+  }
 ) {
   const { options, client, log } = deps;
   const { branch, committedAt } = git;
@@ -309,7 +319,13 @@ export async function getParentCommits(
     // @see https://www.chromatic.com/docs/branching-and-baselines#squash-and-rebase-merging
     const lastHeadBuildCommit = pullRequest.lastHeadBuild?.commit;
     if (lastHeadBuildCommit) {
-      if (await commitExists(deps, lastHeadBuildCommit)) {
+      // The user can opt out of these baselines with `--ignore-merged-pr-builds`. A merged PR's
+      // last head build sits on the PR branch rather than the target branch, so on a squash-merge
+      // target branch it is not reachable from HEAD and can rank ahead of the real mainline
+      // baseline. Merge-point tracking below is deliberately left intact.
+      if (ignoreMergedPrBuilds) {
+        log.debug(`Skipping merged PR build commit ${lastHeadBuildCommit}`);
+      } else if (await commitExists(deps, lastHeadBuildCommit)) {
         log.debug(`Adding merged PR build commit ${lastHeadBuildCommit} to commits with builds`);
         commitsWithBuilds.push(lastHeadBuildCommit);
       } else {

--- a/node-src/lib/getConfiguration.ts
+++ b/node-src/lib/getConfiguration.ts
@@ -29,6 +29,7 @@ const configurationSchema = z
     exitZeroOnChanges: z.union([z.string(), z.boolean()]),
     exitOnceUploaded: z.union([z.string(), z.boolean()]),
     ignoreLastBuildOnBranch: z.string(),
+    ignoreMergedPrBuilds: z.union([z.string(), z.boolean()]),
     gitTimeout: z.number().min(MINIMUM_GIT_TIMEOUT_SECONDS).optional(),
 
     buildScriptName: z.string(),

--- a/node-src/lib/getOptions.test.ts
+++ b/node-src/lib/getOptions.test.ts
@@ -57,6 +57,7 @@ describe('getOptions', () => {
       zip: undefined,
 
       ignoreLastBuildOnBranch: undefined,
+      ignoreMergedPrBuilds: undefined,
       preserveMissingSpecs: undefined,
 
       buildScriptName: 'build-storybook',
@@ -122,6 +123,15 @@ describe('getOptions', () => {
       debug: true,
       interactive: false,
       storybookLogFile: false,
+    });
+  });
+
+  it('accepts a branch glob or a bare flag for --ignore-merged-pr-builds', async () => {
+    expect(getOptions(getContext(['--ignore-merged-pr-builds', 'main']))).toMatchObject({
+      ignoreMergedPrBuilds: 'main',
+    });
+    expect(getOptions(getContext(['--ignore-merged-pr-builds']))).toMatchObject({
+      ignoreMergedPrBuilds: true,
     });
   });
 

--- a/node-src/lib/getOptions.ts
+++ b/node-src/lib/getOptions.ts
@@ -94,6 +94,7 @@ export const getPartialOptions = (ctx: InitialContext): Partial<Options> => {
     skipUpdateCheck: undefined,
 
     ignoreLastBuildOnBranch: undefined,
+    ignoreMergedPrBuilds: undefined,
     preserveMissingSpecs: undefined,
 
     buildScriptName: undefined,
@@ -148,6 +149,7 @@ export const getPartialOptions = (ctx: InitialContext): Partial<Options> => {
     exitZeroOnChanges: trueIfSet(flags.exitZeroOnChanges),
     exitOnceUploaded: trueIfSet(flags.exitOnceUploaded),
     ignoreLastBuildOnBranch: flags.ignoreLastBuildOnBranch,
+    ignoreMergedPrBuilds: trueIfSet(flags.ignoreMergedPrBuilds),
     // deprecated
     preserveMissingSpecs: flags.preserveMissing,
 

--- a/node-src/lib/parseArguments.ts
+++ b/node-src/lib/parseArguments.ts
@@ -37,6 +37,7 @@ export default function parseArguments(argv: string[]) {
       --exit-zero-on-changes [branch]           If all tests render successfully but visual changes are found, exit with code 0 rather than the usual exit code 1. Only for [branch], if specified. Globs are supported via picomatch.
       --externals <filepath>                    Disable TurboSnap when any of these files have changed since the baseline build. Globs are supported via picomatch. This flag can be specified multiple times. Requires --only-changed.
       --ignore-last-build-on-branch <branch>    Do not use the last build on this branch as a baseline if it is no longer in history (i.e. branch was rebased). Globs are supported via picomatch.
+      --ignore-merged-pr-builds [branch]        Do not consider builds on the head branches of merged pull requests as baseline candidates. Only for [branch], if specified. Globs are supported via picomatch. Note: with squash or rebase merges this means squash/rebase merges are not detected and you may lose baselines, unless you use --auto-accept-changes on the target branch.
       --only-changed [branch]                   Enables TurboSnap: Only run stories affected by files changed since the baseline build. Only for [branch], if specified. Globs are supported via picomatch. For all other snapshots, TurboSnap will copy the baselines from the previous commit.
       --only-story-files <filepath>             Only run a single story or a subset of stories by their filename(s). Specify the full path to the story file relative to the root of your Storybook project. Globs are supported via picomatch. This flag can be specified multiple times.
       --only-story-names <storypath>            Only run a single story or a subset of stories. Story paths typically look like "Path/To/Story". Globs are supported via picomatch. This flag can be specified multiple times.
@@ -97,6 +98,7 @@ export default function parseArguments(argv: string[]) {
         exitZeroOnChanges: { type: 'string' },
         externals: { type: 'string', isMultiple: true },
         ignoreLastBuildOnBranch: { type: 'string' },
+        ignoreMergedPrBuilds: { type: 'string' },
         onlyChanged: { type: 'string' },
         onlyStoryFiles: { type: 'string', isMultiple: true },
         onlyStoryNames: { type: 'string', isMultiple: true },

--- a/node-src/tasks/gitInfo.ts
+++ b/node-src/tasks/gitInfo.ts
@@ -57,6 +57,7 @@ export interface GitInfoInput {
   isLocalBuild: boolean;
   skip: boolean | string;
   ignoreLastBuildOnBranch?: string;
+  ignoreMergedPrBuilds?: boolean | string;
   onlyChanged: boolean | string;
   externals?: string[];
   untraced?: string[];
@@ -149,6 +150,7 @@ export async function gatherGitInfo(
     isLocalBuild,
     skip,
     ignoreLastBuildOnBranch,
+    ignoreMergedPrBuilds,
     onlyChanged,
     externals,
     untraced,
@@ -266,6 +268,7 @@ export async function gatherGitInfo(
     {
       git,
       ignoreLastBuildOnBranch: git.matchesBranch(ignoreLastBuildOnBranch || false),
+      ignoreMergedPrBuilds: git.matchesBranch(ignoreMergedPrBuilds || false),
     }
   );
   git.parentCommits = parentCommits;
@@ -464,6 +467,7 @@ export const extractGitInfoInput = (ctx: Context): GitInfoInput => ({
   isLocalBuild: ctx.options.isLocalBuild,
   skip: ctx.options.skip,
   ignoreLastBuildOnBranch: ctx.options.ignoreLastBuildOnBranch,
+  ignoreMergedPrBuilds: ctx.options.ignoreMergedPrBuilds,
   onlyChanged: ctx.options.onlyChanged,
   externals: ctx.options.externals,
   untraced: ctx.options.untraced,

--- a/node-src/types.ts
+++ b/node-src/types.ts
@@ -33,6 +33,7 @@ export interface Flags {
   exitZeroOnChanges?: string;
   externals?: string[];
   ignoreLastBuildOnBranch?: string;
+  ignoreMergedPrBuilds?: string;
   onlyChanged?: string;
   onlyStoryFiles?: string[];
   onlyStoryNames?: string[];
@@ -108,6 +109,7 @@ export interface Options extends Configuration {
   exitOnceUploaded: boolean | string;
   isLocalBuild: boolean;
   ignoreLastBuildOnBranch: Flags['ignoreLastBuildOnBranch'];
+  ignoreMergedPrBuilds: boolean | string;
   preserveMissingSpecs: boolean;
   originalArgv: string[];
 


### PR DESCRIPTION
Adds an opt-in `--ignore-merged-pr-builds [branch]` flag so that builds on the head branches of merged pull requests are not considered baseline candidates in `getParentCommits`.

Context, evidence and prior art: #1449 and #332.

> Rebased onto `main` (18.7.2) and now a single commit. #1450 (`--first-parent-baseline`) is withdrawn per the discussion on #1449, so this PR no longer depends on it.

## Why

On a squash-merge trunk, a merged PR's `lastHeadBuild.commit` is not an ancestor of the trunk HEAD, and it is usually *newer* than the correct mainline baseline — so it ranks first and wins.

In our monorepo (`master` is squash-merge only: 298 of 300 mainline commits have a single parent) this was reliably fatal to TurboSnap. Canonical case, Chromatic build **#176855**:

- Baseline selected: `de26f7655`, the head of the PR branch whose squash merge *created* the build's HEAD commit.
- Resulting diff: **1,304 files** (429 frontend, plus `package.json` and `yarn.lock`), against a correct diff of **67 files / 3 frontend files**.
- The spurious dependency-manifest delta tripped `findChangedDependencies` and disabled TurboSnap outright: **0 inherited, 3,865 captured** snapshots.

We audited every baseline Chromatic chose over a sample window: **all 23 were non-ancestors of HEAD**, i.e. all 23 came from this block. After deploying a fork with this behaviour disabled (2026-07-23), measured across master builds:

| | before | after |
| --- | --- | --- |
| TurboSnap bail rate on master | 57.3% | 4.7% |
| captured snapshots per build | ~2,800 | ~385 |

Baseline selection became a tight forward-moving chain — e.g. build 177203 baselines on the HEAD of build 177190, the immediately preceding snapshot-producing master build.

This is also the flag #332 asked for. That issue ended with @tmeasday building the requester a `disable-squash-merge-check` branch and saying "I'll also discuss adding this as a permanent flag to the CLI"; it was then closed because the GitHub 502s that motivated it were fixed, so the knob itself never landed.

## Safety, and the tradeoff

The injection exists so squash/rebase merges don't lose baselines ([docs](https://www.chromatic.com/docs/branching-and-baselines#squash-and-rebase-merging)), and @tmeasday flagged the exposure on #332:

> This means that if you are using squash or rebase merges they will not be detected and you may lose baselines, unless you use `--auto-accept-changes` on your main branch.

That is why the flag is opt-in and branch-glob scoped, and why the caveat is spelled out in the help text rather than only in the docs.

On what makes it survivable on a trunk, I'm taking @tmeasday's formulation from #1449 over my original wording:

> The squash commit on the trunk contains all the changes from the merged-PR head build. So all of those stories will be recaptured on the squash commit's build, even without the head build as an ancestor. Auto accepting those changes means that all the (assumed to be accepted) changes from the PR will update the trunk branch's baselines.

We run `autoAcceptChanges: 'master'` (and have since well before this patch), which is what makes that hold for us. To be clear this is a how-to in the docs, not a recommendation, and it carries real downsides — see #1449.

No backend change is required: no new GraphQL field and no new production dependency, so the README's "new features must be on Chromatic production first" policy doesn't bite.

## Behaviour

Default (flag unset) behaviour is unchanged.

```yaml
with:
  ignoreMergedPrBuilds: master
```

```jsonc
{ "ignoreMergedPrBuilds": "master" }
```

Bare `--ignore-merged-pr-builds` means `true`, via `trueIfSet`.

## Implementation

Standard option plumbing: help text + `flags`, `Flags`/`Options`, `getOptions`, Zod schema, `action.yml`, `action-src/main.ts`, and `GitInfoInput`/`extractGitInfoInput` resolved through `git.matchesBranch` in the `gitInfo` task, so `node-src/git/` keeps taking a plain boolean.

The behavioural change is deliberately narrow — one `else if` arm in the merged-PR loop:

```ts
if (ignoreMergedPrBuilds) {
  log.debug(`Skipping merged PR build commit ${lastHeadBuildCommit}`);
} else if (await commitExists(deps, lastHeadBuildCommit)) {
```

It suppresses **only** the baseline injection. `MergeCommitsQuery` still runs and `mergePointCommits` is still populated, so `isMergePoint` on the returned `visitedCommits` is unaffected — an earlier version of this patch skipped the whole block, which would have silently dropped that metadata for anyone using the flag. Net effect on `getParentCommits.ts` is +20/−2, and the existing body is untouched (no re-indentation to read past).

## Testing

- `node-src/git/getParentCommits.test.ts`, new `ignoreMergedPrBuilds` describe block:
  - `twoRoots`, merged PR's head build (`MISSING`) *not* in the repository, so it can only enter via this block: default → `['MISSING', 'A']`, with the flag → `['A']`. Covers the `extraParentCommits` "blindly appending to parents" path.
  - `twoRoots`, merged PR's head build (`B`) present in the repository but **not an ancestor of HEAD**: default → `['B', 'A']`, with the flag → `['A']`. This is the shape our production case actually took.
  - `simpleLoop`, flag on: asserts `isMergePoint` is still `true` for the merge commit and `false` for a non-merge commit, pinning the metadata preservation described above.
- `node-src/lib/getOptions.test.ts`: glob form, bare-flag `trueIfSet` path, and the defaults assertion.
- `yarn tsc --noEmit`, `yarn lint`, `yarn build`, `yarn test` all clean locally on top of 18.7.2 (1,268 passing, 2 skipped).

## Naming

Happy to rename if you prefer — alternatives: `--ignore-merged-pr-baselines`, or `--skip-squash-merge-check` (matches #332's language).

Also happy for this to be hidden/undocumented or `--experimental-*`-prefixed, and to be deprecated whenever TurboSnap 2.0 makes it unnecessary — see #1449.

## Labels

Requesting `minor` + `release` — I don't have permission to set them.
