### PR TITLE
[TurboSnap v2] Filter data URLs

### DIFF
--- a/node-src/lib/turbosnap/v2/paths.test.ts
+++ b/node-src/lib/turbosnap/v2/paths.test.ts
@@ -5,6 +5,7 @@ import {
   canonicalFileNames,
   canonicalImporters,
   isNodeModulesPath,
+  isSyntheticFile,
   moduleFileNames,
   normalizeStatsPath,
   resolveStatsPath,
@@ -175,6 +176,12 @@ describe('canonicalImporters', () => {
 });
 
 describe('normalizeStatsPath', () => {
+  it('leaves inline data URLs unchanged', () => {
+    const dataUrl = 'data:font/ttf;base64,AAAAAAAAAAAAAAAAAA';
+
+    expect(normalizeStatsPath(dataUrl, projectRoot)).toBe(dataUrl);
+  });
+
   it('keeps a project-relative path as-is, with its ./ prefix', () => {
     expect(normalizeStatsPath('./src/Button.stories.tsx', projectRoot)).toBe(
       './src/Button.stories.tsx'
@@ -263,5 +270,15 @@ describe('isNodeModulesPath', () => {
     ['an empty path', ''],
   ])('is false for %s', (_description, filePath) => {
     expect(isNodeModulesPath(filePath)).toBe(false);
+  });
+});
+
+describe('isSyntheticFile', () => {
+  it('recognizes an inline data URL by its leading scheme', () => {
+    expect(isSyntheticFile('data:font/ttf;base64,AAAAAAAAAAAAAAAAAA')).toBe(true);
+  });
+
+  it('does not mistake a real path containing data: for a synthetic module', () => {
+    expect(isSyntheticFile('/repo/packages/data:exports/src/font.ts')).toBe(false);
   });
 });

--- a/node-src/lib/turbosnap/v2/paths.ts
+++ b/node-src/lib/turbosnap/v2/paths.ts
@@ -106,6 +106,19 @@ export function isNodeModulesPath(filePath: string): boolean {
 }
 
 /**
+ * Whether a file path names a synthetic module whose contents do not exist as a file on disk.
+ *
+ * @param path The module name from the stats file.
+ *
+ * @returns Whether the path must not be resolved or read from disk.
+ */
+export function isSyntheticFile(path: FilePath): boolean {
+  // Note: The file path of the data: "files" start with `data:image/svg+xml` or similar rather than
+  // a directory path.
+  return path.includes('virtual:') || path.startsWith('data:');
+}
+
+/**
  * Strips a trailing ` + N modules` suffix from a concatenated module's name, leaving the root file.
  *
  * @param statsPath The module name from the stats file.
@@ -120,8 +133,8 @@ export function stripConcatenatedModuleSuffix(statsPath: FilePath): FilePath {
  * Converts a stats module path into the canonical manifest key: a POSIX path relative to the
  * Storybook project root. Relative stats paths are first resolved from `statsRoot`, because a
  * builder may name them from the repository root even though manifest keys anchor at the project.
- * Virtual modules (e.g. Vite's `virtual:` entries) have no on-disk location and are returned
- * unchanged.
+ * Synthetic modules (e.g. Vite's `virtual:` entries and inline `data:` URLs) have no on-disk
+ * location and are returned unchanged.
  *
  * @param statsPath The module name from the stats file (relative like `./src/x` or absolute).
  * @param projectRoot The absolute Storybook project root to anchor against.
@@ -134,7 +147,7 @@ export function normalizeStatsPath(
   projectRoot: AbsolutePath,
   statsRoot: AbsolutePath = projectRoot
 ): FilePath {
-  if (statsPath.includes('virtual:')) {
+  if (isSyntheticFile(statsPath)) {
     return statsPath;
   }
 

--- a/node-src/lib/turbosnap/v2/statsGraph.test.ts
+++ b/node-src/lib/turbosnap/v2/statsGraph.test.ts
@@ -94,6 +94,33 @@ describe('readStatsGraph concatenated modules', () => {
 });
 
 describe('readStatsGraph unhashable paths', () => {
+  it('skips an inline data URL rather than treating it as a file path', async () => {
+    const dataUrl = `data:font/ttf;base64,AAAAAAAAAAAAAAAAAA`;
+    const { input } = createFixture();
+
+    const graph = await readStatsGraph(
+      { modules: [{ id: 1, name: dataUrl, reasons: [] }] },
+      {
+        ...input,
+        projectFiles: {
+          ...input.projectFiles,
+          isFile: (absolutePath) => {
+            if (absolutePath.includes(dataUrl)) {
+              throw new Error('ENAMETOOLONG: name too long');
+            }
+            return input.projectFiles.isFile(absolutePath);
+          },
+        },
+      }
+    );
+
+    expect(graph.hashes.size).toBe(0);
+    expect(
+      graph.files.has(dataUrl),
+      'expected dataUrl to be in the list of files found in the graph'
+    ).toBe(true);
+  });
+
   it('skips a module named after a directory rather than failing the read', async () => {
     const story = '/repo/packages/ui/src/Button.stories.tsx';
     // rspack names one record after a directory on `storybook-builder-rsbuild` 3.3.0/3.3.1. Reading

--- a/node-src/lib/turbosnap/v2/statsGraph.ts
+++ b/node-src/lib/turbosnap/v2/statsGraph.ts
@@ -5,6 +5,7 @@ import {
   canonicalFileNames,
   canonicalImporters,
   isNodeModulesPath,
+  isSyntheticFile,
   moduleFileNames,
   normalizeStatsPath,
   resolveStatsPath,
@@ -140,11 +141,11 @@ function ensureFile(
  * Resolves a stats module path to the absolute on-disk file to hash, or undefined when there is
  * nothing hashable there.
  *
- * Virtual modules (e.g. Vite's `virtual:` entries) have no on-disk location. Skipping them is stats
- * policy, which is why it is asked here rather than of the disk. Beyond that, only a regular file is
- * hashable, and what counts as one is the module's rule; see {@link ProjectFiles.isFile}. Skipping a
- * name with no file loses no evidence, because such a name is never a source file and so can never be
- * edited as one.
+ * Synthetic modules (e.g. Vite's `virtual:` entries and inline `data:` URLs) have no on-disk
+ * location. Skipping them is stats policy, which is why it is asked here rather than of the disk.
+ * Beyond that, only a regular file is hashable, and what counts as one is the module's rule; see
+ * {@link ProjectFiles.isFile}. Skipping a name with no file loses no evidence, because such a name is
+ * never a source file and so can never be edited as one.
  *
  * @param rawPath The module name from the stats file.
  * @param statsRoot The directory relative stats paths are named from.
@@ -157,7 +158,7 @@ function hashableAbsolutePath(
   statsRoot: string,
   projectFiles: ProjectFiles
 ): string | undefined {
-  if (rawPath.includes('virtual:')) return undefined;
+  if (isSyntheticFile(rawPath)) return undefined;
   const absolutePath = resolveStatsPath(rawPath, statsRoot);
   return projectFiles.isFile(absolutePath) ? absolutePath : undefined;
 }


### PR DESCRIPTION
Apparently data URLs (stuff like `data:font/ttf` and `data:image/svg+xml` can show up in `preview-stats.json` so we need to filter those out because they won't exist on the file system.

We do, however, still add them to the `files` section of the manifest because they're part of the Storybook bundle details.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>18.7.3--canary.1470.33409206966.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@18.7.3--canary.1470.33409206966.0
  # or 
  yarn add chromatic@18.7.3--canary.1470.33409206966.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
