### PR TITLE
Expand E2E verbiage

### DIFF
--- a/node-src/tasks/prepare/traceChangedFiles.test.ts
+++ b/node-src/tasks/prepare/traceChangedFiles.test.ts
@@ -143,7 +143,7 @@ describe('traceChangedFiles', () => {
 
     let err;
     try {
-      await traceChangedFiles(deps(), { turboSnapContext: ctx });
+      await traceChangedFiles({ ...deps(), options: { vitest: true } }, { turboSnapContext: ctx });
     } catch (error) {
       err = error;
     }

--- a/node-src/tasks/prepare/traceChangedFiles.ts
+++ b/node-src/tasks/prepare/traceChangedFiles.ts
@@ -1,9 +1,9 @@
 import * as turbosnap from '@cli/turbosnap';
 
-import { isE2EBuild } from '../../lib/e2eUtils';
 import { groupUntracedFilesByGlob, rewriteErrorMessage } from '../../lib/utilities';
 import { Context, Deps } from '../../types';
 import { bailed, traced, tracing } from '../../ui/tasks/prepare';
+import { testType } from '../../ui/tasks/utilities';
 
 // These are the special characters that need to be escaped in the filename
 // because they are used as special characters in picomatch
@@ -38,7 +38,6 @@ export async function traceChangedFiles(
   input: TraceChangedFilesInput
 ): Promise<TraceChangedFilesOutput> {
   const ctx = input.turboSnapContext;
-  const type = isE2EBuild(ctx.options) ? 'test' : 'story';
 
   if (!ctx.turboSnap || ctx.turboSnap.unavailable) return {};
 
@@ -70,7 +69,7 @@ export async function traceChangedFiles(
     if (!deps.options.interactive) {
       if (!deps.options.traceChanged) {
         deps.log.info(
-          `Found affected ${type} files:\n${Object.entries(result.onlyStoryFiles)
+          `Found affected ${testType(deps)} files:\n${Object.entries(result.onlyStoryFiles)
             .flatMap(([id, files]) => files.map((f) => `  ${f} [${id}]`))
             .join('\n')}`
         );
@@ -89,8 +88,15 @@ export async function traceChangedFiles(
     if (!deps.options.interactive) {
       const { statsPath } = ctx.fileInfo ?? {};
       const { changedFiles } = ctx.git;
-      deps.log.info(`Failed to retrieve dependent ${type} files`, { statsPath, changedFiles, err });
+      deps.log.info(`Failed to retrieve dependent ${testType(deps)} files`, {
+        statsPath,
+        changedFiles,
+        err,
+      });
     }
-    throw rewriteErrorMessage(err, `Could not retrieve dependent ${type} files.\n${err.message}`);
+    throw rewriteErrorMessage(
+      err,
+      `Could not retrieve dependent ${testType(deps)} files.\n${err.message}`
+    );
   }
 }

--- a/node-src/ui/messages/info/tracedAffectedFiles.stories.ts
+++ b/node-src/ui/messages/info/tracedAffectedFiles.stories.ts
@@ -71,6 +71,18 @@ export const TracedAffectedFiles = () =>
     } as any
   );
 
+export const TracedAffectedFilesE2E = () =>
+  tracedAffectedFiles(
+    {
+      options: { playwright: true, storybookBaseDir: 'src' },
+      turboSnap: { tracedPaths: new Set(tracedPaths) },
+    } as any,
+    {
+      changedFiles: ['src/app/dashboard/index.ts'],
+      affectedModules,
+    } as any
+  );
+
 export const TracedAffectedFilesExpanded = () =>
   tracedAffectedFiles(
     {

--- a/node-src/ui/messages/info/tracedAffectedFiles.ts
+++ b/node-src/ui/messages/info/tracedAffectedFiles.ts
@@ -4,6 +4,7 @@ import pluralize from 'pluralize';
 import { groupUntracedFilesByGlob } from '../../../lib/utilities';
 import { Context, Module, TurboSnap } from '../../../types';
 import { info } from '../../components/icons';
+import { testType } from '../../tasks/utilities';
 
 const printFilePath = (filepath: string, basedir: string, expanded: boolean) => {
   const result =
@@ -27,8 +28,6 @@ export const traceSuggestions = `If you are having trouble with tracing, please 
   3. Make sure you have the correct storybook config file path.\nYou can either set the flags storybook-base-dir or storybook-config-dir to help TurboSnap find the correct storybook config file.\n
 `;
 
-// TODO: refactor this function
-
 export default (
   ctx: Context,
   {
@@ -51,7 +50,11 @@ export default (
   const printPath = (filepath: string) => printFilePath(filepath, basedir, expanded);
 
   const changed = pluralize('changed files', changedFiles.length, true);
-  const affected = pluralize('affected story files', Object.keys(affectedModules).length, true);
+  const affected = pluralize(
+    `affected ${testType(ctx)} files`,
+    Object.keys(affectedModules).length,
+    true
+  );
 
   let directoryDebug;
 
@@ -126,7 +129,7 @@ export default (
       }${results}\n${indent}∟ ${printPath(part)}${note}${printModules(part, indent)}`;
     }
 
-    return results + chalk`\n${'  '.repeat(parts.length)}∟ {cyan [story index]}`;
+    return results + chalk`\n${'  '.repeat(parts.length)}∟ {cyan [${testType(ctx)} index]}`;
   });
 
   const note = chalk`\n\nSet {bold ${flag}} to {bold 'expanded'} to reveal underlying modules.`;

--- a/node-src/ui/messages/info/tracedAffectedFilesE2E.stories.ts
+++ b/node-src/ui/messages/info/tracedAffectedFilesE2E.stories.ts
@@ -1,16 +1,16 @@
 import tracedAffectedFiles from './tracedAffectedFiles';
 
 export default {
-  title: 'CLI/Messages/Info',
+  title: 'CLI/Messages/Info/E2E',
 };
 
 const rootPath = './chromatic-cli';
 const tracedPaths = [
-  'src/app/dashboard/index.ts + 3 modules\nsrc/app/settings/Settings.stories.tsx + 2 modules',
-  'src/app/dashboard/index.ts + 3 modules\nsrc/app/payment/Payment.stories.tsx',
-  'src/app/dashboard/index.ts + 3 modules\nsrc/actions/index.ts\nsrc/app/components/Login.story.tsx + 1 modules',
-  'src/app/dashboard/index.ts + 3 modules\nsrc/actions/index.ts\nsrc/app/index.ts\nsrc/app/settings/Settings.stories.tsx + 2 modules',
-  'src/app/dashboard/index.ts + 3 modules\nsrc/actions/utils.ts + 5 modules\nsrc/app/components/Provider.tsx\nsrc/app/payment/Modal.tsx + 2 modules\nsrc/app/payment/Modal.stories.tsx',
+  'src/app/dashboard/index.ts + 3 modules\nsrc/app/settings/Settings.test.ts + 2 modules',
+  'src/app/dashboard/index.ts + 3 modules\nsrc/app/payment/Payment.test.ts',
+  'src/app/dashboard/index.ts + 3 modules\nsrc/actions/index.ts\nsrc/app/components/Login.test.ts',
+  'src/app/dashboard/index.ts + 3 modules\nsrc/actions/index.ts\nsrc/app/index.ts\nsrc/app/settings/Settings.test.ts + 2 modules',
+  'src/app/dashboard/index.ts + 3 modules\nsrc/actions/utils.ts + 5 modules\nsrc/app/components/Provider.ts\nsrc/app/payment/Modal.ts + 2 modules\nsrc/app/payment/Modal.test.ts',
 ];
 
 const modulesByName = {
@@ -23,14 +23,14 @@ const modulesByName = {
       { name: 'src/hooks/useEvent.ts' },
     ],
   },
-  'src/app/settings/Settings.stories.tsx + 2 modules': {
+  'src/app/settings/Settings.test.ts + 2 modules': {
     id: 2,
-    name: 'src/app/settings/Settings.stories.tsx + 2 modules',
+    name: 'src/app/settings/Settings.test.ts + 2 modules',
     modules: [{ name: 'src/app/settings/Settings.tsx' }, { name: 'src/app/settings/DarkMode.tsx' }],
   },
-  'src/app/components/Login.story.tsx + 1 modules': {
+  'src/app/components/Login.test.ts + 1 modules': {
     id: 3,
-    name: 'src/app/components/Login.story.tsx + 1 modules',
+    name: 'src/app/components/Login.test.ts + 1 modules',
     modules: [{ name: 'src/app/components/Login.tsx' }],
   },
   'src/actions/utils.ts + 5 modules': {
@@ -44,10 +44,10 @@ const modulesByName = {
       { name: 'src/utils/comments/index.ts' },
     ],
   },
-  'src/app/payment/Modal.tsx + 2 modules': {
+  'src/app/payment/Modal.ts + 2 modules': {
     id: 5,
-    name: 'src/app/payment/Modal.tsx + 2 modules',
-    modules: [{ name: 'src/app/components/Modal.tsx' }, { name: 'src/actions/state.ts' }],
+    name: 'src/app/payment/Modal.ts + 2 modules',
+    modules: [{ name: 'src/app/components/Modal.ts' }, { name: 'src/actions/state.ts' }],
   },
 };
 
@@ -62,7 +62,7 @@ const affectedModules = Object.fromEntries(
 export const TracedAffectedFiles = () =>
   tracedAffectedFiles(
     {
-      options: { storybookBaseDir: 'src' },
+      options: { storybookBaseDir: 'src', vitest: true },
       turboSnap: { tracedPaths: new Set(tracedPaths) },
     } as any,
     {
@@ -74,8 +74,9 @@ export const TracedAffectedFiles = () =>
 export const TracedAffectedFilesExpanded = () =>
   tracedAffectedFiles(
     {
-      options: { traceChanged: 'expanded' },
+      options: { traceChanged: 'expanded', vitest: true },
       turboSnap: { rootPath, tracedPaths: new Set(tracedPaths) },
+      vitest: true,
     } as any,
     {
       changedFiles: ['src/app/dashboard/index.ts'],
@@ -88,7 +89,7 @@ export const TracedAffectedFilesExpanded = () =>
 export const TracedAffectedFilesExpandedUntraced = () =>
   tracedAffectedFiles(
     {
-      options: { traceChanged: 'expanded' },
+      options: { traceChanged: 'expanded', vitest: true },
       turboSnap: { rootPath, tracedPaths: new Set(tracedPaths) },
       untracedFiles: [
         { filepath: 'src/stories/Button.jsx', glob: '**/stories/**' },
@@ -107,7 +108,7 @@ export const TracedAffectedFilesExpandedUntraced = () =>
 export const TracedAffectedFilesExpandedBailed = () =>
   tracedAffectedFiles(
     {
-      options: { traceChanged: 'expanded' },
+      options: { traceChanged: 'expanded', vitest: true },
       turboSnap: {
         rootPath,
         tracedPaths: new Set(tracedPaths),
@@ -127,7 +128,7 @@ export const TracedAffectedFilesExpandedBailed = () =>
 export const TracedAffectedFilesCompact = () =>
   tracedAffectedFiles(
     {
-      options: { traceChanged: 'compact' },
+      options: { traceChanged: 'compact', vitest: true },
     } as any,
     {
       changedFiles: ['src/app/dashboard/index.ts'],

--- a/node-src/ui/tasks/prepare.ts
+++ b/node-src/ui/tasks/prepare.ts
@@ -1,10 +1,9 @@
 import path from 'path';
 import pluralize from 'pluralize';
 
-import { isE2EBuild } from '../../lib/e2eUtils';
 import { isPackageManifestFile } from '../../lib/utilities';
 import { Context } from '../../types';
-import { buildType } from './utilities';
+import { buildType, capitalize, testType } from './utilities';
 
 export const initial = (ctx: Context) => ({
   status: 'initial',
@@ -93,11 +92,10 @@ export const invalidReactNative = (
 
 export const tracing = (ctx: Pick<Context, 'git' | 'options'>) => {
   const files = pluralize('file', ctx.git.changedFiles?.length, true);
-  const testType = isE2EBuild(ctx.options) ? 'test' : 'story';
 
   return {
     status: 'updating',
-    title: `Retrieving ${testType} files affected by recent changes`,
+    title: `Retrieving ${testType(ctx)} files affected by recent changes`,
     output: `Traversing dependencies for ${files} that changed since the last build`,
   };
 };
@@ -127,12 +125,11 @@ export const bailed = (ctx: Pick<Context, 'turboSnap'>) => {
 };
 
 export const traced = (ctx: Pick<Context, 'options' | 'onlyStoryFiles'>) => {
-  const testType = isE2EBuild(ctx.options) ? 'test' : 'story';
-  const files = pluralize(`${testType} file`, ctx.onlyStoryFiles?.length, true);
+  const files = pluralize(`${testType(ctx)} file`, ctx.onlyStoryFiles?.length, true);
 
   return {
     status: 'updating',
-    title: `Retrieved ${testType} files affected by recent changes`,
+    title: `Retrieved ${testType(ctx)} files affected by recent changes`,
     output: `Found ${files} affected by recent changes`,
   };
 };
@@ -147,6 +144,6 @@ export const success = (ctx: Context) => {
   return {
     status: 'success',
     title: 'Preparation complete',
-    output: `${buildType(ctx)} files validated and prepared for upload`,
+    output: `${capitalize(buildType(ctx))} files validated and prepared for upload`,
   };
 };

--- a/node-src/ui/tasks/snapshot.ts
+++ b/node-src/ui/tasks/snapshot.ts
@@ -3,17 +3,16 @@ import pluralize from 'pluralize';
 import { isE2EBuild } from '../../lib/e2eUtils';
 import { getDuration } from '../../lib/tasks';
 import { Context } from '../../types';
-
-const testType = (ctx: Context) => (isE2EBuild(ctx.options) ? 'test suite' : 'stories');
+import { suiteType, testType } from './utilities';
 
 export const initial = (ctx: Context) => ({
   status: 'initial',
-  title: `Test your ${testType(ctx)}`,
+  title: `Test your ${suiteType(ctx)}`,
 });
 
 export const dryRun = (ctx: Context) => ({
   status: 'skipped',
-  title: `Test your ${testType(ctx)}`,
+  title: `Test your ${suiteType(ctx)}`,
   output: 'Skipped due to --dry-run',
 });
 
@@ -55,7 +54,7 @@ export const pending = (
   if (!build) {
     return {
       status: 'pending',
-      title: `Test your ${isE2EBuild(options) ? 'test suite' : 'stories'}`,
+      title: `Test your ${suiteType({ options })}`,
       output: 'This may take a few minutes',
     };
   }
@@ -68,8 +67,12 @@ export const pending = (
   }
 
   const { errors, e2eErrors, tests, skips } = stats(ctx);
+  // The output string already contains `tests` so E2E would say `Running N tests for tests...`
+  // which is a redundant. Instead, we only add the unit if it's a Storybook build so it says
+  // `Running N tests...`.
+  const unit = isE2EBuild(options) ? '' : ` for ${pluralize(testType(ctx))}`;
   const matching = options.onlyStoryNames
-    ? ` for stories matching ${options.onlyStoryNames.map((v) => `'${v}'`).join(', ')}`
+    ? `${unit} matching ${options.onlyStoryNames.map((v) => `'${v}'`).join(', ')}`
     : '';
   const affected = onlyStoryFiles ? ' affected by recent changes' : '';
   const skipping = build.testCount > build.actualTestCount ? ` (skipping ${skips})` : '';
@@ -152,7 +155,7 @@ export const buildCanceled = (ctx: Context) => {
 export const skipped = (ctx: Context) => {
   return {
     status: 'skipped',
-    title: `Test your ${testType(ctx)}`,
+    title: `Test your ${suiteType(ctx)}`,
     output: ctx.isPublishOnly
       ? `No UI tests or UI review enabled`
       : `Skipped due to ${ctx.options.list ? '--list' : '--exit-once-uploaded'}`,

--- a/node-src/ui/tasks/terminology.test.ts
+++ b/node-src/ui/tasks/terminology.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from 'vitest';
+
+import { Context } from '../../types';
+import tracedAffectedFiles from '../messages/info/tracedAffectedFiles';
+import { success as prepareSuccess, traced, tracing } from './prepare';
+import { pending as snapshotPending } from './snapshot';
+import { runOnlyFiles, runOnlyNames } from './verify';
+
+const E2E_FLAVORS = [
+  ['Playwright', { playwright: true }],
+  ['Cypress', { cypress: true }],
+  ['Vitest', { vitest: true }],
+] as const;
+
+function cases(storybookText: string, e2eText: string, files = ['a', 'b']) {
+  return [
+    { name: 'Storybook', options: {}, files, output: storybookText },
+    ...E2E_FLAVORS.map(([name, options]) => ({ name, options, files, output: e2eText })),
+  ];
+}
+
+describe('TurboSnap terminology', () => {
+  it.each(
+    cases(
+      'Retrieving story files affected by recent changes',
+      'Retrieving test files affected by recent changes'
+    )
+  )('tracing uses $name terminology', ({ options, files, output }) => {
+    expect(tracing({ options, git: { changedFiles: files } } as Context).title).toBe(output);
+  });
+
+  it.each([
+    ...cases(
+      'Found 1 story file affected by recent changes',
+      'Found 1 test file affected by recent changes',
+      ['a']
+    ),
+    ...cases(
+      'Found 2 story files affected by recent changes',
+      'Found 2 test files affected by recent changes'
+    ),
+  ])('traced uses $name terminology: $output', ({ options, files, output }) => {
+    expect(traced({ options, onlyStoryFiles: files } as Context).output).toBe(output);
+  });
+
+  it.each([
+    ...cases(
+      'Snapshots will be limited to 1 story file affected by recent changes',
+      'Snapshots will be limited to 1 test file affected by recent changes',
+      ['a']
+    ),
+    ...cases(
+      'Snapshots will be limited to 2 story files affected by recent changes',
+      'Snapshots will be limited to 2 test files affected by recent changes'
+    ),
+  ])('runOnlyFiles uses $name terminology: $output', ({ options, files, output }) => {
+    expect(runOnlyFiles({ options, onlyStoryFiles: files } as Context).output).toBe(output);
+  });
+
+  it.each(
+    cases(
+      "Snapshots will be limited to story files matching 'src/**'",
+      "Snapshots will be limited to test files matching 'src/**'"
+    )
+  )(
+    'runOnlyFiles uses $name terminology for an explicit --only-story-files glob',
+    ({ options, output }) => {
+      expect(
+        runOnlyFiles({ options: { ...options, onlyStoryFiles: ['src/**'] } } as Context).output
+      ).toBe(output);
+    }
+  );
+
+  it.each(
+    cases(
+      "Snapshots will be limited to stories matching 'Button/*'",
+      "Snapshots will be limited to tests matching 'Button/*'"
+    )
+  )('runOnlyNames uses $name terminology', ({ options, output }) => {
+    expect(
+      runOnlyNames({ options: { ...options, onlyStoryNames: ['Button/*'] } } as Context).output
+    ).toBe(output);
+  });
+
+  it.each(
+    cases("Running 2 tests for stories matching 'Button/*'", "Running 2 tests matching 'Button/*'")
+  )('snapshot pending uses $name terminology', ({ options, output }) => {
+    const build = {
+      actualTestCount: 2,
+      testCount: 2,
+      errorCount: 0,
+      changeCount: 0,
+      specCount: 2,
+      componentCount: 1,
+      actualCaptureCount: 2,
+    };
+    expect(
+      snapshotPending({
+        build,
+        options: { ...options, onlyStoryNames: ['Button/*'] },
+      } as Context).title
+    ).toBe(output);
+  });
+
+  it.each([
+    ...cases(
+      'Traced 1 changed file to 1 affected story file',
+      'Traced 1 changed file to 1 affected test file'
+    ),
+    ...cases('∟ [story index]', '∟ [test index]'),
+  ])('tracedAffectedFiles uses $name terminology: $output', ({ options, output }) => {
+    const message = tracedAffectedFiles(
+      {
+        options,
+        turboSnap: { tracedPaths: new Set(['src/a.ts\nsrc/a.stories.ts']) },
+      } as Context,
+      {
+        changedFiles: ['src/a.ts'],
+        affectedModules: { 'src/a.stories.ts': ['src/a.stories.ts'] },
+        modulesByName: {},
+        normalize: (name: string) => name,
+      }
+    );
+
+    expect(message).toContain(output);
+  });
+
+  it.each(
+    cases(
+      'Storybook files validated and prepared for upload',
+      'Test suite files validated and prepared for upload'
+    )
+  )('prepare success uses $name terminology', ({ options, output }) => {
+    expect(prepareSuccess({ options } as Context).output).toBe(output);
+  });
+});

--- a/node-src/ui/tasks/utilities.ts
+++ b/node-src/ui/tasks/utilities.ts
@@ -5,4 +5,29 @@ export const buildType = (ctx: Pick<Context, 'options'>) => {
   if (isE2EBuild(ctx.options)) return 'test suite';
   return 'Storybook';
 };
+
+/**
+ * The name for a single unit of work in the build, for use in user-facing messages. E2E projects
+ * (Playwright, Cypress, Vitest) have tests; Storybook projects have stories.
+ *
+ * @param ctx The context set when executing the CLI.
+ *
+ * @returns 'test' for E2E builds, 'story' otherwise.
+ */
+export function testType(ctx: Pick<Context, 'options'>) {
+  return isE2EBuild(ctx.options) ? 'test' : 'story';
+}
+
+/**
+ * The name for what the build tests as a whole, for use in user-facing messages such as
+ * "Test your ___". E2E projects test a suite; Storybook projects test stories.
+ *
+ * @param ctx The context set when executing the CLI.
+ *
+ * @returns 'test suite' for E2E builds, 'stories' otherwise.
+ */
+export function suiteType(ctx: Pick<Context, 'options'>) {
+  return isE2EBuild(ctx.options) ? 'test suite' : 'stories';
+}
+
 export const capitalize = (string: string) => string.charAt(0).toUpperCase() + string.slice(1);

--- a/node-src/ui/tasks/verify.ts
+++ b/node-src/ui/tasks/verify.ts
@@ -1,8 +1,7 @@
 import pluralize from 'pluralize';
 
-import { isE2EBuild } from '../../lib/e2eUtils';
 import { Context } from '../../types';
-import { buildType } from './utilities';
+import { buildType, testType } from './utilities';
 
 export const initial = (ctx: Context) => ({
   status: 'initial',
@@ -31,19 +30,21 @@ export const runOnlyFiles = (ctx: Pick<Context, 'options' | 'onlyStoryFiles'>) =
   status: 'pending',
   title: 'Starting partial build',
   output: ctx.options.onlyStoryFiles
-    ? `Snapshots will be limited to story files matching ${ctx.options.onlyStoryFiles
+    ? `Snapshots will be limited to ${testType(ctx)} files matching ${ctx.options.onlyStoryFiles
         .map((v) => `'${v}'`)
         .join(', ')}`
-    : `Snapshots will be limited to ${ctx.onlyStoryFiles?.length} story files affected by recent changes`,
+    : `Snapshots will be limited to ${pluralize(
+        `${testType(ctx)} files`,
+        ctx.onlyStoryFiles?.length,
+        true
+      )} affected by recent changes`,
 });
 
 export const runOnlyNames = (ctx: Pick<Context, 'options'>) => {
-  const testType = isE2EBuild(ctx.options) ? 'tests' : 'stories';
-
   return {
     status: 'pending',
     title: 'Starting partial build',
-    output: `Snapshots will be limited to ${testType} matching ${ctx.options.onlyStoryNames
+    output: `Snapshots will be limited to ${pluralize(testType(ctx))} matching ${ctx.options.onlyStoryNames
       ?.map((v) => `'${v}'`)
       .join(', ')}`,
   };


### PR DESCRIPTION
We found some spots where E2E verbiage wasn't showing up (so we were referencing 'stories' instead of 'tests'). This expands that so we cover more log outputs.

I also added a `terminology.test.ts` file so it's much easier to see what we expect and ensure we get that output in the test suite.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>18.7.4--canary.1474.34369816688.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@18.7.4--canary.1474.34369816688.0
  # or 
  yarn add chromatic@18.7.4--canary.1474.34369816688.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
