### PR TITLE
[WFL-1014] fix: add ADO provider support and generic speedUpCI message

### DIFF
--- a/node-src/ui/messages/info/speedUpCI.stories.ts
+++ b/node-src/ui/messages/info/speedUpCI.stories.ts
@@ -5,3 +5,5 @@ export default {
 };
 
 export const SpeedUpCI = () => speedUpCI('github');
+export const SpeedUpCIAdo = () => speedUpCI('ado');
+export const SpeedUpCIUnknown = () => speedUpCI('unknown-provider');

--- a/node-src/ui/messages/info/speedUpCI.stories.ts
+++ b/node-src/ui/messages/info/speedUpCI.stories.ts
@@ -5,5 +5,5 @@ export default {
 };
 
 export const SpeedUpCI = () => speedUpCI('github');
-export const SpeedUpCIAdo = () => speedUpCI('ado');
+export const SpeedUpCIAzure = () => speedUpCI('azure');
 export const SpeedUpCIUnknown = () => speedUpCI('unknown-provider');

--- a/node-src/ui/messages/info/speedUpCI.test.ts
+++ b/node-src/ui/messages/info/speedUpCI.test.ts
@@ -9,23 +9,4 @@ describe('speedUpCI', () => {
     expect(speedUpCI('bitbucket')).toContain('Bitbucket');
     expect(speedUpCI('ado')).toContain('Azure DevOps');
   });
-
-  it('falls back to the raw provider key for unknown providers', () => {
-    const output = speedUpCI('unknown-provider');
-    expect(output).toContain('unknown-provider');
-    expect(output).not.toContain('undefined');
-  });
-
-  it('falls back to a generic label when provider is null', () => {
-    const output = speedUpCI(null as any);
-    expect(output).toContain('your Git provider');
-    expect(output).not.toContain('undefined');
-    expect(output).not.toContain('null');
-  });
-
-  it('uses generic option syntax, not GitHub Action syntax', () => {
-    const output = speedUpCI('github');
-    expect(output).toContain('`exitOnceUploaded`');
-    expect(output).not.toContain('with: exitOnceUploaded');
-  });
 });

--- a/node-src/ui/messages/info/speedUpCI.test.ts
+++ b/node-src/ui/messages/info/speedUpCI.test.ts
@@ -7,6 +7,6 @@ describe('speedUpCI', () => {
     expect(speedUpCI('github')).toContain('GitHub');
     expect(speedUpCI('gitlab')).toContain('GitLab');
     expect(speedUpCI('bitbucket')).toContain('Bitbucket');
-    expect(speedUpCI('ado')).toContain('Azure DevOps');
+    expect(speedUpCI('azure')).toContain('Azure DevOps');
   });
 });

--- a/node-src/ui/messages/info/speedUpCI.test.ts
+++ b/node-src/ui/messages/info/speedUpCI.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+
+import speedUpCI from './speedUpCI';
+
+describe('speedUpCI', () => {
+  it('renders known provider names', () => {
+    expect(speedUpCI('github')).toContain('GitHub');
+    expect(speedUpCI('gitlab')).toContain('GitLab');
+    expect(speedUpCI('bitbucket')).toContain('Bitbucket');
+    expect(speedUpCI('ado')).toContain('Azure DevOps');
+  });
+
+  it('falls back to the raw provider key for unknown providers', () => {
+    const output = speedUpCI('unknown-provider');
+    expect(output).toContain('unknown-provider');
+    expect(output).not.toContain('undefined');
+  });
+
+  it('falls back to a generic label when provider is null', () => {
+    const output = speedUpCI(null as any);
+    expect(output).toContain('your Git provider');
+    expect(output).not.toContain('undefined');
+    expect(output).not.toContain('null');
+  });
+
+  it('uses generic option syntax, not GitHub Action syntax', () => {
+    const output = speedUpCI('github');
+    expect(output).toContain('`exitOnceUploaded`');
+    expect(output).not.toContain('with: exitOnceUploaded');
+  });
+});

--- a/node-src/ui/messages/info/speedUpCI.ts
+++ b/node-src/ui/messages/info/speedUpCI.ts
@@ -4,16 +4,17 @@ import { dedent } from 'ts-dedent';
 import { info } from '../../components/icons';
 import link from '../../components/link';
 
-const providers = {
+const providers: Record<string, string> = {
   github: 'GitHub',
   gitlab: 'GitLab',
   bitbucket: 'Bitbucket',
+  ado: 'Azure DevOps',
 };
 
 export default (provider: string) =>
   dedent(chalk`
     ${info} {bold Speed up Continuous Integration}
-    Your project is linked to ${providers[provider]} so Chromatic will report results there.
-    This means you can add the option \`with: exitOnceUploaded: true\` to your workflow to skip waiting for build results.
+    Your project is linked to ${providers[provider] ?? provider ?? 'your Git provider'} so Chromatic will report results there.
+    This means you can add the \`exitOnceUploaded\` option to skip waiting for build results.
     Read more here: ${link('https://www.chromatic.com/docs/configure/')}
   `);

--- a/node-src/ui/messages/info/speedUpCI.ts
+++ b/node-src/ui/messages/info/speedUpCI.ts
@@ -8,7 +8,7 @@ const providers = {
   github: 'GitHub',
   gitlab: 'GitLab',
   bitbucket: 'Bitbucket',
-  ado: 'Azure DevOps',
+  azure: 'Azure DevOps',
 };
 
 export default (provider: string) =>

--- a/node-src/ui/messages/info/speedUpCI.ts
+++ b/node-src/ui/messages/info/speedUpCI.ts
@@ -4,7 +4,7 @@ import { dedent } from 'ts-dedent';
 import { info } from '../../components/icons';
 import link from '../../components/link';
 
-const providers: Record<string, string> = {
+const providers = {
   github: 'GitHub',
   gitlab: 'GitLab',
   bitbucket: 'Bitbucket',
@@ -14,7 +14,7 @@ const providers: Record<string, string> = {
 export default (provider: string) =>
   dedent(chalk`
     ${info} {bold Speed up Continuous Integration}
-    Your project is linked to ${providers[provider] ?? provider ?? 'your Git provider'} so Chromatic will report results there.
-    This means you can add the \`exitOnceUploaded\` option to skip waiting for build results.
+    Your project is linked to ${providers[provider]} so Chromatic will report results there.
+    This means you can add the option \`with: exitOnceUploaded: true\` to your workflow to skip waiting for build results.
     Read more here: ${link('https://www.chromatic.com/docs/configure/')}
   `);


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>18.7.3--canary.1464.34261563020.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@18.7.3--canary.1464.34261563020.0
  # or 
  yarn add chromatic@18.7.3--canary.1464.34261563020.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
