### PR TITLE
Filter `.storybook/*.md` and `.storybook/*.txt` changes from TurboSnap v2

### DIFF
--- a/node-src/lib/turbosnap/v1/getDependentStoryFiles.ts
+++ b/node-src/lib/turbosnap/v1/getDependentStoryFiles.ts
@@ -14,7 +14,7 @@ import tracedAffectedFiles from '../../../ui/messages/info/tracedAffectedFiles';
 import bailFile from '../../../ui/messages/warnings/bailFile';
 import { relativeTo } from '../../getStorybookProjectRoot';
 import { posix } from '../../posix';
-import { isPackageManifestFile, matchesFile } from '../../utilities';
+import { isDocumentationFile, isPackageManifestFile, matchesFile } from '../../utilities';
 import { TraceChangedFilesResult } from '../types';
 import { SUPPORTED_LOCK_FILES } from './findChangedDependencies';
 
@@ -27,11 +27,6 @@ const INTERNALS = [/\/webpack\/runtime\//, /^\(webpack\)/];
 
 const isPackageLockFile = (name: string) =>
   SUPPORTED_LOCK_FILES.some((lockfile) => name.endsWith(lockfile));
-
-// Documentation files inside the config dir (e.g. `.storybook/README.md`) don't affect the built
-// Storybook, so a change to them shouldn't trigger a full rebuild.
-const isDocumentationFile = (name: string) =>
-  ['.md', '.txt'].some((extension) => name.toLowerCase().endsWith(extension));
 
 const isUserModule = (module_: Module | Reason) =>
   (module_ as Module).id !== undefined &&

--- a/node-src/lib/turbosnap/v2/manifest.golden.test.ts
+++ b/node-src/lib/turbosnap/v2/manifest.golden.test.ts
@@ -70,15 +70,19 @@ const GOLDEN_FILE_HASHES = {
   [entryPreview]: '1111111111111111',
   '/repo/packages/ui/.storybook/main.ts': '2222222222222222',
   '/repo/packages/ui/.storybook/static/mockServiceWorker.js': '3333333333333333',
+  // Documentation in the static dir is included
+  '/repo/packages/ui/.storybook/static/README.md': '4444444444444444',
+  // Documentation in the config dir is NOT included
+  '/repo/packages/ui/.storybook/README.md': '5555555555555555',
 };
 
 const GOLDEN_DIRECTORY_TREE = {
-  '/repo/packages/ui/.storybook': ['main.ts', 'preview.ts', 'theme.ts', 'static'],
-  '/repo/packages/ui/.storybook/static': ['mockServiceWorker.js'],
+  '/repo/packages/ui/.storybook': ['main.ts', 'preview.ts', 'theme.ts', 'README.md', 'static'],
+  '/repo/packages/ui/.storybook/static': ['mockServiceWorker.js', 'README.md'],
 };
 
 // The published values. See the header before touching these.
-const GOLDEN_STORYBOOK_HASH = 'd86162bf43ae36ba';
+const GOLDEN_STORYBOOK_HASH = 'e1e50323c00bf67a';
 
 const GOLDEN_STORY_FILES: Record<string, string> = {
   './src/Button.stories.tsx': '7b79c90e28f3ac31',
@@ -90,7 +94,7 @@ const GOLDEN_STORYBOOK_FILES: Record<string, string> = {
   storybookGlobals: '372009144b241f17',
   storybookVersion: '9.1.20',
   storybookConfigFiles: 'ccdd11764306552f',
-  staticFiles: 'c9527f087ba3d740',
+  staticFiles: '44658ab79756b51f',
 };
 
 function goldenFixture() {

--- a/node-src/lib/turbosnap/v2/outOfGraphFiles.test.ts
+++ b/node-src/lib/turbosnap/v2/outOfGraphFiles.test.ts
@@ -70,6 +70,35 @@ describe('hashOutOfGraphFiles', () => {
     expect([...staticFiles.keys()]).toEqual(['./.storybook/static/mockServiceWorker.js']);
   });
 
+  it('skips documentation files anywhere in the config dir', async () => {
+    const disk: InMemoryDisk = {
+      directories: {
+        '/repo/packages/ui/.storybook': ['main.ts', 'README.md', 'NOTES.TXT', 'nested'],
+        '/repo/packages/ui/.storybook/nested': ['guide.md'],
+      },
+    };
+
+    const { storybookConfigFiles } = await hashOutOfGraphFiles(makeInput(disk));
+
+    // Docs in the config dir shouldn't affect the built Storybook, so they stay out of the roll-up
+    // hash.
+    expect([...storybookConfigFiles.keys()]).toEqual(['./.storybook/main.ts']);
+  });
+
+  // This matches the behavior of v1 which only ignores docs in the config dir.
+  it('keeps documentation files in a static dir', async () => {
+    const disk: InMemoryDisk = {
+      directories: {
+        '/repo/packages/ui/.storybook': ['main.ts', 'static'],
+        '/repo/packages/ui/.storybook/static': ['terms.md'],
+      },
+    };
+
+    const { staticFiles } = await hashOutOfGraphFiles(makeInput(disk));
+
+    expect([...staticFiles.keys()]).toEqual(['./.storybook/static/terms.md']);
+  });
+
   it('returns an empty static section when staticDirs is unset', async () => {
     const disk: InMemoryDisk = {
       directories: { '/repo/packages/ui/.storybook': ['main.ts'] },

--- a/node-src/lib/turbosnap/v2/outOfGraphFiles.ts
+++ b/node-src/lib/turbosnap/v2/outOfGraphFiles.ts
@@ -1,3 +1,4 @@
+import { isDocumentationFile } from '../../utilities';
 import { FileHash, FilePath, rollUpEntryHashes } from './graph';
 import { ManifestInput } from './manifestInput';
 import { normalizeStatsPath } from './paths';
@@ -49,14 +50,16 @@ export async function hashOutOfGraphFiles(input: OutOfGraphInput): Promise<OutOf
   const staticFilePaths = input.staticDirs.flatMap((directory) =>
     input.projectFiles.listTree(directory)
   );
-
-  // A file can only belong to one section, so collect the static directories first and filter them
-  // out later.
   const staticFileSet = new Set(staticFilePaths);
 
   return {
+    // A file belongs only to one section, so a file in a static dir is not a config file.
+    // Documentation in the config dir (e.g. `.storybook/README.md`) shouldn't affect the built
+    // Storybook, so it stays out of the config roll-up too.
     storybookConfigFiles: await hashByManifestPath(
-      configPaths.filter((filePath) => !staticFileSet.has(filePath)),
+      configPaths.filter(
+        (filePath) => !staticFileSet.has(filePath) && !isDocumentationFile(filePath)
+      ),
       input.projectRoot,
       input.projectFiles
     ),

--- a/node-src/lib/utilities.ts
+++ b/node-src/lib/utilities.ts
@@ -71,6 +71,17 @@ export const groupUntracedFilesByGlob = (untracedFiles: NonNullable<Context['unt
     .join('\n');
 };
 
+/**
+ * Whether a file is a documentation file.
+ *
+ * @param filePath The path to the file.
+ *
+ * @returns True if the file is a documentation file.
+ */
+export function isDocumentationFile(filePath: string) {
+  return ['.md', '.txt'].some((extension) => filePath.toLowerCase().endsWith(extension));
+}
+
 export const isPackageManifestFile = (filePath: string) =>
   [/(^|\/)package\.json$/].some((re) => re.test(filePath));
 


### PR DESCRIPTION
In #1446, we started filtering `*.md` and `*.txt` files from the Storybook config directory. This applies the same to TurboSnap v2.

> [!NOTE]
> This changes the golden hash test which means it'll bust cache for some users. Nobody is actively running this algorithm for capture decisions so it's not a risk.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>18.7.5--canary.1482.34400085516.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@18.7.5--canary.1482.34400085516.0
  # or 
  yarn add chromatic@18.7.5--canary.1482.34400085516.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
