### PR TITLE
Return capture counts on bypassed builds

### DIFF
--- a/node-src/lib/upload.ts
+++ b/node-src/lib/upload.ts
@@ -80,6 +80,48 @@ mutation PrepareBuild(
 }
 `;
 
+// If the build is skipped, we need to pull some of the build stats separately so we can return them
+// to the CLI/Action output. These line up with the fields in the return shape of `run()` in
+// node-src/index.ts.
+const SkippedBuildQuery = `
+  query SkippedBuildQuery($number: Int!) {
+    app {
+      build(number: $number) {
+        specCount
+        componentCount
+        testCount
+        changeCount
+        errorCount: testCount(statuses: [BROKEN])
+        actualTestCount: testCount(statuses: [IN_PROGRESS])
+        interactionTestFailuresCount
+        actualCaptureCount
+        inheritedCaptureCount
+      }
+    }
+  }
+`;
+
+export type SkippedBuildFields = Partial<
+  Pick<
+    NonNullable<Context['build']>,
+    | 'specCount'
+    | 'componentCount'
+    | 'testCount'
+    | 'changeCount'
+    | 'errorCount'
+    | 'actualTestCount'
+    | 'interactionTestFailuresCount'
+    | 'actualCaptureCount'
+    | 'inheritedCaptureCount'
+  >
+>;
+
+interface SkippedBuildQueryResult {
+  app: {
+    build: SkippedBuildFields;
+  };
+}
+
 interface UploadBuildMutationResult {
   uploadBuild: {
     info?: {
@@ -160,6 +202,7 @@ export interface UploadBuildResult {
     webUrl: string;
     snapshotCount: number;
   };
+  skippedBuild?: SkippedBuildFields;
 }
 
 /**
@@ -274,6 +317,23 @@ export async function uploadBuild(
           Sentry.captureException(err);
         });
 
+      // Query the skipped build for some stats that we'll return to the CLI/Action output.
+      let skippedBuild: SkippedBuildFields | undefined;
+      try {
+        const { app } = await ctx.client.runQuery<SkippedBuildQueryResult>(
+          SkippedBuildQuery,
+          { number: ctx.announcedBuild.number },
+          { headers: { Authorization: `Bearer ${ctx.announcedBuild.reportToken}` } }
+        );
+        skippedBuild = app.build;
+      } catch (err) {
+        ctx.log.error(
+          `Failed to query fields for skipped build ${uploadBuild.build?.id}, continuing`,
+          err
+        );
+        Sentry.captureException(err);
+      }
+
       return {
         sentinelUrls,
         uploadedBytes,
@@ -281,6 +341,7 @@ export async function uploadBuild(
         skippedByTurboSnap: true,
         // In this case, we should only have a single ancestor build.
         ancestorBuild: uploadBuild.build.ancestorBuilds?.[0],
+        skippedBuild,
       };
     }
 

--- a/node-src/renderer/upload.ts
+++ b/node-src/renderer/upload.ts
@@ -1,4 +1,9 @@
-import { applyUploadOutput, extractUploadInput, uploadProject } from '../tasks/upload';
+import {
+  applyUploadOutput,
+  applyUploadPartial,
+  extractUploadInput,
+  uploadProject,
+} from '../tasks/upload';
 import { Context } from '../types';
 import { dryRun, initial, starting, success } from '../ui/tasks/upload';
 import { fallbackFailureState, runTask } from './engine';
@@ -20,6 +25,7 @@ export async function renderUpload(ctx: Context): Promise<void> {
         pending: starting,
         success,
         skipped: dryRun,
+        partial: (context: Context) => starting(context),
         failure: (context: Context, error: Error) =>
           fallbackFailureState(
             context.isReactNativeApp
@@ -31,6 +37,7 @@ export async function renderUpload(ctx: Context): Promise<void> {
       extractInput: extractUploadInput,
       run: uploadProject,
       applyOutput: applyUploadOutput,
+      applyPartial: applyUploadPartial,
     },
     getRenderer(ctx, clackProgressBarRenderer)
   );

--- a/node-src/tasks/upload.test.ts
+++ b/node-src/tasks/upload.test.ts
@@ -369,11 +369,27 @@ describe('uploadProject', () => {
       });
     });
 
-    it('skips the task without uploading when the build is SKIPPED', async () => {
+    it('halts the pipeline without uploading when the build is SKIPPED, carrying the queried build fields', async () => {
+      // In the case of a bypassed build, we query for all the information counts to return to the CLI/Action caller.
+      const skippedBuild = {
+        webUrl: 'https://www.chromatic.com/build?appId=abc&number=96',
+        specCount: 5,
+        componentCount: 3,
+        testCount: 5,
+        changeCount: 0,
+        errorCount: 0,
+        actualTestCount: 0,
+        interactionTestFailuresCount: 0,
+        actualCaptureCount: 0,
+        inheritedCaptureCount: 12,
+      };
       const client = { runQuery: vi.fn() };
-      client.runQuery.mockResolvedValue({
-        uploadBuild: { build: { id: '2', status: 'SKIPPED' }, userErrors: [] },
-      });
+      client.runQuery
+        .mockResolvedValueOnce({
+          uploadBuild: { build: { id: '2', status: 'SKIPPED' }, userErrors: [] },
+        })
+        .mockResolvedValueOnce({ prepareBuild: true })
+        .mockResolvedValueOnce({ app: { build: skippedBuild } });
 
       const ctx = {
         client,
@@ -383,13 +399,51 @@ describe('uploadProject', () => {
         sourceDir: '/static/',
         options: {},
         fileInfo,
-        announcedBuild: { id: '1' },
+        announcedBuild: { id: '1', number: 42, reportToken: 'report-token' },
         onlyStoryFiles: [],
       } as any;
       const result = await runUpload(ctx);
 
-      expect(result).toEqual({ kind: 'skip' });
+      expect(client.runQuery).toHaveBeenCalledWith(
+        expect.stringMatching(/SkippedBuildQuery/),
+        { number: 42 },
+        { headers: { Authorization: 'Bearer report-token' } }
+      );
+      expect(result).toEqual({
+        kind: 'partial',
+        output: expect.objectContaining({ skippedByTurboSnap: true, skippedBuild }),
+      });
       expect(http.fetch).not.toHaveBeenCalled();
+    });
+
+    it('still halts the pipeline with an undefined skippedBuild when the query throws', async () => {
+      const client = { runQuery: vi.fn() };
+      client.runQuery
+        .mockResolvedValueOnce({
+          uploadBuild: { build: { id: '2', status: 'SKIPPED' }, userErrors: [] },
+        })
+        .mockResolvedValueOnce({ prepareBuild: true })
+        .mockRejectedValueOnce(new Error('skipped build query failed'));
+
+      const ctx = {
+        client,
+        env: environment,
+        log,
+        http,
+        sourceDir: '/static/',
+        options: {},
+        fileInfo,
+        announcedBuild: { id: '1', number: 42, reportToken: 'report-token' },
+        onlyStoryFiles: [],
+      } as any;
+      const result = await runUpload(ctx);
+
+      expect(result).toEqual({
+        kind: 'partial',
+        output: expect.objectContaining({ skippedByTurboSnap: true, skippedBuild: undefined }),
+      });
+      expect(vi.mocked(Sentry.captureException)).toHaveBeenCalled();
+      expect(http.fetch).not.toHaveBeenCalled(); // we're not checking for sentinel files
     });
 
     it('logs the TurboSnap skip messages with ancestor build details when SKIPPED', async () => {
@@ -476,7 +530,7 @@ describe('uploadProject', () => {
       } as any;
       const result = await runUpload(ctx);
 
-      expect(result).toEqual({ kind: 'skip' });
+      expect(result).toMatchObject({ kind: 'partial', output: { skippedByTurboSnap: true } });
       expect(skipLogger.error).toHaveBeenCalledWith(
         expect.stringContaining('Failed to prepare skipped build 2'),
         error

--- a/node-src/tasks/upload.ts
+++ b/node-src/tasks/upload.ts
@@ -1,6 +1,6 @@
 import path from 'path';
 
-import { uploadBuild } from '../lib/upload';
+import { SkippedBuildFields, uploadBuild } from '../lib/upload';
 import { throttle } from '../lib/utilities';
 import { waitForSentinel } from '../lib/waitForSentinel';
 import { Context, Deps, FileDesc, TaskResult } from '../types';
@@ -22,6 +22,7 @@ export interface UploadOutput {
   uploadedFiles: number;
   skippedByTurboSnap?: boolean;
   ancestorBuild?: Context['ancestorBuild'];
+  skippedBuild?: SkippedBuildFields;
 }
 
 const buildFileList = (ctx: Context, withHashes: boolean): FileDesc[] => {
@@ -45,27 +46,40 @@ const uploadAndWaitForSentinels = async (
   ctx: Context,
   files: FileDesc[]
 ): Promise<UploadOutput> => {
-  const { sentinelUrls, uploadedBytes, uploadedFiles, skippedByTurboSnap, ancestorBuild } =
-    await uploadBuild(ctx, files, {
-      onProgress: throttle(
-        (progress, total) => {
-          const percentage = Math.round((progress / total) * 100);
-          deps.report({
-            output: uploading(ctx, { percentage }).output,
-            progress: { progress, total, unit: 'bytes' },
-          });
-        },
-        // Avoid spamming the logs with progress updates in non-interactive mode
-        ctx.options.interactive ? 100 : ctx.env.CHROMATIC_OUTPUT_INTERVAL
-      ),
-      onError: (error: Error, path?: string) => {
-        throw path === error.message ? new Error(failed(ctx, { path }).output) : error;
+  const {
+    sentinelUrls,
+    uploadedBytes,
+    uploadedFiles,
+    skippedByTurboSnap,
+    ancestorBuild,
+    skippedBuild,
+  } = await uploadBuild(ctx, files, {
+    onProgress: throttle(
+      (progress, total) => {
+        const percentage = Math.round((progress / total) * 100);
+        deps.report({
+          output: uploading(ctx, { percentage }).output,
+          progress: { progress, total, unit: 'bytes' },
+        });
       },
-    });
+      // Avoid spamming the logs with progress updates in non-interactive mode
+      ctx.options.interactive ? 100 : ctx.env.CHROMATIC_OUTPUT_INTERVAL
+    ),
+    onError: (error: Error, path?: string) => {
+      throw path === error.message ? new Error(failed(ctx, { path }).output) : error;
+    },
+  });
 
   // A TurboSnap-skipped build uploads nothing and has no sentinels to wait for.
   if (skippedByTurboSnap || sentinelUrls.length === 0) {
-    return { sentinelUrls, uploadedBytes, uploadedFiles, skippedByTurboSnap, ancestorBuild };
+    return {
+      sentinelUrls,
+      uploadedBytes,
+      uploadedFiles,
+      skippedByTurboSnap,
+      ancestorBuild,
+      skippedBuild,
+    };
   }
 
   deps.report({ output: finalizing(ctx).output });
@@ -83,17 +97,20 @@ const uploadAndWaitForSentinels = async (
   return { sentinelUrls, uploadedBytes, uploadedFiles };
 };
 
-// A fully-TurboSnapped build halts the pipeline (kind:'skip'). The upload frame renders bare; the
-// two TurboSnap success messages are logged here so they flush as free-standing blocks below the
-// task frames (verify/snapshot never run to log them themselves).
+// A bypassed build halts the pipeline early (kind:'partial' sets ctx.skip). The upload frame
+// renders bare; the success message is logged here so it flushes as a free-standing block below the
+// task frames (verify/snapshot never run to log them themselves). The queried skipped-build fields
+// are carried on the partial output so they land on ctx.build for the action outputs, since verify
+// never runs to populate them.
 const skipTurboSnapped = (
   deps: Deps,
   ctx: Context,
-  ancestorBuild: UploadOutput['ancestorBuild']
-): TaskResult<UploadOutput> => {
+  output: UploadOutput
+): TaskResult<UploadOutput, UploadOutput> => {
+  const { ancestorBuild } = output;
   deps.log.info(turboSnapEnabled({ ...ctx, skip: true, ancestorBuild }));
   deps.log.info(buildFullyTurboSnapped({ ancestorBuild }));
-  return { kind: 'skip' };
+  return { kind: 'partial', output };
 };
 
 /**
@@ -107,7 +124,7 @@ const skipTurboSnapped = (
 export async function uploadProject(
   deps: Deps,
   input: UploadInput
-): Promise<TaskResult<UploadOutput>> {
+): Promise<TaskResult<UploadOutput, UploadOutput>> {
   const ctx = input.uploadContext;
 
   if (ctx.options.dryRun) {
@@ -117,7 +134,7 @@ export async function uploadProject(
   try {
     const output = await uploadAndWaitForSentinels(deps, ctx, buildFileList(ctx, true));
     if (output.skippedByTurboSnap) {
-      return skipTurboSnapped(deps, ctx, output.ancestorBuild);
+      return skipTurboSnapped(deps, ctx, output);
     }
     return { kind: 'continue', output };
   } catch {
@@ -126,7 +143,7 @@ export async function uploadProject(
     // results are discarded simply by running again.
     const output = await uploadAndWaitForSentinels(deps, ctx, buildFileList(ctx, false));
     if (output.skippedByTurboSnap) {
-      return skipTurboSnapped(deps, ctx, output.ancestorBuild);
+      return skipTurboSnapped(deps, ctx, output);
     }
     return { kind: 'continue', output };
   }
@@ -138,4 +155,10 @@ export const applyUploadOutput = (ctx: Context, output: UploadOutput) => {
   ctx.sentinelUrls = output.sentinelUrls;
   ctx.uploadedBytes = output.uploadedBytes;
   ctx.uploadedFiles = output.uploadedFiles;
+};
+
+export const applyUploadPartial = (ctx: Context, output: UploadOutput) => {
+  // A bypassed build halts the pipeline here, so verify never runs to populate a full build object.
+  // Apply the fields we queried from the skipped build so the index.ts outputs block reads them.
+  ctx.build = { ...ctx.build, ...output.skippedBuild } as Context['build'];
 };


### PR DESCRIPTION
Closes #1466 

When we added bypassed builds, we failed to query for the build counts on the skipped build. Instead, they were all returning `undefined` instead of the real values.

This adds another query to the Index service to grab the real counts from the build and returns them back to `run()` within `node-src/index.ts` to populate those fields.

I QA'ed this one on my test project:

### Before

<img width="423" height="340" alt="Screenshot 2026-08-26 at 4 31 50 PM" src="https://github.com/user-attachments/assets/48123182-3d28-4f77-bed4-98c5a3801011" />

### After (I did confirm the build was bypassed)

<img width="369" height="342" alt="Screenshot 2026-08-26 at 5 05 24 PM" src="https://github.com/user-attachments/assets/8188e266-f79d-4f4c-823e-a6a6e8606e6a" />

> [!NOTE]
> I'm just writing out _all_ output fields. `buildUrl` is still `undefined` which is expected because bypassed builds don't show up in the Chromatic UI.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>18.6.3--canary.1467.33181670768.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@18.6.3--canary.1467.33181670768.0
  # or 
  yarn add chromatic@18.6.3--canary.1467.33181670768.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
