### PR TITLE
fix: `chromaui/action` to resolve correct E2E package when multiple are installed

### DIFF
--- a/node-src/lib/e2e.test.ts
+++ b/node-src/lib/e2e.test.ts
@@ -1,10 +1,44 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, onTestFinished, vi } from 'vitest';
 
 import { getE2EBuildCommand } from './e2e';
 import { exitCodes } from './setExitCode';
 import TestLogger from './testLogger';
+import { patchModulePath } from './testUtilities';
+
+const PLAYWRIGHT_BUILD_ARCHIVE_BINARY = '@chromatic-com/playwright/bin/build-archive-storybook';
+
+// Mock @antfu/ni to detect package manager as npm
+vi.mock(import('@antfu/ni'), async (importOriginal) => ({
+  ...(await importOriginal()),
+  getCliCommand: async (runner, args, options) => runner('npm', args, options),
+}));
 
 describe('getE2EBuildCommand', () => {
+  const deps = { options: { inAction: false } as any, log: new TestLogger() };
+
+  it("can resolve E2E package when it's installed", async () => {
+    const expectedBinary = '/path/to/playwright/bin/build-archive-storybook';
+    const restore = patchModulePath(PLAYWRIGHT_BUILD_ARCHIVE_BINARY, expectedBinary);
+    onTestFinished(restore);
+
+    const command = await getE2EBuildCommand(deps, 'playwright', ['--output-dir=./source-dir/']);
+
+    expect(command).toBe(`node ${expectedBinary} --output-dir=./source-dir/`);
+  });
+
+  it('throws original package resolving errors', async () => {
+    const restore = patchModulePath(
+      PLAYWRIGHT_BUILD_ARCHIVE_BINARY,
+      'any',
+      new Error('ERR_PACKAGE_PATH_NOT_EXPORTED')
+    );
+    onTestFinished(restore);
+
+    await expect(
+      getE2EBuildCommand(deps, 'playwright', ['--output-dir=./source-dir/'])
+    ).rejects.toThrow('ERR_PACKAGE_PATH_NOT_EXPORTED');
+  });
+
   it('throws a TaskFailure with the MISSING_DEPENDENCY exit code when the E2E package is not installed', async () => {
     const deps = { options: { inAction: false } as any, log: new TestLogger() };
 
@@ -14,6 +48,16 @@ describe('getE2EBuildCommand', () => {
       name: 'TaskFailure',
       exitCode: exitCodes.MISSING_DEPENDENCY,
       userError: true,
+    });
+  });
+
+  describe('in action', () => {
+    const deps = { options: { inAction: true } as any, log: new TestLogger() };
+
+    it('invokes E2E package via package manager', async () => {
+      const command = await getE2EBuildCommand(deps, 'playwright', ['--output-dir=./source-dir/']);
+
+      expect(command).toBe('npm exec -- build-archive-storybook --output-dir=./source-dir/');
     });
   });
 });

