### PR TITLE
Strip webpack escape characters in file paths

### DIFF
--- a/node-src/lib/turbosnap/v2/paths.test.ts
+++ b/node-src/lib/turbosnap/v2/paths.test.ts
@@ -227,6 +227,12 @@ describe('normalizeStatsPath', () => {
     expect(normalizeStatsPath('./src/a.ts + 1 module', projectRoot)).toBe('./src/a.ts');
   });
 
+  it('keys a NUL-escaped filename by the name it really has on disk', () => {
+    expect(normalizeStatsPath('./node_modules/es5-ext/array/\0#/e-index-of.js', projectRoot)).toBe(
+      './node_modules/es5-ext/array/#/e-index-of.js'
+    );
+  });
+
   it('resolves a relative stats path against statsRoot, not the project root', () => {
     // A builder may name relative paths from the repository root even though manifest keys anchor at
     // the project, so the same file has to normalize back to a project-relative key.
@@ -244,6 +250,29 @@ describe('resolveStatsPath', () => {
   it('returns an absolute path unchanged', () => {
     expect(resolveStatsPath('/repo/packages/shared/theme.ts', projectRoot)).toBe(
       '/repo/packages/shared/theme.ts'
+    );
+  });
+
+  it.each([
+    [
+      "webpack's escape for a literal hash",
+      './node_modules/es5-ext/array/\0#/e-index-of.js',
+      '/repo/packages/ui/node_modules/es5-ext/array/#/e-index-of.js',
+    ],
+    ['several escapes in one path', './a/\0#/b/\0#/c.js', '/repo/packages/ui/a/#/b/#/c.js'],
+    ['a marker with nothing after it', './src/Button.tsx\0', '/repo/packages/ui/src/Button.tsx'],
+    [
+      'an escape alongside a concatenation suffix',
+      './node_modules/es5-ext/array/\0#/e-index-of.js + 2 modules',
+      '/repo/packages/ui/node_modules/es5-ext/array/#/e-index-of.js',
+    ],
+  ])('strips %s', (_name, statsPath, expected) => {
+    expect(resolveStatsPath(statsPath, projectRoot)).toBe(expected);
+  });
+
+  it('leaves an unescaped hash alone, since webpack reads it as a fragment', () => {
+    expect(resolveStatsPath('./src/Button.tsx#fragment', projectRoot)).toBe(
+      '/repo/packages/ui/src/Button.tsx#fragment'
     );
   });
 });

--- a/node-src/lib/turbosnap/v2/paths.ts
+++ b/node-src/lib/turbosnap/v2/paths.ts
@@ -168,7 +168,7 @@ function prefixInProjectPath(relativePath: FilePath): FilePath {
 
 /**
  * Resolves a stats module path to an absolute on-disk path for hashing, anchoring relative paths at
- * the Storybook project root.
+ * the Storybook project root. Escape markers are removed first; see {@link stripNullBytes}.
  *
  * @param statsPath The module name from the stats file.
  * @param statsRoot The absolute directory relative stats paths are named from.
@@ -176,6 +176,18 @@ function prefixInProjectPath(relativePath: FilePath): FilePath {
  * @returns The absolute path to the file on disk.
  */
 export function resolveStatsPath(statsPath: FilePath, statsRoot: AbsolutePath): AbsolutePath {
-  const stripped = stripConcatenatedModuleSuffix(statsPath);
+  const stripped = stripNullBytes(stripConcatenatedModuleSuffix(statsPath));
   return path.isAbsolute(stripped) ? stripped : path.resolve(statsRoot, stripped);
+}
+
+/**
+ * Removes the NUL bytes webpack uses to escape a path (`#` is `\0#`), leaving the name the file has
+ * on disk.
+ *
+ * @param statsPath The module name from the stats file.
+ *
+ * @returns The name with the escape markers removed.
+ */
+function stripNullBytes(statsPath: FilePath): FilePath {
+  return statsPath.replaceAll('\0', '');
 }

--- a/node-src/lib/turbosnap/v2/statsGraph.test.ts
+++ b/node-src/lib/turbosnap/v2/statsGraph.test.ts
@@ -121,6 +121,33 @@ describe('readStatsGraph unhashable paths', () => {
     ).toBe(true);
   });
 
+  it('asks the disk about a NUL-escaped filename by its real name', async () => {
+    // Webpack escapes a literal `#` in a filename as `\0#`, so we need to unescape it to get the
+    // real path on disk.
+    const escaped = '/repo/packages/ui/node_modules/es5-ext/array/\0#/e-index-of.js';
+    const onDisk = '/repo/packages/ui/node_modules/es5-ext/array/#/e-index-of.js';
+
+    const { input } = createFixture({ fileHashes: { [onDisk]: 'E' } });
+    const graph = await readStatsGraph(
+      { modules: [{ id: 1, name: escaped, reasons: [] }] },
+      {
+        ...input,
+        projectFiles: {
+          ...input.projectFiles,
+          isFile: (absolutePath) => {
+            if (absolutePath.includes('\0')) {
+              throw new TypeError("The argument 'path' must be a string without null bytes (\0)");
+            }
+            return input.projectFiles.isFile(absolutePath);
+          },
+        },
+      }
+    );
+
+    expect(graph.hashes.get('./node_modules/es5-ext/array/#/e-index-of.js')).toBe('E');
+    expect(graph.files.has('./node_modules/es5-ext/array/#/e-index-of.js')).toBe(true);
+  });
+
   it('skips a module named after a directory rather than failing the read', async () => {
     const story = '/repo/packages/ui/src/Button.stories.tsx';
     // rspack names one record after a directory on `storybook-builder-rsbuild` 3.3.0/3.3.1. Reading


### PR DESCRIPTION
Closes CAP-5067

Looks like Webpack can add NUL byte escape characters based on the file paths. We need to remove those in order to get the correct file path on disk to hash the file.

For example:

`path/#/to/file.js` is `path/\u0000#/to/file.js` in the Webpack output of `preview-stats.json`.

That output is then converted to `path/\0#/to/file.js` when we do a `JSON.parse` so we can simply strip those out and we're left with the real file path: `path/#/to/file.js`.


<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>18.8.2--canary.1484.34614158315.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@18.8.2--canary.1484.34614158315.0
  # or 
  yarn add chromatic@18.8.2--canary.1484.34614158315.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
