### PR TITLE
Set component owners if present

### DIFF
--- a/node-src/lib/componentowners.test.ts
+++ b/node-src/lib/componentowners.test.ts
@@ -1,0 +1,77 @@
+import { mkdir, mkdtemp, rm, writeFile } from 'fs/promises';
+import { tmpdir } from 'os';
+import path from 'path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { trySetComponentOwnersIfPresent } from './componentowners';
+import TestLogger from './testLogger';
+
+describe('trySetComponentOwnersIfPresent', () => {
+  let rootPath: string;
+  let log: TestLogger;
+  const client = { runQuery: vi.fn() };
+
+  beforeEach(async () => {
+    rootPath = await mkdtemp(path.join(tmpdir(), 'componentowners-'));
+    log = new TestLogger();
+    client.runQuery.mockReset();
+  });
+
+  afterEach(async () => {
+    await rm(rootPath, { recursive: true, force: true });
+  });
+
+  const setOwners = () =>
+    trySetComponentOwnersIfPresent(
+      { client, log } as unknown as Parameters<typeof trySetComponentOwnersIfPresent>[0],
+      rootPath,
+      'build-id'
+    );
+
+  it.each(['# Some header stuff\nForms/* alice@example.com\n', ''])(
+    'sends the repository-root file contents unchanged: %j',
+    async (content) => {
+      await writeFile(path.join(rootPath, 'COMPONENTOWNERS'), content, 'utf8');
+
+      await setOwners();
+
+      expect(client.runQuery).toHaveBeenCalledExactlyOnceWith(
+        expect.stringMatching(/mutation SetComponentOwners\b/),
+        { buildId: 'build-id', content }
+      );
+      expect(log.warn).not.toHaveBeenCalled();
+    }
+  );
+
+  it('skips the mutation silently when the file is absent', async () => {
+    await expect(setOwners()).resolves.toBeUndefined();
+
+    expect(client.runQuery).not.toHaveBeenCalled();
+    expect(log.warn).not.toHaveBeenCalled();
+  });
+
+  it('warns instead of throwing when the file cannot be read', async () => {
+    await mkdir(path.join(rootPath, 'COMPONENTOWNERS'));
+
+    await expect(setOwners()).resolves.toBeUndefined();
+
+    expect(client.runQuery).not.toHaveBeenCalled();
+    expect(log.warn).toHaveBeenCalledExactlyOnceWith(
+      'Unable to set component owners.',
+      expect.objectContaining({ code: 'EISDIR' })
+    );
+  });
+
+  it('warns instead of throwing when the mutation fails', async () => {
+    await writeFile(path.join(rootPath, 'COMPONENTOWNERS'), 'Forms/* alice@example.com', 'utf8');
+    const mutationError = new Error('Component owners mutation failed');
+    client.runQuery.mockRejectedValue(mutationError);
+
+    await expect(setOwners()).resolves.toBeUndefined();
+
+    expect(log.warn).toHaveBeenCalledExactlyOnceWith(
+      'Unable to set component owners.',
+      mutationError
+    );
+  });
+});

--- a/node-src/lib/componentowners.ts
+++ b/node-src/lib/componentowners.ts
@@ -1,0 +1,41 @@
+import { readFile } from 'fs/promises';
+import path from 'path';
+
+import { Deps } from '../types';
+
+const SetComponentOwnersMutation = `
+  mutation SetComponentOwners($buildId: ObjID!, $content: String!) {
+    setComponentOwners(buildId: $buildId, content: $content) {
+      buildId
+    }
+  }
+`;
+
+/**
+ * Tries to set component owners based on the COMPONENTOWNERS file, if present at the repository root.
+ * Setting component owners is best effort and should never fail the build. Because of this, this function
+ * never throws.
+ *
+ * @param deps Dependencies (the GraphQL client, the logger)
+ * @param rootPath Absolute path to the repository root.
+ * @param buildId ID of the announced build.
+ */
+export async function trySetComponentOwnersIfPresent(
+  deps: Readonly<Pick<Deps, 'client' | 'log'>>,
+  rootPath: string,
+  buildId: string
+) {
+  try {
+    const content = await readFile(path.join(rootPath, 'COMPONENTOWNERS'), 'utf8');
+    await deps.client.runQuery(SetComponentOwnersMutation, {
+      buildId,
+      content,
+    });
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+      // COMPONENTOWNERS file not present. Skip and move on.
+      return;
+    }
+    deps.log.warn('Unable to set component owners.', err);
+  }
+}

