### PR TITLE
[TurboSnap v2] Add runner entrypoint

### DIFF
--- a/node-src/lib/turbosnap/v2/index.test.ts
+++ b/node-src/lib/turbosnap/v2/index.test.ts
@@ -1,0 +1,169 @@
+import * as Sentry from '@sentry/node';
+import path from 'path';
+import { describe, expect, it, vi } from 'vitest';
+
+import GraphQLClient from '../../../io/graphqlClient';
+import { Stats } from '../../../types';
+import { traceChangedFiles } from './index';
+import { ProjectFiles } from './projectFiles';
+import { InMemoryDisk, inMemoryProjectFiles } from './projectFiles.fake';
+
+// The only boundary the module cannot describe as a value stays mocked: error reporting, whose whole
+// job is a side effect. The network is faked through the injected client rather than the api module,
+// so the mutation input the Index receives is the thing asserted. Everything below traceChangedFiles
+// — the manifest build and its serialization — runs for real against the disk described in `disk`.
+vi.mock('@sentry/node', () => ({
+  captureException: vi.fn(),
+}));
+
+const projectRoot = '/repo/packages/ui';
+const configDirectory = `${projectRoot}/.storybook`;
+
+const STORY = './src/Button.stories.tsx';
+const PREVIEW = './.storybook/preview.ts';
+const DEPENDENCY = './node_modules/react/index.js';
+const STORIES_ENTRY = './storybook-stories.js';
+const CONFIG_ENTRY = './storybook-config-entry.js';
+
+// The names a builder generates have no file on disk; everything else the stats mention does, which
+// is what keeps a test from having to list every source file its stats name.
+const SYNTHETIC = ['storybook-stories.js', 'storybook-config-entry.js', '|lazy|'];
+
+const manifestOutputDirectory = '/repo/packages/ui/storybook-static';
+
+function setup() {
+  const disk: InMemoryDisk = {
+    directories: {
+      [configDirectory]: ['main.ts', 'preview.ts', 'static'],
+      [`${configDirectory}/static`]: ['logo.svg'],
+    },
+    packageVersions: { storybook: '9.1.20' },
+    isAbsent: (candidate) => SYNTHETIC.some((name) => candidate.includes(name)),
+  };
+  const runQuery = vi.fn().mockResolvedValue({
+    buildUploadHashes: { build: { turboSnapStatus: 'APPLIED', turboSnapMechanism: 'HASH_BASED' } },
+  });
+  return { disk, projectFiles: inMemoryProjectFiles(disk), runQuery };
+}
+
+type Fixture = ReturnType<typeof setup>;
+
+describe('traceChangedFiles', () => {
+  it('uploads and writes a manifest when the stats build a healthy manifest', async () => {
+    const fixture = setup();
+
+    await expect(trace(fixture)).resolves.toEqual({ status: 'fallback' });
+
+    expect(uploaded(fixture)).toEqual({
+      buildId: 'build-id',
+      storybookHash: expect.any(String),
+      storybookConfigHashes: {
+        preview: expect.any(String),
+        storybookVersion: '9.1.20',
+        storybookConfigFiles: expect.any(String),
+        staticFiles: expect.any(String),
+      },
+      storyFileHashes: { [STORY]: expect.any(String) },
+    });
+    expect(writtenManifest(fixture).storybookConfigHashes).toEqual({
+      preview: expect.any(String),
+      storybookVersion: '9.1.20',
+      storybookConfigFiles: expect.any(String),
+      staticFiles: expect.any(String),
+    });
+    expect(writtenManifest(fixture).storybookConfigFiles).toEqual({
+      './.storybook/main.ts': expect.any(String),
+      [PREVIEW]: expect.any(String),
+    });
+    expect(writtenManifest(fixture).staticFiles).toEqual({
+      './.storybook/static/logo.svg': expect.any(String),
+    });
+    expect(writtenManifest(fixture).storyFiles).toEqual({ [STORY]: expect.any(String) });
+    expect(Sentry.captureException).not.toHaveBeenCalled();
+  });
+
+  it('falls back without uploading when manifest construction fails', async () => {
+    const fixture = setup();
+    // A file the sweep found and then could not read is the one unreadability the module treats as a
+    // bug rather than an answer; see ProjectFiles.
+    const error = new Error('Could not hash /repo/packages/ui/src/Button.stories.tsx');
+
+    await expect(
+      trace(fixture, {
+        hashAll: () => {
+          throw error;
+        },
+      })
+    ).resolves.toEqual({ status: 'fallback' });
+
+    expect(Sentry.captureException).toHaveBeenCalled();
+    expect(fixture.runQuery).not.toHaveBeenCalled();
+  });
+
+  it('falls back without uploading when writing the manifest fails', async () => {
+    const fixture = setup();
+    const error = new Error('the manifest directory is gone');
+
+    await expect(
+      trace(fixture, {
+        writeFile: () => {
+          throw error;
+        },
+      })
+    ).resolves.toEqual({ status: 'fallback' });
+
+    expect(Sentry.captureException).toHaveBeenCalled();
+    expect(fixture.runQuery).not.toHaveBeenCalled();
+  });
+
+  it('falls back when uploading the hashes to the Index fails', async () => {
+    const fixture = setup();
+    const error = Object.assign(new Error('request timed out'), { code: 'ETIMEDOUT' });
+    fixture.runQuery.mockRejectedValue(error);
+
+    await expect(trace(fixture)).resolves.toEqual({ status: 'fallback' });
+
+    expect(Sentry.captureException).toHaveBeenCalled();
+    // The manifest is still written before the upload, so the failure remains debuggable.
+    expect(writtenManifest(fixture).storyFiles).toEqual({ [STORY]: expect.any(String) });
+  });
+});
+
+// Runs the entry point against the fixture's disk, with the fake client as its only network. A
+// `patchFiles` override replaces adapter methods for the paths only a failing read or write reaches.
+function trace({ projectFiles, runQuery }: Fixture, patchFiles: Partial<ProjectFiles> = {}) {
+  return traceChangedFiles({
+    graphqlClient: { runQuery } as unknown as GraphQLClient,
+    buildId: 'build-id',
+    stats: stats(),
+    manifestOutputDirectory,
+    projectRoot,
+    configDir: configDirectory,
+    staticDirs: [`${configDirectory}/static`],
+    projectFiles: { ...projectFiles, ...patchFiles },
+  });
+}
+
+// A stats file describing a healthy graph: a story imported by the stories entry, the preview
+// imported by the config entry, and the one `node_modules` file that makes a dependency visible.
+function stats(): Stats {
+  return {
+    modules: [
+      { id: 1, name: STORY, reasons: [{ moduleName: STORIES_ENTRY }] },
+      { id: 2, name: PREVIEW, reasons: [{ moduleName: CONFIG_ENTRY }] },
+      { id: 3, name: DEPENDENCY, reasons: [{ moduleName: STORY }] },
+    ],
+  };
+}
+
+// The mutation input the Index received, or undefined when nothing was uploaded.
+function uploaded({ runQuery }: Fixture) {
+  return runQuery.mock.calls[0]?.[1]?.input;
+}
+
+// The diagnostic manifest as written, or undefined when none was written.
+function writtenManifest({ disk }: Fixture) {
+  const contents =
+    disk.writtenFiles?.[path.join(manifestOutputDirectory, 'turbosnap-manifest.json')];
+  return contents === undefined ? undefined : JSON.parse(contents);
+}

