### PR TITLE
Support PNPM when installing dependencies

### DIFF
--- a/node-src/index.test.ts
+++ b/node-src/index.test.ts
@@ -340,7 +340,7 @@ vi.mock('./git/getParentCommits', () => ({
 }));
 
 vi.mock('./lib/installDependencies', () => ({
-  default: vi.fn(() => Promise.resolve('')),
+  installDependencies: vi.fn(() => Promise.resolve('')),
 }));
 
 const getCommit = vi.mocked(git.getCommit);

--- a/node-src/lib/installDependencies.test.ts
+++ b/node-src/lib/installDependencies.test.ts
@@ -1,0 +1,44 @@
+import { getCliCommand as unmockedGetCliCommand } from '@antfu/ni';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { installDependencies } from './installDependencies';
+
+vi.mock('@antfu/ni');
+
+const getCliCommand = vi.mocked(unmockedGetCliCommand);
+
+afterEach(() => vi.restoreAllMocks());
+
+describe('installDependencies', () => {
+  it('runs the detected install command and returns the result without buffering stdout/stderr', async () => {
+    const stdout = vi.spyOn(process.stdout, 'write');
+    const stderr = vi.spyOn(process.stderr, 'write');
+    getCliCommand.mockResolvedValue('node --version');
+
+    const result = await installDependencies();
+
+    expect(getCliCommand).toHaveBeenCalledWith(expect.any(Function), [], { programmatic: true });
+    expect(result?.stdout).toMatch(/^v\d+/);
+    expect(stdout).not.toHaveBeenCalled();
+    expect(stderr).not.toHaveBeenCalled();
+  });
+
+  it('captures failure output instead of writing it to the parent process', async () => {
+    const stdout = vi.spyOn(process.stdout, 'write');
+    const stderr = vi.spyOn(process.stderr, 'write');
+    getCliCommand.mockResolvedValue('node --invalid-install-test-option');
+
+    await expect(installDependencies()).rejects.toMatchObject({
+      stderr: expect.stringContaining('--invalid-install-test-option'),
+    });
+
+    expect(stdout).not.toHaveBeenCalled();
+    expect(stderr).not.toHaveBeenCalled();
+  });
+
+  it('fails when no install command is resolved', async () => {
+    getCliCommand.mockResolvedValue(undefined);
+
+    await expect(installDependencies()).rejects.toThrow();
+  });
+});

--- a/node-src/lib/installDependencies.test.ts
+++ b/node-src/lib/installDependencies.test.ts
@@ -1,44 +1,52 @@
 import { getCliCommand as unmockedGetCliCommand } from '@antfu/ni';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import { installDependencies } from './installDependencies';
+import { runCommand as unmockedRunCommand } from './shell/shell';
 
 vi.mock('@antfu/ni');
+vi.mock('./shell/shell');
 
 const getCliCommand = vi.mocked(unmockedGetCliCommand);
