### PR TITLE
Remove TurboSnap v2 Sentry fingerprinting

### DIFF
--- a/node-src/lib/turbosnap/index.test.ts
+++ b/node-src/lib/turbosnap/index.test.ts
@@ -154,9 +154,7 @@ describe('traceChangedFiles', () => {
 
     await expect(traceChangedFiles(ctx)).resolves.toBe(v1Result);
 
-    expect(Sentry.captureException).toHaveBeenCalledWith(error, {
-      fingerprint: ['TurboSnap v2', 'Failed to trace changed files'],
-    });
+    expect(Sentry.captureException).toHaveBeenCalledWith(error);
     expect(traceChangedFilesV1).toHaveBeenCalledOnce();
   });
 

--- a/node-src/lib/turbosnap/index.ts
+++ b/node-src/lib/turbosnap/index.ts
@@ -67,8 +67,6 @@ async function runTurboSnapV2(ctx: Context, stats: Stats): Promise<void> {
       'Failed to trace changed files with TurboSnap v2; this does not affect TurboSnap v1',
       error
     );
-    Sentry.captureException(error, {
-      fingerprint: ['TurboSnap v2', 'Failed to trace changed files'],
-    });
+    Sentry.captureException(error);
   }
 }

--- a/node-src/lib/turbosnap/v2/index.test.ts
+++ b/node-src/lib/turbosnap/v2/index.test.ts
@@ -96,7 +96,7 @@ describe('traceChangedFiles', () => {
       })
     ).resolves.toEqual({ status: 'fallback' });
 
-    expect(Sentry.captureException).toHaveBeenCalled();
+    expect(Sentry.captureException).toHaveBeenCalledWith(error);
     expect(fixture.runQuery).not.toHaveBeenCalled();
   });
 
@@ -112,7 +112,7 @@ describe('traceChangedFiles', () => {
       })
     ).resolves.toEqual({ status: 'fallback' });
 
-    expect(Sentry.captureException).toHaveBeenCalled();
+    expect(Sentry.captureException).toHaveBeenCalledWith(error);
     expect(fixture.runQuery).not.toHaveBeenCalled();
   });
 
@@ -123,7 +123,7 @@ describe('traceChangedFiles', () => {
 
     await expect(trace(fixture)).resolves.toEqual({ status: 'fallback' });
 
-    expect(Sentry.captureException).toHaveBeenCalled();
+    expect(Sentry.captureException).toHaveBeenCalledWith(error);
     // The manifest is still written before the upload, so the failure remains debuggable.
     expect(writtenManifest(fixture).storyFiles).toEqual({ [STORY]: expect.any(String) });
   });

--- a/node-src/lib/turbosnap/v2/index.ts
+++ b/node-src/lib/turbosnap/v2/index.ts
@@ -57,9 +57,7 @@ export async function traceChangedFiles(
     });
   } catch (error) {
     input.log.error('Failed to build manifest for TurboSnap v2', error);
-    Sentry.captureException(error, {
-      fingerprint: ['TurboSnap v2', 'Failed to build manifest'],
-    });
+    Sentry.captureException(error);
     return { status: 'fallback' };
   }
   input.log.debug('Generated manifest for TurboSnap v2');
@@ -70,9 +68,7 @@ export async function traceChangedFiles(
     writeManifest(manifest, input.manifestPath, input.projectFiles);
   } catch (error) {
     input.log.error('Failed to write manifest for TurboSnap v2', error);
-    Sentry.captureException(error, {
-      fingerprint: ['TurboSnap v2', 'Failed to write manifest'],
-    });
+    Sentry.captureException(error);
     return { status: 'fallback' };
   }
   input.log.debug(`Wrote manifest for TurboSnap v2 to ${input.manifestPath}`);
@@ -83,9 +79,7 @@ export async function traceChangedFiles(
     await uploadHashes(input.graphqlClient, input.buildId, manifest);
   } catch (error) {
     input.log.error('Failed to upload hashes for TurboSnap v2', error);
-    Sentry.captureException(error, {
-      fingerprint: ['TurboSnap v2', 'Failed to upload hashes'],
-    });
+    Sentry.captureException(error);
     return { status: 'fallback' };
   }
   input.log.debug('Uploaded hashes for TurboSnap v2 to Chromatic');

--- a/node-src/lib/uploadMetadataFiles.test.ts
+++ b/node-src/lib/uploadMetadataFiles.test.ts
@@ -167,9 +167,7 @@ describe('uploadMetadataFiles', () => {
 
     await expect(uploadMetadataFiles(ctx)).resolves.toBeUndefined();
 
-    expect(Sentry.captureException).toHaveBeenCalledWith(expect.any(Error), {
-      fingerprint: ['UploadMetadataFilesError'],
-    });
+    expect(Sentry.captureException).toHaveBeenCalledWith(expect.any(Error));
     expect(ctx.log.resume).toHaveBeenCalled();
   });
 });

--- a/node-src/lib/uploadMetadataFiles.ts
+++ b/node-src/lib/uploadMetadataFiles.ts
@@ -82,7 +82,7 @@ export async function uploadMetadataFiles(ctx: Context) {
     // Log the error but don't rethrow to fail upwards. This step is a best-effort stage and
     // shouldn't impact the build pipeline.
     ctx.log.debug('Failed to upload metadata files to Chromatic', err);
-    Sentry.captureException(err, { fingerprint: ['UploadMetadataFilesError'] });
+    Sentry.captureException(err);
   }
 }
 


### PR DESCRIPTION
I initially added Sentry fingerprinting to group errors together based on where in the algorithm they occurred. Turns out, this is far less useful than I thought. Therefore, I'm removing them and letting the Sentry magic categorize them automatically for us to see if that's better.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>18.7.4--canary.1480.34369803123.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@18.7.4--canary.1480.34369803123.0
  # or 
  yarn add chromatic@18.7.4--canary.1480.34369803123.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
