### PR TITLE
[TurboSnap v2] Add subcommand to generate v2 manifest

### DIFF
--- a/bin-src/register.js
+++ b/bin-src/register.js
@@ -10,6 +10,8 @@ const commands = {
   'react-native-build': () =>
     import('./reactNativeBuild').then(({ main }) => main(process.argv.slice(3))),
   trace: () => import('./trace').then(({ main: traceMain }) => traceMain(process.argv.slice(3))),
+  'turbosnap-manifest': () =>
+    import('./turbosnapManifest').then(({ main }) => main(process.argv.slice(3))),
   'trim-stats-file': () =>
     import('./trimStatsFile').then(({ main: trimMain }) => trimMain(process.argv.slice(3))),
 };

--- a/bin-src/turbosnapManifest.test.ts
+++ b/bin-src/turbosnapManifest.test.ts
@@ -1,0 +1,149 @@
+import { buildManifest, serializeManifest } from '@cli/turbosnap/v2/manifest';
+import { realProjectFiles } from '@cli/turbosnap/v2/projectFiles';
+import { existsSync } from 'fs';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { getRepositoryRoot } from '../node-src/git/git';
+import TestLogger from '../node-src/lib/testLogger';
+import { readStatsFile } from '../node-src/tasks/readStatsFile';
+import { main } from './turbosnapManifest';
+
+const testLogger = new TestLogger();
+const manifest = { storybookHash: 'abc' };
+const serialized = { storybookHash: 'abc', storyFiles: {} };
+const projectFiles = { readFile: vi.fn() };
+
+vi.mock('fs', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('fs')>()),
+  existsSync: vi.fn(() => true),
+}));
+
+vi.mock('@cli/turbosnap/v2/manifest', () => ({
+  buildManifest: vi.fn(() => manifest),
+  serializeManifest: vi.fn(() => serialized),
+}));
+
+vi.mock('@cli/turbosnap/v2/projectFiles', () => ({
+  realProjectFiles: vi.fn(() => projectFiles),
+}));
+
+vi.mock('../node-src/git/git', () => ({
+  getRepositoryRoot: vi.fn(() => '/repo'),
+}));
+
+vi.mock('../node-src/tasks/readStatsFile', () => ({
+  readStatsFile: vi.fn(() => ({ modules: [] })),
+}));
+
+vi.mock('../node-src/lib/log', () => ({
+  createLogger: vi.fn(() => testLogger),
+}));
+
+beforeEach(() => {
+  vi.spyOn(process, 'cwd').mockReturnValue('/repo');
+  vi.spyOn(process.stdout, 'write').mockReturnValue(true);
+  vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('turbosnap-manifest', () => {
+  it('builds the manifest from the default stats file in the current directory', async () => {
+    await main([]);
+
+    expect(readStatsFile).toHaveBeenCalledWith('/repo/storybook-static/preview-stats.json');
+    expect(buildManifest).toHaveBeenCalledWith(
+      { modules: [] },
+      {
+        projectRoot: '/repo',
+        configDir: '/repo/.storybook',
+        staticDirs: [],
+        projectFiles,
+      }
+    );
+    expect(realProjectFiles).toHaveBeenCalled();
+  });
+
+  it('resolves the project root from --storybook-base-dir, relative to the repository root', async () => {
+    await main(['-b', 'packages/ui']);
+
+    expect(getRepositoryRoot).toHaveBeenCalled();
+    expect(readStatsFile).toHaveBeenCalledWith(
+      '/repo/packages/ui/storybook-static/preview-stats.json'
+    );
+    expect(buildManifest).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        projectRoot: '/repo/packages/ui',
+        configDir: '/repo/packages/ui/.storybook',
+      })
+    );
+  });
+
+  it('resolves the project root from STORYBOOK_BASE_DIR when no flag is passed', async () => {
+    vi.stubEnv('STORYBOOK_BASE_DIR', 'packages/ui');
+    vi.resetModules();
+
+    // The env var is read when the module loads, so this command needs its own import.
+    const { main: mainWithEnvironment } = await import('./turbosnapManifest');
+    await mainWithEnvironment([]);
+
+    expect(buildManifest).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ projectRoot: '/repo/packages/ui' })
+    );
+
+    vi.unstubAllEnvs();
+  });
+
+  it('resolves each --static-dir against the project root', async () => {
+    await main(['-b', 'packages/ui', '--static-dir', 'public,assets/images']);
+
+    expect(buildManifest).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        staticDirs: ['/repo/packages/ui/public', '/repo/packages/ui/assets/images'],
+      })
+    );
+  });
+
+  it('resolves --config-dir and --stats-file against the project root', async () => {
+    await main(['-c', 'config/storybook', '-s', 'dist/stats.json']);
+
+    expect(readStatsFile).toHaveBeenCalledWith('/repo/dist/stats.json');
+    expect(buildManifest).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ configDir: '/repo/config/storybook' })
+    );
+  });
+
+  it('writes the serialized manifest to stdout', async () => {
+    await main([]);
+
+    expect(serializeManifest).toHaveBeenCalledWith(manifest);
+    expect(process.stdout.write).toHaveBeenCalledWith(JSON.stringify(serialized, undefined, 2));
+  });
+
+  it('names the missing stats file and prints the help, without building anything', async () => {
+    vi.mocked(existsSync).mockReturnValueOnce(false);
+
+    await main(['-s', 'dist/stats.json']);
+
+    expect(testLogger.errors[0]).toContain('No stats file at /repo/dist/stats.json');
+    expect(testLogger.errors[1]).toContain('--stats-file');
+    expect(process.exit).toHaveBeenCalledWith(1);
+    expect(buildManifest).not.toHaveBeenCalled();
+  });
+
+  it('logs the message and exits when building the manifest fails', async () => {
+    vi.mocked(buildManifest).mockRejectedValueOnce(new Error('bad stats file'));
+
+    await main([]);
+
+    expect(testLogger.error).toHaveBeenCalledWith('Error: bad stats file');
+    expect(process.exit).toHaveBeenCalledWith(1);
+    expect(process.stdout.write).not.toHaveBeenCalled();
+  });
+});

