### PR TITLE
:sparkles: Track pnpm-lock.yaml as a "package metadata file".

### DIFF
--- a/node-src/__mocks__/dependencyChanges/pnpm-catalog-after/package.json
+++ b/node-src/__mocks__/dependencyChanges/pnpm-catalog-after/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "storybook-demo",
+  "version": "1.0.0",
+  "dependencies": {
+    "is-odd": "catalog:"
+  }
+}

--- a/node-src/__mocks__/dependencyChanges/pnpm-catalog-after/pnpm-lock.yaml
+++ b/node-src/__mocks__/dependencyChanges/pnpm-catalog-after/pnpm-lock.yaml
@@ -1,0 +1,37 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+catalogs:
+  default:
+    is-odd:
+      specifier: 2.0.0
+      version: 2.0.0
+
+importers:
+
+  .:
+    dependencies:
+      is-odd:
+        specifier: 'catalog:'
+        version: 2.0.0
+
+packages:
+
+  is-number@4.0.0:
+    resolution: {integrity: sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==}
+    engines: {node: '>=0.10.0'}
+
+  is-odd@2.0.0:
+    resolution: {integrity: sha512-OTiixgpZAT1M4NHgS5IguFp/Vz2VI3U7Goh4/HA1adtwyLtSBrxYlcSYkhpAE07s4fKEcjrFxyvtQBND4vFQyQ==}
+    engines: {node: '>=0.10.0'}
+
+snapshots:
+
+  is-number@4.0.0: {}
+
+  is-odd@2.0.0:
+    dependencies:
+      is-number: 4.0.0

--- a/node-src/__mocks__/dependencyChanges/pnpm-catalog-before/package.json
+++ b/node-src/__mocks__/dependencyChanges/pnpm-catalog-before/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "storybook-demo",
+  "version": "1.0.0",
+  "dependencies": {
+    "is-odd": "catalog:"
+  }
+}

--- a/node-src/__mocks__/dependencyChanges/pnpm-catalog-before/pnpm-lock.yaml
+++ b/node-src/__mocks__/dependencyChanges/pnpm-catalog-before/pnpm-lock.yaml
@@ -1,0 +1,37 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+catalogs:
+  default:
+    is-odd:
+      specifier: 3.0.1
+      version: 3.0.1
+
+importers:
+
+  .:
+    dependencies:
+      is-odd:
+        specifier: 'catalog:'
+        version: 3.0.1
+
+packages:
+
+  is-number@6.0.0:
+    resolution: {integrity: sha512-Wu1VHeILBK8KAWJUAiSZQX94GmOE45Rg6/538fKwiloUu21KncEkYGPqob2oSZ5mUT73vLGrHQjKw3KMPwfDzg==}
+    engines: {node: '>=0.10.0'}
+
+  is-odd@3.0.1:
+    resolution: {integrity: sha512-CQpnWPrDwmP1+SMHXZhtLtJv90yiyVfluGsX5iNCVkrhQtU3TQHsUWPG9wkdk9Lgd5yNpAg9jQEo90CBaXgWMA==}
+    engines: {node: '>=4'}
+
+snapshots:
+
+  is-number@6.0.0: {}
+
+  is-odd@3.0.1:
+    dependencies:
+      is-number: 6.0.0

--- a/node-src/lib/turbosnap/v1/compareBaseline.test.ts
+++ b/node-src/lib/turbosnap/v1/compareBaseline.test.ts
@@ -13,18 +13,18 @@ const getContext: any = (baselineCommits: string[]) => ({
   git: { baselineCommits },
 });
 
