### PR TITLE
TurboSnap v2 release (runs alongside v1)

### DIFF
--- a/bin-src/turbosnapManifest.test.ts
+++ b/bin-src/turbosnapManifest.test.ts
@@ -57,6 +57,7 @@ describe('turbosnap-manifest', () => {
     expect(buildManifest).toHaveBeenCalledWith(
       { modules: [] },
       {
+        log: testLogger,
         projectRoot: '/repo',
         configDir: '/repo/.storybook',
         staticDirs: [],

--- a/bin-src/turbosnapManifest.ts
+++ b/bin-src/turbosnapManifest.ts
@@ -95,12 +95,13 @@ export async function main(argv: string[]) {
     }
 
     const manifest = await buildManifest(await readStatsFile(statsPath), {
+      log,
       projectRoot,
       configDir: path.resolve(projectRoot, cli.flags.configDir),
       staticDirs: (cli.flags.staticDir?.split(',') ?? []).map((directory) =>
         path.resolve(projectRoot, directory)
       ),
-      projectFiles: realProjectFiles(),
+      projectFiles: realProjectFiles(log),
     });
 
     process.stdout.write(JSON.stringify(serializeManifest(manifest), undefined, 2));

--- a/node-src/lib/turbosnap/index.test.ts
+++ b/node-src/lib/turbosnap/index.test.ts
@@ -1,47 +1,177 @@
-import { describe, expect, it } from 'vitest';
+import * as Sentry from '@sentry/node';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { readStatsFile } from '../../tasks/readStatsFile';
 import { traceChangedFiles } from '.';
+import { traceChangedFiles as traceChangedFilesV1 } from './v1';
+import { traceChangedFiles as traceChangedFilesV2 } from './v2';
+import { realProjectFiles } from './v2/projectFiles';
+
+vi.mock('@sentry/node', () => ({
+  captureException: vi.fn(),
+}));
+
+vi.mock('../../tasks/readStatsFile', () => ({
+  readStatsFile: vi.fn(),
+}));
+
+vi.mock('./v1', () => ({
+  traceChangedFiles: vi.fn(),
+}));
+
+vi.mock('./v2', () => ({
+  traceChangedFiles: vi.fn(),
+}));
+
+vi.mock('./v2/projectFiles', () => ({
+  realProjectFiles: vi.fn(() => ({ kind: 'real-project-files' })),
+}));
+
+const stats = { modules: [] };
+const v1Result = {
+  status: 'traced' as const,
+  onlyStoryFiles: { button: ['./src/Button.stories.tsx'] },
+  turboSnap: {},
+  untracedFiles: [],
+};
+
+function makeContext() {
+  return {
+    turboSnap: {},
+    options: {},
+    git: { changedFiles: ['./src/Button.tsx'] },
+    fileInfo: { statsPath: '/repo/packages/ui/storybook-static/preview-stats.json' },
+    client: { runQuery: vi.fn() },
+    announcedBuild: { id: 'head-build' },
+    sourceDir: '/repo/packages/ui/storybook-static',
+    storybook: {
+      projectRoot: '/repo/packages/ui',
+      configDir: '/repo/packages/ui/.storybook',
+      staticDirs: ['/repo/packages/ui/public'],
+    },
+  } as any;
+}
+
+beforeEach(() => {
+  vi.mocked(readStatsFile).mockResolvedValue(stats);
+  vi.mocked(traceChangedFilesV2).mockResolvedValue({ status: 'fallback' });
+  vi.mocked(traceChangedFilesV1).mockResolvedValue(v1Result);
+});
 
 describe('traceChangedFiles', () => {
-  it('returns skipped when TurboSnap is unavailable', async () => {
+  it('returns skipped without running either generation when TurboSnap is unavailable', async () => {
     const ctx = {
       options: {},
       git: {},
       turboSnap: { unavailable: true },
     } as any;
 
-    const result = await traceChangedFiles(ctx);
+    await expect(traceChangedFiles(ctx)).resolves.toStrictEqual({ status: 'skipped' });
 
-    expect(result).toStrictEqual({ status: 'skipped' });
+    expect(readStatsFile).not.toHaveBeenCalled();
+    expect(traceChangedFilesV2).not.toHaveBeenCalled();
+    expect(traceChangedFilesV1).not.toHaveBeenCalled();
   });
 
-  it('returns skipped when there are no changed files from git', async () => {
+  it('returns skipped without running either generation when there are no changed files', async () => {
     const ctx = {
       git: {},
       turboSnap: {},
     } as any;
 
-    const result = await traceChangedFiles(ctx);
+    await expect(traceChangedFiles(ctx)).resolves.toStrictEqual({ status: 'skipped' });
 
-    expect(result).toStrictEqual({ status: 'skipped' });
+    expect(readStatsFile).not.toHaveBeenCalled();
+    expect(traceChangedFilesV2).not.toHaveBeenCalled();
+    expect(traceChangedFilesV1).not.toHaveBeenCalled();
   });
 
-  it('throws if stats file is not found', async () => {
-    const packageMetadataChanges = [{ changedFiles: ['./package.json'], commit: 'abcdef' }];
+  it('throws if the stats file is not found', async () => {
     const ctx = {
       options: {},
       sourceDir: '/static/',
-      git: { changedFiles: ['./example.js', './package.json'], packageMetadataChanges },
+      git: { changedFiles: ['./example.js'] },
       turboSnap: {},
     } as any;
 
-    let err;
-    try {
-      await traceChangedFiles(ctx);
-    } catch (error) {
-      err = error;
-    }
-    expect(err.message).toContain('TurboSnap requires a stats file');
-    expect(ctx.turboSnap.bailReason).toBeUndefined();
+    await expect(traceChangedFiles(ctx)).rejects.toThrow('TurboSnap requires a stats file');
+
+    expect(readStatsFile).not.toHaveBeenCalled();
+    expect(traceChangedFilesV2).not.toHaveBeenCalled();
+    expect(traceChangedFilesV1).not.toHaveBeenCalled();
+  });
+
+  it('keeps an unreadable stats file terminal for both generations', async () => {
+    const ctx = makeContext();
+    const error = new Error('stats file is unreadable');
+    vi.mocked(readStatsFile).mockRejectedValue(error);
+
+    await expect(traceChangedFiles(ctx)).rejects.toBe(error);
+
+    expect(readStatsFile).toHaveBeenCalledOnce();
+    expect(traceChangedFilesV2).not.toHaveBeenCalled();
+    expect(traceChangedFilesV1).not.toHaveBeenCalled();
+  });
+
+  it('reads the stats once and gives the same graph and Storybook paths to both generations', async () => {
+    const ctx = makeContext();
+    const projectFiles = realProjectFiles();
+    vi.mocked(realProjectFiles).mockReturnValue(projectFiles as any);
+
+    await traceChangedFiles(ctx);
+
+    expect(readStatsFile).toHaveBeenCalledOnce();
+    expect(readStatsFile).toHaveBeenCalledWith(ctx.fileInfo.statsPath);
+    expect(traceChangedFilesV2).toHaveBeenCalledWith({
+      graphqlClient: ctx.client,
+      buildId: 'head-build',
+      stats,
+      manifestOutputDirectory: '/repo/packages/ui/storybook-static/.chromatic',
+      projectRoot: ctx.storybook.projectRoot,
+      configDir: ctx.storybook.configDir,
+      staticDirs: ctx.storybook.staticDirs,
+      projectFiles,
+    });
+    expect(traceChangedFilesV1).toHaveBeenCalledWith(ctx, stats, ctx.fileInfo.statsPath);
+  });
+
+  it('runs v2 before v1 and returns only the v1 result', async () => {
+    const ctx = makeContext();
+
+    await expect(traceChangedFiles(ctx)).resolves.toBe(v1Result);
+
+    expect(vi.mocked(traceChangedFilesV2).mock.invocationCallOrder[0]).toBeLessThan(
+      vi.mocked(traceChangedFilesV1).mock.invocationCallOrder[0]
+    );
+  });
+
+  it('still runs v1 when v2 Bails', async () => {
+    const ctx = makeContext();
+    vi.mocked(traceChangedFilesV2).mockResolvedValue({ status: 'fallback' });
+
+    await expect(traceChangedFiles(ctx)).resolves.toBe(v1Result);
+
+    expect(traceChangedFilesV2).toHaveBeenCalledOnce();
+    expect(traceChangedFilesV1).toHaveBeenCalledOnce();
+  });
+
+  it('reports an unexpected v2 rejection and still returns the v1 result', async () => {
+    const ctx = makeContext();
+    const error = new Error('v2 escaped its own error handling');
+    vi.mocked(traceChangedFilesV2).mockRejectedValue(error);
+
+    await expect(traceChangedFiles(ctx)).resolves.toBe(v1Result);
+
+    expect(Sentry.captureException).toHaveBeenCalledWith(error, {
+      fingerprint: ['TurboSnap v2', 'Failed to trace changed files'],
+    });
+    expect(traceChangedFilesV1).toHaveBeenCalledOnce();
+  });
+
+  it('does not report an exception when v2 succeeds', async () => {
+    await traceChangedFiles(makeContext());
+
+    expect(traceChangedFilesV2).toHaveBeenCalledOnce();
+    expect(Sentry.captureException).not.toHaveBeenCalled();
   });
 });

--- a/node-src/lib/turbosnap/index.test.ts
+++ b/node-src/lib/turbosnap/index.test.ts
@@ -78,18 +78,18 @@ describe('traceChangedFiles', () => {
     expect(traceChangedFilesV1).not.toHaveBeenCalled();
   });
 
-  it('returns skipped without running either generation when there are no changed files', async () => {
-    const ctx = {
-      git: {},
-      turboSnap: {},
-    } as any;
+  it.each([[], undefined])(
+    'returns skipped and only runs TurboSnap v2 when there are no changed files (arg: %s)',
+    async (changedFiles) => {
+      const ctx = { ...makeContext(), git: { changedFiles } };
 
-    await expect(traceChangedFiles(ctx)).resolves.toStrictEqual({ status: 'skipped' });
+      await expect(traceChangedFiles(ctx)).resolves.toStrictEqual({ status: 'skipped' });
 
-    expect(readStatsFile).not.toHaveBeenCalled();
-    expect(traceChangedFilesV2).not.toHaveBeenCalled();
-    expect(traceChangedFilesV1).not.toHaveBeenCalled();
-  });
+      expect(readStatsFile).toHaveBeenCalled();
+      expect(traceChangedFilesV2).toHaveBeenCalled();
+      expect(traceChangedFilesV1).not.toHaveBeenCalled();
+    }
+  );
 
   it('throws if the stats file is not found', async () => {
     const ctx = { ...makeContext(), fileInfo: undefined };

--- a/node-src/lib/turbosnap/index.test.ts
+++ b/node-src/lib/turbosnap/index.test.ts
@@ -141,16 +141,6 @@ describe('traceChangedFiles', () => {
     );
   });
 
-  it('still runs v1 when v2 Bails', async () => {
-    const ctx = makeContext();
-    vi.mocked(traceChangedFilesV2).mockResolvedValue({ status: 'fallback' });
-
-    await expect(traceChangedFiles(ctx)).resolves.toBe(v1Result);
-
-    expect(traceChangedFilesV2).toHaveBeenCalledOnce();
-    expect(traceChangedFilesV1).toHaveBeenCalledOnce();
-  });
-
   it('reports an unexpected v2 rejection and still returns the v1 result', async () => {
     const ctx = makeContext();
     const error = new Error('v2 escaped its own error handling');

--- a/node-src/lib/turbosnap/index.test.ts
+++ b/node-src/lib/turbosnap/index.test.ts
@@ -2,6 +2,7 @@ import * as Sentry from '@sentry/node';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { readStatsFile } from '../../tasks/readStatsFile';
+import TestLogger from '../testLogger';
 import { traceChangedFiles } from '.';
 import { traceChangedFiles as traceChangedFilesV1 } from './v1';
 import { traceChangedFiles as traceChangedFilesV2 } from './v2';
@@ -39,6 +40,7 @@ const v1Result = {
 
 function makeContext() {
   return {
+    log: new TestLogger(),
     turboSnap: {},
     options: {},
     git: { changedFiles: ['./src/Button.tsx'] },
@@ -119,6 +121,7 @@ describe('traceChangedFiles', () => {
     expect(readStatsFile).toHaveBeenCalledOnce();
     expect(readStatsFile).toHaveBeenCalledWith(ctx.fileInfo.statsPath);
     expect(traceChangedFilesV2).toHaveBeenCalledWith({
+      log: ctx.log,
       graphqlClient: ctx.client,
       buildId: 'head-build',
       stats,

--- a/node-src/lib/turbosnap/index.test.ts
+++ b/node-src/lib/turbosnap/index.test.ts
@@ -126,7 +126,7 @@ describe('traceChangedFiles', () => {
       graphqlClient: ctx.client,
       buildId: 'head-build',
       stats,
-      manifestOutputDirectory: '/repo/packages/ui/storybook-static/.chromatic',
+      manifestPath: '/repo/packages/ui/storybook-static/.chromatic/turbosnap-manifest.json',
       projectRoot: ctx.storybook.projectRoot,
       configDir: ctx.storybook.configDir,
       staticDirs: ctx.storybook.staticDirs,

--- a/node-src/lib/turbosnap/index.test.ts
+++ b/node-src/lib/turbosnap/index.test.ts
@@ -23,8 +23,10 @@ vi.mock('./v2', () => ({
   traceChangedFiles: vi.fn(),
 }));
 
+const projectFiles = { kind: 'real-project-files' };
+
 vi.mock('./v2/projectFiles', () => ({
-  realProjectFiles: vi.fn(() => ({ kind: 'real-project-files' })),
+  realProjectFiles: vi.fn(),
 }));
 
 const stats = { modules: [] };
@@ -53,6 +55,7 @@ function makeContext() {
 }
 
 beforeEach(() => {
+  vi.mocked(realProjectFiles).mockReturnValue(projectFiles as any);
   vi.mocked(readStatsFile).mockResolvedValue(stats);
   vi.mocked(traceChangedFilesV2).mockResolvedValue({ status: 'fallback' });
   vi.mocked(traceChangedFilesV1).mockResolvedValue(v1Result);
@@ -87,12 +90,7 @@ describe('traceChangedFiles', () => {
   });
 
   it('throws if the stats file is not found', async () => {
-    const ctx = {
-      options: {},
-      sourceDir: '/static/',
-      git: { changedFiles: ['./example.js'] },
-      turboSnap: {},
-    } as any;
+    const ctx = { ...makeContext(), fileInfo: undefined };
 
     await expect(traceChangedFiles(ctx)).rejects.toThrow('TurboSnap requires a stats file');
 
@@ -115,8 +113,6 @@ describe('traceChangedFiles', () => {
 
   it('reads the stats once and gives the same graph and Storybook paths to both generations', async () => {
     const ctx = makeContext();
-    const projectFiles = realProjectFiles();
-    vi.mocked(realProjectFiles).mockReturnValue(projectFiles as any);
 
     await traceChangedFiles(ctx);
 

--- a/node-src/lib/turbosnap/index.ts
+++ b/node-src/lib/turbosnap/index.ts
@@ -24,8 +24,7 @@ export async function traceChangedFiles(ctx: Context): Promise<TraceChangedFiles
   if (!ctx.fileInfo?.statsPath) {
     // If we don't know the SB version, we should assume we don't support `--stats-json`
     const nonLegacyStatsSupported =
-      ctx.storybook?.version &&
-      semver.gte(semver.coerce(ctx.storybook.version) || '0.0.0', '8.0.0');
+      ctx.storybook.version && semver.gte(semver.coerce(ctx.storybook.version) || '0.0.0', '8.0.0');
 
     throw new Error(missingStatsFile({ legacy: !nonLegacyStatsSupported }));
   }

--- a/node-src/lib/turbosnap/index.ts
+++ b/node-src/lib/turbosnap/index.ts
@@ -35,7 +35,9 @@ export async function traceChangedFiles(ctx: Context): Promise<TraceChangedFiles
   // V2 catches every anticipated failure itself. A rejection here is a defect in those guards: it
   // must be observable, but it must never affect the v1 decision or the customer's build.
   try {
+    ctx.log.debug('Tracing changed files with TurboSnap v2');
     await traceChangedFilesV2({
+      log: ctx.log,
       graphqlClient: ctx.client,
       buildId: ctx.announcedBuild.id,
       stats,
@@ -43,13 +45,18 @@ export async function traceChangedFiles(ctx: Context): Promise<TraceChangedFiles
       projectRoot: ctx.storybook.projectRoot,
       configDir: ctx.storybook.configDir,
       staticDirs: ctx.storybook.staticDirs,
-      projectFiles: realProjectFiles(),
+      projectFiles: realProjectFiles(ctx.log),
     });
   } catch (error) {
+    ctx.log.error(
+      'Failed to trace changed files with TurboSnap v2; this does not affect TurboSnap v1',
+      error
+    );
     Sentry.captureException(error, {
       fingerprint: ['TurboSnap v2', 'Failed to trace changed files'],
     });
   }
 
+  ctx.log.debug('Tracing changed files with TurboSnap v1');
   return traceChangedFilesV1(ctx, stats, statsPath);
 }

--- a/node-src/lib/turbosnap/index.ts
+++ b/node-src/lib/turbosnap/index.ts
@@ -1,9 +1,14 @@
+import * as Sentry from '@sentry/node';
+import path from 'path';
 import semver from 'semver';
 
+import { readStatsFile } from '../../tasks/readStatsFile';
 import { Context } from '../../types';
 import missingStatsFile from '../../ui/messages/errors/missingStatsFile';
 import { TraceChangedFilesResult } from './types';
 import { traceChangedFiles as traceChangedFilesV1 } from './v1';
+import { traceChangedFiles as traceChangedFilesV2 } from './v2';
+import { realProjectFiles } from './v2/projectFiles';
 
 /**
  * Determines which story files are affected by the changed git files, bailing out of TurboSnap
@@ -25,5 +30,27 @@ export async function traceChangedFiles(ctx: Context): Promise<TraceChangedFiles
     throw new Error(missingStatsFile({ legacy: !nonLegacyStatsSupported }));
   }
 
-  return traceChangedFilesV1(ctx);
+  const statsPath = ctx.fileInfo.statsPath;
+  const stats = await readStatsFile(statsPath);
+
+  // V2 catches every anticipated failure itself. A rejection here is a defect in those guards: it
+  // must be observable, but it must never affect the v1 decision or the customer's build.
+  try {
+    await traceChangedFilesV2({
+      graphqlClient: ctx.client,
+      buildId: ctx.announcedBuild.id,
+      stats,
+      manifestOutputDirectory: path.join(ctx.sourceDir, '.chromatic'),
+      projectRoot: ctx.storybook.projectRoot,
+      configDir: ctx.storybook.configDir,
+      staticDirs: ctx.storybook.staticDirs,
+      projectFiles: realProjectFiles(),
+    });
+  } catch (error) {
+    Sentry.captureException(error, {
+      fingerprint: ['TurboSnap v2', 'Failed to trace changed files'],
+    });
+  }
+
+  return traceChangedFilesV1(ctx, stats, statsPath);
 }

--- a/node-src/lib/turbosnap/index.ts
+++ b/node-src/lib/turbosnap/index.ts
@@ -7,7 +7,7 @@ import missingStatsFile from '../../ui/messages/errors/missingStatsFile';
 import { TraceChangedFilesResult } from './types';
 import { traceChangedFiles as traceChangedFilesV1 } from './v1';
 import { traceChangedFiles as traceChangedFilesV2 } from './v2';
-import { getManifestOutputDirectory } from './v2/manifest';
+import { getManifestPath } from './v2/manifest';
 import { realProjectFiles } from './v2/projectFiles';
 
 /**
@@ -39,7 +39,7 @@ export async function traceChangedFiles(ctx: Context): Promise<TraceChangedFiles
       graphqlClient: ctx.client,
       buildId: ctx.announcedBuild.id,
       stats,
-      manifestOutputDirectory: getManifestOutputDirectory(ctx.sourceDir),
+      manifestPath: getManifestPath(ctx.sourceDir),
       projectRoot: ctx.storybook.projectRoot,
       configDir: ctx.storybook.configDir,
       staticDirs: ctx.storybook.staticDirs,

--- a/node-src/lib/turbosnap/index.ts
+++ b/node-src/lib/turbosnap/index.ts
@@ -20,7 +20,6 @@ import { realProjectFiles } from './v2/projectFiles';
  */
 export async function traceChangedFiles(ctx: Context): Promise<TraceChangedFilesResult> {
   if (!ctx.turboSnap || ctx.turboSnap.unavailable) return { status: 'skipped' };
-  if (!ctx.git.changedFiles) return { status: 'skipped' };
   if (!ctx.fileInfo?.statsPath) {
     // If we don't know the SB version, we should assume we don't support `--stats-json`
     const nonLegacyStatsSupported =
@@ -55,6 +54,10 @@ export async function traceChangedFiles(ctx: Context): Promise<TraceChangedFiles
     Sentry.captureException(error, {
       fingerprint: ['TurboSnap v2', 'Failed to trace changed files'],
     });
+  }
+
+  if (!ctx.git.changedFiles || ctx.git.changedFiles.length === 0) {
+    return { status: 'skipped' };
   }
 
   ctx.log.debug('Tracing changed files with TurboSnap v1');

--- a/node-src/lib/turbosnap/index.ts
+++ b/node-src/lib/turbosnap/index.ts
@@ -1,5 +1,4 @@
 import * as Sentry from '@sentry/node';
-import path from 'path';
 import semver from 'semver';
 
 import { readStatsFile } from '../../tasks/readStatsFile';
@@ -8,6 +7,7 @@ import missingStatsFile from '../../ui/messages/errors/missingStatsFile';
 import { TraceChangedFilesResult } from './types';
 import { traceChangedFiles as traceChangedFilesV1 } from './v1';
 import { traceChangedFiles as traceChangedFilesV2 } from './v2';
+import { getManifestOutputDirectory } from './v2/manifest';
 import { realProjectFiles } from './v2/projectFiles';
 
 /**
@@ -40,7 +40,7 @@ export async function traceChangedFiles(ctx: Context): Promise<TraceChangedFiles
       graphqlClient: ctx.client,
       buildId: ctx.announcedBuild.id,
       stats,
-      manifestOutputDirectory: path.join(ctx.sourceDir, '.chromatic'),
+      manifestOutputDirectory: getManifestOutputDirectory(ctx.sourceDir),
       projectRoot: ctx.storybook.projectRoot,
       configDir: ctx.storybook.configDir,
       staticDirs: ctx.storybook.staticDirs,

--- a/node-src/lib/turbosnap/v1/index.test.ts
+++ b/node-src/lib/turbosnap/v1/index.test.ts
@@ -4,7 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { exitCodes } from '../../setExitCode';
 import TestLogger from '../../testLogger';
-import { traceChangedFiles } from '.';
+import { traceChangedFiles as traceChangedFilesV1 } from '.';
 import { classifyTagsFromError as classifyTagsFromErrorDep } from './classifyBailRootCause';
 import {
   BaselineCheckoutFailedError,
@@ -29,17 +29,6 @@ vi.mock('./findChangedDependencies', async (importOriginal) => {
 vi.mock('./findChangedPackageFiles');
 vi.mock('./getDependentStoryFiles');
 vi.mock('./classifyBailRootCause');
-vi.mock('../../../tasks/readStatsFile', () => ({
-  readStatsFile: () =>
-    Promise.resolve({
-      modules: [
-        {
-          id: '../../../__mocks__/storybookBaseDir/test.ts',
-          name: '../../../__mocks__/storybookBaseDir/test.ts',
-        },
-      ],
-    }),
-}));
 
 const getDependentStoryFiles = vi.mocked(getDependentStoryFilesDep);
 const findChangedPackageFiles = vi.mocked(findChangedPackageFilesDep);
@@ -51,6 +40,17 @@ const captureException = vi.mocked(Sentry.captureException);
 const environment = { CHROMATIC_RETRIES: 2, CHROMATIC_OUTPUT_INTERVAL: 0 };
 const log = new TestLogger();
 const http = { fetch: vi.fn() };
+const statsPath = '/static/preview-stats.json';
+const stats = {
+  modules: [
+    {
+      id: '../../../__mocks__/storybookBaseDir/test.ts',
+      name: '../../../__mocks__/storybookBaseDir/test.ts',
+    },
+  ],
+};
+
+const traceChangedFiles = (ctx: any) => traceChangedFilesV1(ctx, stats, statsPath);
 
 afterEach(() => {
   vi.restoreAllMocks();
@@ -341,23 +341,5 @@ describe('traceChangedFiles', () => {
     expect(result.status).toBe('bailed');
     expect(ctx.turboSnap.bailReason).toBeUndefined();
     expect(ctx.git.changedDependencyNames).toBeUndefined();
-  });
-
-  it('throws if stats file is not found', async () => {
-    const packageMetadataChanges = [{ changedFiles: ['./package.json'], commit: 'abcdef' }];
-    const ctx = {
-      options: {},
-      sourceDir: '/static/',
-      git: { changedFiles: ['./example.js', './package.json'], packageMetadataChanges },
-      turboSnap: {},
-    } as any;
-
-    let err;
-    try {
-      await traceChangedFiles(ctx);
-    } catch (error) {
-      err = error;
-    }
-    expect(err.message).toContain('TurboSnap requires a stats file');
   });
 });

--- a/node-src/lib/turbosnap/v1/index.ts
+++ b/node-src/lib/turbosnap/v1/index.ts
@@ -1,8 +1,4 @@
-import semver from 'semver';
-
-import { readStatsFile } from '../../../tasks/readStatsFile';
-import { ChangedPackageFilesBailReason, Context, TurboSnap } from '../../../types';
-import missingStatsFile from '../../../ui/messages/errors/missingStatsFile';
+import { ChangedPackageFilesBailReason, Context, Stats, TurboSnap } from '../../../types';
 import bailFile from '../../../ui/messages/warnings/bailFile';
 import { checkStorybookBaseDirectory } from '../../checkStorybookBaseDirectory';
 import { TraceChangedFilesResult } from '../types';
@@ -18,23 +14,17 @@ import { getDependentStoryFiles } from './getDependentStoryFiles';
  * when necessary.
  *
  * @param ctx The context set when executing the CLI.
+ * @param stats The parsed Stats Graph, read once by the dispatcher for both generations.
+ * @param statsPath The path the Stats Graph was read from, used in v1 trace reporting.
  *
  * @returns The trace result: skipped, bailed, or traced with the affected story files.
  */
 // eslint-disable-next-line complexity
-export async function traceChangedFiles(ctx: Context): Promise<TraceChangedFilesResult> {
-  // This is an additional check from lib/turbosnap/index.ts in case we call this function directly
-  // from another file.
-  if (!ctx.fileInfo?.statsPath) {
-    // If we don't know the SB version, we should assume we don't support `--stats-json`
-    const nonLegacyStatsSupported =
-      ctx.storybook?.version &&
-      semver.gte(semver.coerce(ctx.storybook.version) || '0.0.0', '8.0.0');
-
-    throw new Error(missingStatsFile({ legacy: !nonLegacyStatsSupported }));
-  }
-
-  const { statsPath } = ctx.fileInfo;
+export async function traceChangedFiles(
+  ctx: Context,
+  stats: Stats,
+  statsPath: string
+): Promise<TraceChangedFilesResult> {
   const { changedFiles = [], packageMetadataChanges } = ctx.git;
 
   // Only set when lockfile analysis ran and succeeded; an empty array means "no changes found".
@@ -83,8 +73,6 @@ export async function traceChangedFiles(ctx: Context): Promise<TraceChangedFiles
       }
     }
   }
-
-  const stats = await readStatsFile(statsPath);
 
   await checkStorybookBaseDirectory(ctx, stats);
 

--- a/node-src/lib/turbosnap/v2/__fixtures__/manifestFixtures.ts
+++ b/node-src/lib/turbosnap/v2/__fixtures__/manifestFixtures.ts
@@ -1,3 +1,4 @@
+import TestLogger from '../../../testLogger';
 import { buildManifest } from '../manifest';
 import { ManifestInput } from '../manifestInput';
 import { InMemoryDisk, inMemoryProjectFiles } from '../projectFiles.fake';
@@ -30,6 +31,7 @@ export function createFixture(overrides: InMemoryDisk = {}): ManifestFixture {
   return {
     disk,
     input: {
+      log: new TestLogger(),
       projectRoot,
       configDir: `${projectRoot}/.storybook`,
       staticDirs: [`${projectRoot}/.storybook/static`],

--- a/node-src/lib/turbosnap/v2/index.test.ts
+++ b/node-src/lib/turbosnap/v2/index.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from 'vitest';
 
 import GraphQLClient from '../../../io/graphqlClient';
 import { Stats } from '../../../types';
+import TestLogger from '../../testLogger';
 import { traceChangedFiles } from './index';
 import { ProjectFiles } from './projectFiles';
 import { InMemoryDisk, inMemoryProjectFiles } from './projectFiles.fake';
@@ -132,6 +133,7 @@ describe('traceChangedFiles', () => {
 // `patchFiles` override replaces adapter methods for the paths only a failing read or write reaches.
 function trace({ projectFiles, runQuery }: Fixture, patchFiles: Partial<ProjectFiles> = {}) {
   return traceChangedFiles({
+    log: new TestLogger(),
     graphqlClient: { runQuery } as unknown as GraphQLClient,
     buildId: 'build-id',
     stats: stats(),

--- a/node-src/lib/turbosnap/v2/index.test.ts
+++ b/node-src/lib/turbosnap/v2/index.test.ts
@@ -1,5 +1,4 @@
 import * as Sentry from '@sentry/node';
-import path from 'path';
 import { describe, expect, it, vi } from 'vitest';
 
 import GraphQLClient from '../../../io/graphqlClient';
@@ -29,7 +28,7 @@ const CONFIG_ENTRY = './storybook-config-entry.js';
 // is what keeps a test from having to list every source file its stats name.
 const SYNTHETIC = ['storybook-stories.js', 'storybook-config-entry.js', '|lazy|'];
 
-const manifestOutputDirectory = '/repo/packages/ui/storybook-static';
+const manifestPath = '/repo/packages/ui/storybook-static/.chromatic/turbosnap-manifest.json';
 
 function setup() {
   const disk: InMemoryDisk = {
@@ -136,7 +135,7 @@ function trace({ projectFiles, runQuery }: Fixture, patchFiles: Partial<ProjectF
     graphqlClient: { runQuery } as unknown as GraphQLClient,
     buildId: 'build-id',
     stats: stats(),
-    manifestOutputDirectory,
+    manifestPath,
     projectRoot,
     configDir: configDirectory,
     staticDirs: [`${configDirectory}/static`],
@@ -163,7 +162,6 @@ function uploaded({ runQuery }: Fixture) {
 
 // The diagnostic manifest as written, or undefined when none was written.
 function writtenManifest({ disk }: Fixture) {
-  const contents =
-    disk.writtenFiles?.[path.join(manifestOutputDirectory, 'turbosnap-manifest.json')];
+  const contents = disk.writtenFiles?.[manifestPath];
   return contents === undefined ? undefined : JSON.parse(contents);
 }

--- a/node-src/lib/turbosnap/v2/index.ts
+++ b/node-src/lib/turbosnap/v2/index.ts
@@ -2,12 +2,14 @@ import * as Sentry from '@sentry/node';
 
 import GraphQLClient from '../../../io/graphqlClient';
 import type { AbsolutePath, Stats } from '../../../types';
+import type { Logger } from '../../log';
 import { TraceChangedFilesResult } from '../types';
-import { buildManifest, writeManifest } from './manifest';
+import { buildManifest, TurboSnapManifest, writeManifest } from './manifest';
 import { ProjectFiles } from './projectFiles';
 import { uploadHashes } from './uploadHashes';
 
 interface TraceChangedFilesInput {
+  log: Logger;
   graphqlClient: GraphQLClient;
   buildId: string;
   stats: Stats;
@@ -44,42 +46,49 @@ export type TraceChangedFilesV2Result = TraceChangedFilesResult | { status: 'fal
 export async function traceChangedFiles(
   input: TraceChangedFilesInput
 ): Promise<TraceChangedFilesV2Result> {
-  let manifest;
+  let manifest: TurboSnapManifest;
   try {
     manifest = await buildManifest(input.stats, {
+      log: input.log,
       projectRoot: input.projectRoot,
       configDir: input.configDir,
       staticDirs: input.staticDirs,
       projectFiles: input.projectFiles,
     });
   } catch (error) {
+    input.log.error('Failed to build manifest for TurboSnap v2', error);
     Sentry.captureException(error, {
       fingerprint: ['TurboSnap v2', 'Failed to build manifest'],
     });
     return { status: 'fallback' };
   }
+  input.log.debug('Generated manifest for TurboSnap v2');
 
   // The manifest is written to the Storybook build output so it can be uploaded with other
   // diagnostic files.
   try {
     writeManifest(manifest, input.manifestPath, input.projectFiles);
   } catch (error) {
+    input.log.error('Failed to write manifest for TurboSnap v2', error);
     Sentry.captureException(error, {
       fingerprint: ['TurboSnap v2', 'Failed to write manifest'],
     });
     return { status: 'fallback' };
   }
+  input.log.debug(`Wrote manifest for TurboSnap v2 to ${input.manifestPath}`);
 
   try {
     // We currently don't care about the output of this function because we'll always fallback to
     // run TurboSnap v1
     await uploadHashes(input.graphqlClient, input.buildId, manifest);
   } catch (error) {
+    input.log.error('Failed to upload hashes for TurboSnap v2', error);
     Sentry.captureException(error, {
       fingerprint: ['TurboSnap v2', 'Failed to upload hashes'],
     });
     return { status: 'fallback' };
   }
+  input.log.debug('Uploaded hashes for TurboSnap v2 to Chromatic');
 
   // Until we want to lean on the v2 output, we always fallback to v1.
   return { status: 'fallback' };

--- a/node-src/lib/turbosnap/v2/index.ts
+++ b/node-src/lib/turbosnap/v2/index.ts
@@ -11,7 +11,7 @@ interface TraceChangedFilesInput {
   graphqlClient: GraphQLClient;
   buildId: string;
   stats: Stats;
-  manifestOutputDirectory: string;
+  manifestPath: string;
   projectRoot: string;
   configDir: AbsolutePath;
   staticDirs: AbsolutePath[];
@@ -30,7 +30,7 @@ export type TraceChangedFilesV2Result = TraceChangedFilesResult | { status: 'fal
  *
  * @param input The input to run TurboSnap 2.0.
  * @param input.stats The preview stats file, read by the caller because v1 traces the same one.
- * @param input.manifestOutputDirectory The directory to write the manifest file to.
+ * @param input.manifestPath The path to write the manifest file to.
  * @param input.projectRoot The absolute Storybook project root used to read source files off disk
  * and to anchor manifest keys.
  * @param input.configDir The absolute Storybook config directory, hashed off disk because it is
@@ -62,7 +62,7 @@ export async function traceChangedFiles(
   // The manifest is written to the Storybook build output so it can be uploaded with other
   // diagnostic files.
   try {
-    writeManifest(manifest, input.manifestOutputDirectory, input.projectFiles);
+    writeManifest(manifest, input.manifestPath, input.projectFiles);
   } catch (error) {
     Sentry.captureException(error, {
       fingerprint: ['TurboSnap v2', 'Failed to write manifest'],

--- a/node-src/lib/turbosnap/v2/manifest.test.ts
+++ b/node-src/lib/turbosnap/v2/manifest.test.ts
@@ -1,4 +1,3 @@
-import path from 'path';
 import { describe, expect, it } from 'vitest';
 
 import { Stats } from '../../../types';
@@ -7,7 +6,7 @@ import {
   manifestWithPreview,
   syntheticAbsent,
 } from './__fixtures__/manifestFixtures';
-import { buildManifest, serializeManifest, writeManifest } from './manifest';
+import { buildManifest, getManifestPath, serializeManifest, writeManifest } from './manifest';
 
 describe('serializeManifest', () => {
   it('converts the manifest maps and sets into JSON-safe objects and arrays', async () => {
@@ -249,15 +248,22 @@ describe('serializeManifest', () => {
   });
 });
 
+describe('getManifestPath', () => {
+  it('places the manifest in the internal directory of the Storybook build', () => {
+    expect(getManifestPath('/repo/packages/ui/storybook-static')).toBe(
+      '/repo/packages/ui/storybook-static/.chromatic/turbosnap-manifest.json'
+    );
+  });
+});
+
 describe('writeManifest', () => {
-  const outputDirectory = '/repo/packages/ui/chromatic';
-  const manifestPath = path.join(outputDirectory, 'turbosnap-manifest.json');
+  const manifestPath = '/repo/packages/ui/storybook-static/.chromatic/turbosnap-manifest.json';
 
   it('writes the serialized manifest as JSON to turbosnap-manifest.json in the output directory', async () => {
     const { disk, input } = createFixture();
     const manifest = await manifestWithPreview('preview.ts');
 
-    writeManifest(manifest, outputDirectory, input.projectFiles);
+    writeManifest(manifest, manifestPath, input.projectFiles);
 
     expect(disk.writtenFiles?.[manifestPath]).toBe(JSON.stringify(serializeManifest(manifest)));
   });
@@ -266,7 +272,7 @@ describe('writeManifest', () => {
     const { disk, input } = createFixture();
     // The file is uploaded to S3 and read back for debugging, so it has to be valid JSON with the
     // Maps and Sets already flattened.
-    writeManifest(await manifestWithPreview('preview.ts'), outputDirectory, input.projectFiles);
+    writeManifest(await manifestWithPreview('preview.ts'), manifestPath, input.projectFiles);
 
     const payload = disk.writtenFiles?.[manifestPath] ?? '';
 

--- a/node-src/lib/turbosnap/v2/manifest.ts
+++ b/node-src/lib/turbosnap/v2/manifest.ts
@@ -195,42 +195,29 @@ function comparePaths(a: FilePath, b: FilePath): number {
 }
 
 /**
- * Locates the internal directory that holds the Manifest for a Storybook build.
+ * Locates the serialized Manifest inside a Storybook build directory. The Manifest lives in the
+ * internal `.chromatic` directory, which is excluded from the build upload and uploaded separately
+ * as build metadata.
  *
  * @param sourceDirectory The Storybook build output directory.
  *
- * @returns The absolute internal metadata directory.
- */
-export function getManifestOutputDirectory(sourceDirectory: string): string {
-  return path.join(sourceDirectory, '.chromatic');
-}
-
-/**
- * Locates the serialized Manifest within its output directory.
- *
- * @param outputDirectory The directory that holds the Manifest.
- *
  * @returns The absolute Manifest path.
  */
-export function getManifestPath(outputDirectory: string): string {
-  return path.join(outputDirectory, 'turbosnap-manifest.json');
+export function getManifestPath(sourceDirectory: string): string {
+  return path.join(sourceDirectory, '.chromatic', 'turbosnap-manifest.json');
 }
 
 /**
- * Writes the entire manifest to a file in the output directory. This is uploaded to S3 for
- * debugging.
+ * Writes the entire manifest to a file. This is uploaded to S3 for debugging.
  *
  * @param manifest The manifest to write.
- * @param outputDirectory The directory to write the manifest file to.
+ * @param manifestPath The path to write the manifest file to.
  * @param projectFiles How to write the disk.
  */
 export function writeManifest(
   manifest: TurboSnapManifest,
-  outputDirectory: string,
+  manifestPath: string,
   projectFiles: ProjectFiles
 ) {
-  projectFiles.writeFile(
-    getManifestPath(outputDirectory),
-    JSON.stringify(serializeManifest(manifest))
-  );
+  projectFiles.writeFile(manifestPath, JSON.stringify(serializeManifest(manifest)));
 }

--- a/node-src/lib/turbosnap/v2/manifest.ts
+++ b/node-src/lib/turbosnap/v2/manifest.ts
@@ -87,6 +87,7 @@ export async function buildManifest(
   input: ManifestInput
 ): Promise<TurboSnapManifest> {
   const { files, hashes, storyFiles } = await readStatsGraph(stats, input);
+  input.log.debug(`Found ${storyFiles.size} story files from preview-stats.json`);
 
   const { h64ToString } = await xxHashWasm();
   const storyFileHashes = new Map<FilePath, FileHash>();
@@ -108,6 +109,10 @@ export async function buildManifest(
     normalizeStatsPath(input.configDir, input.projectRoot),
     h64ToString
   );
+  input.log.debug(
+    `Attributed ${attribution.previewSubtree.size} files to the preview config subtree`
+  );
+  input.log.debug(`Found ${attribution.storybookGlobals.size} global files not linked to a story`);
 
   // The preview core runtime may not exist in the module graph, so no file hash can see a Storybook
   // upgrade there. Track the version instead; it is a plain string, not a hash.
@@ -122,6 +127,12 @@ export async function buildManifest(
   for (const [key, hash] of rollUpOutOfGraphFiles(outOfGraphFiles, h64ToString)) {
     storybookConfigHashes.set(key, hash);
   }
+  input.log.debug(
+    `Hashed ${outOfGraphFiles.staticFiles.size} static files in ${input.staticDirs.join(', ')}`
+  );
+  input.log.debug(
+    `Hashed ${outOfGraphFiles.storybookConfigFiles.size} storybook config files in ${input.configDir}`
+  );
 
   // The backend's top-level "did Storybook change at all?" gate: the key and hash of every story
   // file plus every `storybookConfigHashes` entry, so additions, removals and renames are all visible

--- a/node-src/lib/turbosnap/v2/manifest.ts
+++ b/node-src/lib/turbosnap/v2/manifest.ts
@@ -195,6 +195,28 @@ function comparePaths(a: FilePath, b: FilePath): number {
 }
 
 /**
+ * Locates the internal directory that holds the Manifest for a Storybook build.
+ *
+ * @param sourceDirectory The Storybook build output directory.
+ *
+ * @returns The absolute internal metadata directory.
+ */
+export function getManifestOutputDirectory(sourceDirectory: string): string {
+  return path.join(sourceDirectory, '.chromatic');
+}
+
+/**
+ * Locates the serialized Manifest within its output directory.
+ *
+ * @param outputDirectory The directory that holds the Manifest.
+ *
+ * @returns The absolute Manifest path.
+ */
+export function getManifestPath(outputDirectory: string): string {
+  return path.join(outputDirectory, 'turbosnap-manifest.json');
+}
+
+/**
  * Writes the entire manifest to a file in the output directory. This is uploaded to S3 for
  * debugging.
  *
@@ -208,7 +230,7 @@ export function writeManifest(
   projectFiles: ProjectFiles
 ) {
   projectFiles.writeFile(
-    path.join(outputDirectory, 'turbosnap-manifest.json'),
+    getManifestPath(outputDirectory),
     JSON.stringify(serializeManifest(manifest))
   );
 }

--- a/node-src/lib/turbosnap/v2/manifestInput.ts
+++ b/node-src/lib/turbosnap/v2/manifestInput.ts
@@ -1,4 +1,5 @@
 import { AbsolutePath } from '../../../types';
+import { Logger } from '../../log';
 import { ProjectFiles } from './projectFiles';
 
 /**
@@ -9,6 +10,8 @@ import { ProjectFiles } from './projectFiles';
  * same project. Each stage narrows it to the fields it actually uses with a `Pick`.
  */
 export interface ManifestInput {
+  /** The logger to use for logging. */
+  log: Logger;
   /** The absolute Storybook project root that canonical manifest keys are relative to. */
   projectRoot: AbsolutePath;
   /**

--- a/node-src/lib/turbosnap/v2/projectFiles.test.ts
+++ b/node-src/lib/turbosnap/v2/projectFiles.test.ts
@@ -266,7 +266,7 @@ describe('realProjectFiles writeFile', () => {
     const root = temporaryDirectory();
     const filePath = path.join(root, 'storybook-static/.chromatic/turbosnap-manifest.json');
 
-    realProjectFiles(log).writeFile(filePath, '{"storybookHash":"abc"}');
+    realProjectFiles().writeFile(filePath, '{"storybookHash":"abc"}');
 
     expect(readFileSync(filePath, 'utf8')).toBe('{"storybookHash":"abc"}');
   });

--- a/node-src/lib/turbosnap/v2/projectFiles.test.ts
+++ b/node-src/lib/turbosnap/v2/projectFiles.test.ts
@@ -11,6 +11,7 @@ import { tmpdir } from 'os';
 import path from 'path';
 import { afterEach, describe, expect, it } from 'vitest';
 
+import TestLogger from '../../testLogger';
 import { realProjectFiles } from './projectFiles';
 
 // The real adapter's whole job is knowing what the disk means, so these run against real temporary
@@ -18,6 +19,7 @@ import { realProjectFiles } from './projectFiles';
 // symlink semantics can only prove the fake follows them.
 let temporaryDirectories: string[] = [];
 let lockedDirectories: string[] = [];
+const log = new TestLogger();
 
 afterEach(() => {
   // Unlock the directories before removal because it's required in order to remove them.
@@ -87,7 +89,7 @@ describe('realProjectFiles listTree', () => {
     write(root, 'static/logo.svg');
     write(root, 'static/nested/deep/font.woff2');
 
-    const files = realProjectFiles().listTree(path.join(root, 'static'));
+    const files = realProjectFiles(log).listTree(path.join(root, 'static'));
 
     expect(files.sort()).toEqual([
       path.join(root, 'static/logo.svg'),
@@ -101,7 +103,7 @@ describe('realProjectFiles listTree', () => {
     mkdirSync(path.join(root, 'static'));
     symlinkSync(target, path.join(root, 'static/logo.svg'));
 
-    const files = realProjectFiles().listTree(path.join(root, 'static'));
+    const files = realProjectFiles(log).listTree(path.join(root, 'static'));
 
     expect(files).toEqual([path.join(root, 'static/logo.svg')]);
   });
@@ -113,7 +115,7 @@ describe('realProjectFiles listTree', () => {
     mkdirSync(path.join(root, 'static'));
     symlinkSync(path.join(root, 'node_modules/pkg/dist'), path.join(root, 'static/vendor'));
 
-    const files = realProjectFiles().listTree(path.join(root, 'static'));
+    const files = realProjectFiles(log).listTree(path.join(root, 'static'));
 
     expect(files.sort()).toEqual([
       path.join(root, 'static/vendor/a.png'),
@@ -128,9 +130,9 @@ describe('realProjectFiles listTree', () => {
     symlinkSync(path.join(root, 'vendor/assets'), path.join(root, 'static/brand'));
     symlinkSync(path.join(root, 'vendor/assets'), path.join(root, 'static/legacy'));
 
-    const before = realProjectFiles().listTree(path.join(root, 'static'));
+    const before = realProjectFiles(log).listTree(path.join(root, 'static'));
     rmSync(path.join(root, 'static/legacy'));
-    const after = realProjectFiles().listTree(path.join(root, 'static'));
+    const after = realProjectFiles(log).listTree(path.join(root, 'static'));
 
     expect(before.sort()).toEqual([
       path.join(root, 'static/brand/logo.svg'),
@@ -144,7 +146,7 @@ describe('realProjectFiles listTree', () => {
     write(root, 'static/keep.svg');
     symlinkSync(path.join(root, 'gone.svg'), path.join(root, 'static/logo.svg'));
 
-    const files = realProjectFiles().listTree(path.join(root, 'static'));
+    const files = realProjectFiles(log).listTree(path.join(root, 'static'));
 
     expect(files).toEqual([path.join(root, 'static/keep.svg')]);
   });
@@ -154,7 +156,7 @@ describe('realProjectFiles listTree', () => {
     write(root, 'static/logo.svg');
     symlinkSync(path.join(root, 'static'), path.join(root, 'static/loop'));
 
-    const files = realProjectFiles().listTree(path.join(root, 'static'));
+    const files = realProjectFiles(log).listTree(path.join(root, 'static'));
 
     expect(files).toEqual([path.join(root, 'static/logo.svg')]);
   });
@@ -162,7 +164,7 @@ describe('realProjectFiles listTree', () => {
   it('is empty for a directory that does not exist, since a missing staticDir is not an error', async () => {
     const root = temporaryDirectory();
 
-    const files = realProjectFiles().listTree(path.join(root, 'absent'));
+    const files = realProjectFiles(log).listTree(path.join(root, 'absent'));
 
     expect(files).toEqual([]);
   });
@@ -174,7 +176,7 @@ describe('realProjectFiles listTree', () => {
     // different point than a missing directory.
     lock(path.join(root, 'locked'));
 
-    const files = realProjectFiles().listTree(path.join(root, 'locked'));
+    const files = realProjectFiles(log).listTree(path.join(root, 'locked'));
 
     expect(files).toEqual([]);
   });
@@ -185,8 +187,8 @@ describe('realProjectFiles isFile and isDirectory', () => {
     const root = temporaryDirectory();
     const filePath = write(root, 'src/Button.tsx');
 
-    expect(realProjectFiles().isFile(filePath)).toBe(true);
-    expect(realProjectFiles().isDirectory(filePath)).toBe(false);
+    expect(realProjectFiles(log).isFile(filePath)).toBe(true);
+    expect(realProjectFiles(log).isDirectory(filePath)).toBe(false);
   });
 
   it('reads a directory as a directory and not a file, which is what keeps EISDIR out of hashing', () => {
@@ -196,16 +198,16 @@ describe('realProjectFiles isFile and isDirectory', () => {
     write(root, 'node_modules/@storybook/react/dist/entry-preview.js');
     const directoryNamedAsAModule = path.join(root, 'node_modules/@storybook/react/dist');
 
-    expect(realProjectFiles().isFile(directoryNamedAsAModule)).toBe(false);
-    expect(realProjectFiles().isDirectory(directoryNamedAsAModule)).toBe(true);
+    expect(realProjectFiles(log).isFile(directoryNamedAsAModule)).toBe(false);
+    expect(realProjectFiles(log).isDirectory(directoryNamedAsAModule)).toBe(true);
   });
 
   it('reads an absent path as false for both', () => {
     const root = temporaryDirectory();
     const absent = path.join(root, 'src/gone.tsx');
 
-    expect(realProjectFiles().isFile(absent)).toBe(false);
-    expect(realProjectFiles().isDirectory(absent)).toBe(false);
+    expect(realProjectFiles(log).isFile(absent)).toBe(false);
+    expect(realProjectFiles(log).isDirectory(absent)).toBe(false);
   });
 
   it('reads a symlink to a file as a file', () => {
@@ -214,7 +216,7 @@ describe('realProjectFiles isFile and isDirectory', () => {
     mkdirSync(path.join(root, 'static'));
     symlinkSync(target, path.join(root, 'static/logo.svg'));
 
-    expect(realProjectFiles().isFile(path.join(root, 'static/logo.svg'))).toBe(true);
+    expect(realProjectFiles(log).isFile(path.join(root, 'static/logo.svg'))).toBe(true);
   });
 });
 
@@ -224,7 +226,7 @@ describe('realProjectFiles hashAll', () => {
     const button = write(root, 'src/Button.tsx');
     const header = write(root, 'src/Header.tsx');
 
-    const hashes = await realProjectFiles().hashAll([button, header]);
+    const hashes = await realProjectFiles(log).hashAll([button, header]);
 
     expect(Object.keys(hashes).sort()).toEqual([button, header].sort());
     expect(hashes[button]).not.toBe(hashes[header]);
@@ -235,13 +237,13 @@ describe('realProjectFiles hashAll', () => {
     const original = write(root, 'src/Button.tsx', 'export const Button = () => null;');
     const copy = write(root, 'src/copy/Button.tsx', 'export const Button = () => null;');
 
-    const hashes = await realProjectFiles().hashAll([original, copy]);
+    const hashes = await realProjectFiles(log).hashAll([original, copy]);
 
     expect(hashes[original]).toBe(hashes[copy]);
   });
 
   it('hashes nothing for no paths', async () => {
-    expect(await realProjectFiles().hashAll([])).toEqual({});
+    expect(await realProjectFiles(log).hashAll([])).toEqual({});
   });
 
   it('read errors throw with the file that it failed to read', async () => {
@@ -252,7 +254,7 @@ describe('realProjectFiles hashAll', () => {
 
     let err: Error | undefined;
     try {
-      await realProjectFiles().hashAll([readable, unreadable]);
+      await realProjectFiles(log).hashAll([readable, unreadable]);
     } catch (error) {
       err = error as Error;
     }
@@ -266,7 +268,7 @@ describe('realProjectFiles writeFile', () => {
     const root = temporaryDirectory();
     const filePath = path.join(root, 'storybook-static/.chromatic/turbosnap-manifest.json');
 
-    realProjectFiles().writeFile(filePath, '{"storybookHash":"abc"}');
+    realProjectFiles(log).writeFile(filePath, '{"storybookHash":"abc"}');
 
     expect(readFileSync(filePath, 'utf8')).toBe('{"storybookHash":"abc"}');
   });
@@ -275,7 +277,7 @@ describe('realProjectFiles writeFile', () => {
     const root = temporaryDirectory();
     const filePath = path.join(root, 'turbosnap-manifest.json');
 
-    realProjectFiles().writeFile(filePath, '{"storybookHash":"abc"}');
+    realProjectFiles(log).writeFile(filePath, '{"storybookHash":"abc"}');
 
     expect(readFileSync(filePath, 'utf8')).toBe('{"storybookHash":"abc"}');
   });
@@ -284,7 +286,7 @@ describe('realProjectFiles writeFile', () => {
     const root = temporaryDirectory();
     const filePath = write(root, 'turbosnap-manifest.json', 'stale');
 
-    realProjectFiles().writeFile(filePath, 'fresh');
+    realProjectFiles(log).writeFile(filePath, 'fresh');
 
     expect(readFileSync(filePath, 'utf8')).toBe('fresh');
   });
@@ -295,7 +297,7 @@ describe('realProjectFiles packageVersion', () => {
     const root = temporaryDirectory();
     install(root, 'storybook', { name: 'storybook', version: '9.1.20' });
 
-    expect(realProjectFiles().packageVersion(root, 'storybook')).toBe('9.1.20');
+    expect(realProjectFiles(log).packageVersion(root, 'storybook')).toBe('9.1.20');
   });
 
   it('walks up from the directory, so a workspace-hoisted install is found', () => {
@@ -304,7 +306,7 @@ describe('realProjectFiles packageVersion', () => {
     mkdirSync(projectRoot, { recursive: true });
     install(repositoryRoot, 'storybook', { name: 'storybook', version: '9.1.20' });
 
-    expect(realProjectFiles().packageVersion(projectRoot, 'storybook')).toBe('9.1.20');
+    expect(realProjectFiles(log).packageVersion(projectRoot, 'storybook')).toBe('9.1.20');
   });
 
   it('reports no version for a package that does not export its own manifest', () => {
@@ -317,19 +319,19 @@ describe('realProjectFiles packageVersion', () => {
       exports: { '.': './index.js' },
     });
 
-    expect(realProjectFiles().packageVersion(root, 'sealed')).toBeUndefined();
+    expect(realProjectFiles(log).packageVersion(root, 'sealed')).toBeUndefined();
   });
 
   it('reports no version for a package whose manifest has none', () => {
     const root = temporaryDirectory();
     install(root, 'storybook', { name: 'storybook' });
 
-    expect(realProjectFiles().packageVersion(root, 'storybook')).toBeUndefined();
+    expect(realProjectFiles(log).packageVersion(root, 'storybook')).toBeUndefined();
   });
 
   it('reports no version for a package that is not installed', () => {
     const root = temporaryDirectory();
 
-    expect(realProjectFiles().packageVersion(root, '@storybook/builder-vite')).toBeUndefined();
+    expect(realProjectFiles(log).packageVersion(root, '@storybook/builder-vite')).toBeUndefined();
   });
 });

--- a/node-src/lib/turbosnap/v2/projectFiles.test.ts
+++ b/node-src/lib/turbosnap/v2/projectFiles.test.ts
@@ -262,6 +262,15 @@ describe('realProjectFiles hashAll', () => {
 });
 
 describe('realProjectFiles writeFile', () => {
+  it('creates absent parent directories before writing', () => {
+    const root = temporaryDirectory();
+    const filePath = path.join(root, 'storybook-static/.chromatic/turbosnap-manifest.json');
+
+    realProjectFiles(log).writeFile(filePath, '{"storybookHash":"abc"}');
+
+    expect(readFileSync(filePath, 'utf8')).toBe('{"storybookHash":"abc"}');
+  });
+
   it('writes the contents to the path, readable back as the same bytes', () => {
     const root = temporaryDirectory();
     const filePath = path.join(root, 'turbosnap-manifest.json');

--- a/node-src/lib/turbosnap/v2/projectFiles.ts
+++ b/node-src/lib/turbosnap/v2/projectFiles.ts
@@ -1,9 +1,11 @@
 import { mkdirSync, readdirSync, readFileSync, realpathSync, statSync, writeFileSync } from 'fs';
+import { Dirent } from 'fs';
 import { createRequire } from 'module';
 import path from 'path';
 
 import { AbsolutePath } from '../../../types';
 import { getFileHashes } from '../../getFileHashes';
+import { Logger } from '../../log';
 import { FileHash } from './graph';
 
 /**
@@ -30,9 +32,11 @@ export interface ProjectFiles {
  * The adapter backed by the real disk. Constructed explicitly by the caller, never defaulted: a
  * default is exactly how a test would silently read the machine it runs on.
  *
+ * @param log The logger to use.
+ *
  * @returns An adapter to read from the real file system.
  */
-export function realProjectFiles(): ProjectFiles {
+export function realProjectFiles(log: Logger): ProjectFiles {
   return {
     isFile: (absolutePath: AbsolutePath) =>
       statSync(absolutePath, { throwIfNoEntry: false })?.isFile() ?? false,
@@ -40,7 +44,7 @@ export function realProjectFiles(): ProjectFiles {
       statSync(absolutePath, { throwIfNoEntry: false })?.isDirectory() ?? false,
     packageVersion: readPackageVersion,
     hashAll: hashFileContents,
-    listTree: (absoluteDirectory: AbsolutePath) => listFilesRecursively(absoluteDirectory),
+    listTree: (absoluteDirectory: AbsolutePath) => listFilesRecursively(log, absoluteDirectory),
     writeFile: (absolutePath: AbsolutePath, contents: string) => {
       mkdirSync(path.dirname(absolutePath), { recursive: true });
       writeFileSync(absolutePath, contents);
@@ -106,6 +110,7 @@ function namePathThatFailed(error: any, absolutePaths: AbsolutePath[]): string {
  * contributes nothing rather than throwing: a configured-but-missing `staticDir` is not an error, and
  * v1 never matches such a path either. The same holds for a broken symlink, whose target can't be read.
  *
+ * @param log The logger to use.
  * @param directory The absolute directory to walk.
  * @param ancestorDirectories Resolved real paths in the current branch, so a symlink cycle
  * terminates without suppressing sibling aliases to the same directory.
@@ -113,13 +118,15 @@ function namePathThatFailed(error: any, absolutePaths: AbsolutePath[]): string {
  * @returns The absolute path of every file found.
  */
 function listFilesRecursively(
+  log: Logger,
   directory: AbsolutePath,
   ancestorDirectories = new Set<AbsolutePath>()
 ): AbsolutePath[] {
   let realDirectory;
   try {
     realDirectory = realpathSync(directory);
-  } catch {
+  } catch (error) {
+    log.debug(`Failed to resolve ${directory} when listing files`, error);
     return [];
   }
 
@@ -132,14 +139,15 @@ function listFilesRecursively(
     let entries;
     try {
       entries = readdirSync(directory, { withFileTypes: true });
-    } catch {
+    } catch (error) {
+      log.debug(`Failed to read directory ${directory} when listing files`, error);
       return [];
     }
 
-    return entries.flatMap((entry) => {
+    return entries.flatMap((entry: Dirent) => {
       const entryPath = path.join(directory, entry.name);
       if (entry.isDirectory()) {
-        return listFilesRecursively(entryPath, ancestorDirectories);
+        return listFilesRecursively(log, entryPath, ancestorDirectories);
       }
       if (entry.isFile()) {
         return [entryPath];
@@ -150,10 +158,11 @@ function listFilesRecursively(
       try {
         const stats = statSync(entryPath);
         if (stats.isDirectory()) {
-          return listFilesRecursively(entryPath, ancestorDirectories);
+          return listFilesRecursively(log, entryPath, ancestorDirectories);
         }
         return stats.isFile() ? [entryPath] : [];
-      } catch {
+      } catch (error) {
+        log.debug(`Failed to stat ${entryPath} when listing files`, error);
         return [];
       }
     });

--- a/node-src/lib/turbosnap/v2/projectFiles.ts
+++ b/node-src/lib/turbosnap/v2/projectFiles.ts
@@ -1,4 +1,4 @@
-import { readdirSync, readFileSync, realpathSync, statSync, writeFileSync } from 'fs';
+import { mkdirSync, readdirSync, readFileSync, realpathSync, statSync, writeFileSync } from 'fs';
 import { createRequire } from 'module';
 import path from 'path';
 
@@ -22,7 +22,7 @@ export interface ProjectFiles {
   ): Promise<Record<AbsolutePath, FileHash>>;
   /** Follows symlinks, names files by the link path, terminates on a cycle, empty when absent. */
   listTree(absoluteDirectory: AbsolutePath): AbsolutePath[];
-  /** Writes the contents to the file, creating or overwriting it. */
+  /** Writes the contents to the file, creating parent directories and overwriting it if present. */
   writeFile(absolutePath: AbsolutePath, contents: string): void;
 }
 
@@ -41,8 +41,10 @@ export function realProjectFiles(): ProjectFiles {
     packageVersion: readPackageVersion,
     hashAll: hashFileContents,
     listTree: (absoluteDirectory: AbsolutePath) => listFilesRecursively(absoluteDirectory),
-    writeFile: (absolutePath: AbsolutePath, contents: string) =>
-      writeFileSync(absolutePath, contents),
+    writeFile: (absolutePath: AbsolutePath, contents: string) => {
+      mkdirSync(path.dirname(absolutePath), { recursive: true });
+      writeFileSync(absolutePath, contents);
+    },
   };
 }
 

--- a/node-src/lib/uploadMetadataFiles.test.ts
+++ b/node-src/lib/uploadMetadataFiles.test.ts
@@ -88,6 +88,33 @@ describe('uploadMetadataFiles', () => {
     expect(logResumeCallOrder).toBeGreaterThan(uploadFilesCallOrder);
   });
 
+  it('uploads the TurboSnap Manifest from the internal build directory', async () => {
+    const runQuery = vi.fn().mockResolvedValue({
+      uploadMetadata: { info: { targets: [] }, userErrors: [] },
+    });
+    const ctx = {
+      ...baseContext,
+      sourceDir: '/repo/storybook-static',
+      announcedBuild: { id: '1' },
+      build: { storybookUrl: 'https://sample-storybook.dev-chromatic.com' },
+      client: { runQuery },
+    } as any;
+
+    await uploadMetadataFiles(ctx);
+
+    expect(runQuery).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        files: expect.arrayContaining([
+          {
+            contentLength: 100,
+            filePath: '.chromatic/turbosnap-manifest.json',
+          },
+        ]),
+      })
+    );
+  });
+
   it('does not throw when the upload fails, reporting to Sentry and resuming the log', async () => {
     vi.mocked(uploadFiles).mockRejectedValueOnce(new Error('network boom'));
 

--- a/node-src/lib/uploadMetadataFiles.test.ts
+++ b/node-src/lib/uploadMetadataFiles.test.ts
@@ -1,4 +1,5 @@
 import * as Sentry from '@sentry/node';
+import { stat } from 'fs';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import TestLogger from './testLogger';
@@ -112,6 +113,33 @@ describe('uploadMetadataFiles', () => {
           },
         ]),
       })
+    );
+  });
+
+  it('omits the TurboSnap Manifest when the build did not write one', async () => {
+    vi.mocked(stat).mockImplementation((filePath, callback: any) =>
+      String(filePath).endsWith('turbosnap-manifest.json')
+        ? callback(new Error('ENOENT'), undefined)
+        : callback(null, { size: 100 })
+    );
+    const runQuery = vi.fn().mockResolvedValue({
+      uploadMetadata: { info: { targets: [] }, userErrors: [] },
+    });
+    const ctx = {
+      ...baseContext,
+      options: { logFile: 'chromatic.log' },
+      sourceDir: '/repo/storybook-static',
+      announcedBuild: { id: '1' },
+      build: { storybookUrl: 'https://sample-storybook.dev-chromatic.com' },
+      client: { runQuery },
+    } as any;
+
+    await uploadMetadataFiles(ctx);
+
+    const { files } = runQuery.mock.calls[0][1];
+    expect(files).toContainEqual(expect.objectContaining({ filePath: '.chromatic/chromatic.log' }));
+    expect(files).not.toContainEqual(
+      expect.objectContaining({ filePath: '.chromatic/turbosnap-manifest.json' })
     );
   });
 

--- a/node-src/lib/uploadMetadataFiles.ts
+++ b/node-src/lib/uploadMetadataFiles.ts
@@ -12,6 +12,7 @@ import {
   MAIN_CONFIG_PATTERN,
   PREVIEW_CONFIG_PATTERN,
 } from './getStorybookMetadata';
+import { getManifestOutputDirectory, getManifestPath } from './turbosnap/v2/manifest';
 import { uploadMetadata } from './upload';
 
 const fileSize = (path: string): Promise<number> =>
@@ -36,7 +37,7 @@ export async function uploadMetadataFiles(ctx: Context) {
         ctx.options.logFile,
         ctx.options.diagnosticsFile,
         ctx.options.storybookLogFile,
-        ctx.sourceDir && path.join(ctx.sourceDir, '.chromatic', 'turbosnap-manifest.json'),
+        ctx.sourceDir && getManifestPath(getManifestOutputDirectory(ctx.sourceDir)),
         await findStorybookConfigFile(ctx.options.storybookConfigDir, MAIN_CONFIG_PATTERN).catch(
           () => undefined
         ),

--- a/node-src/lib/uploadMetadataFiles.ts
+++ b/node-src/lib/uploadMetadataFiles.ts
@@ -12,7 +12,7 @@ import {
   MAIN_CONFIG_PATTERN,
   PREVIEW_CONFIG_PATTERN,
 } from './getStorybookMetadata';
-import { getManifestOutputDirectory, getManifestPath } from './turbosnap/v2/manifest';
+import { getManifestPath } from './turbosnap/v2/manifest';
 import { uploadMetadata } from './upload';
 
 const fileSize = (path: string): Promise<number> =>
@@ -37,7 +37,7 @@ export async function uploadMetadataFiles(ctx: Context) {
         ctx.options.logFile,
         ctx.options.diagnosticsFile,
         ctx.options.storybookLogFile,
-        ctx.sourceDir && getManifestPath(getManifestOutputDirectory(ctx.sourceDir)),
+        ctx.sourceDir && getManifestPath(ctx.sourceDir),
         await findStorybookConfigFile(ctx.options.storybookConfigDir, MAIN_CONFIG_PATTERN).catch(
           () => undefined
         ),

--- a/node-src/lib/uploadMetadataFiles.ts
+++ b/node-src/lib/uploadMetadataFiles.ts
@@ -36,6 +36,7 @@ export async function uploadMetadataFiles(ctx: Context) {
         ctx.options.logFile,
         ctx.options.diagnosticsFile,
         ctx.options.storybookLogFile,
+        ctx.sourceDir && path.join(ctx.sourceDir, '.chromatic', 'turbosnap-manifest.json'),
         await findStorybookConfigFile(ctx.options.storybookConfigDir, MAIN_CONFIG_PATTERN).catch(
           () => undefined
         ),

--- a/node-src/tasks/build/index.ts
+++ b/node-src/tasks/build/index.ts
@@ -17,6 +17,7 @@ export interface BuildInput {
   projectId?: string;
   runtimeMetadata?: Context['runtimeMetadata'];
   git: Context['git'];
+  turboSnap?: Context['turboSnap'];
 }
 
 export interface BuildOutput {
@@ -88,7 +89,7 @@ async function buildWebProject(deps: Deps, input: BuildInput): Promise<TaskResul
       sourceDir,
       flags: input.flags,
       storybook: input.storybook,
-      changedFiles: input.git.changedFiles,
+      turboSnap: input.turboSnap,
     }
   );
 
@@ -144,6 +145,7 @@ export const extractBuildInput = (ctx: Context): BuildInput => ({
   projectId: ctx.announcedBuild?.app?.id,
   runtimeMetadata: ctx.runtimeMetadata,
   git: ctx.git,
+  turboSnap: ctx.turboSnap,
 });
 
 export const applyBuildOutput = (ctx: Context, output: BuildOutput) => {

--- a/node-src/tasks/build/setBuildCommand.test.ts
+++ b/node-src/tasks/build/setBuildCommand.test.ts
@@ -26,7 +26,7 @@ describe('setBuildCommand', () => {
         ...baseInput,
         sourceDir: './source-dir/',
         storybook: { version: '6.2.0' },
-        changedFiles: ['./index.js'],
+        turboSnap: {},
       }
     );
 
@@ -47,7 +47,7 @@ describe('setBuildCommand', () => {
         ...baseInput,
         sourceDir: './source-dir/',
         storybook: { version: '6.2.0' },
-        changedFiles: ['./index.js'],
+        turboSnap: {},
       }
     );
 
@@ -68,7 +68,7 @@ describe('setBuildCommand', () => {
         ...baseInput,
         sourceDir: './source-dir/',
         storybook: { version: '6.2.0' },
-        changedFiles: ['./index.js'],
+        turboSnap: {},
       }
     );
 
@@ -80,6 +80,54 @@ describe('setBuildCommand', () => {
     expect(result).toEqual('pnpm run build:storybook');
   });
 
+  it('emits the stats file when TurboSnap is enabled', async () => {
+    getCliCommand.mockReturnValue(Promise.resolve('npm run build:storybook'));
+
+    const result = await setBuildCommand(
+      { ...baseDeps, options: { buildScriptName: 'build:storybook' } },
+      { ...baseInput, sourceDir: './source-dir/', turboSnap: {} }
+    );
+
+    expect(getCliCommand).toHaveBeenCalledWith(
+      expect.anything(),
+      ['build:storybook', '--output-dir=./source-dir/', '--webpack-stats-json=./source-dir/'],
+      { programmatic: true }
+    );
+    expect(result).toEqual('npm run build:storybook');
+  });
+
+  it('emits the stats file when TurboSnap bailed on a rebuild', async () => {
+    getCliCommand.mockReturnValue(Promise.resolve('npm run build:storybook'));
+
+    const result = await setBuildCommand(
+      { ...baseDeps, options: { buildScriptName: 'build:storybook' } },
+      { ...baseInput, sourceDir: './source-dir/', turboSnap: { status: 'bailed' } }
+    );
+
+    expect(getCliCommand).toHaveBeenCalledWith(
+      expect.anything(),
+      ['build:storybook', '--output-dir=./source-dir/', '--webpack-stats-json=./source-dir/'],
+      { programmatic: true }
+    );
+    expect(result).toEqual('npm run build:storybook');
+  });
+
+  it('does not emit the stats file when TurboSnap is unavailable', async () => {
+    getCliCommand.mockReturnValue(Promise.resolve('npm run build:storybook'));
+
+    const result = await setBuildCommand(
+      { ...baseDeps, options: { buildScriptName: 'build:storybook' } },
+      { ...baseInput, sourceDir: './source-dir/', turboSnap: { unavailable: true } }
+    );
+
+    expect(getCliCommand).toHaveBeenCalledWith(
+      expect.anything(),
+      ['build:storybook', '--output-dir=./source-dir/'],
+      { programmatic: true }
+    );
+    expect(result).toEqual('npm run build:storybook');
+  });
+
   it('uses --build-command, if set', async () => {
     getCliCommand.mockReturnValue(Promise.resolve('npm run build:storybook'));
 
@@ -89,7 +137,7 @@ describe('setBuildCommand', () => {
         ...baseInput,
         sourceDir: './source-dir/',
         storybook: { version: '6.2.0' },
-        changedFiles: ['./index.js'],
+        turboSnap: {},
       }
     );
 
@@ -105,7 +153,7 @@ describe('setBuildCommand', () => {
         ...baseInput,
         sourceDir: './source-dir/',
         storybook: { version: '6.1.0' },
-        changedFiles: ['./index.js'],
+        turboSnap: {},
       }
     );
     expect(log.warn).toHaveBeenCalledWith(
@@ -122,7 +170,7 @@ describe('setBuildCommand', () => {
         ...baseInput,
         sourceDir: './source-dir/',
         storybook: { version: '8.4.0' },
-        changedFiles: ['./index.js'],
+        turboSnap: {},
       }
     );
 
@@ -143,7 +191,7 @@ describe('setBuildCommand', () => {
         ...baseInput,
         sourceDir: './source-dir/',
         storybook: { version: '8.5.0' },
-        changedFiles: ['./index.js'],
+        turboSnap: {},
       }
     );
 
@@ -160,7 +208,7 @@ describe('setBuildCommand', () => {
 
     const result = await setBuildCommand(
       { ...baseDeps, options: { buildScriptName: 'build:storybook' } },
-      { ...baseInput, sourceDir: './source-dir/', changedFiles: ['./index.js'] }
+      { ...baseInput, sourceDir: './source-dir/', turboSnap: {} }
     );
 
     expect(getCliCommand).toHaveBeenCalledWith(

--- a/node-src/tasks/build/setBuildCommand.ts
+++ b/node-src/tasks/build/setBuildCommand.ts
@@ -12,7 +12,7 @@ interface SetBuildCommandInput {
   sourceDir: string;
   flags: Context['flags'];
   storybook?: Context['storybook'];
-  changedFiles?: string[];
+  turboSnap?: Context['turboSnap'];
 }
 
 const isStatsFlagSupported = (storybook?: Context['storybook']) => {
@@ -40,7 +40,7 @@ export const setBuildCommand = async (
     buildCommandOptions.push(`--output-dir=${input.sourceDir}`);
   }
 
-  if (input.changedFiles) {
+  if (input.turboSnap && !input.turboSnap.unavailable) {
     if (isStatsFlagSupported(input.storybook)) {
       buildCommandOptions.push(`${getStatsFlag(input.storybook)}=${input.sourceDir}`);
     } else {

--- a/node-src/tasks/prepare/index.test.ts
+++ b/node-src/tasks/prepare/index.test.ts
@@ -1,0 +1,48 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { prepareProject } from '.';
+import { calculateFileHashes } from './calculateFileHashes';
+import { traceChangedFiles } from './traceChangedFiles';
+import { validateAndroidArtifact } from './validateAndroidArtifact';
+import { validateFiles } from './validateFiles';
+
+vi.mock('./calculateFileHashes');
+vi.mock('./traceChangedFiles');
+vi.mock('./validateAndroidArtifact');
+vi.mock('./validateFiles');
+
+beforeEach(() => {
+  vi.mocked(validateAndroidArtifact).mockResolvedValue(undefined);
+  vi.mocked(calculateFileHashes).mockResolvedValue({});
+});
+
+describe('prepareProject', () => {
+  it('gives TurboSnap a corrected source directory before tracing', async () => {
+    const fileInfo = {
+      lengths: [],
+      paths: [],
+      statsPath: '/repo/actual-storybook/preview-stats.json',
+      total: 0,
+    };
+    vi.mocked(validateFiles).mockResolvedValue({
+      fileInfo,
+      sourceDir: '/repo/actual-storybook',
+    });
+    vi.mocked(traceChangedFiles).mockImplementation(async (_deps, { turboSnapContext }) => {
+      expect(turboSnapContext.sourceDir).toBe('/repo/actual-storybook');
+      expect(turboSnapContext.fileInfo).toBe(fileInfo);
+      return {};
+    });
+    const turboSnapContext = {
+      sourceDir: '/repo/configured-storybook',
+    } as any;
+
+    await prepareProject({} as any, {
+      isReactNativeApp: false,
+      sourceDir: '/repo/configured-storybook',
+      turboSnapContext,
+    });
+
+    expect(traceChangedFiles).toHaveBeenCalledOnce();
+  });
+});

--- a/node-src/tasks/prepare/index.ts
+++ b/node-src/tasks/prepare/index.ts
@@ -42,8 +42,9 @@ export async function prepareProject(
 
   await validateAndroidArtifact({ sourceDir, browsers: input.browsers });
 
-  // TurboSnap reads the freshly-validated stats file; validateFiles may have corrected the directory.
+  // TurboSnap reads the freshly validated paths; validateFiles may have corrected the directory.
   input.turboSnapContext.fileInfo = fileInfo;
+  input.turboSnapContext.sourceDir = sourceDir;
   const { onlyStoryFiles } = await traceChangedFiles(deps, {
     turboSnapContext: input.turboSnapContext,
   });

--- a/node-src/tasks/prepare/traceChangedFiles.ts
+++ b/node-src/tasks/prepare/traceChangedFiles.ts
@@ -39,7 +39,6 @@ export async function traceChangedFiles(
   const ctx = input.turboSnapContext;
 
   if (!ctx.turboSnap || ctx.turboSnap.unavailable) return {};
-  if (!ctx.git.changedFiles) return {};
 
   deps.report(tracing({ git: ctx.git, options: deps.options }));
 


### PR DESCRIPTION
Closes CAP-4979

This PR merges PRs #1457 and #1459 together since `gh stack` closed them for some reason.

This PR ultimately:
1. Runs TurboSnap v2 alongside v1
2. Adds some logging throughout the v2 pipeline at the proper levels (despite not impacting the results unless flagged into v2 on the Index service)

> [!NOTE]
> We're uploading the manifest file to S3 no matter what. We don't detect if the manifest was actually written in the run (so a previous build's manifest can show up on the latest build). I decided to ignore this for now since no other metadata file handles this case either and it's a much larger change.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>18.8.0--canary.1463.33183522467.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@18.8.0--canary.1463.33183522467.0
  # or 
  yarn add chromatic@18.8.0--canary.1463.33183522467.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
