### PR TITLE
fix: build failures not to reference Storybook when in Vitest run

### DIFF
--- a/node-src/tasks/verify/verifyBuild.test.ts
+++ b/node-src/tasks/verify/verifyBuild.test.ts
@@ -242,4 +242,39 @@ describe('verifyBuild', () => {
       Viewport width in mode 'w30000h1000' is out of range [200, 2560]"
     `);
   });
+
+  it('logs Vitest test run build failure reasons and throws error with exit code of 23', async () => {
+    const client = { runQuery: vi.fn() };
+    client.runQuery.mockReturnValue({
+      app: {
+        build: {
+          startedAt: Date.now(),
+          failureReason: "Viewport width in mode 'w30000h1000' is out of range [200, 2560]",
+        },
+      },
+    });
+
+    await expect(
+      verifyBuild(buildDeps(client), {
+        ...defaultInput,
+        options: { ...defaultInput.options, vitest: true },
+      })
+    ).rejects.toThrow(
+      expect.objectContaining({
+        message: 'Failed to publish build',
+        exitCode: exitCodes.STORYBOOK_BROKEN,
+      })
+    );
+
+    const warning = log.warn.mock.calls[0][0];
+    expect(warning).toMatchInlineSnapshot(`
+      "✖ Failed to process your Vitest test run
+      This is usually caused by an issue with your test or configuration, not Chromatic.
+      Review the error below, then update the affected test or configuration and rerun Vitest.
+
+      Viewport width in mode 'w30000h1000' is out of range [200, 2560]
+
+      View the published archives at https://61b0a4b8ebf0e344c2aa231c-wdooytetbw.dev-chromatic.com/"
+    `);
+  });
 });

--- a/node-src/tasks/verify/verifyBuild.test.ts
+++ b/node-src/tasks/verify/verifyBuild.test.ts
@@ -18,6 +18,7 @@ const defaultInput = {
   options: {},
   matchesBranch: () => false,
   announcedBuild: { number: 1, reportToken: 'report-token' },
+  storybookUrl: 'https://61b0a4b8ebf0e344c2aa231c-wdooytetbw.dev-chromatic.com/',
 } as any;
 
 describe('verifyBuild', () => {
@@ -209,5 +210,36 @@ describe('verifyBuild', () => {
     const result = await verifyBuild(buildDeps(client), defaultInput);
     expect(result.isPublishOnly).toBe(true);
     expect(result.skipSnapshots).toBe(true);
+  });
+
+  it('logs build failure reasons and throws error with exit code of 23', async () => {
+    const client = { runQuery: vi.fn() };
+    client.runQuery.mockReturnValue({
+      app: {
+        build: {
+          startedAt: Date.now(),
+          failureReason: "Viewport width in mode 'w30000h1000' is out of range [200, 2560]",
+        },
+      },
+    });
+
+    await expect(verifyBuild(buildDeps(client), defaultInput)).rejects.toThrow(
+      expect.objectContaining({
+        message: 'Failed to publish build',
+        exitCode: exitCodes.STORYBOOK_BROKEN,
+      })
+    );
+
+    const warning = log.warn.mock.calls[0][0];
+    expect(warning).toMatchInlineSnapshot(`
+      "✖ Failed to extract stories from your Storybook
+      This is usually a problem with your published Storybook, not with Chromatic.
+
+      Build and open your Storybook locally and check the browser console for errors.
+      Visit your published Storybook at https://61b0a4b8ebf0e344c2aa231c-wdooytetbw.dev-chromatic.com/
+      The following error was encountered while running your Storybook:
+
+      Viewport width in mode 'w30000h1000' is out of range [200, 2560]"
+    `);
   });
 });

--- a/node-src/ui/messages/errors/brokenStorybook.stories.ts
+++ b/node-src/ui/messages/errors/brokenStorybook.stories.ts
@@ -21,5 +21,14 @@ const storybookUrl = 'https://61b0a4b8ebf0e344c2aa231c-wdooytetbw.dev-chromatic.
 
 export const BrokenStorybook = () => brokenStorybook(ctx, { failureReason, storybookUrl });
 
+export const BrokenStorybookVitest = () =>
+  brokenStorybook(
+    { ...ctx, options: { vitest: true } },
+    {
+      failureReason: "Viewport width in mode 'w30000h1000' is out of range [200, 2560]",
+      storybookUrl,
+    }
+  );
+
 export const BrokenStorybookReactNative = () =>
   brokenStorybook({ ...ctx, isReactNativeApp: true }, { failureReason, storybookUrl });

--- a/node-src/ui/messages/errors/brokenStorybook.ts
+++ b/node-src/ui/messages/errors/brokenStorybook.ts
@@ -5,10 +5,25 @@ import { Context } from '../../../types';
 import { error } from '../../components/icons';
 import link from '../../components/link';
 
-export default (ctx: Pick<Context, 'isReactNativeApp'>, { failureReason, storybookUrl }) => {
+export default (
+  ctx: Pick<Context, 'isReactNativeApp'> & { options?: Pick<Context['options'], 'vitest'> },
+  { failureReason, storybookUrl }
+) => {
   const visitStorybookLine = ctx.isReactNativeApp
     ? ''
     : `\n    Visit your published Storybook at ${link(storybookUrl)}`;
+
+  if (ctx.options?.vitest) {
+    return dedent(chalk`
+      ${error} {bold Failed to process your Vitest test run}
+      This is usually caused by an issue with your test or configuration, not Chromatic.
+      Review the error below, then update the affected test or configuration and rerun Vitest.
+
+      ${failureReason.trim()}
+
+      View the published archives at ${link(storybookUrl)}
+    `);
+  }
 
   return `${dedent(chalk`
     ${error} {bold Failed to extract stories from your Storybook}


### PR DESCRIPTION
- Fixes TE-3

If uploaded Storybook errors on the server side, users can currently see following error message with references to Storybook and stories:

<img width="714" height="143" alt="image" src="https://github.com/user-attachments/assets/fa450a83-0aca-46fe-b36d-dedb8730bbfa" />

After this PR they see:

<img width="696" height="126" alt="image" src="https://github.com/user-attachments/assets/d20f56ad-1914-4627-9670-d32d8ad5865a" />




<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>18.7.4--canary.1473.34369811571.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@18.7.4--canary.1473.34369811571.0
  # or 
  yarn add chromatic@18.7.4--canary.1473.34369811571.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