-
-afterEach(() => vi.restoreAllMocks());
+const runCommand = vi.mocked(unmockedRunCommand);
 
 describe('installDependencies', () => {
-  it('runs the detected install command and returns the result without buffering stdout/stderr', async () => {
-    const stdout = vi.spyOn(process.stdout, 'write');
-    const stderr = vi.spyOn(process.stderr, 'write');
-    getCliCommand.mockResolvedValue('node --version');
+  it('runs the install command detected for the project, without streaming its output', async () => {
+    getCliCommand.mockResolvedValue('yarn install');
 
-    const result = await installDependencies();
+    await installDependencies();
 
     expect(getCliCommand).toHaveBeenCalledWith(expect.any(Function), [], { programmatic: true });
-    expect(result?.stdout).toMatch(/^v\d+/);
-    expect(stdout).not.toHaveBeenCalled();
-    expect(stderr).not.toHaveBeenCalled();
+    // An exact match keeps `stdio` out of the options, so output stays buffered.
+    expect(runCommand).toHaveBeenCalledWith('yarn install', { timeout: expect.any(Number) });
   });
 
-  it('captures failure output instead of writing it to the parent process', async () => {
-    const stdout = vi.spyOn(process.stdout, 'write');
-    const stderr = vi.spyOn(process.stderr, 'write');
-    getCliCommand.mockResolvedValue('node --invalid-install-test-option');
+  it('fails when the install command fails', async () => {
+    const failure = new Error('yarn install exited with code 1');
+    getCliCommand.mockResolvedValue('yarn install');
+    runCommand.mockRejectedValue(failure);
 
-    await expect(installDependencies()).rejects.toMatchObject({
-      stderr: expect.stringContaining('--invalid-install-test-option'),
-    });
+    let err;
+    try {
+      await installDependencies();
+    } catch (error) {
+      err = error;
+    }
 
-    expect(stdout).not.toHaveBeenCalled();
-    expect(stderr).not.toHaveBeenCalled();
+    expect(err).toBe(failure);
   });
 
-  it('fails when no install command is resolved', async () => {
+  it('fails when no install command is detected', async () => {
     getCliCommand.mockResolvedValue(undefined);
 
-    await expect(installDependencies()).rejects.toThrow();
+    let err;
+    try {
+      await installDependencies();
+    } catch (error) {
+      err = error;
+    }
+
+    expect(err).toEqual(new Error('Unable to determine the package manager install command'));
+    expect(runCommand).not.toHaveBeenCalled();
   });
 });

--- a/node-src/lib/installDependencies.ts
+++ b/node-src/lib/installDependencies.ts
@@ -5,7 +5,7 @@ import { runCommand } from './shell/shell';
 /**
  * Install dependencies using the package manager specified in the project's package.json.
  *
- * @returns A promise that resolves when the command completes.
+ * @returns The result of the install command.
  */
 export async function installDependencies() {
   const command = await getCliCommand(parseNi, [], { programmatic: true });
@@ -13,5 +13,5 @@ export async function installDependencies() {
     throw new Error('Unable to determine the package manager install command');
   }
 
-  return runCommand(command);
+  return runCommand(command, { timeout: 10 * 60 * 1000 });
 }

--- a/node-src/lib/installDependencies.ts
+++ b/node-src/lib/installDependencies.ts
@@ -1,10 +1,17 @@
-import { parseNi, run } from '@antfu/ni';
+import { getCliCommand, parseNi } from '@antfu/ni';
+
+import { runCommand } from './shell/shell';
 
 /**
  * Install dependencies using the package manager specified in the project's package.json.
  *
  * @returns A promise that resolves when the command completes.
  */
-export function installDependencies() {
-  return run(parseNi, [], { programmatic: true });
+export async function installDependencies() {
+  const command = await getCliCommand(parseNi, [], { programmatic: true });
+  if (!command) {
+    throw new Error('Unable to determine the package manager install command');
+  }
+
+  return runCommand(command);
 }

--- a/node-src/lib/installDependencies.ts
+++ b/node-src/lib/installDependencies.ts
@@ -1,22 +1,10 @@
-import { SpawnOptions } from 'child_process';
-import { spawn } from 'yarn-or-npm';
+import { parseNi, run } from '@antfu/ni';
 
-const installDependencies = (options?: SpawnOptions) =>
-  new Promise((resolve, reject) => {
-    let stdout = '';
-    let stderr = '';
-    const child = spawn(['install'], options);
-    child.stdout?.on('data', (chunk) => {
-      stdout += chunk;
-    });
-    child.stderr?.on('data', (chunk) => {
-      stderr += chunk;
-    });
-    child.on('error', reject);
-    child.on('close', (code) => {
-      if (code === 0) resolve(stdout);
-      else reject(stderr);
-    });
-  });
-
-export default installDependencies;
+/**
+ * Install dependencies using the package manager specified in the project's package.json.
+ *
+ * @returns A promise that resolves when the command completes.
+ */
+export function installDependencies() {
+  return run(parseNi, [], { programmatic: true });
+}

--- a/node-src/tasks/prepareWorkspace.test.ts
+++ b/node-src/tasks/prepareWorkspace.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 
 import * as git from '../git/git';
-import installDeps from '../lib/installDependencies';
+import { installDependencies as unmockedInstallDependencies } from '../lib/installDependencies';
 import { TaskFailure } from '../lib/setExitCode';
 import TestLogger from '../lib/testLogger';
 import { runPrepareWorkspace } from './prepareWorkspace';
@@ -13,7 +13,7 @@ const checkout = vi.mocked(git.checkout);
 const isClean = vi.mocked(git.isClean);
 const isUpToDate = vi.mocked(git.isUpToDate);
 const findMergeBase = vi.mocked(git.findMergeBase);
-const installDependencies = vi.mocked(installDeps);
+const installDependencies = vi.mocked(unmockedInstallDependencies);
 
 const log = new TestLogger();
 const input = { patchHeadRef: 'head', patchBaseRef: 'base' };

--- a/node-src/tasks/prepareWorkspace.ts
+++ b/node-src/tasks/prepareWorkspace.ts
@@ -1,5 +1,5 @@
 import { checkout, findMergeBase, getUpdateMessage, isClean, isUpToDate } from '../git/git';
-import installDependencies from '../lib/installDependencies';
+import { installDependencies } from '../lib/installDependencies';
 import { exitCodes, TaskFailure } from '../lib/setExitCode';
 import { Context, Deps, TaskFunction } from '../types';
 import mergeBaseNotFound from '../ui/messages/errors/mergeBaseNotFound';

--- a/node-src/tasks/restoreWorkspace.test.ts
+++ b/node-src/tasks/restoreWorkspace.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 
 import * as git from '../git/git';
-import installDeps from '../lib/installDependencies';
+import { installDependencies as unmockedInstallDependencies } from '../lib/installDependencies';
 import TestLogger from '../lib/testLogger';
 import { runRestoreWorkspace } from './restoreWorkspace';
 
@@ -10,7 +10,7 @@ vi.mock('../lib/installDependencies');
 
 const checkoutPrevious = vi.mocked(git.checkoutPrevious);
 const discardChanges = vi.mocked(git.discardChanges);
-const installDependencies = vi.mocked(installDeps);
+const installDependencies = vi.mocked(unmockedInstallDependencies);
 
 describe('runRestoreWorkspace', () => {
   it('discards changes, checks out the previous branch and reinstalls dependencies', async () => {

--- a/node-src/tasks/restoreWorkspace.ts
+++ b/node-src/tasks/restoreWorkspace.ts
@@ -1,5 +1,5 @@
 import { checkoutPrevious, discardChanges } from '../git/git';
-import installDependencies from '../lib/installDependencies';
+import { installDependencies } from '../lib/installDependencies';
 import { Deps } from '../types';
 import { pending, success } from '../ui/tasks/restoreWorkspace';
 

--- a/node-src/tasks/restoreWorkspace.ts
+++ b/node-src/tasks/restoreWorkspace.ts
@@ -12,11 +12,11 @@ export type RestoreWorkspaceDeps = Pick<Deps, 'log' | 'options'>;
  *
  * @param ctx The CLI context, or any subset of `Deps` that provides `log` and `options`.
  */
-export const runRestoreWorkspace = async (ctx: RestoreWorkspaceDeps) => {
+export async function runRestoreWorkspace(ctx: RestoreWorkspaceDeps) {
   ctx.log.info(pending().output);
   await discardChanges(ctx); // we need a clean state before checkout
   await checkoutPrevious(ctx);
   await installDependencies();
   await discardChanges(ctx); // drop lockfile changes
   ctx.log.info(success().title);
-};
+}


### PR DESCRIPTION
We used an older package (`yarn-or-npm`) to install dependencies for patch builds. As the name would suggest, this doesn't support PNPM so this PR changes that!

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>18.7.0--canary.1462.32890848472.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@18.7.0--canary.1462.32890848472.0
  # or 
  yarn add chromatic@18.7.0--canary.1462.32890848472.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