--- a/node-src/lib/e2e.test.ts
+++ b/node-src/lib/e2e.test.ts
@@ -60,24 +60,15 @@ describe('getE2EBuildCommand', () => {
         patchModulePath(PLAYWRIGHT_BUILD_ARCHIVE_BINARY, '/path/to/playwright-bin'),
         patchModulePath(CYPRESS_BUILD_ARCHIVE_BINARY, '/path/to/cypress-bin'),
       ];
-      onTestFinished(() => void cleanups.reverse().map((cleanup) => cleanup()));
+      onTestFinished(() => {
+        for (const cleanup of cleanups.reverse()) {
+          cleanup();
+        }
+      });
 
       const command = await getE2EBuildCommand(deps, 'playwright', ['--output-dir=./source-dir/']);
 
       expect(command).toBe(`node /path/to/playwright-bin --output-dir=./source-dir/`);
-    });
-
-    it('throws original package resolving errors', async () => {
-      const restore = patchModulePath(
-        PLAYWRIGHT_BUILD_ARCHIVE_BINARY,
-        'any',
-        new Error('ERR_PACKAGE_PATH_NOT_EXPORTED')
-      );
-      onTestFinished(restore);
-
-      await expect(
-        getE2EBuildCommand(deps, 'playwright', ['--output-dir=./source-dir/'])
-      ).rejects.toThrow('ERR_PACKAGE_PATH_NOT_EXPORTED');
     });
 
     it("fallbacks to invoke E2E package via package manager when it's not installed", async () => {

--- a/node-src/lib/e2e.test.ts
+++ b/node-src/lib/e2e.test.ts
@@ -6,6 +6,7 @@ import TestLogger from './testLogger';
 import { patchModulePath } from './testUtilities';
 
 const PLAYWRIGHT_BUILD_ARCHIVE_BINARY = '@chromatic-com/playwright/bin/build-archive-storybook';
+const CYPRESS_BUILD_ARCHIVE_BINARY = '@chromatic-com/cypress/bin/build-archive-storybook';
 
 // Mock @antfu/ni to detect package manager as npm
 vi.mock(import('@antfu/ni'), async (importOriginal) => ({
@@ -54,7 +55,32 @@ describe('getE2EBuildCommand', () => {
   describe('in action', () => {
     const deps = { options: { inAction: true } as any, log: new TestLogger() };
 
-    it('invokes E2E package via package manager', async () => {
+    it('can resolve E2E package when multiple are installed', async () => {
+      const cleanups = [
+        patchModulePath(PLAYWRIGHT_BUILD_ARCHIVE_BINARY, '/path/to/playwright-bin'),
+        patchModulePath(CYPRESS_BUILD_ARCHIVE_BINARY, '/path/to/cypress-bin'),
+      ];
+      onTestFinished(() => void cleanups.reverse().map((cleanup) => cleanup()));
+
+      const command = await getE2EBuildCommand(deps, 'playwright', ['--output-dir=./source-dir/']);
+
+      expect(command).toBe(`node /path/to/playwright-bin --output-dir=./source-dir/`);
+    });
+
+    it('throws original package resolving errors', async () => {
+      const restore = patchModulePath(
+        PLAYWRIGHT_BUILD_ARCHIVE_BINARY,
+        'any',
+        new Error('ERR_PACKAGE_PATH_NOT_EXPORTED')
+      );
+      onTestFinished(restore);
+
+      await expect(
+        getE2EBuildCommand(deps, 'playwright', ['--output-dir=./source-dir/'])
+      ).rejects.toThrow('ERR_PACKAGE_PATH_NOT_EXPORTED');
+    });
+
+    it("fallbacks to invoke E2E package via package manager when it's not installed", async () => {
       const command = await getE2EBuildCommand(deps, 'playwright', ['--output-dir=./source-dir/']);
 
       expect(command).toBe('npm exec -- build-archive-storybook --output-dir=./source-dir/');

--- a/node-src/lib/e2e.ts
+++ b/node-src/lib/e2e.ts
@@ -1,3 +1,6 @@
+import { createRequire } from 'node:module';
+import path from 'node:path';
+
 import { AGENTS, getCliCommand, Runner } from '@antfu/ni';
 
 import { Deps } from '../types';
@@ -39,15 +42,30 @@ export async function getE2EBuildCommand(
   flag: 'playwright' | 'cypress' | 'vitest',
   buildCommandOptions: string[]
 ) {
-  // The action cannot "peer depend" on or import anything. So instead, we must attempt to exec
-  // the binary directly.
+  const dependencyName = `@chromatic-com/${flag}`;
+
   if (deps.options.inAction) {
+    // Try resolving the binary from working directory first, then fallback to package manager.
+    try {
+      const projectRequire = createRequire(path.join(process.cwd(), 'package.json'));
+      return [
+        'node',
+        projectRequire.resolve(`${dependencyName}/bin/${buildBinName}`),
+        ...buildCommandOptions,
+      ].join(' ');
+    } catch (err) {
+      if (err.code !== 'MODULE_NOT_FOUND') {
+        throw err;
+      }
+    }
+
+    // The action cannot "peer depend" on or import anything. So instead, we must attempt to exec the binary directly.
+    // This will fail if user has both `@chromatic-com/playwright` and `@chromatic-com/cypress` installed.
     return await getCliCommand(parseNexec, [buildBinName, ...buildCommandOptions], {
       programmatic: true,
     });
   }
 
-  const dependencyName = `@chromatic-com/${flag}`;
   try {
     return [
       'node',

--- a/node-src/lib/e2e.ts
+++ b/node-src/lib/e2e.ts
@@ -53,14 +53,12 @@ export async function getE2EBuildCommand(
         projectRequire.resolve(`${dependencyName}/bin/${buildBinName}`),
         ...buildCommandOptions,
       ].join(' ');
-    } catch (err) {
-      if (err.code !== 'MODULE_NOT_FOUND') {
-        throw err;
-      }
+    } catch {
+      // Ignore error and fallback to package manager
     }
 
     // The action cannot "peer depend" on or import anything. So instead, we must attempt to exec the binary directly.
-    // This will fail if user has both `@chromatic-com/playwright` and `@chromatic-com/cypress` installed.
+    // This will fail if user has multiple packages that define identically named `build-archive-storybook` bin.
     return await getCliCommand(parseNexec, [buildBinName, ...buildCommandOptions], {
       programmatic: true,
     });

--- a/node-src/lib/testUtilities.ts
+++ b/node-src/lib/testUtilities.ts
@@ -9,16 +9,21 @@ import { Module } from 'node:module';
  *
  * @param from Input of `require.resolve(<from>)`
  * @param to Output of the mocked call, as in `const to = require.resolve(<from>)`
+ * @param error
  *
  * @returns `function restore()` that restores mock back to original implementation
  */
-export function patchModulePath(from: string, to: string) {
+export function patchModulePath(from: string, to: string, error?: Error) {
   // @ts-expect-error -- untyped
   const original = Module._resolveFilename;
 
   // @ts-expect-error -- untyped
   Module._resolveFilename = (request: string, parent: NodeModule) => {
     if (request === from) {
+      if (error) {
+        throw error;
+      }
+
       return to;
     }
 

--- a/node-src/lib/testUtilities.ts
+++ b/node-src/lib/testUtilities.ts
@@ -9,7 +9,7 @@ import { Module } from 'node:module';
  *
  * @param from Input of `require.resolve(<from>)`
  * @param to Output of the mocked call, as in `const to = require.resolve(<from>)`
- * @param error
+ * @param error Optional error to throw instead of returning `to`
  *
  * @returns `function restore()` that restores mock back to original implementation
  */


### PR DESCRIPTION
- Closes SB-1674.
- Closes TE-1.

Fix verified by @jonniebigodes in the ticket above.

If user has multiple npm packages installed that define `build-archive-storybook`, Chromatic CLI may pick the wrong one when it does `npm exec -- build-archive-storybook`. Npm has support for defining package name as `npm exec --package=@chromatic-com/playwright -- build-archive-storybook`, but even that doesn't work. The tickets above have minimal reproductions if you'd like to try running the commands yourself.

To fix this we'll check if we can resolve path to the installed package and call it directly. If it's not installed, we fallback to the old logic.

First commit adds more tests to `getE2EBuildCommand`, second one applies the fix.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>18.7.2--canary.1465.33192636470.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@18.7.2--canary.1465.33192636470.0
  # or 
  yarn add chromatic@18.7.2--canary.1465.33192636470.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