--- a/node-src/lib/turbosnap/v2/index.ts
+++ b/node-src/lib/turbosnap/v2/index.ts
@@ -1,0 +1,86 @@
+import * as Sentry from '@sentry/node';
+
+import GraphQLClient from '../../../io/graphqlClient';
+import type { AbsolutePath, Stats } from '../../../types';
+import { TraceChangedFilesResult } from '../types';
+import { buildManifest, writeManifest } from './manifest';
+import { ProjectFiles } from './projectFiles';
+import { uploadHashes } from './uploadHashes';
+
+interface TraceChangedFilesInput {
+  graphqlClient: GraphQLClient;
+  buildId: string;
+  stats: Stats;
+  manifestOutputDirectory: string;
+  projectRoot: string;
+  configDir: AbsolutePath;
+  staticDirs: AbsolutePath[];
+  projectFiles: ProjectFiles;
+}
+
+/**
+ * The result of running TurboSnap v2. In addition to the shared trace statuses, v2 can return
+ * 'fallback' to tell the caller it can't be trusted to trace this build and v1 should run instead.
+ */
+export type TraceChangedFilesV2Result = TraceChangedFilesResult | { status: 'fallback' };
+
+/**
+ * Determines which story files are affected by the changed source file hashes, bailing out of
+ * TurboSnap when necessary.
+ *
+ * @param input The input to run TurboSnap 2.0.
+ * @param input.stats The preview stats file, read by the caller because v1 traces the same one.
+ * @param input.manifestOutputDirectory The directory to write the manifest file to.
+ * @param input.projectRoot The absolute Storybook project root used to read source files off disk
+ * and to anchor manifest keys.
+ * @param input.configDir The absolute Storybook config directory, hashed off disk because it is
+ * never a bundler input.
+ * @param input.staticDirs The absolute static directories, hashed off disk for the same reason.
+ * @param input.projectFiles How to read the disk; see {@link ProjectFiles}. Required rather than
+ * defaulted, so a caller cannot silently reach the real disk.
+ *
+ * @returns The TurboSnap result.
+ */
+export async function traceChangedFiles(
+  input: TraceChangedFilesInput
+): Promise<TraceChangedFilesV2Result> {
+  let manifest;
+  try {
+    manifest = await buildManifest(input.stats, {
+      projectRoot: input.projectRoot,
+      configDir: input.configDir,
+      staticDirs: input.staticDirs,
+      projectFiles: input.projectFiles,
+    });
+  } catch (error) {
+    Sentry.captureException(error, {
+      fingerprint: ['TurboSnap v2', 'Failed to build manifest'],
+    });
+    return { status: 'fallback' };
+  }
+
+  // The manifest is written to the Storybook build output so it can be uploaded with other
+  // diagnostic files.
+  try {
+    writeManifest(manifest, input.manifestOutputDirectory, input.projectFiles);
+  } catch (error) {
+    Sentry.captureException(error, {
+      fingerprint: ['TurboSnap v2', 'Failed to write manifest'],
+    });
+    return { status: 'fallback' };
+  }
+
+  try {
+    // We currently don't care about the output of this function because we'll always fallback to
+    // run TurboSnap v1
+    await uploadHashes(input.graphqlClient, input.buildId, manifest);
+  } catch (error) {
+    Sentry.captureException(error, {
+      fingerprint: ['TurboSnap v2', 'Failed to upload hashes'],
+    });
+    return { status: 'fallback' };
+  }
+
+  // Until we want to lean on the v2 output, we always fallback to v1.
+  return { status: 'fallback' };
+}


### PR DESCRIPTION
Related to CAP-4864

This adds the true entrypoint into TurboSnap v2. It builds the manifest, writes the output, then sends the meaningful hashes up to the Index to compare them to the baseline. Since we're running v1 and v2 at the same time, this will always fallback no matter where it errors.

The function signature is based on v1 but I'm open to changing it if we want.

> [!NOTE]
> This does NOT handle any bails. Most of those will be happening on the Index side of things.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>18.6.1--canary.1453.32890848833.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@18.6.1--canary.1453.32890848833.0
  # or 
  yarn add chromatic@18.6.1--canary.1453.32890848833.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