-async function getMockedDependencies(headName: string, baseName: string) {
+async function getMockedDependencies(headName: string, baseName: string, lockfile = 'yarn.lock') {
   const ctx = getContext();
   return {
     head: await getDependencies(ctx, {
       rootPath: path.join(__dirname, `../../../__mocks__/dependencyChanges/${headName}`),
       manifestPath: 'package.json',
-      lockfilePath: 'yarn.lock',
+      lockfilePath: lockfile,
     }),
     base: await getDependencies(ctx, {
       rootPath: path.join(__dirname, `../../../__mocks__/dependencyChanges/${baseName}`),
       manifestPath: 'package.json',
-      lockfilePath: 'yarn.lock',
+      lockfilePath: lockfile,
     }),
   };
 }
@@ -70,5 +70,21 @@ describe('compareBaseline', () => {
     const baselineChanges = await compareBaseline(head, base);
 
     expect(baselineChanges).toEqual(new Set(['husky']));
+  });
+
+  // Regression test for pnpm catalogs: bumping a catalog-pinned version only changes
+  // pnpm-lock.yaml (the `catalogs:` and `importers:` entries) -- package.json keeps the
+  // `catalog:` specifier unchanged. Fixtures were generated with a real `pnpm install
+  // --lockfile-only` after editing pnpm-workspace.yaml's catalog, not hand-written, so this
+  // exercises the real snyk pnpm lockfile parser against a real catalog-format lockfile.
+  it('finds changed dependency names for a pnpm catalog version bump', async () => {
+    const { head, base } = await getMockedDependencies(
+      'pnpm-catalog-after',
+      'pnpm-catalog-before',
+      'pnpm-lock.yaml'
+    );
+    const baselineChanges = await compareBaseline(head, base);
+
+    expect(baselineChanges).toEqual(new Set(['is-odd', 'is-number']));
   });
 });

--- a/node-src/lib/turbosnap/v1/findChangedPackageFiles.test.ts
+++ b/node-src/lib/turbosnap/v1/findChangedPackageFiles.test.ts
@@ -154,6 +154,24 @@ describe('findChangedPackageFiles', () => {
       await findChangedPackageFiles(ctx, [{ commit: 'A', changedFiles: ['package.json'] }])
     ).toStrictEqual(['package.json']);
   });
