### PR TITLE
Pass .mdx files, if changed, using onlyStoryFiles to the index.

### DIFF
--- a/node-src/lib/turbosnap/v1/getDependentStoryFiles.test.ts
+++ b/node-src/lib/turbosnap/v1/getDependentStoryFiles.test.ts
@@ -1260,6 +1260,90 @@ describe('getDependentStoryFiles', () => {
     );
     expect(result.turboSnap.bailReason).toBeUndefined();
   });
+
+  describe('MDX files', () => {
+    // If MDX files change, we want to include them in onlyStoryFiles so that a new storybook gets
+    // uploaded and we generate a build with the updated MDX content.
+    it('includes a changed MDX file that is part of the Storybook build', async () => {
+      const changedFiles = ['src/Introduction.mdx'];
+      const modules = [
+        {
+          id: './src/Introduction.mdx',
+          name: './src/Introduction.mdx',
+          reasons: [],
+        },
+        {
+          id: './src/foo.stories.js',
+          name: './src/foo.stories.js',
+          reasons: [{ moduleName: CSF_GLOB }],
+        },
+        {
+          id: CSF_GLOB,
+          name: CSF_GLOB,
+          reasons: [{ moduleName: './.storybook/generated-stories-entry.js' }],
+        },
+      ];
+      const ctx = getContext();
+      const result = await getDependentStoryFiles(ctx, { modules }, statsPath, changedFiles);
+      expect(result).toMatchObject({
+        status: 'traced',
+        onlyStoryFiles: {
+          './src/Introduction.mdx': ['src/Introduction.mdx'],
+        },
+      });
+      expect(result.turboSnap.bailReason).toBeUndefined();
+    });
+
+    it('does not include a changed MDX file that is not part of the Storybook build', async () => {
+      const changedFiles = ['docs/unrelated.mdx'];
+      const modules = [
+        {
+          id: './src/foo.stories.js',
+          name: './src/foo.stories.js',
+          reasons: [{ moduleName: CSF_GLOB }],
+        },
+        {
+          id: CSF_GLOB,
+          name: CSF_GLOB,
+          reasons: [{ moduleName: './.storybook/generated-stories-entry.js' }],
+        },
+      ];
+      const ctx = getContext();
+      const result = await getDependentStoryFiles(ctx, { modules }, statsPath, changedFiles);
+      expect(result).toMatchObject({
+        status: 'traced',
+        onlyStoryFiles: {},
+      });
+    });
+
+    it('still respects --untraced for a changed MDX file that would otherwise be included directly', async () => {
+      const changedFiles = ['src/Introduction.mdx'];
+      const modules = [
+        {
+          id: './src/Introduction.mdx',
+          name: './src/Introduction.mdx',
+          reasons: [],
+        },
+        {
+          id: './src/foo.stories.js',
+          name: './src/foo.stories.js',
+          reasons: [{ moduleName: CSF_GLOB }],
+        },
+        {
+          id: CSF_GLOB,
+          name: CSF_GLOB,
+          reasons: [{ moduleName: './.storybook/generated-stories-entry.js' }],
+        },
+      ];
+      const ctx = getContext({ untraced: ['**/*.mdx'] });
+      const result = await getDependentStoryFiles(ctx, { modules }, statsPath, changedFiles);
+      expect(result).toMatchObject({
+        status: 'traced',
+        onlyStoryFiles: {},
+        untracedFiles: [{ filepath: 'src/Introduction.mdx', glob: '**/*.mdx' }],
+      });
+    });
+  });
 });
 
 describe('normalizePath', () => {

--- a/node-src/lib/turbosnap/v1/getDependentStoryFiles.ts
+++ b/node-src/lib/turbosnap/v1/getDependentStoryFiles.ts
@@ -349,6 +349,22 @@ export async function getDependentStoryFiles(
 
   // First, check the files that have changed according to git
   tracedFiles.map((posixPath) => traceName(posixPath));
+
+  for (const file of tracedFiles) {
+    // We want to add MDX files that changed into the affectedModuleIds, but only if
+    // these are part of the storybook build.
+    if (!file.endsWith('.mdx')) {
+      continue;
+    }
+
+    const module_ = modulesByName.get(file);
+    if (!module_?.id) {
+      continue;
+    }
+
+    affectedModuleIds.add(module_.id);
+  }
+
   // If more were found during that process, check them too.
   while (toCheck.length > 0) {
     const [id, tracePath] = toCheck.pop() as TraceToCheck;


### PR DESCRIPTION
This disables the bypassed builds when an MDX file changes. While there will be no changes in story files, we add the changed MDX files to the build using a selector logic in `getDependentStoryFiles.ts`. Tests were also added for this behavior.

**Test on Production**:

- https://www.chromatic.com/build?appId=65aada8f52ca60fe7b941eec&number=4 (Note the change in `Colors.mdx` between builds 4 and 5 - that was the only change to the mealdrop repository)
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>18.8.0--canary.1477.33900854737.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@18.8.0--canary.1477.33900854737.0
  # or 
  yarn add chromatic@18.8.0--canary.1477.33900854737.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