--- a/bin-src/turbosnapManifest.ts
+++ b/bin-src/turbosnapManifest.ts
@@ -31,6 +31,8 @@ const { STORYBOOK_BASE_DIR } = process.env;
  * The main entrypoint for `chromatic turbosnap-manifest`.
  *
  * @param argv A list of arguments passed.
+ *
+ * @returns Nothing
  */
 export async function main(argv: string[]) {
   const cli = meow(
@@ -89,7 +91,7 @@ export async function main(argv: string[]) {
     if (!existsSync(statsPath)) {
       log.error(`No stats file at ${statsPath}\n`);
       log.error(cli.help);
-      process.exit(1);
+      return process.exit(1);
     }
 
     const manifest = await buildManifest(await readStatsFile(statsPath), {

--- a/bin-src/turbosnapManifest.ts
+++ b/bin-src/turbosnapManifest.ts
@@ -1,0 +1,109 @@
+import { buildManifest, serializeManifest } from '@cli/turbosnap/v2/manifest';
+import { realProjectFiles } from '@cli/turbosnap/v2/projectFiles';
+import { existsSync } from 'fs';
+import meow from 'meow';
+import path from 'path';
+
+import { getRepositoryRoot } from '../node-src/git/git';
+import { getStorybookProjectRoot } from '../node-src/lib/getStorybookProjectRoot';
+import { createLogger } from '../node-src/lib/log';
+import { readStatsFile } from '../node-src/tasks/readStatsFile';
+
+/**
+ * Utility to build the TurboSnap v2 manifest from a preview-stats.json and print it to stdout.
+ *
+ * Command:
+ *   chromatic turbosnap-manifest [-s|--stats-file] [-b|--storybook-base-dir] [-c|--config-dir] [--static-dir]
+ *
+ * Usage example:
+ *   npx chromatic turbosnap-manifest -b packages/ui > turbosnap-manifest.json
+ *
+ * The command flags have sensible defaults so the user may not need to supply too many flags.
+ * Likely, the most used flag is going to be `--storybook-base-dir`/`-b` for monorepos.
+ *
+ * Because the manifest hashes files off disk, run this in the repo that produced the original
+ * `preview-stats.json` file.
+ */
+
+const { STORYBOOK_BASE_DIR } = process.env;
+
+/**
+ * The main entrypoint for `chromatic turbosnap-manifest`.
+ *
+ * @param argv A list of arguments passed.
+ */
+export async function main(argv: string[]) {
+  const cli = meow(
+    `
+    Usage
+      $ chromatic turbosnap-manifest [-s|--stats-file] [-b|--storybook-base-dir] [-c|--config-dir] [--static-dir]
+
+    Options
+      --stats-file, -s <filepath>           Path to preview-stats.json, relative to the Storybook project root. (default: 'storybook-static/preview-stats.json')
+      --storybook-base-dir, -b <dirname>    Relative path from repository root to Storybook project root. Alternatively, set STORYBOOK_BASE_DIR. Use when your Storybook is located in a subdirectory of your repository. (default: the current directory)
+      --config-dir, -c <dirname>            Storybook config directory, relative to the Storybook project root. (default: '.storybook')
+      --static-dir <dirnames>               Comma-separated static directories, relative to the Storybook project root. (default: none)
+    `,
+    {
+      argv,
+      description: 'Build the TurboSnap v2 manifest from a stats file',
+      flags: {
+        statsFile: {
+          type: 'string',
+          alias: 's',
+          default: 'storybook-static/preview-stats.json',
+        },
+        storybookBaseDir: {
+          type: 'string',
+          alias: 'b',
+          // meow rejects an undefined default, and there is no static one: an unset base directory
+          // means the current directory, which is resolved in the handler.
+          ...(STORYBOOK_BASE_DIR && { default: STORYBOOK_BASE_DIR }),
+        },
+        configDir: {
+          type: 'string',
+          alias: 'c',
+          default: '.storybook',
+        },
+        staticDir: {
+          type: 'string',
+        },
+      },
+    }
+  );
+
+  // Errors go to stderr, and info/debug logs are suppressed at this level, so the manifest JSON is
+  // the only thing on stdout.
+  const log = createLogger({}, { logPrefix: '', logLevel: 'error' });
+
+  try {
+    const projectRoot = getStorybookProjectRoot({
+      storybookBaseDir: cli.flags.storybookBaseDir,
+      gitRootPath: await getRepositoryRoot({ log }),
+    });
+
+    // The stats file is the one input with no default that works everywhere, so a project whose
+    // Storybook builds elsewhere hits this first. Name the path we looked at and repeat the flags,
+    // rather than leaving the user with a bare ENOENT.
+    const statsPath = path.resolve(projectRoot, cli.flags.statsFile);
+    if (!existsSync(statsPath)) {
+      log.error(`No stats file at ${statsPath}\n`);
+      log.error(cli.help);
+      process.exit(1);
+    }
+
+    const manifest = await buildManifest(await readStatsFile(statsPath), {
+      projectRoot,
+      configDir: path.resolve(projectRoot, cli.flags.configDir),
+      staticDirs: (cli.flags.staticDir?.split(',') ?? []).map((directory) =>
+        path.resolve(projectRoot, directory)
+      ),
+      projectFiles: realProjectFiles(),
+    });
+
+    process.stdout.write(JSON.stringify(serializeManifest(manifest), undefined, 2));
+  } catch (err) {
+    log.error(`Error: ${err.message}`);
+    process.exit(1);
+  }
+}

--- a/node-src/lib/turbosnap/v2/index.test.ts
+++ b/node-src/lib/turbosnap/v2/index.test.ts
@@ -1,0 +1,169 @@
+import * as Sentry from '@sentry/node';
+import path from 'path';
+import { describe, expect, it, vi } from 'vitest';
+
+import GraphQLClient from '../../../io/graphqlClient';
+import { Stats } from '../../../types';
+import { traceChangedFiles } from './index';
+import { ProjectFiles } from './projectFiles';
+import { InMemoryDisk, inMemoryProjectFiles } from './projectFiles.fake';
+
+// The only boundary the module cannot describe as a value stays mocked: error reporting, whose whole
+// job is a side effect. The network is faked through the injected client rather than the api module,
+// so the mutation input the Index receives is the thing asserted. Everything below traceChangedFiles
+// — the manifest build and its serialization — runs for real against the disk described in `disk`.
+vi.mock('@sentry/node', () => ({
+  captureException: vi.fn(),
+}));
+
+const projectRoot = '/repo/packages/ui';
+const configDirectory = `${projectRoot}/.storybook`;
+
+const STORY = './src/Button.stories.tsx';
+const PREVIEW = './.storybook/preview.ts';
+const DEPENDENCY = './node_modules/react/index.js';
+const STORIES_ENTRY = './storybook-stories.js';
+const CONFIG_ENTRY = './storybook-config-entry.js';
+
+// The names a builder generates have no file on disk; everything else the stats mention does, which
+// is what keeps a test from having to list every source file its stats name.
+const SYNTHETIC = ['storybook-stories.js', 'storybook-config-entry.js', '|lazy|'];
+
+const manifestOutputDirectory = '/repo/packages/ui/storybook-static';
+
+function setup() {
+  const disk: InMemoryDisk = {
+    directories: {
+      [configDirectory]: ['main.ts', 'preview.ts', 'static'],
+      [`${configDirectory}/static`]: ['logo.svg'],
+    },
+    packageVersions: { storybook: '9.1.20' },
+    isAbsent: (candidate) => SYNTHETIC.some((name) => candidate.includes(name)),
+  };
+  const runQuery = vi.fn().mockResolvedValue({
+    buildUploadHashes: { build: { turboSnapStatus: 'APPLIED', turboSnapMechanism: 'HASH_BASED' } },
+  });
+  return { disk, projectFiles: inMemoryProjectFiles(disk), runQuery };
+}
+
+type Fixture = ReturnType<typeof setup>;
+
+describe('traceChangedFiles', () => {
+  it('uploads and writes a manifest when the stats build a healthy manifest', async () => {
+    const fixture = setup();
+
+    await expect(trace(fixture)).resolves.toEqual({ status: 'fallback' });
+
+    expect(uploaded(fixture)).toEqual({
+      buildId: 'build-id',
+      storybookHash: expect.any(String),
+      storybookConfigHashes: {
+        preview: expect.any(String),
+        storybookVersion: '9.1.20',
+        storybookConfigFiles: expect.any(String),
+        staticFiles: expect.any(String),
+      },
+      storyFileHashes: { [STORY]: expect.any(String) },
+    });
+    expect(writtenManifest(fixture).storybookConfigHashes).toEqual({
+      preview: expect.any(String),
+      storybookVersion: '9.1.20',
+      storybookConfigFiles: expect.any(String),
+      staticFiles: expect.any(String),
+    });
+    expect(writtenManifest(fixture).storybookConfigFiles).toEqual({
+      './.storybook/main.ts': expect.any(String),
+      [PREVIEW]: expect.any(String),
+    });
+    expect(writtenManifest(fixture).staticFiles).toEqual({
+      './.storybook/static/logo.svg': expect.any(String),
+    });
+    expect(writtenManifest(fixture).storyFiles).toEqual({ [STORY]: expect.any(String) });
+    expect(Sentry.captureException).not.toHaveBeenCalled();
+  });
+
+  it('falls back without uploading when manifest construction fails', async () => {
+    const fixture = setup();
+    // A file the sweep found and then could not read is the one unreadability the module treats as a
+    // bug rather than an answer; see ProjectFiles.
+    const error = new Error('Could not hash /repo/packages/ui/src/Button.stories.tsx');
+
+    await expect(
+      trace(fixture, {
+        hashAll: () => {
+          throw error;
+        },
+      })
+    ).resolves.toEqual({ status: 'fallback' });
+
+    expect(Sentry.captureException).toHaveBeenCalled();
+    expect(fixture.runQuery).not.toHaveBeenCalled();
+  });
+
+  it('falls back without uploading when writing the manifest fails', async () => {
+    const fixture = setup();
+    const error = new Error('the manifest directory is gone');
+
+    await expect(
+      trace(fixture, {
+        writeFile: () => {
+          throw error;
+        },
+      })
+    ).resolves.toEqual({ status: 'fallback' });
+
+    expect(Sentry.captureException).toHaveBeenCalled();
+    expect(fixture.runQuery).not.toHaveBeenCalled();
+  });
+
+  it('falls back when uploading the hashes to the Index fails', async () => {
+    const fixture = setup();
+    const error = Object.assign(new Error('request timed out'), { code: 'ETIMEDOUT' });
+    fixture.runQuery.mockRejectedValue(error);
+
+    await expect(trace(fixture)).resolves.toEqual({ status: 'fallback' });
+
+    expect(Sentry.captureException).toHaveBeenCalled();
+    // The manifest is still written before the upload, so the failure remains debuggable.
+    expect(writtenManifest(fixture).storyFiles).toEqual({ [STORY]: expect.any(String) });
+  });
+});
+
+// Runs the entry point against the fixture's disk, with the fake client as its only network. A
+// `patchFiles` override replaces adapter methods for the paths only a failing read or write reaches.
+function trace({ projectFiles, runQuery }: Fixture, patchFiles: Partial<ProjectFiles> = {}) {
+  return traceChangedFiles({
+    graphqlClient: { runQuery } as unknown as GraphQLClient,
+    buildId: 'build-id',
+    stats: stats(),
+    manifestOutputDirectory,
+    projectRoot,
+    configDir: configDirectory,
+    staticDirs: [`${configDirectory}/static`],
+    projectFiles: { ...projectFiles, ...patchFiles },
+  });
+}
+
+// A stats file describing a healthy graph: a story imported by the stories entry, the preview
+// imported by the config entry, and the one `node_modules` file that makes a dependency visible.
+function stats(): Stats {
+  return {
+    modules: [
+      { id: 1, name: STORY, reasons: [{ moduleName: STORIES_ENTRY }] },
+      { id: 2, name: PREVIEW, reasons: [{ moduleName: CONFIG_ENTRY }] },
+      { id: 3, name: DEPENDENCY, reasons: [{ moduleName: STORY }] },
+    ],
+  };
+}
+
+// The mutation input the Index received, or undefined when nothing was uploaded.
+function uploaded({ runQuery }: Fixture) {
+  return runQuery.mock.calls[0]?.[1]?.input;
+}
+
+// The diagnostic manifest as written, or undefined when none was written.
+function writtenManifest({ disk }: Fixture) {
+  const contents =
+    disk.writtenFiles?.[path.join(manifestOutputDirectory, 'turbosnap-manifest.json')];
+  return contents === undefined ? undefined : JSON.parse(contents);
+}

--- a/node-src/lib/turbosnap/v2/index.ts
+++ b/node-src/lib/turbosnap/v2/index.ts
@@ -1,0 +1,86 @@
+import * as Sentry from '@sentry/node';
+
+import GraphQLClient from '../../../io/graphqlClient';
+import type { AbsolutePath, Stats } from '../../../types';
+import { TraceChangedFilesResult } from '../types';
+import { buildManifest, writeManifest } from './manifest';
+import { ProjectFiles } from './projectFiles';
+import { uploadHashes } from './uploadHashes';
+
+interface TraceChangedFilesInput {
+  graphqlClient: GraphQLClient;
+  buildId: string;
+  stats: Stats;
+  manifestOutputDirectory: string;
+  projectRoot: string;
+  configDir: AbsolutePath;
+  staticDirs: AbsolutePath[];
+  projectFiles: ProjectFiles;
+}
+
+/**
+ * The result of running TurboSnap v2. In addition to the shared trace statuses, v2 can return
+ * 'fallback' to tell the caller it can't be trusted to trace this build and v1 should run instead.
+ */
+export type TraceChangedFilesV2Result = TraceChangedFilesResult | { status: 'fallback' };
+
+/**
+ * Determines which story files are affected by the changed source file hashes, bailing out of
+ * TurboSnap when necessary.
+ *
+ * @param input The input to run TurboSnap 2.0.
+ * @param input.stats The preview stats file, read by the caller because v1 traces the same one.
+ * @param input.manifestOutputDirectory The directory to write the manifest file to.
+ * @param input.projectRoot The absolute Storybook project root used to read source files off disk
+ * and to anchor manifest keys.
+ * @param input.configDir The absolute Storybook config directory, hashed off disk because it is
+ * never a bundler input.
+ * @param input.staticDirs The absolute static directories, hashed off disk for the same reason.
+ * @param input.projectFiles How to read the disk; see {@link ProjectFiles}. Required rather than
+ * defaulted, so a caller cannot silently reach the real disk.
+ *
+ * @returns The TurboSnap result.
+ */
+export async function traceChangedFiles(
+  input: TraceChangedFilesInput
+): Promise<TraceChangedFilesV2Result> {
+  let manifest;
+  try {
+    manifest = await buildManifest(input.stats, {
+      projectRoot: input.projectRoot,
+      configDir: input.configDir,
+      staticDirs: input.staticDirs,
+      projectFiles: input.projectFiles,
+    });
+  } catch (error) {
+    Sentry.captureException(error, {
+      fingerprint: ['TurboSnap v2', 'Failed to build manifest'],
+    });
+    return { status: 'fallback' };
+  }
+
+  // The manifest is written to the Storybook build output so it can be uploaded with other
+  // diagnostic files.
+  try {
+    writeManifest(manifest, input.manifestOutputDirectory, input.projectFiles);
+  } catch (error) {
+    Sentry.captureException(error, {
+      fingerprint: ['TurboSnap v2', 'Failed to write manifest'],
+    });
+    return { status: 'fallback' };
+  }
+
+  try {
+    // We currently don't care about the output of this function because we'll always fallback to
+    // run TurboSnap v1
+    await uploadHashes(input.graphqlClient, input.buildId, manifest);
+  } catch (error) {
+    Sentry.captureException(error, {
+      fingerprint: ['TurboSnap v2', 'Failed to upload hashes'],
+    });
+    return { status: 'fallback' };
+  }
+
+  // Until we want to lean on the v2 output, we always fallback to v1.
+  return { status: 'fallback' };
+}


### PR DESCRIPTION
Closes CAP-4976

This adds a super helpful CLI subcommand to generate the TurboSnap v2 manifest so we can see it in action!

> [!NOTE]
> All the CLI flags were based on the `trace` subcommand.

To test, run this version of the CLI in a Storybook project that has a built `preview-stats.json` via `npx chromatic@<canary version> turbosnap-manifest`. If it's a monorepo, also pass `-b <directory of project>` and it should spit out the manifest to stdout!

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>18.6.1--canary.1456.32890855370.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@18.6.1--canary.1456.32890855370.0
  # or 
  yarn add chromatic@18.6.1--canary.1456.32890855370.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