+
+  it('considers pnpm-lock.yaml changed since its YAML contents cannot be parsed as JSON', async () => {
+    // pnpm-lock.yaml is YAML, not JSON, so it can never be diffed via arePackageDependenciesEqual;
+    // it should always fall into the "can't be traced, treat as changed" path, the same way a
+    // yarn.lock change woul dbe treated
+    execGitCommand.mockImplementation(async (_, input) => {
+      const regexResults = /show\s([^:]*):(.*)/g.exec(input);
+      if (!regexResults) return '';
+      const [, commit] = regexResults;
+      return commit === 'A'
+        ? "lockfileVersion: '9.0'\ncatalogs:\n  default:\n    react: 18.2.0\n"
+        : "lockfileVersion: '9.0'\ncatalogs:\n  default:\n    react: 18.3.0\n";
+    });
+
+    expect(
+      await findChangedPackageFiles(ctx, [{ commit: 'A', changedFiles: ['pnpm-lock.yaml'] }])
+    ).toStrictEqual(['pnpm-lock.yaml']);
+  });
 });
 
 describe('arePackageDependenciesEqual', () => {

--- a/node-src/lib/utilities.test.ts
+++ b/node-src/lib/utilities.test.ts
@@ -1,7 +1,13 @@
 import chalk from 'chalk';
 import { describe, expect, it } from 'vitest';
 
-import { groupUntracedFilesByGlob, isPackageManifestFile, matchesFile } from './utilities';
+import {
+  groupUntracedFilesByGlob,
+  isPackageLockFile,
+  isPackageManifestFile,
+  isPackageMetadataFile,
+  matchesFile,
+} from './utilities';
 
 chalk.level = 0;
 
@@ -81,5 +87,65 @@ describe('isPackageManifestFile', () => {
 
   it('returns false for non-package-manifest files in directory', () => {
     expect(isPackageManifestFile('path/to/something.json')).toBe(false);
+  });
+});
+
+describe('isPackageLockFile', () => {
+  it('returns true for package-lock.json at root', () => {
+    expect(isPackageLockFile('package-lock.json')).toBe(true);
+  });
+
+  it('returns true for yarn.lock at root', () => {
+    expect(isPackageLockFile('yarn.lock')).toBe(true);
+  });
+
+  it('returns true for yarn.lock in a directory', () => {
+    expect(isPackageLockFile('path/to/yarn.lock')).toBe(true);
+  });
+
+  it('returns true for pnpm-lock.yaml at root', () => {
+    expect(isPackageLockFile('pnpm-lock.yaml')).toBe(true);
+  });
+
+  it('returns true for pnpm-lock.yaml in a directory', () => {
+    expect(isPackageLockFile('path/to/pnpm-lock.yaml')).toBe(true);
+  });
+
+  it('returns false for non-lock files at root', () => {
+    expect(isPackageLockFile('something.yaml')).toBe(false);
+  });
+
+  it('returns false for non-lock files in a directory', () => {
+    expect(isPackageLockFile('path/to/something.yaml')).toBe(false);
+  });
+
+  it('returns false for pnpm-workspace.yaml', () => {
+    expect(isPackageLockFile('pnpm-workspace.yaml')).toBe(false);
+  });
+});
+
+describe('isPackageMetadataFile', () => {
+  it('returns true for package.json', () => {
+    expect(isPackageMetadataFile('package.json')).toBe(true);
+  });
+
+  it('returns true for package-lock.json', () => {
+    expect(isPackageMetadataFile('package-lock.json')).toBe(true);
+  });
+
+  it('returns true for yarn.lock', () => {
+    expect(isPackageMetadataFile('yarn.lock')).toBe(true);
+  });
+
+  it('returns true for pnpm-lock.yaml', () => {
+    expect(isPackageMetadataFile('pnpm-lock.yaml')).toBe(true);
+  });
+
+  it('returns true for pnpm-lock.yaml in a monorepo subdirectory', () => {
+    expect(isPackageMetadataFile('packages/app/pnpm-lock.yaml')).toBe(true);
+  });
+
+  it('returns false for unrelated files', () => {
+    expect(isPackageMetadataFile('src/index.ts')).toBe(false);
   });
 });

--- a/node-src/lib/utilities.ts
+++ b/node-src/lib/utilities.ts
@@ -75,7 +75,9 @@ export const isPackageManifestFile = (filePath: string) =>
   [/(^|\/)package\.json$/].some((re) => re.test(filePath));
 
 export const isPackageLockFile = (filePath: string) =>
-  [/(^|\/)package-lock\.json$/, /(^|\/)yarn\.lock$/].some((re) => re.test(filePath));
+  [/(^|\/)package-lock\.json$/, /(^|\/)yarn\.lock$/, /(^|\/)pnpm-lock\.yaml$/].some((re) =>
+    re.test(filePath)
+  );
 
 export const isPackageMetadataFile = (filePath: string) =>
   isPackageManifestFile(filePath) || isPackageLockFile(filePath);


### PR DESCRIPTION
Currently, `isPackageMetadataFile()` returns `false` for `pnpm-lock.yaml`. If a commit's only meaningful change is to that file, `git.packageMetadataChanges` in `gitInfo.ts` won't include it. Because `packageMetadataChanges` ends up empty, `findChangedDependencies()`, which is gated on `isPackageMetadataFile()` having non-zero length, is never called at all, so no dependency changes are ever computed for that commit. `getDependentStoryFiles()` still runs, but since `pnpm-lock.yaml` isn't part of the module graph, it finds nothing affected. The result is that a build is created, but with zero story files flagged as changed.

This PR changes the behavior so that `pnpm-lock.yaml` is flagged as a "package metadata file". This routes to `findChangedDependencies()` (which, oddly, already _does_ parse and check `pnpm-lock.yaml`), and dependency changes are identified in the same way they would be if a change to `yarn.lock` was made _without_ a change to `package.json`. 

Fixes CAP-4975.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>18.8.0--canary.1471.33213179804.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@18.8.0--canary.1471.33213179804.0
  # or 
  yarn add chromatic@18.8.0--canary.1471.33213179804.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