--- a/node-src/lib/uploadFiles.ts
+++ b/node-src/lib/uploadFiles.ts
@@ -26,7 +26,7 @@ export async function uploadFiles(
 
   await Promise.all(
     targets.map(({ contentLength, filePath, formAction, formFields, localPath }) => {
-      let fileProgress = 0; // The bytes uploaded for this this particular file
+      let fileProgress = 0; // The bytes uploaded for this particular file
 
       ctx.log.debug(`Uploading ${filePath} (${filesize(contentLength)}) to ${formAction}`);
 

--- a/node-src/tasks/initialize/componentowners.test.ts
+++ b/node-src/tasks/initialize/componentowners.test.ts
@@ -1,0 +1,78 @@
+import TestLogger from '@cli/testLogger';
+import { mkdtemp, rm, writeFile } from 'fs/promises';
+import { tmpdir } from 'os';
+import path from 'path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { AnnouncedBuild } from '../../types';
+import { announceBuild } from './announceBuild';
+import { initialize } from './index';
+
+vi.mock('./announceBuild');
+vi.mock('./gatherEnvironment');
+vi.mock('./getRuntimeMetadata');
+
+describe('component owners during initialization', () => {
+  const content = 'Forms/* alice@example.com';
+  const announcedBuild = { id: 'announced-build-id' } as AnnouncedBuild;
+  const client = { runQuery: vi.fn() };
+  let rootPath: string;
+  let deps: Parameters<typeof initialize>[0];
+  let input: Parameters<typeof initialize>[1];
+
+  beforeEach(async () => {
+    rootPath = await mkdtemp(path.join(tmpdir(), 'initialize-componentowners-'));
+    await writeFile(path.join(rootPath, 'COMPONENTOWNERS'), content, 'utf8');
+    client.runQuery.mockReset();
+    vi.mocked(announceBuild).mockResolvedValue(announcedBuild);
+    deps = { client, log: new TestLogger(), options: {} } as unknown as typeof deps;
+    input = { partialAnnounceBuildInput: { git: { rootPath } } } as typeof input;
+  });
+
+  afterEach(async () => {
+    await rm(rootPath, { recursive: true, force: true });
+  });
+
+  it('sets owners for the newly announced build', async () => {
+    await expect(initialize(deps, input)).resolves.toMatchObject({ kind: 'continue' });
+
+    expect(client.runQuery).toHaveBeenCalledExactlyOnceWith(
+      expect.stringMatching(/mutation SetComponentOwners\b/),
+      { buildId: announcedBuild.id, content }
+    );
+  });
+
+  it('preserves the initialization result when setting owners fails', async () => {
+    const error = new Error('Component owners mutation failed');
+    client.runQuery.mockRejectedValue(error);
+
+    await expect(initialize(deps, input)).resolves.toMatchObject({
+      kind: 'continue',
+      output: { announcedBuild },
+    });
+
+    expect(deps.log.warn).toHaveBeenCalledExactlyOnceWith('Unable to set component owners.', error);
+  });
+
+  it('sets owners during a dry run when the file exists', async () => {
+    await expect(
+      initialize({ ...deps, options: { ...deps.options, dryRun: true } }, input)
+    ).resolves.toMatchObject({ kind: 'continue' });
+
+    expect(client.runQuery).toHaveBeenCalledExactlyOnceWith(
+      expect.stringMatching(/mutation SetComponentOwners\b/),
+      { buildId: announcedBuild.id, content }
+    );
+  });
+
+  it('does not set owners when the repository root is unavailable', async () => {
+    input.partialAnnounceBuildInput.git.rootPath = undefined;
+
+    await expect(initialize(deps, input)).resolves.toMatchObject({ kind: 'continue' });
+
+    expect(client.runQuery).not.toHaveBeenCalled();
+    expect(deps.log.warn).toHaveBeenCalledExactlyOnceWith(
+      'git.rootPath unexpectedly undefined. Should have been set in the gitInfo task upstream.'
+    );
+  });
+});

--- a/node-src/tasks/initialize/index.test.ts
+++ b/node-src/tasks/initialize/index.test.ts
@@ -89,7 +89,7 @@ describe('initialize', () => {
 describe('extractInitializeInput', () => {
   it('extracts announceBuild input fields from context', () => {
     const ctx = {
-      git: { commit: 'abc123', parentCommits: ['def456'] },
+      git: { rootPath: '/repo', commit: 'abc123', parentCommits: ['def456'] },
       turboSnap: { unavailable: false },
       rebuildForBuildId: 'build-id',
       storybook: { version: '7.0.0' },

--- a/node-src/tasks/initialize/index.ts
+++ b/node-src/tasks/initialize/index.ts
@@ -1,4 +1,5 @@
 import { createAnalyticsClient } from '@cli/analytics';
+import { trySetComponentOwnersIfPresent } from '@cli/componentowners';
 import { validateStorybookReactNativeVersion } from '@cli/react-native/validateStorybookVersion';
 
 import { AnnouncedBuild, Context, Deps, RuntimeMetadata, TaskResult } from '../../types';
@@ -11,9 +12,6 @@ import { getRuntimeMetadata } from './getRuntimeMetadata';
 type InitializeDeps = Pick<Deps, 'log' | 'env' | 'client' | 'options' | 'pkg'>;
 
 interface InitializeInput {
-  // currently, only announceBuild takes any input, but I'm structuring this way to match the
-  // structure of other tasks. If other subtasks within initialize need input in the future,
-  // this is where it goes.
   partialAnnounceBuildInput: Omit<AnnounceBuildInput, 'environment' | 'runtimeMetadata'>; // omitted fields come from subtasks
 }
 
@@ -42,6 +40,16 @@ export async function initialize(
     environment,
     runtimeMetadata,
   });
+  const { rootPath } = input.partialAnnounceBuildInput.git;
+  // rootPath is always set at this point. Context god object techdebt just
+  // prevents TS from knowing that here. The if check just narrows the type.
+  if (rootPath) {
+    await trySetComponentOwnersIfPresent(deps, rootPath, announcedBuild.id);
+  } else {
+    deps.log.warn(
+      'git.rootPath unexpectedly undefined. Should have been set in the gitInfo task upstream.'
+    );
+  }
   return { kind: 'continue', output: { environment, runtimeMetadata, announcedBuild } };
 }
 


### PR DESCRIPTION
# Description

This PR sets component owners based on the `COMPONENTOWNERS` file during the `upload` task. A few functional requirements inform the implementation:
1. Setting component owners is best effort and should never fail the build.
2. We only support `COMPONENTOWNERS` files at the repo root.
3. The CLI does no parsing/validation of the file. We just send it.

Because of that first requirement, the added function swallows and logs its own errors because in this case, "what should happen when this fails?" is knowledge that is owned by the feature, not something that only the caller knows. So good information hiding practice suggests putting the try/catch inside the function itself. I just wanted to call that decision out, since it's the opposite of usual best practices.

I also decided to put this mutation inside the `initialize` task, alongside announcing the build, rather than during the upload stage that was previously discussed in the ticket. I felt that aligned better with what this work is doing (setting a type of build metadata), whereas putting it in upload aligned with the implementation detail of how that work was done (uploading a file, though technically not, since we're sending the file's contents in a mutation, not uploading it anywhere, but you get the idea). This seemed like a better fit to me. It also allows us to set component owners even on dry runs, matching announce build.

# Manual QA

I ran three builds:
1. No `COMPONENTOWNERS` file present.
2. `COMPONENTOWNERS` file is present (copied the file from the monorepo)
3. `COMPONENTOWNERS` directory present, forcing an error.

All three builds succeeded. No CLI output for builds 1 and 2. Build 3 showed the warning log `Unable to set component owners. EISDIR: illegal operation on a directory, read`.

Mongo shows no component owners for builds 1 and 3, and successful component owners for build 2:
```
database> db.componentOwners.findOne({buildId: ObjectId('6aa172c60a55c4809b5097f6')})
null
database> db.componentOwners.findOne({buildId: ObjectId('6aa1734a0a55c4809b509800')})
{
  _id: ObjectId('6aa1734a65c02b8fed816c8a'),
  buildId: ObjectId('6aa1734a0a55c4809b509800'),
  createdAt: ISODate('2026-09-09T14:55:06.731Z'),
  rules: [
    { pattern: '*', owners: [ 'estelle@chromatic.com' ] },
    {
      pattern: 'Example/Button/*',
      owners: [ 'kate@chromatic.com', 'estelle@chromatic.com' ]
    },
    { pattern: 'Example/Header/*', owners: [ 'jennifer@chromatic.com' ] }
  ],
  updatedAt: ISODate('2026-09-09T14:55:06.731Z')
}
database> db.componentOwners.findOne({buildId: ObjectId('6aa173ba0a55c4809b50980a')})
null
database>
```

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>18.9.0--canary.1478.34497647280.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@18.9.0--canary.1478.34497647280.0
  # or 
  yarn add chromatic@18.9.0--canary.1478.34497647280.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
