### PR TITLE
fix: descriptive TurboSnap errors in Vitest runs

### DIFF
--- a/node-src/lib/checkStorybookBaseDirectory.test.ts
+++ b/node-src/lib/checkStorybookBaseDirectory.test.ts
@@ -122,4 +122,21 @@ describe('checkStorybookBaseDir', () => {
     getRepositoryRoot.mockResolvedValueOnce(path.resolve(process.cwd(), '..'));
     await expect(checkStorybookBaseDirectory(ctx, stats)).resolves.toBeUndefined();
   });
+
+  it('should throw an error if no source modules exists in Vitest run', async () => {
+    const ctx = getContext();
+    ctx.options.vitest = true;
+
+    const stats = {
+      modules: [{ id: null, name: './storybook-stories.js' }], // builder-webpack5 virtual file
+    };
+
+    await expect(() => checkStorybookBaseDirectory(ctx, stats)).rejects
+      .toThrowErrorMatchingInlineSnapshot(`
+      [Error: ✖ TurboSnap failed
+      Vitest run did not produce source file information for TurboSnap.
+      Make sure you've enabled chromaticPlugin({ turboSnap: true }) in your test Vitest configuration before running tests.
+      ℹ Read more at https://www.chromatic.com/docs/vitest/turbosnap]
+    `);
+  });
 });

--- a/node-src/lib/checkStorybookBaseDirectory.ts
+++ b/node-src/lib/checkStorybookBaseDirectory.ts
@@ -5,6 +5,7 @@ import path from 'path';
 import { getRepositoryRoot } from '../git/git';
 import { Context, Stats } from '../types';
 import { invalidStorybookBaseDirectory } from '../ui/messages/errors/invalidStorybookBaseDirectory';
+import { turboSnapDisabledVitest } from '../ui/messages/errors/turboSnapDisabledVitest';
 import { exitCodes, setExitCode } from './setExitCode';
 
 /**
@@ -24,10 +25,19 @@ export async function checkStorybookBaseDirectory(ctx: Context, stats: Stats) {
   const { storybookBaseDir: storybookBaseDirectory = path.relative(repositoryRoot, '') } =
     ctx.options;
 
-  // Find all js(x)/ts(x) files in stats that are not in node_modules
+  // Find all js(x)/ts(x) files in stats that are not in node_modules, and are not Storybook's virtual files
   const sourceModuleFiles = stats.modules.filter(
-    (module: any) => !module.name.includes('node_modules') && /\.(js|jsx|ts|tsx)$/.test(module.name)
+    (module: any) =>
+      !module.name.includes('node_modules') &&
+      module.name !== './storybook-stories.js' && // builder-webpack5 virtual file
+      /\.(js|jsx|ts|tsx)$/.test(module.name)
   );
+
+  // This can happen if `vitest run` is run without the chromaticPlugin({ turboSnap: true })
+  // and `chromatic --vitest --only-changed` is run afterwards.
+  if (ctx.options.vitest && sourceModuleFiles.length === 0) {
+    throw new Error(turboSnapDisabledVitest());
+  }
 
   // GitHub Actions seems to have a default ulimit of 1024, so we limit concurrency to stay under
   const limitConcurrency = pLimit(1000);

--- a/node-src/lib/checkStorybookBaseDirectory.ts
+++ b/node-src/lib/checkStorybookBaseDirectory.ts
@@ -36,6 +36,7 @@ export async function checkStorybookBaseDirectory(ctx: Context, stats: Stats) {
   // This can happen if `vitest run` is run without the chromaticPlugin({ turboSnap: true })
   // and `chromatic --vitest --only-changed` is run afterwards.
   if (ctx.options.vitest && sourceModuleFiles.length === 0) {
+    setExitCode(ctx, exitCodes.INVALID_OPTIONS, true);
     throw new Error(turboSnapDisabledVitest());
   }
 

--- a/node-src/lib/setExitCode.ts
+++ b/node-src/lib/setExitCode.ts
@@ -1,7 +1,7 @@
 import { Context } from '../types';
 
 /**
- * Keep this in sync with https://github.com/chromaui/chromatic-docs/blob/main/cli.md#exit-codes
+ * Keep this in sync with https://github.com/chromaui/chromatic-docs/blob/main/src/content/configuration/cli.mdx#exit-codes
  */
 export const exitCodes = {
   // Generic results

--- a/node-src/tasks/prepare/traceChangedFiles.test.ts
+++ b/node-src/tasks/prepare/traceChangedFiles.test.ts
@@ -134,4 +134,21 @@ describe('traceChangedFiles', () => {
     expect(ctx.turboSnap.bailReason).toBeUndefined();
     expect(err.message).toBe('Could not retrieve dependent story files.\nstats file not found');
   });
+
+  it('wraps the missing stats file error without recording a bail reason in Vitest run', async () => {
+    const ctx = turboSnapContext();
+    ctx.options.vitest = true;
+    const missingStatsError = new Error('stats file not found');
+    traceChangedFilesTurbosnap.mockRejectedValue(missingStatsError);
+
+    let err;
+    try {
+      await traceChangedFiles(deps(), { turboSnapContext: ctx });
+    } catch (error) {
+      err = error;
+    }
+
+    expect(ctx.turboSnap.bailReason).toBeUndefined();
+    expect(err.message).toBe('Could not retrieve dependent test files.\nstats file not found');
+  });
 });

