### PR TITLE
Ignore `ENAMETOOLONG` errors

### DIFF
--- a/node-src/lib/turbosnap/v2/projectFiles.test.ts
+++ b/node-src/lib/turbosnap/v2/projectFiles.test.ts
@@ -210,6 +210,32 @@ describe('realProjectFiles isFile and isDirectory', () => {
     expect(realProjectFiles(log).isDirectory(absent)).toBe(false);
   });
 
+  it('ignores a name too long for the file system', () => {
+    // Some builders name a module after their whole loader chain instead of a real file path that
+    // lives on disk. It's unlikely for a real file path to be larger than ENAMETOOLONG so we'll
+    // simply ignore it and move on.
+    const root = temporaryDirectory();
+    const tooLongToName = path.join(root, `styles.module.css?source=${'A'.repeat(26_000)}`);
+
+    expect(realProjectFiles(log).isFile(tooLongToName)).toBe(false);
+    expect(realProjectFiles(log).isDirectory(tooLongToName)).toBe(false);
+  });
+
+  it("throws for a failure that isn't the name being too long, because a file we cannot read is a real error", () => {
+    const root = temporaryDirectory();
+    const unreadable = write(root, 'locked/Secret.tsx');
+    // Locking the directory, not the file: stat reads the name from its parent, so an unreadable
+    // file still stats fine while an unsearchable directory fails with EACCES.
+    lock(path.join(root, 'locked'));
+
+    expect(() => realProjectFiles(log).isFile(unreadable)).toThrow(
+      expect.objectContaining({ code: 'EACCES' })
+    );
+    expect(() => realProjectFiles(log).isDirectory(unreadable)).toThrow(
+      expect.objectContaining({ code: 'EACCES' })
+    );
+  });
+
   it('reads a symlink to a file as a file', () => {
     const root = temporaryDirectory();
     const target = write(root, 'vendor/real-logo.svg');

--- a/node-src/lib/turbosnap/v2/projectFiles.ts
+++ b/node-src/lib/turbosnap/v2/projectFiles.ts
@@ -1,5 +1,5 @@
 import { mkdirSync, readdirSync, readFileSync, realpathSync, statSync, writeFileSync } from 'fs';
-import { Dirent } from 'fs';
+import { Dirent, Stats } from 'fs';
 import { createRequire } from 'module';
 import path from 'path';
 
@@ -13,7 +13,9 @@ import { FileHash } from './graph';
  * live here rather than at each call site.
  */
 export interface ProjectFiles {
+  /** False when the path names are too long. Every other failure throws. */
   isFile(absolutePath: AbsolutePath): boolean;
+  /** False when the path names are too long. Every other failure throws. */
   isDirectory(absolutePath: AbsolutePath): boolean;
   /** Undefined when unresolvable; resolves the package manifest, not a dist path. */
   packageVersion(fromDirectory: AbsolutePath, packageName: string): string | undefined;
@@ -38,10 +40,9 @@ export interface ProjectFiles {
  */
 export function realProjectFiles(log: Logger): ProjectFiles {
   return {
-    isFile: (absolutePath: AbsolutePath) =>
-      statSync(absolutePath, { throwIfNoEntry: false })?.isFile() ?? false,
+    isFile: (absolutePath: AbsolutePath) => statFile(log, absolutePath)?.isFile() ?? false,
     isDirectory: (absolutePath: AbsolutePath) =>
-      statSync(absolutePath, { throwIfNoEntry: false })?.isDirectory() ?? false,
+      statFile(log, absolutePath)?.isDirectory() ?? false,
     packageVersion: readPackageVersion,
     hashAll: hashFileContents,
     listTree: (absoluteDirectory: AbsolutePath) => listFilesRecursively(log, absoluteDirectory),
@@ -50,6 +51,21 @@ export function realProjectFiles(log: Logger): ProjectFiles {
       writeFileSync(absolutePath, contents);
     },
   };
+}
+
+function statFile(log: Logger, absolutePath: AbsolutePath): Stats | undefined {
+  try {
+    return statSync(absolutePath, { throwIfNoEntry: false });
+  } catch (error) {
+    // If the file path is too long, then it's likely not a real file so we skip it.
+    if (error.code === 'ENAMETOOLONG') {
+      log.debug(
+        `Unable to read file path of ${absolutePath.length} characters, skipping since it's not likely to be a real file`
+      );
+      return undefined;
+    }
+    throw error;
+  }
 }
 
 /**


### PR DESCRIPTION
Closes CAP-5066

Some file paths within `preview-stats.json` are longer than the maximum allowed length for `fs.statSync`. From what I've seen, these are all synthetic paths generated by the builder. Since they're unlikely to be real file paths, we're going to log those errors and skip them.

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>18.8.2--canary.1485.34614153841.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install chromatic@18.8.2--canary.1485.34614153841.0
  # or 
  yarn add chromatic@18.8.2--canary.1485.34614153841.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