--- a/node-src/tasks/prepare/traceChangedFiles.ts
+++ b/node-src/tasks/prepare/traceChangedFiles.ts
@@ -1,5 +1,6 @@
 import * as turbosnap from '@cli/turbosnap';
 
+import { isE2EBuild } from '../../lib/e2eUtils';
 import { groupUntracedFilesByGlob, rewriteErrorMessage } from '../../lib/utilities';
 import { Context, Deps } from '../../types';
 import { bailed, traced, tracing } from '../../ui/tasks/prepare';
@@ -37,6 +38,7 @@ export async function traceChangedFiles(
   input: TraceChangedFilesInput
 ): Promise<TraceChangedFilesOutput> {
   const ctx = input.turboSnapContext;
+  const type = isE2EBuild(ctx.options) ? 'test' : 'story';
 
   if (!ctx.turboSnap || ctx.turboSnap.unavailable) return {};
   if (!ctx.git.changedFiles) return {};
@@ -69,7 +71,7 @@ export async function traceChangedFiles(
     if (!deps.options.interactive) {
       if (!deps.options.traceChanged) {
         deps.log.info(
-          `Found affected story files:\n${Object.entries(result.onlyStoryFiles)
+          `Found affected ${type} files:\n${Object.entries(result.onlyStoryFiles)
             .flatMap(([id, files]) => files.map((f) => `  ${f} [${id}]`))
             .join('\n')}`
         );
@@ -88,8 +90,8 @@ export async function traceChangedFiles(
     if (!deps.options.interactive) {
       const { statsPath } = ctx.fileInfo ?? {};
       const { changedFiles } = ctx.git;
-      deps.log.info('Failed to retrieve dependent story files', { statsPath, changedFiles, err });
+      deps.log.info(`Failed to retrieve dependent ${type} files`, { statsPath, changedFiles, err });
     }
-    throw rewriteErrorMessage(err, `Could not retrieve dependent story files.\n${err.message}`);
+    throw rewriteErrorMessage(err, `Could not retrieve dependent ${type} files.\n${err.message}`);
   }
 }

--- a/node-src/ui/messages/errors/turboSnapDisabledVitest.stories.ts
+++ b/node-src/ui/messages/errors/turboSnapDisabledVitest.stories.ts
@@ -1,0 +1,7 @@
+import { turboSnapDisabledVitest } from './turboSnapDisabledVitest';
+
+export default {
+  title: 'CLI/Messages/Errors',
+};
+
+export const TurboSnapDisabledVitest = () => turboSnapDisabledVitest();

--- a/node-src/ui/messages/errors/turboSnapDisabledVitest.ts
+++ b/node-src/ui/messages/errors/turboSnapDisabledVitest.ts
@@ -1,0 +1,15 @@
+import chalk from 'chalk';
+import { dedent } from 'ts-dedent';
+
+import { error, info } from '../../components/icons';
+import link from '../../components/link';
+
+const docsUrl = 'https://www.chromatic.com/docs/vitest/turbosnap';
+
+export const turboSnapDisabledVitest = () =>
+  dedent(chalk`
+    ${error} TurboSnap failed
+    Vitest run did not produce source file information for TurboSnap.
+    Make sure you've enabled ${chalk.bold('chromaticPlugin({ turboSnap: true })')} in your test Vitest configuration before running tests.
+    ${info} Read more at ${link(docsUrl)}
+  `);

--- a/smoke-tests/pnpm-workspace.yaml
+++ b/smoke-tests/pnpm-workspace.yaml
@@ -1,5 +1,5 @@
 # Ignore package manager versions so CI can install whatever version is needed
-managePackageManagerVersions: false
+pmOnFail: ignore
 
 # pnpm blocks dependency build scripts unless approved
 allowBuilds:


### PR DESCRIPTION
- Fixes TE-4

If user runs `chromatic --vitest --only-changed` but hasn't had `chromaticPlugin({ turboSnap: true })` in the previous `vitest run` run, they currently see following message:

<img width="822" height="81" alt="image" src="https://github.com/user-attachments/assets/bbefb40c-ea63-4e14-911b-5ce7b688a920" />


After this PR they see:

<img width="861" height="81" alt="image" src="https://github.com/user-attachments/assets/fb19e12f-cf04-4577-afe5-7d1ced9ec47f" />


- [x] @jonniebigodes to verify preview build works as expected
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>18.7.4--canary.1468.34369807992.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@18.7.4--canary.1468.34369807992.0
  # or 
  yarn add chromatic@18.7.4--canary.1468.34369807992.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
